### PR TITLE
Heretic tweaks so rounds stop failing to start on lowpop

### DIFF
--- a/Resources/Prototypes/Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/Goobstation/Heretic/GameRules/roundstart.yml
@@ -5,6 +5,7 @@
   - type: HereticRule
   - type: GameRule
     minPlayers: 20
+    cancelPresetOnTooFewPlayers: false
     delay:
       min: 30
       max: 60


### PR DESCRIPTION
Turns out there's a toggle for this
:cl:
- fix: Lowpop rounds that roll heretic will no longer get sent back to lobby if there aren't enough players

