### PR TITLE
halves the chance for svs to roll

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,7 +3,7 @@
   weights:
     Nukeops: 0.20
     Traitor: 0.60
-    SpyVsSpy: 0.20
+    SpyVsSpy: 0.10
     Changeling: 0.20
     Zombie: 0.04
     Zombieteors: 0.01


### PR DESCRIPTION
i have no idea to actually test if this works but it either does or it doesnt

**Changelog**
:cl: hivehum
- tweak: Spy v Spy is now less common.
