### PR TITLE
flask in the regular warden locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -50,6 +50,7 @@
       - id: DoorRemoteArmory
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
+      - id: DrinkShinyFlask
       - id: ClothingBackpackElectropack
         amount: 2
       - id: RemoteSignaller


### PR DESCRIPTION
extension of https://github.com/impstation/imp-station-14/pull/272. the original pr only added the flask to the hardsuit-filled warden locker, which is used on only a few maps

**Changelog**
:cl:
- add: The regular version of the warden's locker now contains a flask, rather than just the hardsuit-filled one.