### PR TITLE
Salt can reveal revenants

### DIFF
--- a/Content.Client/Revenant/RevealRevenantOnCollideSystem.cs
+++ b/Content.Client/Revenant/RevealRevenantOnCollideSystem.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Revenant.EntitySystems;
+
+namespace Content.Client.Revenant;
+
+public sealed partial class RevealRevenantOnCollideSystem : SharedRevealRevenantOnCollideSystem
+{
+}

--- a/Content.Server/Revenant/EntitySystems/RevealRevenantOnCollideSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevealRevenantOnCollideSystem.cs
@@ -1,0 +1,55 @@
+using Content.Shared.Revenant.EntitySystems;
+using Content.Shared.Revenant.Components;
+using Content.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics;
+
+namespace Content.Server.Revenant.EntitySystems;
+
+public sealed partial class RevealRevenantOnCollideSystem : SharedRevealRevenantOnCollideSystem
+{
+    [Dependency] private readonly FixtureSystem _fixtures = default!;
+    [Dependency] private readonly CollisionWakeSystem _collisionWake = default!;
+
+    private const string FixtureId = "revenantReveal";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RevealRevenantOnCollideComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<RevealRevenantOnCollideComponent, ComponentShutdown>(OnShutdown);
+    }
+
+    private IPhysShape GetOrCreateShape(EntityUid uid, FixturesComponent? fixtures = null)
+    {
+        if (Resolve(uid, ref fixtures))
+            if (fixtures.Fixtures.TryGetValue("fix1", out var fix))
+                return fix.Shape;
+
+        return new PhysShapeCircle(0.35f);
+    }
+
+    private void OnStartup(EntityUid uid, RevealRevenantOnCollideComponent comp, ComponentStartup args)
+    {
+        var fixtures = EnsureComp<FixturesComponent>(uid);
+        _fixtures.TryCreateFixture(uid,
+            GetOrCreateShape(uid, fixtures),
+            FixtureId,
+            hard: false,
+            collisionMask: (int)CollisionGroup.GhostImpassable,
+            collisionLayer: (int)CollisionGroup.GhostImpassable,
+            manager: fixtures
+        );
+
+        // Disable collision wake so that it can trigger collisions even when sitting still
+        var collisionWake = EnsureComp<CollisionWakeComponent>(uid);
+        _collisionWake.SetEnabled(uid, false, collisionWake);
+    }
+
+    private void OnShutdown(EntityUid uid, RevealRevenantOnCollideComponent comp, ComponentShutdown args)
+    {
+        _fixtures.DestroyFixture(uid, FixtureId);
+    }
+}

--- a/Content.Shared/Revenant/Components/RevealRevenantOnCollideComponent.cs
+++ b/Content.Shared/Revenant/Components/RevealRevenantOnCollideComponent.cs
@@ -1,0 +1,18 @@
+namespace Content.Shared.Revenant.Components;
+
+[RegisterComponent]
+public sealed partial class RevealRevenantOnCollideComponent : Component
+{
+    /// <summary>
+    /// Popup text to show the revenant upon revealing. Works with
+    /// localization strings as well.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string PopupText;
+
+    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan RevealTime;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan? StunTime;
+}

--- a/Content.Shared/Revenant/Components/RevealRevenantOnCollideComponent.cs
+++ b/Content.Shared/Revenant/Components/RevealRevenantOnCollideComponent.cs
@@ -1,18 +1,20 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared.Revenant.Components;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RevealRevenantOnCollideComponent : Component
 {
     /// <summary>
     /// Popup text to show the revenant upon revealing. Works with
     /// localization strings as well.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public string PopupText;
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public string PopupText = "revenant-revealed-default";
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public TimeSpan RevealTime = TimeSpan.FromSeconds(5);
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public TimeSpan? StunTime;
 }

--- a/Content.Shared/Revenant/Components/RevealRevenantOnCollideComponent.cs
+++ b/Content.Shared/Revenant/Components/RevealRevenantOnCollideComponent.cs
@@ -10,8 +10,8 @@ public sealed partial class RevealRevenantOnCollideComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string PopupText;
 
-    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan RevealTime;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan RevealTime = TimeSpan.FromSeconds(5);
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan? StunTime;

--- a/Content.Shared/Revenant/EntitySystems/SharedRevealRevenantOnCollideSystem.cs
+++ b/Content.Shared/Revenant/EntitySystems/SharedRevealRevenantOnCollideSystem.cs
@@ -32,7 +32,11 @@ public abstract class SharedRevealRevenantOnCollideSystem : EntitySystem
             return;
 
         if (!string.IsNullOrEmpty(comp.PopupText) && !_status.HasStatusEffect(args.OtherEntity, CorporealStatusId))
