### PR TITLE
Slight revenant nerfs and an additional escape hatch

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantStasisSystem.cs
@@ -123,6 +123,9 @@ public sealed partial class RevenantStasisSystem : EntitySystem
 
     private void OnGrindAttempt(EntityUid uid, RevenantStasisComponent comp, GrindAttemptEvent args)
     {
+        if (!comp.Revenant.Comp.GrindingRequiresSalt)
+            return;
+
         foreach (var reagent in args.Reagents)
         {
             if (_tags.HasAnyTag(reagent, "Salt", "Holy"))

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -45,6 +45,14 @@ public sealed partial class RevenantComponent : Component
     public bool ExorcismRequiresBibleUser = true;
 
     /// <summary>
+    /// If true, grinding a revenant's ectoplasm will require
+    /// putting salt in the reagent grinder. Otherwise, the
+    /// grinder will explode.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool GrindingRequiresSalt = true;
+
+    /// <summary>
     /// The entity's current max amount of essence. Can be increased
     /// through harvesting player souls.
     /// </summary>
@@ -98,7 +106,7 @@ public sealed partial class RevenantComponent : Component
     #region Haunt Ability
 
     [DataField("hauntDebuffs"), ViewVariables(VVAccess.ReadWrite)]
-    public Vector2 HauntDebuffs = new(2, 6);
+    public Vector2 HauntDebuffs = new(3, 8);
 
     [DataField("hauntStolenEssencePerWitness"), ViewVariables(VVAccess.ReadWrite)]
     public FixedPoint2 HauntStolenEssencePerWitness = 2.5;

--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -18,7 +18,7 @@
       sprite: Mobs/Ghosts/revenant.rsi
       state: icon
     event: !type:RevenantHauntActionEvent
-    useDelay: 15
+    useDelay: 20
 
 - type: entity
   id: ActionRevenantDefile

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -45,6 +45,7 @@
   - type: GhostTakeoverAvailable
   - type: Revenant
     exorcismRequiresBibleUser: true # Escape hatch, change to false if revenant becomes too OP
+    grindingRequiresSalt: true # Escape hatch, change to false if revenant becomes too OP
     malfunctionWhitelist:
       components:
       # emag lockers open


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Made the Haunt stun slightly longer to give crew a better chance at attacking the revenant. Also added an additional option to the YML of the revenant in case it becomes too difficult to put down.

**Changelog**

:cl: TGRCDev
- tweak: Revenant's Haunt ability stuns itself for slightly longer, and has a longer cooldown
