### PR TITLE
Revenants enter stasis on death

### DIFF
--- a/Content.Client/Revenant/RevenantStasisComponent.cs
+++ b/Content.Client/Revenant/RevenantStasisComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Client.Revenant;
+
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class RevenantStasisComponent : Component
+{
+}

--- a/Content.Client/Revenant/RevenantStasisSystem.cs
+++ b/Content.Client/Revenant/RevenantStasisSystem.cs
@@ -1,6 +1,7 @@
+using Content.Shared.Examine;
 using Content.Shared.Interaction.Events;
 
-namespace Content.Client.Revenant.EntitySystems;
+namespace Content.Client.Revenant;
 
 public sealed partial class RevenantStasisSystem : EntitySystem
 {
@@ -9,6 +10,12 @@ public sealed partial class RevenantStasisSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<RevenantStasisComponent, ChangeDirectionAttemptEvent>(OnAttemptDirection);
+        SubscribeLocalEvent<RevenantStasisComponent, ExaminedEvent>(OnExamine);
+    }
+
+    private void OnExamine(Entity<RevenantStasisComponent> entity, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("revenant-stasis-regenerating"));
     }
 
     private void OnAttemptDirection(EntityUid uid, RevenantStasisComponent comp, ChangeDirectionAttemptEvent args)

--- a/Content.Client/Revenant/RevenantStasisSystem.cs
+++ b/Content.Client/Revenant/RevenantStasisSystem.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Interaction.Events;
+
+namespace Content.Client.Revenant.EntitySystems;
+
+public sealed partial class RevenantStasisSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RevenantStasisComponent, ChangeDirectionAttemptEvent>(OnAttemptDirection);
+    }
+
+    private void OnAttemptDirection(EntityUid uid, RevenantStasisComponent comp, ChangeDirectionAttemptEvent args)
+    {
+        args.Cancel();
+    }
+}

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -295,6 +295,12 @@ namespace Content.Server.Construction
                 }
             }
 
+            // Inform consumed items that they have been consumed
+            foreach (var entity in container.ContainedEntities.ToArray())
+            {
+                RaiseLocalEvent(entity, new ConstructionConsumedObjectEvent(entity, newEntity));
+            }
+
             // We now get rid of all them.
             ShutdownContainers();
 

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -628,4 +628,16 @@ namespace Content.Server.Construction
     {
         public HandleResult? Result;
     }
+
+    public sealed class ConstructionConsumedObjectEvent : EntityEventArgs
+    {
+        public EntityUid Old;
+        public EntityUid New;
+
+        public ConstructionConsumedObjectEvent(EntityUid oldEnt, EntityUid newEnt)
+        {
+            Old = oldEnt;
+            New = newEnt;
+        }
+    }
 }

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -85,11 +85,14 @@ namespace Content.Server.Kitchen.EntitySystems
                 if (outputContainer is null || !_solutionContainersSystem.TryGetFitsInDispenser(outputContainer.Value, out var containerSoln, out var containerSolution))
                     continue;
 
+                List<EntityUid> toDelete = new();
+                List<(EntityUid, int)> toSet = new();
+
                 foreach (var item in inputContainer.ContainedEntities.ToList())
                 {
                     var solution = active.Program switch
                     {
-                        GrinderProgram.Grind => GetGrindSolution(item),
+                        GrinderProgram.Grind => TryGrindSolution(item, (uid, reagentGrinder), inputContainer.ContainedEntities),
                         GrinderProgram.Juice => CompOrNull<ExtractableComponent>(item)?.JuiceSolution,
                         _ => null,
                     };
@@ -115,18 +118,23 @@ namespace Content.Server.Kitchen.EntitySystems
                         scaledSolution.ScaleSolution(fitsCount);
                         solution = scaledSolution;
 
-                        _stackSystem.SetCount(item, stack.Count - fitsCount); // Setting to 0 will QueueDel
+                        toSet.Add((item, stack.Count - fitsCount));
                     }
                     else
                     {
                         if (solution.Volume > containerSolution.AvailableVolume)
                             continue;
 
-                        QueueDel(item);
+                        toDelete.Add(item);
                     }
 
                     _solutionContainersSystem.TryAddSolution(containerSoln.Value, solution);
                 }
