### PR TITLE
More Shoes / Loadout Options

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -66,9 +66,11 @@ loadout-group-chef-shoes = Chef shoes
 
 loadout-group-librarian-jumpsuit = Librarian jumpsuit
 loadout-group-librarian-neck = Librarian neck
+loadout-group-librarian-shoes = Librarian shoes
 
 loadout-group-lawyer-jumpsuit = Lawyer jumpsuit
 loadout-group-lawyer-neck = Lawyer neck
+loadout-group-lawyer-shoes = Lawyer shoes
 
 loadout-group-chaplain-head = Chaplain head
 loadout-group-chaplain-mask = Chaplain mask
@@ -106,11 +108,13 @@ loadout-group-mime-jumpsuit = Mime jumpsuit
 loadout-group-mime-backpack = Mime backpack
 loadout-group-mime-neck = Mime neck
 loadout-group-mime-outerclothing = Mime outer clothing
+loadout-group-mime-shoes = Mime shoes
 loadout-group-mime-belt = Mime belt
 
 loadout-group-musician-jumpsuit = Musician jumpsuit
 loadout-group-musician-neck = Musician neck
 loadout-group-musician-outerclothing = Musician outer clothing
+loadout-group-musician-shoes = Musician shoes
 
 # Cargo
 loadout-group-quartermaster-head = Quartermaster head
@@ -211,6 +215,7 @@ loadout-group-detective-head = Detective head
 loadout-group-detective-neck = Detective neck
 loadout-group-detective-jumpsuit = Detective jumpsuit
 loadout-group-detective-outerclothing = Detective outer clothing
+loadout-group-detective-shoes = Detective shoes
 
 loadout-group-brigmedic-head = Brigmedic head
 loadout-group-brigmedic-neck = Brigmedic neck
@@ -265,6 +270,7 @@ loadout-group-reporter-shoes = Reporter shoes
 
 loadout-group-psychologist-jumpsuit = Psychologist jumpsuit
 loadout-group-psychologist-neck = Psychologist neck
+loadout-group-psychologist-shoes = Psychologist shoes
 
 loadout-group-boxer-jumpsuit = Boxer jumpsuit
 loadout-group-boxer-gloves = Boxer gloves

--- a/Resources/Prototypes/Entities/Clothing/Neck/ties.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/ties.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ClothingNeckBase
   id: ClothingNeckTieRed
-  name: red-tie
+  name: red tie
   description: A neosilk clip-on red tie.
   components:
   - type: Sprite
@@ -24,7 +24,7 @@
     sprite: Clothing/Neck/Ties/dettie.rsi
   - type: Clothing
     sprite: Clothing/Neck/Ties/dettie.rsi
-    
+
 - type: entity
   parent: ClothingNeckBase
   id: ClothingNeckTieSci

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -39,6 +39,12 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitBartenderPurple
 
+# Neck
+- type: loadout
+  id: RedTie
+  equipment:
+    neck: ClothingNeckTieRed
+
 # Outer clothing
 - type: loadout
   id: BartenderApron

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -198,7 +198,7 @@
 
 # Shoes
 - type: loadout
-  id: CaptainShoes
+  id: LacedShoes
   equipment:
     shoes: ClothingShoesBootsLaceup
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -71,17 +71,7 @@
 
 # Shoes
 - type: loadout
-  id: HoPShoes
-  equipment:
-    shoes: ClothingShoesColorBrown
-
-- type: loadout
-  id: HoPShoesBlack
-  equipment:
-    shoes: ClothingShoesBootsLaceup
-
-- type: loadout
-  id: HoPShoesBrown
+  id: LeatherShoes
   equipment:
     shoes: ClothingShoesLeather
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -145,7 +145,8 @@
   id: CaptainShoes
   name: loadout-group-captain-shoes
   loadouts:
-  - CaptainShoes
+  - LacedShoes
+  - LeatherShoes
   - CaptainJumpBoots
 
 - type: loadoutGroup
@@ -195,9 +196,9 @@
   id: HoPShoes
   name: loadout-group-hop-shoes
   loadouts:
