### PR TITLE
Add Chaplain PoisonBottle to Trinkets [Do Not Merge]

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -58,6 +58,7 @@ loadout-group-chaplain-mask = Chaplain mask
 loadout-group-chaplain-jumpsuit = Chaplain jumpsuit
 loadout-group-chaplain-outerclothing = Chaplain outer clothing
 loadout-group-chaplain-neck = Chaplain neck
+loadout-group-chaplain-bottle = Ritual Qualification
 
 loadout-group-janitor-head = Janitor head
 loadout-group-janitor-jumpsuit = Janitor jumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/chaplain.yml
@@ -1,3 +1,13 @@
+# Poison bottle
+- type: loadoutEffectGroup
+  id: ChaplainRitual
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChaplain
+      time: 72000 #20 hrs
+
 # Head
 - type: loadout
   id: ChaplainHead
@@ -77,3 +87,13 @@
   id: ChaplainHoodie
   equipment:
     outerClothing: ClothingOuterHoodieChaplain
+
+ # Poison bottle
+- type: loadout
+  id: DrinkPoisonWinebottleFull
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ChaplainRitual
+  storage:
+    back:
+    - DrinkPoisonWinebottleFull

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -334,6 +334,13 @@
   - ChaplainNeck
 
 - type: loadoutGroup
+  id: ChaplainRitual
+  name: loadout-group-chaplain-bottle
+  minLimit: 0
+  loadouts:
+  - DrinkPoisonWinebottleFull
+
+- type: loadoutGroup
   id: JanitorHead
   name: loadout-group-janitor-head
   minLimit: 0

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -122,6 +122,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - ChaplainRitual
   - GroupSpeciesBreathTool
 
 - type: roleLoadout


### PR DESCRIPTION
<!--
Impstation note: there's no need to read all the official contributing guidelines, but please DON'T combine upstream changes with your own changes. Make separate pull requests for separate changes.
-->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
Chaplain now gets a nice little trinket of a poison bottle. Perfect for any Ritual of Agony!!

![Content Client_12ewDKxJy1](https://github.com/user-attachments/assets/2514ebc2-c8be-4ea7-b13c-f47c5ad7db7e)


**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added new poison bottle chaplain trinket.

