### PR TITLE
Add bronzeheart to HoS locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -326,6 +326,7 @@
     - id: SecurityTechFabCircuitboard
     - id: WeaponDisabler
     - id: WantedListCartridge
+    - id: ClothingNeckBronzeheart
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable


### PR DESCRIPTION
adds bronzeheart to the Head of Security locker. my reasoning:
-the medal case has one medal for every department, then the bronzeheart and medal of crewmanship
-HoP already has their own medal of crewmanship to give out (even though the captain also has one), so it makes sense a non-captain job would have their own bronzeheart
-encourages rewarding good security officers (they could use the encouragement), but has the flexibility to be given out to anyone
-exceptional bravery usually falls under the HoS's purview
-one of the toughest jobs in the game deserves a treat

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Pinkbat5
- add: Added bronzeheart medal to Head of Security locker.
