### PR TITLE
Artifact depth 4 foam tweak

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -752,6 +752,8 @@
     maxFoamAmount: 40
     reagents:
     - SpaceDrugs
+    - BrosochloricBros
+    - Pilk
     - Nocturine
     - MuteToxin
     - Phlogiston


### PR DESCRIPTION
<!--
Impstation note: there's no need to read all the official contributing guidelines, but please DON'T combine upstream changes with your own changes. Make separate pull requests for separate changes.
-->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: indirectly nerfed chance of depth 4 foam being really really dangerous by adding additional reagents to roll from in the list
- add: BROS are now in the depth 4 artifact foam
- add: something more evil than any foam before is now in the depth 4 artifact foam