### PR TITLE
announcer updates and weight adjustments

### DIFF
--- a/Resources/Prototypes/Announcers/!randomAnnouncers.yml
+++ b/Resources/Prototypes/Announcers/!randomAnnouncers.yml
@@ -1,9 +1,9 @@
 - type: weightedRandom
   id: RandomAnnouncers
   weights:
-    Intern: 0.15
-    MedBot: 0.5
+    Intern: 0.1
+    MedBot: 0.6
     Michael: 0.3
     NEIL: 0.3
-    TikTok: 0.15
-    VoxFem: 1
+    TikTok: 0.1
+    VoxFem: 1.2

--- a/Resources/Prototypes/Announcers/intern.yml
+++ b/Resources/Prototypes/Announcers/intern.yml
@@ -102,7 +102,7 @@
     #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    # - id: snailMigrationLowPop # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: brosSpawn # BROS are appearing in vents. UNGH
     #   path: events/vent_critters.ogg

--- a/Resources/Prototypes/Announcers/intern.yml
+++ b/Resources/Prototypes/Announcers/intern.yml
@@ -98,6 +98,14 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
+    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigration # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: brosSpawn # BROS are appearing in vents. UNGH
+    #   path: events/vent_critters.ogg
     # - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
     #   path: events/immovable_rod_spawn.ogg
     - id: ionStorm # AI-controlled equipment are now weird, check their laws

--- a/Resources/Prototypes/Announcers/medbot.yml
+++ b/Resources/Prototypes/Announcers/medbot.yml
@@ -96,6 +96,14 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
+    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigration # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: brosSpawn # BROS are appearing in vents. UNGH
+    #   path: events/vent_critters.ogg
     # - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
     #   path: events/immovable_rod_spawn.ogg
     - id: ionStorm # AI-controlled equipment are now weird, check their laws

--- a/Resources/Prototypes/Announcers/medbot.yml
+++ b/Resources/Prototypes/Announcers/medbot.yml
@@ -100,7 +100,7 @@
     #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    # - id: snailMigrationLowPop # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: brosSpawn # BROS are appearing in vents. UNGH
     #   path: events/vent_critters.ogg

--- a/Resources/Prototypes/Announcers/michael.yml
+++ b/Resources/Prototypes/Announcers/michael.yml
@@ -98,6 +98,14 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
+    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigration # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: brosSpawn # BROS are appearing in vents. UNGH
+    #   path: events/vent_critters.ogg
     # - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
     #   path: events/immovable_rod_spawn.ogg
     # - id: ionStorm # AI-controlled equipment are now weird, check their laws

--- a/Resources/Prototypes/Announcers/michael.yml
+++ b/Resources/Prototypes/Announcers/michael.yml
@@ -102,7 +102,7 @@
     #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    # - id: snailMigrationLowPop # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: brosSpawn # BROS are appearing in vents. UNGH
     #   path: events/vent_critters.ogg

--- a/Resources/Prototypes/Announcers/neil.yml
+++ b/Resources/Prototypes/Announcers/neil.yml
@@ -98,6 +98,14 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
+    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigration # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: brosSpawn # BROS are appearing in vents. UNGH
+    #   path: events/vent_critters.ogg
     # - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
     #   path: events/immovable_rod_spawn.ogg
     # - id: ionStorm # AI-controlled equipment are now weird, check their laws

--- a/Resources/Prototypes/Announcers/neil.yml
+++ b/Resources/Prototypes/Announcers/neil.yml
@@ -102,7 +102,7 @@
     #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    # - id: snailMigrationLowPop # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: brosSpawn # BROS are appearing in vents. UNGH
     #   path: events/vent_critters.ogg

--- a/Resources/Prototypes/Announcers/template
+++ b/Resources/Prototypes/Announcers/template
@@ -126,7 +126,7 @@
       path: events/vent_critters.ogg
     - id: snailMigration # Adorable little snails are appearing in vents
       path: events/vent_critters.ogg
-    - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    - id: snailMigrationLowPop # Adorable little snails are appearing in vents
       path: events/vent_critters.ogg
     - id: brosSpawn # BROS are appearing in vents. UNGH
       path: events/vent_critters.ogg

--- a/Resources/Prototypes/Announcers/template
+++ b/Resources/Prototypes/Announcers/template
@@ -122,6 +122,14 @@
       path: events/vent_critters.ogg
     - id: spiderSpawn # Some simple spiders are appearing in vents
       path: events/vent_critters.ogg
+    - id: trashAnimalMigration # Trash-eating critters are appearing in vents
+      path: events/vent_critters.ogg
+    - id: snailMigration # Adorable little snails are appearing in vents
+      path: events/vent_critters.ogg
+    - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+      path: events/vent_critters.ogg
+    - id: brosSpawn # BROS are appearing in vents. UNGH
+      path: events/vent_critters.ogg
     - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
       path: events/immovable_rod_spawn.ogg
     - id: ionStorm # AI-controlled equipment are now weird, check their laws

--- a/Resources/Prototypes/Announcers/tiktok.yml
+++ b/Resources/Prototypes/Announcers/tiktok.yml
@@ -98,6 +98,14 @@
       path: events/vent_critters.ogg
     - id: spiderSpawn # Some simple spiders are appearing in vents
       path: events/vent_critters.ogg
+    - id: trashAnimalMigration # Trash-eating critters are appearing in vents
+      path: events/vent_critters.ogg
+    - id: snailMigration # Adorable little snails are appearing in vents
+      path: events/vent_critters.ogg
+    - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+      path: events/vent_critters.ogg
+    - id: brosSpawn # BROS are appearing in vents. UNGH
+      path: events/vent_critters.ogg
     - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
       path: events/immovable_rod_spawn.ogg
     - id: ionStorm # AI-controlled equipment are now weird, check their laws

--- a/Resources/Prototypes/Announcers/tiktok.yml
+++ b/Resources/Prototypes/Announcers/tiktok.yml
@@ -102,7 +102,7 @@
       path: events/vent_critters.ogg
     - id: snailMigration # Adorable little snails are appearing in vents
       path: events/vent_critters.ogg
-    - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    - id: snailMigrationLowPop # Adorable little snails are appearing in vents
       path: events/vent_critters.ogg
     - id: brosSpawn # BROS are appearing in vents. UNGH
       path: events/vent_critters.ogg

--- a/Resources/Prototypes/Announcers/voxfem.yml
+++ b/Resources/Prototypes/Announcers/voxfem.yml
@@ -96,6 +96,14 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
+    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigration # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    #   path: events/vent_critters.ogg
+    # - id: brosSpawn # BROS are appearing in vents. UNGH
+    #   path: events/vent_critters.ogg
     # - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
     #   path: events/immovable_rod_spawn.ogg
     - id: ionStorm # AI-controlled equipment are now weird, check their laws

--- a/Resources/Prototypes/Announcers/voxfem.yml
+++ b/Resources/Prototypes/Announcers/voxfem.yml
@@ -100,7 +100,7 @@
     #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: snailMigrationLowpop # Adorable little snails are appearing in vents
+    # - id: snailMigrationLowPop # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: brosSpawn # BROS are appearing in vents. UNGH
     #   path: events/vent_critters.ogg


### PR DESCRIPTION
new vent critters events (trash animal, snail, BROS) have received proper voice line support. this only affects tiktok announcer as of now. intern and tiktok have been made rarer, while medibot and voxfem have been made more common.

please don't look at the commit history. for some reason putting ! in gitbash just converted it to git add-A. embarrassing

:cl:
- tweak: Announcer rarities have been adjusted.
