### PR TITLE
pink alert now causes the shuttle to take 20 minutes to arrive

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -76,4 +76,4 @@
       color: Pink
       emergencyLightColor: Pink
       forceEnableEmergencyLights: true
-      shuttleTime: 600
+      shuttleTime: 1200


### PR DESCRIPTION
snuff out your revolution or die

**Changelog**

:cl: hivehum
- tweak: The evacuation shuttle now takes 20 minutes to arrive when the station alert level is Pink.