### PR TITLE
Listings that you can't purchase now show up in the bottom of their category as Unavailable

### DIFF
--- a/Content.Client/Store/Ui/StoreListingControl.xaml.cs
+++ b/Content.Client/Store/Ui/StoreListingControl.xaml.cs
@@ -45,6 +45,9 @@ public sealed partial class StoreListingControl : Control
 
     private bool CanBuy()
     {
+        if (!_data.Buyable)
+            return false;
+
         if (!_hasBalance)
             return false;
 
@@ -62,6 +65,10 @@ public sealed partial class StoreListingControl : Control
         {
             var timeLeftToBuy = stationTime - _data.RestockTime;
             StoreItemBuyButton.Text = timeLeftToBuy.Duration().ToString(@"mm\:ss");
+        }
+        else if (!_data.Buyable)
+        {
+            StoreItemBuyButton.Text = "Unavailable";
         }
         else
         {

--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -119,6 +119,9 @@ public sealed partial class StoreSystem
             {
                 var args = new ListingConditionArgs(buyer, storeEntity, listing, EntityManager);
                 var conditionsMet = true;
+                listing.Buyable = true;
+                if (listing.Priority >= 1000)
+                    listing.Priority -= 1000;
 
                 foreach (var condition in listing.Conditions)
                 {
@@ -130,7 +133,11 @@ public sealed partial class StoreSystem
                 }
 
                 if (!conditionsMet)
-                    continue;
+                {
+                    listing.Buyable = false;
+                    if (listing.Priority < 1000)
+                        listing.Priority += 1000;
+                }
             }
 
             yield return listing;

--- a/Content.Shared/Store/ListingPrototype.cs
+++ b/Content.Shared/Store/ListingPrototype.cs
@@ -28,6 +28,7 @@ public partial class ListingData : IEquatable<ListingData>
         other.Description,
         other.Conditions,
         other.Icon,
+        other.Buyable,
         other.Priority,
         other.ProductEntity,
         other.ProductAction,
@@ -53,6 +54,7 @@ public partial class ListingData : IEquatable<ListingData>
         string? description,
         List<ListingCondition>? conditions,
         SpriteSpecifier? icon,
+        bool buyable,
         int priority,
         EntProtoId? productEntity,
         EntProtoId? productAction,
@@ -74,6 +76,7 @@ public partial class ListingData : IEquatable<ListingData>
         Description = description;
         Conditions = conditions?.ToList();
         Icon = icon;
+        Buyable = buyable;
         Priority = priority;
         ProductEntity = productEntity;
         ProductAction = productAction;
@@ -138,6 +141,12 @@ public partial class ListingData : IEquatable<ListingData>
     /// </summary>
     [DataField]
     public SpriteSpecifier? Icon;
+
+    /// <summary>
+    /// Labels a listing as available to purchase
+    /// </summary>
+    [DataField]
+    public bool Buyable = true;
 
     /// <summary>
     /// The priority for what order the listings will show up in on the menu.
@@ -285,6 +294,7 @@ public sealed partial class ListingDataWithCostModifiers : ListingData
             listingData.Description,
             listingData.Conditions,
             listingData.Icon,
+            listingData.Buyable,
             listingData.Priority,
             listingData.ProductEntity,
             listingData.ProductAction,


### PR DESCRIPTION
This should be it? I tested it on every store currently available to players. Might have to do some work later on priority stuff but for now I want to put it in and get feedback. 

:cl:
- add: Listings that you can't purchase now show up at the bottom of their category as Unavailable
