### PR TITLE
Flash Immunity for All Sec Eyewear

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -188,7 +188,7 @@
   parent: [ClothingEyesBase, BaseCommandContraband]
   id: ClothingEyesGlassesCommand
   name: administration glasses
-  description: Upgraded sunglasses that provide flash immunity and show ID card status. 
+  description: Upgraded sunglasses that provide flash immunity and show ID card status.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/commandglasses.rsi

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -52,7 +52,7 @@
   parent: [ClothingEyesBase, ShowSecurityIcons, BaseRestrictedContraband]
   id: ClothingEyesHudSecurity
   name: security hud
-  description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status and security records.
+  description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status and security records. Comes with flash-proof contact lenses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/sec.rsi
@@ -61,6 +61,7 @@
   - type: Tag
     tags:
     - HudSecurity
+  - type: FlashImmunity
 
 - type: entity
   parent: [ClothingEyesBase, BaseCommandContraband]
@@ -155,7 +156,7 @@
   parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons, BaseSecurityCommandContraband]
   id: ClothingEyesHudMedSec
   name: medsec hud
-  description: An eye display that looks like a mixture of medical and security huds.
+  description: An eye display that looks like a mixture of medical and security huds. Comes with flash-proof contact lenses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/medsec.rsi
@@ -164,6 +165,7 @@
   - type: Construction
     graph: HudMedSec
     node: medsecHud
+  - type: FlashImmunity
 
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
@@ -251,12 +253,13 @@
   parent: [ClothingEyesHudSecurity, ClothingHeadEyeBaseFlippable]
   id: ClothingEyesEyepatchHudSecurity
   name: security hud eyepatch
-  description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status and security records. For true patriots.
+  description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status and security records. For true patriots. Comes with flash-proof contact lenses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/secpatch.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/secpatch.rsi
+  - type: FlashImmunity
 
 - type: entity
   parent: [ClothingEyesEyepatchHudSecurity,  ClothingHeadEyeBaseFlipped]


### PR DESCRIPTION
Updates sec hud, medsec hud, and sec hud eyepatch to have flash immunity so sec players have some style options and don't go blind when just passing the front desk on Packed. Adds "flash-proof contact lenses" to their descriptions.  Since sunglasses are so plentiful anyway and do the same thing, it's probably fine.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: shaseng
- tweak: Added flash immunity sec hud, medsec hud, and sec hud eyepatch.