### PR TITLE
Add scrambled accent + small fixes

### DIFF
--- a/Resources/Locale/en-US/accent/accents.ftl
+++ b/Resources/Locale/en-US/accent/accents.ftl
@@ -145,7 +145,7 @@ accent-words-possum-4 = Grrrah.
 
 # TomatoKiller
 accent-words-tomato-1 = Totato!
-accent-words-tomato-2 = Trotect
+accent-words-tomato-2 = Trotect.
 accent-words-tomato-3 = Mastet?
 accent-words-tomato-4 = Reaty!
 accent-words-tomato-5 = Water...

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -28,7 +28,7 @@ trait-pirate-accent-name = Pirate accent
 trait-pirate-accent-desc = You can't stop speaking like a pirate!
 
 trait-accentless-name = Accentless
-trait-accentless-desc = You don't have the accent that your species would usually have
+trait-accentless-desc = You don't have the accent that your species would usually have.
 
 trait-frontal-lisp-name = Frontal lisp
 trait-frontal-lisp-desc = You thpeak with a lithp.
@@ -70,7 +70,10 @@ trait-french-name = French accent
 trait-french-desc = You speak with the cadence of someone who has cast off their vow of silence.
 
 trait-spanish-name = Spanish accent
-trait-spanish-desc = You speak with the accent of someone who grew up in Earth Spain
+trait-spanish-desc = You speak with the accent of someone who grew up in Earth Spain.
 
 trait-snalien-name = Slow talker
 trait-snalien-desc = Yyoouu taallk rreeaallyy... rreeaallyy... sslloowwllyy.
+
+trait-scrambled-name = Scrambled Speech
+trait-scrambled-desc = There was an accident with a tesla engine, now others have trouble understanding you.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -75,5 +75,5 @@ trait-spanish-desc = You speak with the accent of someone who grew up in Earth S
 trait-snalien-name = Slow talker
 trait-snalien-desc = Yyoouu taallk rreeaallyy... rreeaallyy... sslloowwllyy.
 
-trait-scrambled-name = Scrambled Speech
+trait-scrambled-name = Scrambled speech
 trait-scrambled-desc = There was an accident with a tesla engine, now others have trouble understanding you.

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -11,6 +11,8 @@
     removes:
     - type: LizardAccent
     - type: MothAccent
+    - type: SnalienAccent
+    - type: GrayAccent
     - type: ReplacementAccent
       accent: dwarf
 
@@ -163,19 +165,10 @@
   - type: RussianAccent
 
 - type: trait
-  id: French
-  name: trait-french-name
-  description: trait-french-desc
+  id: Scrambled
+  name: trait-scrambled-name
+  description: trait-scrambled-desc
   category: SpeechTraits
   cost: 2
   components:
-  - type: FrenchAccent
-
-- type: trait
-  id: Spanish
-  name: trait-spanish-name
-  description: trait-spanish-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: SpanishAccent
+  - type: ScrambledAccent

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -94,6 +94,17 @@
     accent: liar
 
 - type: trait
+  id: Scrambled
+  name: trait-scrambled-name
+  description: trait-scrambled-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ScrambledAccent
+
+# 2 Cost
+
+- type: trait
   id: Snalien
   name: trait-snalien-name
   description: trait-snalien-desc
@@ -101,8 +112,6 @@
   cost: 2
   components:
   - type: SnalienAccent
-
-# 2 Cost
 
 - type: trait
   id: SocialAnxiety
@@ -163,12 +172,3 @@
   cost: 2
   components:
   - type: RussianAccent
-
-- type: trait
-  id: Scrambled
-  name: trait-scrambled-name
-  description: trait-scrambled-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: ScrambledAccent


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Adds the scrambled speech accent/trait in honor of flanburgr + accentless now works for our two unique species.
Also fixed a few lines that didn't have proper punctuation because it bothered me

![image](https://github.com/user-attachments/assets/65c4d373-4764-4f98-b930-f5adb58e319c)
![image2](https://github.com/user-attachments/assets/eec83ba6-358b-4a31-9a04-16e092905a50)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added the scrambled speech trait. Understand nobody now can you.
- fix: Accentless now works for snails and gray.
- fix: Removed duplicate accents.
