### PR TITLE
hos/warden winter coats

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -79,3 +79,8 @@
   id: HeadofSecurityWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterHoS
+
+- type: loadout
+  id: HeadofSecurityWinterCoatUnarmored
+  equipment:
+    outerClothing: ClothingOuterWinterHoSUnarmored

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -30,3 +30,8 @@
   id: WardenArmoredWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterWarden
+
+- type: loadout
+  id: WardenWinterCoatUnarmored
+  equipment:
+    outerClothing: ClothingOuterWinterWardenUnarmored

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -967,6 +967,7 @@
   loadouts:
   - HeadofSecurityCoat
   - HeadofSecurityWinterCoat
+  - HeadofSecurityWinterCoatUnarmored
 
 - type: loadoutGroup
   id: WardenHead
@@ -989,6 +990,7 @@
   loadouts:
   - WardenCoat
   - WardenArmoredWinterCoat
+  - WardenWinterCoatUnarmored
 
 - type: loadoutGroup
   id: SecurityHead


### PR DESCRIPTION
these were already in the files, but unavailable in loadouts. you could only get them from the uniform printer. This Has To Change.

**Changelog**
:cl:
- add: The Warden and Head of Security can now pick winter coats in their loadouts.
