### PR TITLE
New drinks again

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/consumable/drink/alcohol.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/drink/alcohol.ftl
@@ -312,3 +312,12 @@ reagent-desc-junglejuice = Dont let the captain see, or youll have to pour it ou
 
 reagent-name-drinkdrink = Drink
 reagent-desc-drinkdrink = Finally.
+
+reagent-name-bloodier-mary = Bloodier Mary
+reagent-desc-bloodier-mary = AH, AH, AHH!
+
+reagent-name-salvagerssoothe = Salvager's Soothe
+reagent-desc-salvagerssoothe = Come home safe, okay? We're counting on you.
+
+reagent-name-donttelldsheriff = Don't Tell D Sherrif
+reagent-desc-donttelldsheriff = If Red Bool gives you wings, this'll give you four wheel drive.

--- a/Resources/Locale/en-US/reagents/meta/consumable/drink/soda.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/drink/soda.ftl
@@ -55,3 +55,6 @@ reagent-desc-shamblers-juice = ~Shake me up some of that Shambler's Juice!~
 reagent-name-kingsoda = King Soda
 reagent-desc-kingsoda = A drink fit for a king. Or a seven year old.
 
+reagent-name-hummingbird = Hummingbird's Delight
+reagent-desc-hummingbird = A favourite of adolescent Vox just about everywhere.
+

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1047,6 +1047,15 @@
   metamorphicMaxFillLevels: 6
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 3
+        refresh: false
 
 - type: reagent
   id: Hooch

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -2292,7 +2292,7 @@
   name: reagent-name-salvagerssoothe
   parent: BaseAlcohol
   desc: reagent-desc-salvagerssoothe
-  physicalDesc: reagent-physical-desc-bubbly
+  physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
   color: "#00ff99"
   recognizable: true

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -2116,7 +2116,7 @@
       - !type:SatiateThirst
         factor: 2
       - !type:GenericStatusEffect
-        key: Drunk
+        key: Drowsiness
         time: 5
         type: Add
     Narcotic:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -2063,6 +2063,12 @@
   physicalDesc: reagent-physical-desc-bubbly
   flavor: cola
   color: "#663100"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/wineglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 0.8
 
 - type: reagent
@@ -2073,6 +2079,12 @@
   physicalDesc: reagent-physical-desc-bubbly
   flavor: rootbeersoda
   color: "#381c07"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/rootbeerglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 6
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 0.8
 
 - type: reagent
@@ -2083,13 +2095,19 @@
   physicalDesc: reagent-physical-desc-evil
   flavor: energydrink
   color: "#ff6500"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/whiskeyglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 4
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Drink:
       effects:
       - !type:SatiateThirst
         factor: 2
       - !type:GenericStatusEffect
-        key: Drowsiness
+        key: Drunk
         time: 5
         type: Add
     Narcotic:
@@ -2106,7 +2124,7 @@
         probability: 0.25
         damage:
           types:
-            Blunt: 20
+            Poison: 5
         conditions:
         - !type:ReagentThreshold
           min: 20
@@ -2122,6 +2140,12 @@
   physicalDesc: reagent-physical-desc-bubbly
   flavor: sweet
   color: "#ffee3e"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/wineglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 0.8
 
 - type: reagent
@@ -2132,6 +2156,12 @@
   physicalDesc: reagent-physical-desc-murky
   flavor: horrible
   color: "#8a8048"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/whiskeyglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 4
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Drink:
       effects:
@@ -2163,6 +2193,12 @@
   physicalDesc: reagent-physical-desc-syrupy
   flavor: sweet
   color: "#e74f4f"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/wineglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 0.9
 
 - type: reagent
@@ -2174,6 +2210,12 @@
   flavor: medicine
   color: "#a12b68"
   recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/beerglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Drink:
       effects:
@@ -2195,6 +2237,12 @@
   physicalDesc: reagent-physical-desc-bubbly
   flavor: spaceshroom
   color: "#310b01"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/lemonadeglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 0.8
 
 - type: reagent
@@ -2206,4 +2254,90 @@
   flavor: drinkdrink
   color: "#10101a"
   recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/aleglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 1
+  
+- type: reagent
+  id: BloodierMary
+  name: reagent-name-bloodier-mary
+  parent: BaseAlcohol
+  desc: reagent-desc-bloodier-mary
+  physicalDesc: reagent-physical-desc-strong-smelling
+  flavor: bloodymary
+  color: "#d12b28"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/bloodymaryglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
+  fizziness: .3 
+  
+- type: reagent
+  id: SalvagersSoothe
+  name: reagent-name-salvagerssoothe
+  parent: BaseAlcohol
+  desc: reagent-desc-salvagerssoothe
+  physicalDesc: reagent-physical-desc-bubbly
+  flavor: medicine
+  color: "#00ff99"
+  recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/moonshineglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 4
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1
+      - !type:AdjustReagent
+        reagent: CarpoToxin
+        amount: -0.25
+    Medicine:
+      effects:
+      - !type:HealthChange
+        probability: 0.75
+        damage:
+          types:
+            Poison: -1
+            Asphyxiation: -1
+            Bloodloss: -0.5
+          groups:
+            Brute: -2
+  fizziness: .7
+  
+- type: reagent
+  id: DontTell
+  name: reagent-name-donttelldsheriff
+  parent: BaseAlcohol
+  desc: reagent-desc-donttelldsheriff
+  physicalDesc: reagent-physical-desc-clear
+  flavor: moonshine
+  color: "#fff4b0"
+  recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/moonshineglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.35
+  fizziness: 0.1

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -274,3 +274,18 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: kingsoda
   color: "#9F3400"
+
+- type: reagent
+  id: HummingBird
+  name: reagent-name-hummingbird
+  parent: BaseSoda
+  desc: reagent-desc-hummingbird
+  physicalDesc: reagent-physical-desc-sweet
+  flavor: sweet
+  color: "#cffff8"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/lemonadeglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 6
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -1388,3 +1388,51 @@
       amount: 1
   products:
     TheDrink: 2
+   
+- type: reaction
+  id: BloodierMary
+  reactants:
+    BloodyMary:
+      amount: 2
+    Blood:
+      amount: 1
+  products:
+    BloodierMary: 3
+    
+- type: reaction
+  id: SalvagersSoothe
+  reactants:
+    Bicaridine:
+      amount: 1
+    Dexalin:
+      amount: 1
+    Dylovene:
+      amount: 1
+    Moonshine:
+      amount: 2
+  products:
+    SalvagersSoothe: 3
+    
+- type: reaction
+  id: HummingBird
+  requiredMixerCategories:
+    - Stir
+  reactants:
+    Water:
+      amount: 4
+    Sugar:
+      amount: 1
+  products:
+    HummingBird: 5
+ 
+- type: reaction
+  id: DontTell
+  requiredMixerCategories:
+    - Stir
+  reactants:
+    Hooch:
+      amount: 1
+    Moonshine:
+      amount: 1
+  products:
+    DontTell: 2


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added Four new drinks: Bloodier Mary, Salvager's Soothe, Hummingbird's Delight, and Dont Tell D Sheriff.
- fix: Hippies Delight now gets you high.


