### PR TITLE
mucin + propulsion gel spill tile reactions

### DIFF
--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -102,6 +102,8 @@
     collection: FootstepBlood
     params:
       volume: 6
+  tileReactions:
+    - !type:SpillTileReaction
 
 - type: reagent
   id: Sap

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -415,3 +415,5 @@
         key: Drowsiness
         time: 2.0
         type: Remove
+  tileReactions:
+    - !type:SpillTileReaction


### PR DESCRIPTION
beck wanted to add these, but they're asleep. just simple spill tile reactions for mucin and propulsion gel to enable them in foam, smoke, whatever

**Changelog**
:cl:
- add: Mucin and propulsion gel are now able to be spread with foam and smoke.