+
+                foreach (var item in toDelete)
+                    Del(item);
+                foreach (var (item, amount) in toSet)
+                    _stackSystem.SetCount(item, amount); // Setting to 0 will QueueDel
 
                 _userInterfaceSystem.ServerSendUiMessage(uid, ReagentGrinderUiKey.Key,
                     new ReagentGrinderWorkCompleteMessage());
@@ -315,12 +323,18 @@ namespace Content.Server.Kitchen.EntitySystems
             _audioSystem.PlayPvs(reagentGrinder.Comp.ClickSound, reagentGrinder.Owner, AudioParams.Default.WithVolume(-2f));
         }
 
-        private Solution? GetGrindSolution(EntityUid uid)
+        private Solution? TryGrindSolution(EntityUid uid, Entity<ReagentGrinderComponent> grinder, IReadOnlyList<EntityUid> contents)
         {
             if (TryComp<ExtractableComponent>(uid, out var extractable)
                 && extractable.GrindableSolution is not null
                 && _solutionContainersSystem.TryGetSolution(uid, extractable.GrindableSolution, out _, out var solution))
             {
+                var ev = new GrindAttemptEvent(grinder, contents);
+                RaiseLocalEvent(uid, ev);
+
+                if (ev.Cancelled)
+                    return null;
+
                 return solution;
             }
             else
@@ -337,6 +351,18 @@ namespace Content.Server.Kitchen.EntitySystems
         private bool CanJuice(EntityUid uid)
         {
             return CompOrNull<ExtractableComponent>(uid)?.JuiceSolution is not null;
+        }
+    }
+
+    public sealed partial class GrindAttemptEvent : CancellableEntityEventArgs
+    {
+        public Entity<ReagentGrinderComponent> Grinder;
+        public IReadOnlyList<EntityUid> Reagents;
+
+        public GrindAttemptEvent(Entity<ReagentGrinderComponent> grinder, IReadOnlyList<EntityUid> reagents)
+        {
+            Grinder = grinder;
+            Reagents = reagents;
         }
     }
 }

--- a/Content.Server/Revenant/Components/RevenantStatisComponent.cs
+++ b/Content.Server/Revenant/Components/RevenantStatisComponent.cs
@@ -1,0 +1,23 @@
+using Content.Server.Revenant.EntitySystems;
+using Content.Shared.Revenant.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Server.Revenant.Components;
+
+[RegisterComponent]
+[Access(typeof(RevenantStasisSystem))]
+[NetworkedComponent]
+public sealed partial class RevenantStasisComponent : Component
+{
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Entity<RevenantComponent> Revenant;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan StasisDuration = TimeSpan.FromSeconds(60);
+
+    public RevenantStasisComponent(TimeSpan stasisDuration, Entity<RevenantComponent> revenant)
+    {
+        StasisDuration = stasisDuration;
+        Revenant = revenant;
+    }
+}

--- a/Content.Server/Revenant/EntitySystems/RevenantAnimatedSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantAnimatedSystem.cs
@@ -73,7 +73,7 @@ public sealed partial class RevenantAnimatedSystem : EntitySystem
         if (HasComp<ItemToggleMeleeWeaponComponent>(ent.Owner) && TryComp<ItemToggleComponent>(ent.Owner, out var toggle))
             _itemToggleSystem.TryActivate((ent.Owner, toggle));
 
-        _popup.PopupEntity(Loc.GetString("revenant-animate-item-animate", ("name", Comp<MetaDataComponent>(ent.Owner).EntityName)), ent.Owner, Filter.Pvs(ent.Owner), true);
+        _popup.PopupEntity(Loc.GetString("revenant-animate-item-animate", ("target", ent.Owner)), ent.Owner, Filter.Pvs(ent.Owner), true);
 
         // Add melee damage if an item doesn't already have it
         if (EnsureHelper<MeleeWeaponComponent>(ent, out var melee))