-  - HoPShoes
-  - HoPShoesBlack
-  - HoPShoesBrown
+  - BrownShoes
+  - LacedShoes
+  - LeatherShoes
   - HoPShoesWhite
 
 - type: loadoutGroup
@@ -319,6 +320,7 @@
   minLimit: 0
   loadouts:
   - ScarfBlack
+  - RedTie
 
 - type: loadoutGroup
   id: BartenderOuterClothing
@@ -335,6 +337,7 @@
   name: loadout-group-bartender-shoes
   loadouts:
   - BlackShoes
+  - LacedShoes
   - ClownShoesExpert
 
 - type: loadoutGroup
@@ -408,6 +411,14 @@
   - ScarfGreen
 
 - type: loadoutGroup
+  id: LibrarianShoes
+  name: loadout-group-librarian-shoes
+  loadouts:
+  - LeatherShoes
+  - LacedShoes
+  - BlackShoes
+
+- type: loadoutGroup
   id: LawyerJumpsuit
   name: loadout-group-lawyer-jumpsuit
   loadouts:
@@ -428,6 +439,13 @@
   minLimit: 0
   loadouts:
   - LawyerNeck
+
+- type: loadoutGroup
+  id: LawyerShoes
+  name: loadout-group-lawyer-shoes
+  loadouts:
+  - LacedShoes
+  - LeatherShoes
 
 - type: loadoutGroup
   id: ChaplainHead
@@ -481,6 +499,7 @@
   name: loadout-group-chaplain-shoes
   loadouts:
   - BlackShoes
+  - LacedShoes
   - ClownShoesExpert
 
 - type: loadoutGroup
@@ -693,6 +712,13 @@
   - MimeWintercoat
 
 - type: loadoutGroup
+  id: MimeShoes
+  name: loadout-group-mime-shoes
+  loadouts:
+  - WhiteShoes
+  - BlackShoes
+
+- type: loadoutGroup
   id: MimeBelt
   name: loadout-group-mime-belt
   loadouts:
@@ -729,6 +755,13 @@
   minLimit: 0
   loadouts:
   - MusicianWintercoat
+
+- type: loadoutGroup
+  id: MusicianShoes
+  name: loadout-group-musician-shoes
+  loadouts:
+  - LacedShoes
+  - BlackShoes
 
 - type: loadoutGroup
   id: Instruments
@@ -963,6 +996,7 @@
   name: loadout-group-chief-engineer-shoes
   loadouts:
   - BrownShoes
+  - WorkBoots
   - EngineeringWinterBoots
 
 - type: loadoutGroup
@@ -1139,6 +1173,8 @@
   name: loadout-group-research-director-shoes
   loadouts:
   - BrownShoes
+  - LeatherShoes
+  - WhiteShoes
   - ScienceWinterBoots
 
 - type: loadoutGroup
@@ -1456,6 +1492,15 @@
   - NoirCoat
 
 - type: loadoutGroup
+  id: DetectiveShoes
+  name: loadout-group-detective-shoes
+  loadouts:
+  - JackBoots
+  - LeatherShoes
+  - SecurityWinterBoots
+  - SecurityClownShoes
+
+- type: loadoutGroup
   id: BrigmedicHead
   name: loadout-group-brigmedic-head
   minLimit: 0
@@ -1572,6 +1617,7 @@
   name: loadout-group-chief-medical-officer-shoes
   loadouts:
   - BrownShoes
+  - WhiteShoes
   - MedicalWinterBoots
 
 - type: loadoutGroup
@@ -1751,6 +1797,7 @@
   name: loadout-group-paramedic-shoes
   loadouts:
   - BlueShoes
+  - WhiteShoes
   - MedicalWinterBoots
 
 - type: loadoutGroup
@@ -1790,6 +1837,7 @@
   name: loadout-group-reporter-shoes
   loadouts:
   - WhiteShoes
+  - LeatherShoes
   - ClownShoesExpert
 
 - type: loadoutGroup
@@ -1805,6 +1853,14 @@
   minLimit: 0
   loadouts:
   - ScarfBlack
