### PR TITLE
BROS update

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2539,6 +2539,7 @@
     - type: Tag
       tags:
       - BROS
+      - Trash
 
 - type: entity
   name: SORB

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2520,7 +2520,7 @@
     - type: Speech
       speechVerb: Cluwne
     - type: Bloodstream
-      bloodMaxVolume: 40
+      bloodMaxVolume: 15
       bloodReagent: VentCrud
     - type: NoSlip
     - type: ZombieImmune


### PR DESCRIPTION
BROS bleed an insane amount. This halves the amount of blood. It also adds the trash tag, helping janitors clean up the aftermath.