### PR TITLE
i think the low numbers on zombieteors and kessler syndrome are fucking with something 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -470,6 +470,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentID: Oculine
+          Quantity: 3
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/carrot.rsi
   - type: Produce
@@ -479,6 +481,8 @@
       reagents:
       - ReagentId: JuiceCarrot
         Quantity: 10
+      - ReagentID: Oculine
+        Quantity: 2
   - type: FoodSequenceElement
     entries:
       Burger: CarrotBurger

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -470,8 +470,6 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 4
-        - ReagentID: Oculine
-          Quantity: 3
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/carrot.rsi
   - type: Produce
@@ -481,8 +479,6 @@
       reagents:
       - ReagentId: JuiceCarrot
         Quantity: 10
-      - ReagentID: Oculine
-        Quantity: 2
   - type: FoodSequenceElement
     entries:
       Burger: CarrotBurger

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -351,8 +351,8 @@
   reactants:
     TableSalt:
       amount: 1
-    JuiceCarrot:
-      amount: 2
+    Blood:
+      amount: 1
     Hydroxide:
       amount: 2
   products:
@@ -561,7 +561,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -5,8 +5,8 @@
     Traitor: 0.50
     SpyVsSpy: 0.03
     Changeling: 0.15
-    Zombie: 0.03
-    Zombieteors: 0.005
+    Zombie: 0.02
+    Zombieteors: 0.01
     Survival: 0.10
-    KesslerSyndrome: 0.005
+    KesslerSyndrome: 0.01
     Revolutionary: 0.03


### PR DESCRIPTION
zombies down 1% and zombmeteors/kessler moved up half a percent

loling if this fixes it because ghoul changed the numbers specifically at wizden's suggestion

**Changelog**
:cl: hivehum
- tweak: FUUUUUUUUUCCCCCCCCCCCCCCCCKKKKKKKKKKK AHHHHHHHHHHHHHHHHHHHHHHHHHHHH AAAAAAAAAAAAAAAAAAAAAAAAA
