### PR TITLE
Game presets can now have cooldowns to prevent back-to-back modes

### DIFF
--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -33,6 +33,13 @@ namespace Content.Server.GameTicking.Presets
         [DataField("maxPlayers")]
         public int? MaxPlayers;
 
+        /// <summary>
+        /// Ensures that this gamemode does not get selected for a number of rounds
+        /// by something like Secret. This is not considered when the preset is forced.
+        /// </summary>
+        [DataField("cooldown")]
+        public int Cooldown = 0;
+
         [DataField("rules", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public IReadOnlyList<string> Rules { get; private set; } = Array.Empty<string>();
 

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -22,6 +22,11 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IComponentFactory _compFact = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+
+    // Dictionary that contains the minimum round number for certain preset
+    // prototypes to be allowed to roll again
+    private static Dictionary<ProtoId<GamePresetPrototype>, int> _nextRoundAllowed = new();
 
     private string _ruleCompName = default!;
 
@@ -45,6 +50,12 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
 
         Log.Info($"Selected {preset.ID} as the secret preset.");
         _adminLogger.Add(LogType.EventStarted, $"Selected {preset.ID} as the secret preset.");
+
+        if (preset.Cooldown > 0)
+        {
+            _nextRoundAllowed[preset.ID] = _ticker.RoundId + preset.Cooldown;
+            Log.Info($"{preset.ID} is now on cooldown until {_nextRoundAllowed[preset.ID]}");
+        }
 
         foreach (var rule in preset.Rules)
         {
@@ -165,6 +176,12 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
 
             if (ruleComp.MinPlayers > players && ruleComp.CancelPresetOnTooFewPlayers)
                 return false;
+        }
+
+        if (_nextRoundAllowed.ContainsKey(selected.ID) && _nextRoundAllowed[selected.ID] > _ticker.RoundId)
+        {
+            Log.Info($"Skipping preset {selected.ID} (Not available until round {_nextRoundAllowed[selected.ID]}");
+            return false;
         }
 
         return true;

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -5,6 +5,7 @@
   name: survival-title
   showInVote: false # secret
   description: survival-description
+  cooldown: 2
   rules:
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
@@ -21,6 +22,7 @@
   name: kessler-syndrome-title
   showInVote: false # secret
   description: kessler-syndrome-description
+  cooldown: 1
   rules:
     - KesslerSyndromeScheduler
     - RampingStationEventScheduler
@@ -166,6 +168,7 @@
   name: spy-vs-spy-title
   description: spy-vs-spy-description
   showInVote: false
+  cooldown: 2
   rules:
     - SpyVsSpy
     - SleeperlessStationEventScheduler
@@ -178,6 +181,7 @@
   name: spy-vs-spy-title
   description: spy-vs-spy-description
   showInVote: false
+  cooldown: 2
   rules:
     - SpyVsSpy3TC
     - SleeperlessStationEventScheduler
@@ -233,6 +237,7 @@
   name: nukeops-title
   description: nukeops-description
   showInVote: false
+  cooldown: 1
   rules:
     - Nukeops
     - SubGamemodesRule
@@ -269,6 +274,7 @@
   name: zombie-title
   description: zombie-description
   showInVote: false
+  cooldown: 1
   rules:
   - Zombie
   - BasicStationEventScheduler
@@ -285,6 +291,7 @@
   name: zombieteors-title
   description: zombieteors-description
   showInVote: false
+  cooldown: 1
   rules:
   - Zombie
   - BasicStationEventScheduler


### PR DESCRIPTION
This is a stopgap while we continue to diagnose why Survival gets rolled so damn often, but also prevents some gamemodes from going back-to-back and becoming obnoxious.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: TGRCDev
- tweak: Some round presets now have cooldowns to prevent them from rolling back-to-back.
