### PR TITLE
cigarettes are now worth 1 speso

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -12,6 +12,8 @@
       - Cigarette
       - Trash
       - PetWearable
+  - type: StaticPrice
+    price: 1
   - type: SpaceGarbage
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigarettes/cigarette.rsi


### PR DESCRIPTION
blame bear for reporting this lol

cigarettes used to be 5 spesos per which meant a cargo tech on bagel with wirecutters and a dream could generate 18k spesos in a few minutes

**Changelog**
:cl: hivehum
- fix: Cigarettes are now functionally worthless.
