### PR TITLE
500 cigarettes made rarer

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -15,7 +15,6 @@
     CheapLighter: 4
     Lighter: 2
     FlippoLighter: 2
-  contrabandInventory:
-    StackOfCigs: 1
   emaggedInventory:
     CigPackSyndicate: 1
+    StackOfCigs: 1


### PR DESCRIPTION
500 cigarettes is a ruined joke. Not a shift goes by without an uncleanable amount of cigarettes littering the station because it's trivial to get. By moving it to the emag inventory, it's now a toy available to only cargo and antag instead of literally everyone. The rarity makes it more special when it's seen.

The other aspect is lag. The item creates 500 entities, often located very close together. The engine doesn't like loading more than 50 things at a time according to wizden, and while it's not a problem on its can certainly contribute.

:cl: aada
- tweak: 500 cigarettes moved to the emag inventory of cigVend.