### PR TITLE
Add brigmedic and roboticist to ID computer

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1048,6 +1048,21 @@
     state: pda-brigmedic
 
 - type: entity
+  parent: BasePDA
+  id: RoboticsPDA
+  name: robotics PDA
+  description: It's covered in scratches.
+  components:
+  - type: Pda
+    id: ResearchIDCard
+    state: pda-roboticist
+  - type: PdaBorderColor
+    borderColor: "#484848"
+    accentVColor: "#d33725"
+  - type: Icon
+    state: pda-roboticist
+
+- type: entity
   parent: ClownPDA
   id: CluwnePDA
   name: cluwne PDA

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -475,6 +475,21 @@
 
 - type: entity
   parent: IDCardStandard
+  id: RoboticsIDCard
+  name: robotics ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: default
+    - state: idroboticist
+  - type: IdCard
+    jobTitle: Roboticist
+    jobIcon: JobIconRoboticist
+  - type: PresetIdCard
+    job: Roboticist
+
+- type: entity
+  parent: IDCardStandard
   id: CentcomIDCard
   name: command officer ID card
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -467,6 +467,11 @@
     layers:
     - state: default
     - state: idbrigmedic
+  - type: IdCard
+    jobTitle: Brigmedic
+    jobIcon: JobIconBrigmedic
+  - type: PresetIdCard
+    job: Brigmedic
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -154,6 +154,11 @@
     id: SciencePDA
 
 - type: loadout
+  id: RoboticistPDA
+  equipment:
+    id: RoboticsPDA
+
+- type: loadout
   id: SeniorResearcherPDA
   effects:
   - !type:GroupLoadoutEffect

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -932,6 +932,7 @@
   name: loadout-group-scientist-id
   loadouts:
   - ScientistPDA
+  - RoboticistPDA
   - SeniorResearcherPDA
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
@@ -2,7 +2,7 @@
   id: Roboticist
   name: job-name-roboticist
   description: job-description-roboticist
-  playTimeTracker: JobRoboticist #Change if the job is ever added proper
+  playTimeTracker: JobRoboticist
   icon: JobIconRoboticist
   setPreference: false
   overrideConsoleVisibility: true

--- a/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
@@ -1,0 +1,12 @@
+- type: job
+  id: Roboticist
+  name: job-name-roboticist
+  description: job-description-roboticist
+  playTimeTracker: JobRoboticist #Change if the job is ever added proper
+  icon: JobIconRoboticist
+  setPreference: false
+  overrideConsoleVisibility: true
+  access:
+  - Research
+  - Medical
+  - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
@@ -1,0 +1,15 @@
+- type: job
+  id: Brigmedic
+  name: job-name-brigmedic
+  description: job-description-brigmedic
+  playTimeTracker: JobBrigmedic
+  canBeAntag: false
+  icon: JobIconBrigmedic
+  setPreference: false
+  overrideConsoleVisibility: true
+  access:
+  - Medical
+  - Security
+  - Brig
+  - Maintenance
+  - External

--- a/Resources/Prototypes/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/Roles/play_time_trackers.yml
@@ -17,6 +17,9 @@
   id: JobBotanist
 
 - type: playTimeTracker
+  id: JobBrigmedic
+
+- type: playTimeTracker
   id: JobCaptain
 
 - type: playTimeTracker
@@ -117,6 +120,9 @@
 
 - type: playTimeTracker
   id: JobResearchDirector
+
+- type: playTimeTracker
+  id: JobRoboticist
 
 - type: playTimeTracker
   id: JobSalvageSpecialist


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Adds brigmedic and roboticist to the ID computer, complete with the job icons on sec/administrative huds
Brigmedic has security, brig, medical and externals access. Roboticist has research and medical access. If you don't want to give the roboticist that bonus access you can always deselect it before handing their ID back.
Also, the brigmedic ID card found in the Warden locker works now, and the roboticist PDA has been re-implemented. Scientists can start with the roboticist PDA, but it'll contain a normal scientist ID-- they'll still need to get the new job icon / accesses from the HoP.

![image2](https://github.com/user-attachments/assets/bf090c4e-e0a1-4856-af7f-c9573bdbf394)
![image](https://github.com/user-attachments/assets/8e5340d4-eb8e-44c0-b14d-f4f5417b47e1)


**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Pinkbat5
- add: HoPs rejoice! Brigmedic and roboticist can be selected as presets in the ID card computer.
- tweak: Scientists can now select the robotics PDA in their loadout.
