### PR TITLE
SvS event fixes, enable SvS in secret rotation

### DIFF
--- a/Content.Server/Objectives/Systems/KeepAliveCondition.cs
+++ b/Content.Server/Objectives/Systems/KeepAliveCondition.cs
@@ -58,7 +58,7 @@ public sealed class KeepAliveConditionSystem : EntitySystem
                 return;
             }
 
-            //Fallback to assign people who COULD be assigned as traitor
+            //Fallback to assign people who COULD be assigned as traitor - might need to just do this from the start on ForceAll rounds, limiting it to existing traitors could be skewing the numbers towards just a few people.
             var allHumans = _mind.GetAliveHumansExcept(args.MindId);
             var allValidTraitorCandidates = new List<EntityUid>();
             if (_traitorRule.CurrentAntagPool != null)

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -139,7 +139,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
                 return;
             }
 
-            //Fallback to assign people who COULD be assigned as traitor
+            //Fallback to assign people who COULD be assigned as traitor - might need to just do this from the start on ForceAll rounds, limiting it to existing traitors could be skewing the numbers towards just a few people.
             var allValidTraitorCandidates = new List<EntityUid>();
             if (_traitorRule.CurrentAntagPool != null)
             {

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -38,6 +38,16 @@
     - id: SleeperAgents
     - id: ZombieOutbreak
 
+- type: entityTable
+  id: SleeperlessAntagEventsTable
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+    - id: ClosetSkeleton
+    - id: DragonSpawn
+    - id: KingRatMigration
+    - id: NinjaSpawn
+    - id: RevenantSpawn
+    - id: ZombieOutbreak
 
 - type: entity
   id: BaseStationEvent

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -206,10 +206,10 @@
 
 - type: entity
   parent: BaseTraitorRuleNoRandomObjectives
-  id: SpyVsSpy5TC
+  id: SpyVsSpy3TC
   components:
   - type: TraitorRule
-    startingBalance: 5
+    startingBalance: 3
   - type: GameRule
     minPlayers: 15
     delay:
@@ -223,6 +223,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
+      fallbackRoles: [ TraitorSleeper ]
       max: 100
       playerRatio: 1
       blacklist:
@@ -243,8 +244,8 @@
   - type: GameRule
     minPlayers: 15
     delay:
-      min: 240
-      max: 420
+      min: 2
+      max: 4
   - type: AntagObjectives
     objectives:
     - KillRandomTraitorSvSObjective
@@ -253,6 +254,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
+      fallbackRoles: [ TraitorSleeper ]
       max: 100
       playerRatio: 1
       blacklist:
@@ -346,6 +348,17 @@
         tableId: CargoGiftsTable
 
 - type: entityTable
+  id: SleeperlessGameRulesTable
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+      - !type:NestedSelector
+        tableId: BasicCalmEventsTable
+      - !type:NestedSelector
+        tableId: SleeperlessAntagEventsTable
+      - !type:NestedSelector
+        tableId: CargoGiftsTable
+
+- type: entityTable
   id: SpaceTrafficControlTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
@@ -363,6 +376,14 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
+
+- type: entity
+  id: SleeperlessStationEventScheduler
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: SleeperlessGameRulesTable
 
 - type: entity
   id: RampingStationEventScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -159,30 +159,6 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
-  id: SecretSpyVsSpy #For Admin Use: Runs SpyVsSpy but shows "Secret" in lobby.
-  alias:
-    - secretsvs
-  name: secret-title
-  description: secret-description
-  showInVote: false #Admin Use
-  rules:
-    - SpyVsSpy
-    - BasicStationEventScheduler
-    - MeteorSwarmScheduler
-    - BasicRoundstartVariation
-
-- type: gamePreset
-  id: SpyVsSpy5TC
-  name: spy-vs-spy-title
-  description: spy-vs-spy-description
-  showInVote: false
-  rules:
-    - SpyVsSpy5TC
-    - BasicStationEventScheduler
-    - MeteorSwarmScheduler
-    - BasicRoundstartVariation
-
-- type: gamePreset
   id: SpyVsSpy
   alias:
     - svs
@@ -192,8 +168,49 @@
   showInVote: false
   rules:
     - SpyVsSpy
-    - BasicStationEventScheduler
+    - SleeperlessStationEventScheduler
     - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
+  id: SpyVsSpy3TC
+  name: spy-vs-spy-title
+  description: spy-vs-spy-description
+  showInVote: false
+  rules:
+    - SpyVsSpy3TC
+    - SleeperlessStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
+  id: SecretSpyVsSpy #For Admin Use: Runs SpyVsSpy but shows "Secret" in lobby.
+  alias:
+    - secretsvs
+  name: secret-title
+  description: secret-description
+  showInVote: false #Admin Use
+  rules:
+    - SpyVsSpy
+    - SleeperlessStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
+  id: SecretSpyVsSpy3TC #For Admin Use: Runs SpyVsSpy3TC but shows "Secret" in lobby.
+  alias:
+    - secretsvs
+  name: secret-title
+  description: secret-description
+  showInVote: false #Admin Use
+  rules:
+    - SpyVsSpy3TC
+    - SleeperlessStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
 - type: gamePreset

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,9 +1,10 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.20
-    Traitor: 0.60
-    Changeling: 0.20
+    Nukeops: 0.10
+    Traitor: 0.50
+    SpyVsSpy: 0.10
+    Changeling: 0.10
     Zombie: 0.04
     Zombieteors: 0.01
     Survival: 0.09

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,10 +1,10 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.10
-    Traitor: 0.50
-    SpyVsSpy: 0.10
-    Changeling: 0.10
+    Nukeops: 0.20
+    Traitor: 0.60
+    SpyVsSpy: 0.20
+    Changeling: 0.20
     Zombie: 0.04
     Zombieteors: 0.01
     Survival: 0.09


### PR DESCRIPTION
A final round of very minor Spy Vs Spy bugfixes, and enabling it in the main secret rotation! 

:cl:
- add: Added Spy Vs Spy to the secret rotation with a weight similar to Nukies and Changeling rounds
- remove: Removed Sleeper Agent event from Spy Vs Spy rounds
- tweak: People with Sleeper Agent but not Syndicate Agent enabled will now also be included in Spy Vs Spy antag selection
- fix: Fixed random ship event scheduler not being included in Spy Vs Spy settings