@@ -144,7 +144,7 @@ public sealed partial class RevenantAnimatedSystem : EntitySystem
             RemCompDeferred(ent, comp);
         }
 
-        _popup.PopupEntity(Loc.GetString("revenant-animate-item-inanimate", ("name", Comp<MetaDataComponent>(ent).EntityName)), ent, Filter.Pvs(ent), true);
+        _popup.PopupEntity(Loc.GetString("revenant-animate-item-inanimate", ("target", ent)), ent, Filter.Pvs(ent), true);
     }
 
     private void OnMobStateChange(Entity<RevenantAnimatedComponent> ent, ref MobStateChangedEvent args)

--- a/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Ghost.Roles.Components;
 using Content.Server.Mind;
 using Content.Server.Revenant.Components;
 using Content.Shared.Alert;
+using Content.Shared.Examine;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Components;
 using Content.Shared.StatusEffect;
@@ -28,6 +29,7 @@ public sealed partial class RevenantStasisSystem : EntitySystem
         SubscribeLocalEvent<RevenantStasisComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<RevenantStasisComponent, StatusEffectEndedEvent>(OnStatusEnded);
         SubscribeLocalEvent<RevenantStasisComponent, ChangeDirectionAttemptEvent>(OnAttemptDirection);
+        SubscribeLocalEvent<RevenantStasisComponent, ExaminedEvent>(OnExamine);
     }
 
     private void OnStartup(EntityUid uid, RevenantStasisComponent component, ComponentStartup args)
@@ -66,6 +68,11 @@ public sealed partial class RevenantStasisSystem : EntitySystem
                 _mind.TransferTo(mindId, component.Revenant);
             QueueDel(uid);
         }
+    }
+
+    private void OnExamine(Entity<RevenantStasisComponent> entity, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("revenant-stasis-regenerating"));
     }
 
     private void OnAttemptDirection(EntityUid uid, RevenantStasisComponent comp, ChangeDirectionAttemptEvent args)

--- a/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
@@ -1,0 +1,75 @@
+using Content.Server.Ghost.Roles;
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.Mind;
+using Content.Server.Revenant.Components;
+using Content.Shared.Alert;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Movement.Components;
+using Content.Shared.StatusEffect;
+
+namespace Content.Server.Revenant.EntitySystems;
+
+public sealed partial class RevenantStasisSystem : EntitySystem
+{
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly GhostRoleSystem _ghostRoles = default!;
+    [Dependency] private readonly MetaDataSystem _meta = default!;
+
+    [ValidatePrototypeId<StatusEffectPrototype>]
+    private const string RevenantStasisId = "Stasis";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RevenantStasisComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<RevenantStasisComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<RevenantStasisComponent, StatusEffectEndedEvent>(OnStatusEnded);
+        SubscribeLocalEvent<RevenantStasisComponent, ChangeDirectionAttemptEvent>(OnAttemptDirection);
+    }
+
+    private void OnStartup(EntityUid uid, RevenantStasisComponent component, ComponentStartup args)
+    {
+        EnsureComp<AlertsComponent>(uid);
+
+        EnsureComp<StatusEffectsComponent>(uid);
+        _statusEffects.TryAddStatusEffect(uid, RevenantStasisId, component.StasisDuration, true);
+
+        var mover = EnsureComp<InputMoverComponent>(uid);
+        mover.CanMove = false;
+        Dirty(uid, mover);
+
+        if (TryComp<GhostRoleComponent>(uid, out var ghostRole))
+            _ghostRoles.UnregisterGhostRole((uid, ghostRole));
+    }
+
+    private void OnShutdown(EntityUid uid, RevenantStasisComponent component, ComponentShutdown args)
+    {
+        if (_statusEffects.HasStatusEffect(uid, RevenantStasisId))
+        {
+            if (_mind.TryGetMind(uid, out var mindId, out var _))
+                _mind.TransferTo(mindId, null);
+            QueueDel(component.Revenant);
+        }
+    }
+
+    private void OnStatusEnded(EntityUid uid, RevenantStasisComponent component, StatusEffectEndedEvent args)
+    {
+        if (args.Key == "Stasis")
+        {
+            _transformSystem.SetCoordinates(component.Revenant, Transform(uid).Coordinates);
+            _transformSystem.AttachToGridOrMap(component.Revenant);
+            _meta.SetEntityPaused(component.Revenant, false);
+            if (_mind.TryGetMind(uid, out var mindId, out var _))
+                _mind.TransferTo(mindId, component.Revenant);
+            QueueDel(uid);
+        }
+    }
+
+    private void OnAttemptDirection(EntityUid uid, RevenantStasisComponent comp, ChangeDirectionAttemptEvent args)
+    {
+        args.Cancel();
+    }
+}

