### PR TITLE
Disable automatic scheduled publish workflow run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,6 @@ concurrency:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 10 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Hopefully should just let us only run it manually because whenever it goes from cron it just fails because it's trying to post an identical version to the cdn