### PR TITLE
Added back overwritten interfaces

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/spelf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/spelf.yml
@@ -14,6 +14,12 @@
   - type: SpelfMoods
   - type: UserInterface
     interfaces:
+      enum.HumanoidMarkingModifierKey.Key:
+        type: HumanoidMarkingModifierBoundUserInterface
+      enum.StrippingUiKey.Key:
+        type: StrippableBoundUserInterface
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
       enum.SpelfMoodsUiKey.Key:
         type: SpelfMoodsBoundUserInterface
   - type: Respirator


### PR DESCRIPTION
Spelves can now be stripped and stuff. 
:cl:
- fix: Spelves are strippable now. Steal their stuff!