--- a/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
@@ -163,7 +163,7 @@ public sealed partial class RevenantStasisSystem : EntitySystem
 
         var revenant = stasis.Revenant;
 
-        if (!HasComp<BibleUserComponent>(args.User))
+        if (revenant.Comp.ExorcismRequiresBibleUser && !HasComp<BibleUserComponent>(args.User))
         {
             _popup.PopupEntity(Loc.GetString("revenant-exorcise-fail", ("bible", bible)), user, user);
             return;

--- a/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Mind;
 using Content.Server.Revenant.Components;
+using Content.Server.VoiceMask;
 using Content.Shared.Alert;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -43,7 +44,6 @@ public sealed partial class RevenantStasisSystem : EntitySystem
         SubscribeLocalEvent<RevenantStasisComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<RevenantStasisComponent, ConstructionConsumedObjectEvent>(OnCrafted);
 
-        // TODO: This code should be in a shared system
         SubscribeLocalEvent<RevenantStasisComponent, AfterInteractUsingEvent>(OnBibleInteract, before: [typeof(BibleSystem)]);
         SubscribeLocalEvent<RevenantStasisComponent, ExorciseRevenantDoAfterEvent>(OnExorcise);
     }
@@ -62,6 +62,9 @@ public sealed partial class RevenantStasisSystem : EntitySystem
         var speech = EnsureComp<SpeechComponent>(uid);
         speech.SpeechVerb = "Ghost";
         Dirty(uid, speech);
+
+        var voice = EnsureComp<VoiceMaskComponent>(uid);
+        voice.VoiceName = Comp<MetaDataComponent>(component.Revenant).EntityName;
 
         if (TryComp<GhostRoleComponent>(uid, out var ghostRole))
             _ghostRoles.UnregisterGhostRole((uid, ghostRole));
@@ -103,9 +106,10 @@ public sealed partial class RevenantStasisSystem : EntitySystem
         speech.SpeechVerb = "Ghost";
         Dirty(args.New, speech);
 
-        var mover = EnsureComp<InputMoverComponent>(uid);
-        mover.CanMove = false;
-        Dirty(uid, mover);
+        EnsureComp<InputMoverComponent>(args.New);
+
+        var voice = EnsureComp<VoiceMaskComponent>(args.New);
+        voice.VoiceName = Comp<MetaDataComponent>(comp.Revenant).EntityName;
 
         if (_mind.TryGetMind(uid, out var mindId, out var _))
             _mind.TransferTo(mindId, args.New);

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using Content.Server.Actions;
 using Content.Server.GameTicking;
+using Content.Server.Mind;
+using Content.Server.Revenant.Components;
 using Content.Server.Store.Components;
 using Content.Server.Store.Systems;
 using Content.Shared.Alert;
@@ -23,6 +25,7 @@ using Content.Shared.Tag;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Revenant.EntitySystems;
 
@@ -45,6 +48,9 @@ public sealed partial class RevenantSystem : EntitySystem
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly VisibilitySystem _visibility = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly MetaDataSystem _meta = default!;
 
     [ValidatePrototypeId<EntityPrototype>]
     private const string RevenantShopId = "ActionRevenantShop";
