### PR TITLE
Maints enemies

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -182,6 +182,10 @@
     - !type:NestedSelector
       tableId: SyndieMaintLoot
       prob: 0.05
+    # Enemy "Loot"
+    - !type:NestedSelector
+      tableId: MaintEnemyTable
+      prob: 0.01
 
 - type: entity
   id: ClosetMaintenanceFilledRandom

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -506,8 +506,9 @@
     children:
     # Weak Enemy
     - id: MobTick
+      weight: 60
     - id: DehydratedSpaceCarp
-      weight: 80
+      weight: 20
     # Strong Enemy
     - !type:GroupSelector
       weight: 20

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -499,3 +499,43 @@
         - Spaceshroom
       chance: 0.6
       offset: 0.0
+
+- type: entityTable
+  id: MaintEnemyTable
+  table: !type:GroupSelector
+    children:
+    # Weak Enemy
+    - id: MobTick
+      weight: 70
+    # Strong Enemy
+    - !type:GroupSelector
+      weight: 25
+      children:
+      - id: MobCarp
+        weight: 5
+      - id: MobCarpMagic
+      - id: MobCarpHolo
+      - id: MobCarpRainbow
+    # Very Strong Enemy
+    - !type:GroupSelector
+      weight: 5
+      children:
+      - id: MobShark
+      - id: MobBearSpace
+      - id: MobSpiderSpace
+
+- type: entity
+  name: Maint Loot Spawner
+  suffix: Enemy
+  id: MaintenanceEnemySpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Mobs/Aliens/Carps/space.rsi
+        state: alive
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: MaintEnemyTable
+      prob: 0.6

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -506,6 +506,7 @@
     children:
     # Weak Enemy
     - id: MobTick
+    - id: DehydratedSpaceCarp
       weight: 80
     # Strong Enemy
     - !type:GroupSelector
@@ -516,7 +517,6 @@
       - id: MobCarpMagic
       - id: MobCarpHolo
       - id: MobCarpRainbow
-      - id: DehydratedSpaceCarp
 
 - type: entity
   name: Maint Loot Spawner

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -506,23 +506,17 @@
     children:
     # Weak Enemy
     - id: MobTick
-      weight: 70
+      weight: 80
     # Strong Enemy
     - !type:GroupSelector
-      weight: 25
+      weight: 20
       children:
       - id: MobCarp
         weight: 5
       - id: MobCarpMagic
       - id: MobCarpHolo
       - id: MobCarpRainbow
-    # Very Strong Enemy
-    - !type:GroupSelector
-      weight: 5
-      children:
-      - id: MobShark
-      - id: MobBearSpace
-      - id: MobSpiderSpace
+      - id: DehydratedSpaceCarp
 
 - type: entity
   name: Maint Loot Spawner

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -87,3 +87,14 @@
   components:
   - type: SalvageMobRestrictions
 
+# - type: entity
+#   id: MobTickMaints
+#   parent: MobTick
+#   suffix: Maintenance
+#   components:
+#   - type: SolutionContainerManager
+#     solutions:
+#       melee:
+#         reagents:
+#         - ReagentId: Toxin  
+#           Quantity: 2


### PR DESCRIPTION
Scouring maintenance as greytide is not very exciting. Sometimes you get something cool, often you're left disappointed. Well now you can also leave dead! More often than not these enemies will be found at the start of the shift, giving medical and security something to do early. The low spawn chance means there's no guarantee there will be even one locker monster all shift. The pool of mobs typically aren't capable of 1v1'ing a greytide anyway, unless you get that 1/2000 Space Spider.

:cl: aada
- add: Rare chance for space ticks to spawn in maints lockers.
- add: Very Rare chance for carp.