### PR TITLE
Trigger/effect probability for artifacts

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
@@ -91,7 +91,7 @@ public sealed partial class ArtifactSystem
         var targetTriggers = allTriggers
             .Where(x => x.TargetDepth == selectedRandomTargetDepth).ToList();
 
-        return _random.Pick(targetTriggers).ID;
+        return GetTriggerIDUsingProb(targetTriggers);;
     }
 
     private string GetRandomEffect(EntityUid artifact, ref ArtifactNode node)
@@ -106,7 +106,7 @@ public sealed partial class ArtifactSystem
         var targetEffects = allEffects
             .Where(x => x.TargetDepth == selectedRandomTargetDepth).ToList();
 
-        return _random.Pick(targetEffects).ID;
+        return GetEffectIDUsingProb(targetEffects);
     }
 
     /// <remarks>
@@ -148,6 +148,73 @@ public sealed partial class ArtifactSystem
         }
 
         return _random.Pick(weights.Keys); //shouldn't happen
+    }
+
+    /// <summary>
+    /// Selects an effect using the probability weight
+    /// </summary>
+    private string GetEffectIDUsingProb(IEnumerable<ArtifactEffectPrototype> effectObjects)
+    {
+        var maxProbID = ""; //Fallback, shouldn't need this
+        var maxProb = 0f;
+        var totalProb = 0f;
+
+        // First iteration - get the effect with the highest probability as fallback, and sum all the probabilities
+        foreach (var effect in effectObjects)
+        {
+            if (maxProb < effect.EffectProb)
+            {
+                maxProb = effect.EffectProb;
+                maxProbID = effect.ID;
+            }
+            totalProb += effect.EffectProb;
+        }
+        var rand = _random.NextFloat(0f, totalProb);
+        var accumulator = 0f;
+
+        // Second iteration - subtract current effect probability from total until total is
+        foreach (var effect in effectObjects)
+        {
+            accumulator += effect.EffectProb;
+            if (rand < accumulator){
+                return effect.ID;
+            }
+        }
+
+        return maxProbID;
+    }
+
+     /// <summary>
+    /// Selects an trigger using the probability weight
+    /// </summary>
+    private string GetTriggerIDUsingProb(IEnumerable<ArtifactTriggerPrototype> triggerObjects)
+    {
+        var maxProbID = ""; //Fallback, shouldn't need this
+        var maxProb = 0f;
+        var totalProb = 0f;
+
+        // First iteration - get the trigger with the highest probability as fallback, and sum all the probabilities
+        foreach (var trigger in triggerObjects)
+        {
+            if (maxProb < trigger.TriggerProb)
+            {
+                maxProb = trigger.TriggerProb;
+                maxProbID = trigger.ID;
+            }
+            totalProb += trigger.TriggerProb;
+        }
+        var rand = _random.NextFloat(0f, totalProb);
+        var accumulator = 0f;
+
+        foreach (var trigger in triggerObjects)
+        {
+            accumulator += trigger.TriggerProb;
+            if (rand < accumulator){
+                return trigger.ID;
+            }
+        }
+
+        return maxProbID;
     }
 
     /// <summary>

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactEffectPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactEffectPrototype.cs
@@ -33,6 +33,9 @@ public sealed partial class ArtifactEffectPrototype : IPrototype
     [DataField("targetDepth")]
     public int TargetDepth = 0;
 
+    [DataField("effectProb")]
+    public float EffectProb = 1f;
+
     [DataField("effectHint")]
     public string? EffectHint;
 

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactTriggerPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactTriggerPrototype.cs
@@ -22,6 +22,9 @@ public sealed partial class ArtifactTriggerPrototype : IPrototype
     [DataField("targetDepth")]
     public int TargetDepth = 0;
 
+    [DataField("triggerProb")]
+    public float TriggerProb = 1f;
+
     [DataField("triggerHint")]
     public string? TriggerHint;
 

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -119,6 +119,34 @@
   - type: MovementAlwaysTouching
   - type: NoSlip
 
+# For Artifact Polymorph
+- type: entity
+  parent: ImmovableRod
+  id: ImmovableRodArtifactPoly
+  suffix: Victim
+  components:
+  - type: ImmovableRod
+    minSpeed: 1
+    maxSpeed: 3
+    destroyTiles: false
+    randomizeVelocity: false
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 200
+  - type: MovementIgnoreGravity
+    gravityState: true
+  - type: InputMover
+  - type: MovementSpeedModifier
+    weightlessAcceleration: 5
+    weightlessModifier: 2
+    weightlessFriction: 0
+    friction: 0
+    frictionNoInput: 0
+  - type: CanMoveInAir
+  - type: MovementAlwaysTouching
+  - type: NoSlip
+
 - type: entity
   parent: ImmovableRodKeepTiles
   id: ImmovableRodKeepTilesStill

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -201,6 +201,18 @@
     revertOnCrit: true
     duration: 25
 
+- type: polymorph
+  id: ArtifactRod
+  configuration:
+    entity: ImmovableRodArtifactPoly #CLANG
+    transferName: true
+    transferDamage: false
+    inventory: None
+    duration: 3
+    forced: true
+    revertOnCrit: false
+    revertOnDeath: false
+
 # Polymorphs for Wizards polymorph self spell
 - type: polymorph
   id: WizardSpider

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -662,6 +662,7 @@
 - type: artifactEffect
   id: EffectBoom
   targetDepth: 4
+  effectProb: 0.75
   effectHint: artifact-effect-hint-environment
   components:
   - type: TriggerArtifact
@@ -763,7 +764,19 @@
     - JuiceThatMakesYouWeh
     - Lead
     - ForeverWeed
+
+- type: artifactEffect
+  id: EffectFoamRomerol
+  targetDepth: 4
+  effectProb: 0.05
+  effectHint: artifact-effect-hint-biochemical
+  components:
+  - type: FoamArtifact
+    minFoamAmount: 30
+    maxFoamAmount: 40
+    reagents:
     - Romerol
+    - Pilk
 
 - type: artifactEffect
   id: EffectPolyClownSpider
@@ -791,6 +804,16 @@
   - type: PolyOthersArtifact
     polymorphPrototypeName: ArtifactBee
     range: 5
+
+- type: artifactEffect
+  id: EffectPolyRod
+  targetDepth: 4
+  effectProb: 0.05
+  effectHint: artifact-effect-hint-polymorph
+  components:
+  - type: PolyOthersArtifact
+    polymorphPrototypeName: ArtifactRod
+    range: 3
 
 - type: artifactEffect
   id: EffectHealAllPowerful
@@ -852,9 +875,9 @@
     - id: PresentRandom
       prob: 0.9
     - id: PresentRandomUnsafe
-      prob: 0.06
+      prob: 0.1
     - id: PresentRandomInsane
-      prob: 0.03
+      prob: 0.05
 
 - type: artifactEffect
   id: EffectBookSpawn

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -813,7 +813,7 @@
   components:
   - type: PolyOthersArtifact
     polymorphPrototypeName: ArtifactRod
-    range: 3
+    range: 2
 
 - type: artifactEffect
   id: EffectHealAllPowerful


### PR DESCRIPTION
Can now add 'EffectProb' and 'TriggerProb' to change how likely a given effect/trigger is relative to each other. Default is one.
This will allow dangerous but rare effects.
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: 
- add: backend change to artifacts - triggers and effects can now have individual probability weights.
- add: very rare new artifact-caused transformation
- tweak: used this to reduce likelyhood of science zombies.