@@ -146,8 +152,14 @@ public sealed partial class RevenantSystem : EntitySystem
 
         if (component.Essence <= 0)
         {
-            Spawn(component.SpawnOnDeathPrototype, Transform(uid).Coordinates);
-            QueueDel(uid);
+            component.Essence = 0;
+            Log.Debug($"Spawning stasisObj at {Transform(uid).Coordinates}");
+            var stasisObj = Spawn(component.SpawnOnDeathPrototype, Transform(uid).Coordinates);
+            AddComp(stasisObj, new RevenantStasisComponent(component.StasisTime, (uid, component)));
+            if (_mind.TryGetMind(uid, out var mindId, out var _))
+                _mind.TransferTo(mindId, stasisObj);
+            _transformSystem.DetachEntity(uid, Comp<TransformComponent>(uid));
+            _meta.SetEntityPaused(uid, true);
         }
         return true;
     }

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -153,9 +153,10 @@ public sealed partial class RevenantSystem : EntitySystem
         if (component.Essence <= 0)
         {
             component.Essence = 0;
-            Log.Debug($"Spawning stasisObj at {Transform(uid).Coordinates}");
+            _statusEffects.TryRemoveAllStatusEffects(uid);
             var stasisObj = Spawn(component.SpawnOnDeathPrototype, Transform(uid).Coordinates);
             AddComp(stasisObj, new RevenantStasisComponent(component.StasisTime, (uid, component)));
+            // TODO: Make a RevenantInStasisComponent and attach that to the inert Revenant entity
             if (_mind.TryGetMind(uid, out var mindId, out var _))
                 _mind.TransferTo(mindId, stasisObj);
             _transformSystem.DetachEntity(uid, Comp<TransformComponent>(uid));

--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -133,7 +133,7 @@ public partial class InventorySystem : EntitySystem
             && _containerSystem.Insert(uid, pocket1)
         )
         {
-            _popup.PopupEntity(Loc.GetString("item-jump-into-pocket", ("name", Comp<MetaDataComponent>(uid).EntityName)), target, target);
+            _popup.PopupEntity(Loc.GetString("item-jump-into-pocket", ("target", uid)), target, target);
             return true;
         }
 
