### PR TITLE
Fixed stinger grenades causing massive lag spikes

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
@@ -9,6 +9,7 @@ using System.Numerics;
 using Content.Shared.Explosion.Components;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Explosion.EntitySystems;
 
@@ -114,8 +115,9 @@ public sealed class ClusterGrenadeSystem : EntitySystem
                         RaiseLocalEvent(uid, ref ev);
                     }
                 }
-                // delete the empty shell of the clusterbomb
-                Del(uid);
+                // TODO: Hide the empty shell before deletion
+                // wait a second before deleting to prevent a flood of errors from projectiles
+                Timer.Spawn(TimeSpan.FromSeconds(1), () => QueueDel(uid));
             }
         }
     }

--- a/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
@@ -115,7 +115,10 @@ public sealed class ClusterGrenadeSystem : EntitySystem
                         RaiseLocalEvent(uid, ref ev);
                     }
                 }
-                // TODO: Hide the empty shell before deletion
+                // move the exploded grenade to null space
+                if (TryComp(uid, out TransformComponent? xform))
+                    _transformSystem.DetachEntity(uid, xform);
+
                 // wait a second before deleting to prevent a flood of errors from projectiles
                 Timer.Spawn(TimeSpan.FromSeconds(1), () => QueueDel(uid));
             }

--- a/Content.Shared/Sound/Components/BaseEmitSoundComponent.cs
+++ b/Content.Shared/Sound/Components/BaseEmitSoundComponent.cs
@@ -14,4 +14,9 @@ public abstract partial class BaseEmitSoundComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField(required: true)]
     public SoundSpecifier? Sound;
+
+    [AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
+    public bool Detach = false;
 }

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -143,12 +143,24 @@ public abstract class SharedEmitSoundSystem : EntitySystem
 
         if (predict)
         {
-            _audioSystem.PlayPredicted(component.Sound, uid, user);
+            if (component.Detach)
+            {
+                if (TryComp(uid, out TransformComponent? xform))
+                    _audioSystem.PlayPredicted(component.Sound, xform.Coordinates, user);
+            }
+            else
+                _audioSystem.PlayPredicted(component.Sound, uid, user);
         }
         else if (_netMan.IsServer)
         {
             // don't predict sounds that client couldn't have played already
-            _audioSystem.PlayPvs(component.Sound, uid);
+            if (component.Detach)
+            {
+                if (TryComp(uid, out TransformComponent? xform))
+                    _audioSystem.PlayPvs(component.Sound, xform.Coordinates);
+            }
+            else
+                _audioSystem.PlayPvs(component.Sound, uid);
         }
     }
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/clusterbang.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/clusterbang.yml
@@ -135,6 +135,7 @@
   - type: EmitSoundOnTrigger
     sound:
       path: "/Audio/Effects/flash_bang.ogg"
+    detach: true
   - type: SpawnOnTrigger
     proto: GrenadeFlashEffect
   - type: TimerTriggerVisuals


### PR DESCRIPTION
This PR makes cluster grenades wait a second before deleting themselves. Previously, they would delete immediately upon explosion. The spawned projectiles would then try to reference the grenade as the "gun" that shot them, but since the entity was deleted, it would throw multiple errors for each projectile. This would flood the server log and cause the server to halt for almost an entire second.

<!--
Impstation note: there's no need to read all the official contributing guidelines, but please DON'T combine upstream changes with your own changes. Make separate pull requests for separate changes.
-->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: TGRCDev
- fix: Stinger grenades no longer cause a massive lag spike