### PR TITLE
loadout extras + title change

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1008,7 +1008,7 @@ namespace Content.Client.Lobby.UI
 
             _loadoutWindow = new LoadoutWindow(Profile, roleLoadout, roleLoadoutProto, _playerManager.LocalSession, collection)
             {
-                Title = jobProto?.ID + "-loadout",
+                Title = Loc.GetString(jobProto?.Name ?? "Job") + " Loadout",
             };
 
             // Refresh the buttons etc.

--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -24,6 +24,12 @@
   equipment:
     eyes: ClothingEyesGlasses
 
+# Cheap sunglasses
+- type: loadout
+  id: GlassesCheapSunglasses
+  equipment:
+    eyes: ClothingEyesGlassesCheapSunglasses
+
 # Special options
 # Jamjar
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -149,3 +149,21 @@
   storage:
     back:
     - PersonalAI
+
+- type: loadout
+  id: FolderBlack
+  storage:
+    back:
+    - BoxFolderBlack
+
+- type: loadout
+  id: BarFlask
+  storage:
+    back:
+    - DrinkFlaskBar
+
+- type: loadout
+  id: NewtonCradle
+  storage:
+    back:
+    - NewtonCradle

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -16,6 +16,9 @@
   - CigarCase
   - CigarGold
   - PersonalAI
+  - FolderBlack
+  - BarFlask
+  - NewtonCradle
   - ClothingNeckLGBTPin
   - ClothingNeckAromanticPin
   - ClothingNeckAsexualPin
@@ -34,6 +37,7 @@
   minLimit: 0
   loadouts:
   - Glasses
+  - GlassesCheapSunglasses
   - GlassesJamjar
   - GlassesJensen
 


### PR DESCRIPTION
adds cheap sunglasses to the common glasses loadout group, and a black folder, a bar flask, and a newton cradle to the trinket loadouts. also adjusted the title of the loadout window since it's been bothering me for a while

old: 
![SS14 Loader_3p3tK27nJY](https://github.com/user-attachments/assets/7f64acca-ce41-4449-a045-835449919133)

new:
![Content Client_s6w0BGE2mU](https://github.com/user-attachments/assets/f8650459-ea8e-49fd-8a1d-9698c781562c)

**Changelog**
:cl:
- add: Cheap sunglasses, a black folder, a bar flask, and a newton cradle are now available as common loadout items.
- tweak: Adjusted the title of loadout windows.