### PR TITLE
Give normal engineers holofans

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -39,6 +39,8 @@
         prob: 0.3
       - id: SprayPainter
         prob: 0.7
+      - id: HolofanProjector
+        prob: 0.1
 
 - type: entity
   id: LockerElectricalSuppliesFilled
@@ -126,6 +128,7 @@
       - id: ClothingShoesBootsMag
       - id: RCD
       - id: RCDAmmo
+      - id: HolofanProjector
 
 - type: entity
   id: LockerEngineerFilled
@@ -139,6 +142,7 @@
       - id: trayScanner
       - id: RCD
       - id: RCDAmmo
+      - id: HolofanProjector
 
 - type: entity
   id: ClosetRadiationSuitFilled


### PR DESCRIPTION
<!--
Impstation note: there's no need to read all the official contributing guidelines, but please DON'T combine upstream changes with your own changes. Make separate pull requests for separate changes.
-->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

Holofans being locked to atmos is nightmarish. Only having, like, 2 people available on a GOOD shift that can effectively respond to problems involving lit firelocks is Bad. Normal engineers need to be able to respond to spaced areas without further causing spacing issues, especially with meteors as frequent as they are.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Drags-His-Tail
- tweak: Put holofan projectors in Station Engineers' lockers, and a low chance for them to show up in tool lockers.
