### PR TITLE
Giving HoS an option to have the normal mask again

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -188,6 +188,7 @@ loadout-group-head-of-security-neck = Head of Security neck
 loadout-group-head-of-security-outerclothing = Head of Security outer clothing
 loadout-group-head-of-security-backpack = Head of Security backpack
 loadout-group-head-of-security-headset = Head of Security headset
+loadout-group-head-of-security-mask = Head of Security mask
 
 loadout-group-warden-head = Warden head
 loadout-group-warden-jumpsuit = Warden jumpsuit

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -69,7 +69,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: DrinkCommandFlaskFull
   # Ok, NT actually only bothered to change the picture on the box for command. Assholes.
   - type: Sprite
     layers:
@@ -112,7 +112,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: DrinkCommandFlaskFull
   - type: Sprite
     layers:
     - state: internals
@@ -149,7 +149,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: DrinkCommandFlaskFull
   # Ok, NT actually only bothered to change the picture on the box for command. Assholes.
   - type: Sprite
     layers:
@@ -192,7 +192,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: DrinkCommandFlaskFull
   - type: Sprite
     layers:
     - state: internals
@@ -229,7 +229,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: DrinkCommandFlaskFull
   # Ok, NT actually only bothered to change the picture on the box for command. Assholes.
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -535,6 +535,8 @@
   name: head of security's gas mask
   description: A compact armored mask made just for the head of security.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/gashos.rsi
   - type: Clothing

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -113,3 +113,9 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: VeteranHOS
+
+# A mask so the HoS can choose to spawn with the standard security gas mask that their new survival box removes
+- type: loadout
+  id: HeadofSecurityMask
+  equipment:
+    mask: ClothingMaskGasSecurity

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -30,6 +30,12 @@
     - Lighter
 
 - type: loadout
+  id: FlippoLighter
+  storage:
+    back:
+    - FlippoLighter
+
+- type: loadout
   id: CigPackGreen
   storage:
     back:

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -8,6 +8,7 @@
   - PlushieLizard
   - PlushieSpaceLizard
   - Lighter
+  - FlippoLighter
   - CigPackGreen
   - CigPackRed
   - CigPackBlue
@@ -1286,6 +1287,13 @@
   - CommandVeteranBackpack
   - CommandVeteranSatchel
   - CommandVeteranDuffel
+
+- type: loadoutGroup
+  id: HeadofSecurityMask
+  name: loadout-group-head-of-security-mask
+  minLimit: 0
+  loadouts:
+  - HeadofSecurityMask
 
 - type: loadoutGroup
   id: WardenHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -367,6 +367,7 @@
   groups:
   - HeadofSecurityHead
   - HeadofSecurityNeck
+  - HeadofSecurityMask
   - HeadofSecurityJumpsuit
   - HeadofSecurityHeadset
   - HeadofSecurityBackpack


### PR DESCRIPTION
:cl:
- add: The HoS can now choose to start with the Security Gas Mask if they miss it
- tweak: The new HoS mask is now a Tiny item as intended so it stops deleting the flare from the survival box
- add: Added a Flippo lighter to loadout trinkets for everyone
- fix: Command Flask added to ALL command survival boxes