### PR TITLE
bunch of small antagonist tweaks

### DIFF
--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.2 },
+            { "Cellular", 0.2 },
         }
     };
 

--- a/Resources/Locale/en-US/communications/terror.ftl
+++ b/Resources/Locale/en-US/communications/terror.ftl
@@ -1,2 +1,5 @@
 terror-dragon = Attention crew, it appears that someone on your station has made an unexpected communication with a strange fish in nearby space.
 terror-revenant = Attention crew, it appears that someone on your station has made an unexpected communication with an otherworldly energy in nearby space.
+terror-ratking = Attention crew, it appears that someone on your station has made an unexpected communication with a regal rodent living in the vents.
+terror-finfin = Attention crew, it appears that someone on your station has made an unexpected communication with your best friend.
+terror-uristswarm = Attention crew, it appears that someone on your station has made an unexpected communication with a swarm of hungry beasts in nearby space.

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
@@ -7,7 +7,10 @@ zombieteors-description = The undead have been unleashed on the station amid a c
 zombie-not-enough-ready-players = Not enough players readied up for the game! There were {$readyPlayersCount} players readied up out of {$minimumPlayers} needed. Can't start Zombies.
 zombie-no-one-ready = No players readied up! Can't start Zombies.
 
-zombie-patientzero-role-greeting = A sense of doom washes over you, like your life is about to end violently, and very soon. Minutes tick down the clock. What will you do?
+zombie-patientzero-role-greeting =
+    A sense of doom washes over you, like your life is about to end violently, and very soon. Minutes tick down the clock.
+    You feel compelled to be in a large crowd, surrounded by all your closest friends. They deserve to die, too. They get to discover what's coming.
+    You are an [color=crimson]initial infected[/color].
 zombie-healing = You feel a stirring in your flesh
 zombie-infection-warning = You feel the virus take hold
 zombie-infection-underway = Your blood begins to thicken

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -11,11 +11,11 @@ ghost-role-information-freeagent-rules = You are a [color=yellow][bold]Free Agen
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
                                          You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
                                          You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
-ghost-role-information-freeagent-rat-king-rules = You are a [color=red][bold]Solo Antagonist[/bold][/color]. Your intentions are clear, and harmful to the station and its crew.
+ghost-role-information-antagonist-rat-king-rules = You are a [color=red][bold]Solo Antagonist[/bold][/color]. Your intentions are clear, and harmful to the station and its crew.
                                           You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
                                           You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
                                           You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
-ghost-role-information-antagonist-rat-king-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
+ghost-role-information-freeagent-rat-king-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
                                          You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
                                          You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -11,7 +11,11 @@ ghost-role-information-freeagent-rules = You are a [color=yellow][bold]Free Agen
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
                                          You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
                                          You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
-ghost-role-information-freeagent-rat-king-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
+ghost-role-information-freeagent-rat-king-rules = You are a [color=red][bold]Solo Antagonist[/bold][/color]. Your intentions are clear, and harmful to the station and its crew.
+                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+                                          You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
+                                          You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
+ghost-role-information-antagonist-rat-king-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
                                          You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
                                          You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -18,7 +18,7 @@
   - type: GhostRole
     name: ghost-role-information-rat-king-name
     description: ghost-role-information-rat-king-description
-    rules: ghost-role-information-freeagent-rat-king-rules
+    rules: ghost-role-information-antagonist-rat-king-rules
     raffle:
       settings: default
   - type: GhostRoleMobSpawner

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -163,6 +163,9 @@
     state: finfin
     rotation: 0
     noRot: false
+  - type: EmitSoundOnSpawn
+    sound:
+      path: /Audio/Effects/tesla_collapse.ogg
 
 - type: entity
   parent: ImmovableRodKeepTilesStill

--- a/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: BaseMinorContraband
   id: ThiefBeacon
-  name: thieving beacon
-  description: A device that will teleport everything around it to the thief's vault at the end of the shift.
+  name: suspicious beacon
+  description: A device that will teleport everything around it... elsewhere... at the end of the shift.
   components:
     - type: ThiefBeacon
     - type: StealArea

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -329,6 +329,8 @@
         sound: "/Audio/Ambience/Antag/zombie_start.ogg"
       components:
       - type: PendingZombie
+        minInitialInfectedGrace: 300
+        maxInitialInfectedGrace: 600
       - type: ZombifyOnDeath
       - type: IncurableZombie
       - type: InitialInfected
@@ -352,7 +354,7 @@
         tableId: CalmPestEventsTable
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
-        
+
 
 - type: entityTable
   id: SleeperlessGameRulesTable

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -4,6 +4,8 @@
   weights:
     Dragon: 1
     Revenant: 1
+    RatKing: 1
+    UristSwarm: 0.25
 
 - type: ninjaHackingThreat
   id: Dragon
@@ -14,3 +16,13 @@
   id: Revenant
   announcement: terror-revenant
   rule: RevenantSpawn
+
+- type: ninjaHackingThreat
+  id: RatKing
+  announcement: terror-ratking
+  rule: KingRatMigration
+
+- type: ninjaHackingThreat
+  id: UristSwarm
+  announcement: terror-uristswarm
+  rule: GameRuleUristSwarm


### PR DESCRIPTION
looked into a few things (making zombie infection do multiple types of damage, can only manually turn when infection is active, making thief beacon chameleon,) that arent in this pr but i would like to add at some point. just above my skill level atm. someone else can do them too im not like possessive about antags

new ninja hack summons are a little jank (sends two announcements) also

**Changelog**
:cl: hivehum
- tweak: A zombie infection progresses significantly faster and more dangerously than before.
- tweak: The initial infected greeting is a little more direct that you are an antagonist.
- tweak: Rat King is now officially considered an antagonist.
- tweak: The thieving beacon has had its name and description changed to be less obvious what it is.
- add: The ninja can now contact two new beings.