+
+- type: loadoutGroup
+  id: PsychologistShoes
+  name: loadout-group-psychologist-shoes
+  loadouts:
+  - LeatherShoes
+  - BlackShoes
+  - WhiteShoes
 
 - type: loadoutGroup
   id: BoxerJumpsuit

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -103,6 +103,7 @@
   - GroupTankHarness
   - LibrarianNeck
   - LibrarianJumpsuit
+  - LibrarianShoes
   - Glasses
   - CommonBackpack
   - Trinkets
@@ -115,6 +116,7 @@
   - GroupTankHarness
   - LawyerNeck
   - LawyerJumpsuit
+  - LawyerShoes
   - Glasses
   - CommonBackpack
   - Trinkets
@@ -193,6 +195,7 @@
   - MimeNeck
   - MimeJumpsuit
   - MimeOuterClothing
+  - MimeShoes
   - Glasses
   - MimeBackpack
   - MimeBelt
@@ -206,6 +209,7 @@
   - MusicianNeck
   - MusicianJumpsuit
   - MusicianOuterClothing
+  - MusicianShoes
   - Glasses
   - CommonBackpack
   - Trinkets
@@ -421,7 +425,7 @@
   - DetectiveNeck
   - DetectiveJumpsuit
   - DetectiveOuterClothing
-  - SecurityShoes
+  - DetectiveShoes
   - SecurityBackpack
   - Trinkets
   - SecurityStar
@@ -564,6 +568,7 @@
   - GroupTankHarness
   - PsychologistNeck
   - PsychologistJumpsuit
+  - PsychologistShoes
   - Glasses
   - MedicalBackpack
   - Trinkets

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -18,7 +18,6 @@
 - type: startingGear
   id: LawyerGear
   equipment:
-    shoes: ClothingShoesBootsLaceup
     id: LawyerPDA
     ears: ClothingHeadsetSecurity
   inhand:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -13,7 +13,6 @@
 - type: startingGear
   id: LibrarianGear
   equipment:
-    shoes: ClothingShoesBootsLaceup
     id: LibrarianPDA
     ears: ClothingHeadsetService
     pocket1: d10Dice

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -22,7 +22,6 @@
   id: MimeGear
   equipment:
     gloves: ClothingHandsGlovesColorWhite
-    shoes: ClothingShoesColorWhite
     pocket1: CrayonMime
     pocket2: Paper
     id: MimePDA

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -15,9 +15,9 @@
     prototype: BoxPerformer
 
 - type: startingGear
-  eyes: ClothingEyesGlassesSunglasses
   id: MusicianGear
   equipment:
+    eyes: ClothingEyesGlassesSunglasses
     id: MusicianPDA
     ears: ClothingHeadsetService
   #storage:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -17,8 +17,6 @@
 - type: startingGear
   id: MusicianGear
   equipment:
-    eyes: ClothingEyesGlassesSunglasses
-    shoes: ClothingShoesBootsLaceup
     id: MusicianPDA
     ears: ClothingHeadsetService
   #storage:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -15,6 +15,7 @@
     prototype: BoxPerformer
 
 - type: startingGear
+  eyes: ClothingEyesGlassesSunglasses
   id: MusicianGear
   equipment:
     id: MusicianPDA

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -15,7 +15,6 @@
 - type: startingGear
   id: PsychologistGear
   equipment:
-    shoes: ClothingShoesLeather
     id: PsychologistPDA
     ears: ClothingHeadsetMedical
   storage:


### PR DESCRIPTION
Adds at least 1 or more additional shoe options for Captain, Mime, Musician, Lawyer, Librarian, Bartender, Psychologist, Paramedic, Detective, Reporter, Chief Engie, Chief Medical, & Research Director.

Also adds an optional red tie for the bartender. Renames the displayname of ClothingNeckTieRed from "red-tie" to "red tie".
Adjusts "HoPShoes" and "CaptainShoes" to be "LeatherShoes" and "LacedShoes" in the loadouts.yml.

![shoeses](https://github.com/user-attachments/assets/b1a9aff2-6a14-4bf0-b9d2-5092b0765368)



Changelog
:cl:
- add: Extra shoe options for Captain, Mime, Musician, Lawyer, Librarian, Bartender, Psychologist, Paramedic, Detective, Reporter, Chief Engie, Chief Medical, & Research Director!
