### PR TITLE
Rat kings and servants can now eat trash

### DIFF
--- a/Content.Server/Body/Components/StomachComponent.cs
+++ b/Content.Server/Body/Components/StomachComponent.cs
@@ -48,6 +48,12 @@ namespace Content.Server.Body.Components
         public EntityWhitelist? SpecialDigestible = null;
 
         /// <summary>
+        ///     If true, allows this stomach to digest regular food alongside food that passes SpecialDigestible
+        /// </summary>
+        [DataField]
+        public bool AdditiveDiet = false;
+
+        /// <summary>
         ///     Used to track how long each reagent has been in the stomach
         /// </summary>
         [ViewVariables]

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -429,8 +429,12 @@ public sealed class FoodSystem : EntitySystem
             // Check if the food is in the whitelist
             if (_whitelistSystem.IsWhitelistPass(ent.Comp1.SpecialDigestible, food))
                 return true;
-            // They can only eat whitelist food and the food isn't in the whitelist. It's not edible.
-            return false;
+
+            if (ent.Comp1.AdditiveDiet)
+                continue;
+            else
+                // They can only eat whitelist food and the food isn't in the whitelist. It's not edible.
+                return false;
         }
 
         if (component.RequiresSpecialDigestion)

--- a/Resources/Locale/en-US/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/flavors/flavor-profiles.ftl
@@ -31,6 +31,7 @@ flavor-base-peppery = peppery
 flavor-base-slimy = slimy
 flavor-base-magical = magical
 flavor-base-fiber = fibrous
+flavor-base-trash = like rubbish
 flavor-base-cold = cold
 flavor-base-spooky = spooky
 flavor-base-smokey = smokey

--- a/Resources/Locale/en-US/reagents/meta/fun.ftl
+++ b/Resources/Locale/en-US/reagents/meta/fun.ftl
@@ -4,6 +4,9 @@ reagent-desc-carpetium = A mystical chemical, usually outsourced from the Clown 
 reagent-name-fiber = fiber
 reagent-desc-fiber = A raw material, usually extracted from wool or other fabric products.
 
+reagent-name-trash = trash
+reagent-desc-trash = A slurry of discarded food, drink and packaging.
+
 reagent-name-buzzochloric-bees = buzzochloric bees
 reagent-desc-buzzochloric-bees = Liquid bees. Oh god it's LIQUID BEES NO-
 

--- a/Resources/Prototypes/Body/Organs/rat.yml
+++ b/Resources/Prototypes/Body/Organs/rat.yml
@@ -11,6 +11,17 @@
   parent: OrganAnimalStomach
   suffix: "rat"
   components:
+  - type: Stomach
+    specialDigestible:
+      tags:
+      - Trash
+    additiveDiet: true
+  - type: Metabolizer
+    maxReagents: 3
+    metabolizerTypes: [ Animal, Rat ]
+    groups:
+    - id: Food
+    - id: Drink
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -567,6 +567,15 @@
     materialComposition:
       Steel: 100
   - type: SpaceGarbage
+  - type: Food
+    requiresSpecialDigestion: true
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+          - ReagentId: Trash
+            Quantity: 10
   - type: StaticPrice
     price: 0
 

--- a/Resources/Prototypes/Flavors/flavors.yml
+++ b/Resources/Prototypes/Flavors/flavors.yml
@@ -115,6 +115,11 @@
   description: flavor-base-fiber
 
 - type: flavor
+  id: trash
+  flavorType: Base
+  description: flavor-base-trash
+
+- type: flavor
   id: cold
   flavorType: Base
   description: flavor-base-cold

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -43,6 +43,28 @@
           type: Moth
 
 - type: reagent
+  id: Trash
+  name: reagent-name-trash
+  desc: reagent-desc-trash
+  physicalDesc: reagent-physical-desc-murky
+  flavor: trash
+  metabolisms:
+    Food:
+      effects:
+        - !type:SatiateHunger
+          conditions:
+            - !type:OrganType
+              type: Rat
+        - !type:HealthChange
+          conditions:
+          - !type:OrganType
+            type: Rat
+            shouldHave: false
+          damage:
+            types:
+              Poison: 0.5
+
+- type: reagent
   id: BuzzochloricBees
   name: reagent-name-buzzochloric-bees
   group: Toxins


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

This PR adds a new option to stomachs with specialized digestion. When `AdditiveDiet` is true, mobs with this stomach will be able to eat regular food AND food defined by their `SpecializedDigestion` whitelist. This is used to add trash to the list of permitted food items for rats.


https://github.com/user-attachments/assets/3b4bcf15-5c4f-4f98-b84d-284c56e25dd3



**Changelog**

:cl: TGRCDev
- tweak: Rat kings and rat servants can now eat trash
