### PR TITLE
Minor artifact trigger changes

### DIFF
--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -233,21 +233,39 @@
   - type: ArtifactExamineTrigger
 
 - type: artifactTrigger
-  id: TriggerAnchorDeep
-  targetDepth: 4
-  triggerHint: artifact-trigger-hint-tool
-  blacklist:
-    components:
-    - Item
-  components:
-  - type: ArtifactAnchorTrigger
-
-- type: artifactTrigger
   id: TriggerMagnetDeep
   targetDepth: 4
   triggerHint: artifact-trigger-hint-magnet
   components:
   - type: ArtifactMagnetTrigger
+
+- type: artifactTrigger
+  id: TriggerMedicalDeep
+  targetDepth: 4
+  triggerHint: artifact-trigger-hint-medical
+  components:
+  - type: Reactive
+    groups:
+      Acidic: [ Touch ]
+    reactions:
+    - reagents: [ Dylovene, Diphenhydramine, Arithrazine, Bicaridine, Dermaline, Dexalin, DexalinPlus, Tricordrazine, Leporazine, Bruizine, Lacerinol, Puncturase, Pyrazine, Insuzine, Kelotane, Hyronalin, Inaprovaline, Epinephrine ]
+      methods: [ Touch ]
+      effects:
+      - !type:ActivateArtifact
+
+- type: artifactTrigger
+  id: TriggerBloodDeep
+  targetDepth: 4
+  triggerHint: artifact-trigger-hint-blood
+  components:
+  - type: Reactive
+    groups:
+      Acidic: [ Touch ]
+    reactions:
+    - reagents: [ Blood, CopperBlood, InsectBlood, Slime, AmmoniaBlood, ZombieBlood ]
+      methods: [ Touch ]
+      effects:
+      - !type:ActivateArtifact
 
 #don't add in new targetdepth values until you have a few
 #or else it will skew heavily towards a few options.


### PR DESCRIPTION
wrenching had to be done off of the scanner, and you had to unwrench to put back on scanner. meaning you could trigger a second node without the chance to know what it was.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: can no longer trigger a depth 4+ artifact by wrenching (forced to wrench off scanner, and unwrench to put back on scanner - so had to potentially trigger the next node -> tesloose on core)
- add: added two other copies of lower triggers that are less (potentially) unavoidably destructive