### PR TITLE
Animated guns no longer bolt themselves by default

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantAnimatedSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantAnimatedSystem.cs
@@ -107,7 +107,7 @@ public sealed partial class RevenantAnimatedSystem : EntitySystem
         if (HasComp<GunComponent>(ent))
         {
             // Goals: Magdump into any nearby creatures, and melee hit them if empty
-            if (TryComp<ChamberMagazineAmmoProviderComponent>(ent, out var bolt))
+            if (ent.Comp.Revenant != null && ent.Comp.Revenant.Value.Comp.AnimateCanBoltGuns && TryComp<ChamberMagazineAmmoProviderComponent>(ent, out var bolt))
                 _gunSystem.SetBoltClosed(ent, bolt, true);
             htn.RootTask = new HTNCompoundTask() { Task = "SimpleRangedHostileCompound" };
         }

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class RevenantComponent : Component
     /// <summary>
     /// If true, only bible users can exorcise this revenant
     /// with a bible.
-    /// 
+    ///
     /// If false, anyone who tries to exorcise a revenant with
     /// a bible will be able to.
     /// </summary>
@@ -277,6 +277,9 @@ public sealed partial class RevenantComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public float AnimateSprintSpeed = DefaultAnimateSprintSpeed;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool AnimateCanBoltGuns = false;
     #endregion
 
     [DataField]


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

This change was made after some discussion in the discord to prevent revenants camping the armory and instantly animating guns when security is arming up.

**Changelog**

:cl: TGRCDev
- tweak: Guns that are animated by a revenant no longer close their own bolt by default.