@@ -141,13 +141,13 @@ public partial class InventorySystem : EntitySystem
             && _containerSystem.Insert(uid, pocket2)
         )
         {
-            _popup.PopupEntity(Loc.GetString("item-jump-into-pocket", ("name", Comp<MetaDataComponent>(uid).EntityName)), target, target);
+            _popup.PopupEntity(Loc.GetString("item-jump-into-pocket", ("target", uid)), target, target);
             return true;
         }
 
         if (_handsSystem.TryPickupAnyHand(target, uid))
         {
-            _popup.PopupEntity(Loc.GetString("item-jump-into-hands", ("name", Comp<MetaDataComponent>(uid).EntityName)), target, target);
+            _popup.PopupEntity(Loc.GetString("item-jump-into-hands", ("name", uid)), target, target);
             return true;
         }
 

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -30,6 +30,9 @@ public sealed partial class RevenantComponent : Component
     [DataField("spawnOnDeathPrototype", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string SpawnOnDeathPrototype = "Ectoplasm";
 
+    [DataField("stasisTime"), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan StasisTime = TimeSpan.FromSeconds(60);
+
     /// <summary>
     /// The entity's current max amount of essence. Can be increased
     /// through harvesting player souls.

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -34,6 +34,16 @@ public sealed partial class RevenantComponent : Component
     public TimeSpan StasisTime = TimeSpan.FromSeconds(60);
 
     /// <summary>
+    /// If true, only bible users can exorcise this revenant
+    /// with a bible.
+    /// 
+    /// If false, anyone who tries to exorcise a revenant with
+    /// a bible will be able to.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool ExorcismRequiresBibleUser = true;
+
+    /// <summary>
     /// The entity's current max amount of essence. Can be increased
     /// through harvesting player souls.
     /// </summary>

--- a/Content.Shared/Revenant/SharedRevenant.cs
+++ b/Content.Shared/Revenant/SharedRevenant.cs
@@ -70,6 +70,11 @@ public sealed partial class RevenantAnimateEvent : EntityTargetActionEvent
 {
 }
 
+[Serializable, NetSerializable]
+public sealed partial class ExorciseRevenantDoAfterEvent : SimpleDoAfterEvent
+{
+}
+
 
 [NetSerializable, Serializable]
 public enum RevenantVisuals : byte

--- a/Content.Shared/StatusEffect/StatusEffectsComponent.cs
+++ b/Content.Shared/StatusEffect/StatusEffectsComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.StatusEffect
         ///     A list of status effect IDs to be allowed
         /// </summary>
         [DataField("allowed", required: true), Access(typeof(StatusEffectsSystem), Other = AccessPermissions.ReadExecute)]
-        public List<string> AllowedEffects = default!;
+        public List<string> AllowedEffects = new();
     }
 
     [RegisterComponent]

--- a/Content.Shared/StatusEffect/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffect/StatusEffectsSystem.cs
@@ -348,7 +348,7 @@ namespace Content.Shared.StatusEffect
 
             if (!_prototypeManager.TryIndex<StatusEffectPrototype>(key, out var proto))
                 return false;
-            if (!status.AllowedEffects.Contains(key) && !proto.AlwaysAllowed)
+            if (!proto.AlwaysAllowed && !status.AllowedEffects.Contains(key))
                 return false;
 
             return true;

--- a/Resources/Locale/en-US/revenant/revenant.ftl
+++ b/Resources/Locale/en-US/revenant/revenant.ftl
@@ -27,3 +27,7 @@ item-jump-into-hands = {CAPITALIZE(THE($target))} jumps into your hands!
 
 revenant-animate-item-animate = {CAPITALIZE(THE($target))} becomes aggressive!
 revenant-animate-item-inanimate = {CAPITALIZE(THE($target))} falls inert.
+
+alerts-revenant-stasis-name = [color=red]Stasis[/color]
+alerts-revenant-stasis-desc = You are in stasis. Your ghostly energy needs time to regenerate.
+revenant-stasis-regenerating = [color=yellow]The revenant's energy is still present![/color]

--- a/Resources/Locale/en-US/revenant/revenant.ftl
+++ b/Resources/Locale/en-US/revenant/revenant.ftl
@@ -22,8 +22,8 @@ revenant-user-interface-essence-amount = [color=plum]{$amount}[/color] Stolen Es
 
 revenant-user-interface-cost = {$price} Essence
 
-item-jump-into-pocket = The {$name} jumps into your pocket!
-item-jump-into-hands = The {$name} jumps into your hands!
+item-jump-into-pocket = {CAPITALIZE(THE($target))} jumps into your pocket!
+item-jump-into-hands = {CAPITALIZE(THE($target))} jumps into your hands!
 
-revenant-animate-item-animate = The {$name} becomes aggressive!
-revenant-animate-item-inanimate = The {$name} falls inert.
+revenant-animate-item-animate = {CAPITALIZE(THE($target))} becomes aggressive!
+revenant-animate-item-inanimate = {CAPITALIZE(THE($target))} falls inert.

--- a/Resources/Locale/en-US/revenant/revenant.ftl
+++ b/Resources/Locale/en-US/revenant/revenant.ftl
@@ -29,5 +29,12 @@ revenant-animate-item-animate = {CAPITALIZE(THE($target))} becomes aggressive!
 revenant-animate-item-inanimate = {CAPITALIZE(THE($target))} falls inert.
 
 alerts-revenant-stasis-name = [color=red]Stasis[/color]
-alerts-revenant-stasis-desc = You are in stasis. Your ghostly energy needs time to regenerate.
+alerts-revenant-stasis-desc = You are in stasis. Your ghostly form needs time to regenerate.
 revenant-stasis-regenerating = [color=yellow]The revenant's energy is still present![/color]
+
+revenant-exorcise-fail = {CAPITALIZE(THE($bible))} has no effect!
+revenant-exorcise-begin-user = You begin exorcising {$revenant} with {THE($bible)}...
+revenant-exorcise-begin-other = {CAPITALIZE(THE($user))} begins to exorcise {$revenant} with {THE($bible)}...
+revenant-exorcise-begin-target = {CAPITALIZE(THE($user))} is exorcising you with {THE($bible)}!
+
+revenant-exorcise-success = {$revenant}'s energy fades away...

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -18,6 +18,7 @@
     - category: Piloting
     - alertType: Corporeal
     - alertType: Stun
+    - alertType: Stasis
     - category: Breathing # Vox gang not calling this oxygen
     - category: Pressure
     - alertType: Bleed

--- a/Resources/Prototypes/Alerts/revenant.yml
+++ b/Resources/Prototypes/Alerts/revenant.yml
@@ -14,6 +14,14 @@
   name: alerts-revenant-corporeal-name
   description: alerts-revenant-corporeal-desc
 
+- type: alert
+  id: Stasis
+  icons:
+  - sprite: Mobs/Ghosts/revenant.rsi
+    state: ectoplasm
+  name: alerts-revenant-stasis-name
+  description: alerts-revenant-stasis-desc
+
 - type: entity
   id: AlertEssenceSpriteView
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -44,6 +44,7 @@
   - type: GhostTakeoverAvailable
   - type: Revenant
     malfunctionWhitelist:
+      exorcismRequiresBibleUser: true # Escape hatch, change to false if revenant becomes too OP
       components:
       # emag lockers open
       - EntityStorage

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -43,8 +43,8 @@
       settings: default
   - type: GhostTakeoverAvailable
   - type: Revenant
+    exorcismRequiresBibleUser: true # Escape hatch, change to false if revenant becomes too OP
     malfunctionWhitelist:
-      exorcismRequiresBibleUser: true # Escape hatch, change to false if revenant becomes too OP
       components:
       # emag lockers open
       - EntityStorage

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -339,6 +339,9 @@
   name: salt
   suffix: Full
   components:
+  - type: Tag
+    tags:
+    - Salt
   - type: Stack
     stackType: SaltOre
   - type: Sprite

--- a/Resources/Prototypes/status_effects.yml
+++ b/Resources/Prototypes/status_effects.yml
@@ -46,6 +46,11 @@
   alert: Corporeal
 
 - type: statusEffect
+  id: Stasis
+  alert: Stasis
+  alwaysAllowed: true
+
+- type: statusEffect
   id: ForcedSleep #I.e., they will not wake on damage or similar
 
 - type: statusEffect

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -798,6 +798,9 @@
   id: HolosignProjector
 
 - type: Tag
+  id: Holy
+
+- type: Tag
   id: HonkerCentralControlModule
 
 - type: Tag
@@ -1173,6 +1176,9 @@
 
 - type: Tag
   id: RollingPin
+
+- type: Tag
+  id: Salt
 
 - type: Tag
   id: SaltShaker


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<details><summary>Checklist (SPOILERS)</summary>
<p>

- [x] Revenant falls into stasis when it reaches 0 essence, and comes back to life if left undisturbed
- [x] Revenant dies if the ectoplasm is destroyed/deleted
- [x] Revenant dies if the ectoplasm is exorcised with a bible
- [x] Revenant can talk as ectoplasm
- [x] Revenant dies if the ectoplasm is grinded with salt. Reagent grinder explodes if salt is not present.
- [x] Crafting a revenant plushie with stasis ectoplasm traps the revenant within the plushie
- [x] Rename ectoplasm/plushie to stasis revenant

</p>
</details> 

https://github.com/user-attachments/assets/3b69bf7d-37ee-4150-ae3e-7fca3c3f1a20

Stasis time was set to 20 seconds for demonstration. Default is 60 seconds.

**Changelog**

:cl: TGRCDev
- tweak: Revenants now enter stasis on death instead of dying outright. You can kill a revenant in stasis by either destroying or exorcising its ectoplasm.