-            _popup.PopupClient(Loc.GetString(comp.PopupText), args.OtherEntity, args.OtherEntity);
+            _popup.PopupClient(
+                Loc.GetString(comp.PopupText, ("revealer", uid), ("revenant", args.OtherEntity)),
+                args.OtherEntity,
+                args.OtherEntity
+            );
 
         _status.TryAddStatusEffect<CorporealComponent>(args.OtherEntity, CorporealStatusId, comp.RevealTime, true);
 

--- a/Content.Shared/Revenant/EntitySystems/SharedRevealRevenantOnCollideSystem.cs
+++ b/Content.Shared/Revenant/EntitySystems/SharedRevealRevenantOnCollideSystem.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Revenant.Components;
+using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
+using Content.Shared.Stunnable;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Revenant.EntitySystems;
+
+public abstract class SharedRevealRevenantOnCollideSystem : EntitySystem
+{
+    [Dependency] private readonly StatusEffectsSystem _status = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    [ValidatePrototypeId<StatusEffectPrototype>]
+    private const string CorporealStatusId = "Corporeal";
+    [ValidatePrototypeId<StatusEffectPrototype>]
+    private const string StunStatusId = "Stun";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RevealRevenantOnCollideComponent, StartCollideEvent>(OnCollideStart);
+    }
+
+    public void OnCollideStart(EntityUid uid, RevealRevenantOnCollideComponent comp, StartCollideEvent args)
+    {
+        if (!HasComp<RevenantComponent>(args.OtherEntity))
+            return;
+
+        if (!string.IsNullOrEmpty(comp.PopupText) && !_status.HasStatusEffect(args.OtherEntity, CorporealStatusId))
+            _popup.PopupClient(Loc.GetString(comp.PopupText), args.OtherEntity, args.OtherEntity);
+
+        _status.TryAddStatusEffect<CorporealComponent>(args.OtherEntity, CorporealStatusId, comp.RevealTime, true);
+
+        if (comp.StunTime != null && !_status.HasStatusEffect(args.OtherEntity, StunStatusId))
+            _stun.TryStun(args.OtherEntity, comp.StunTime.Value, true);
+    }
+}

--- a/Resources/Locale/en-US/revenant/revenant.ftl
+++ b/Resources/Locale/en-US/revenant/revenant.ftl
@@ -38,3 +38,6 @@ revenant-exorcise-begin-other = {CAPITALIZE(THE($user))} begins to exorcise {$re
 revenant-exorcise-begin-target = {CAPITALIZE(THE($user))} is exorcising you with {THE($bible)}!
 
 revenant-exorcise-success = {$revenant}'s energy fades away...
+
+revenant-revealed-default = {CAPITALIZE(THE($revealer))} weakens your ethereal cloak!
+revenant-revealed-salt = The salt puddle weakens your ethereal cloak!

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -342,6 +342,9 @@
   - type: Tag
     tags:
     - Salt
+  - type: RevealRevenantOnCollide
+    revealTime: 5
+    popupText: revenant-revealed-salt
   - type: Stack
     stackType: SaltOre
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -343,8 +343,6 @@
     tags:
     - Salt
   - type: RevealRevenantOnCollide
-    revealTime: 5
-    popupText: revenant-revealed-salt
   - type: Stack
     stackType: SaltOre
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -22,6 +22,7 @@
     bibleUserOnly: true
   - type: Summonable
     specialItem: SpawnPointGhostRemilia
+  - type: RevealRevenantOnCollide
   - type: ReactionMixer
     mixMessage: "bible-mixing-success"
     reactionTypes:

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -191,6 +191,11 @@
         damage:
           types:
             Poison: 4
+  tileReactions:
+    - !type:EnsureTileReaction
+      components:
+        - type: RevealRevenantOnCollide
+          popupText: revenant-revealed-salt
 
 - type: reagent
   id: Syrup


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

- [x] Salt ore items will reveal the revenant
- [x] Puddles of table salt will reveal the revenant
- [x] Bibles and other "holy" items will reveal the revenant


https://github.com/user-attachments/assets/f4bb6939-369e-4cca-aab8-75b810e83f57



**Changelog**

:cl: TGRCDev
- tweak: Placing salt on the ground now reveals revenants who pass over it.
