### PR TITLE
Changed wildcard spelf moods to only appear upon emagging

### DIFF
--- a/Content.Client/Impstation/Spelfs/SpelfMoodSystem.cs
+++ b/Content.Client/Impstation/Spelfs/SpelfMoodSystem.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Impstation.Spelfs;
+
+namespace Content.Client.Impstation.Spelfs;
+
+public sealed partial class SpelfMoodSystem : SharedSpelfMoodSystem
+{
+}

--- a/Content.Server/Impstation/Spelfs/SpelfMoodSystem.cs
+++ b/Content.Server/Impstation/Spelfs/SpelfMoodSystem.cs
@@ -211,12 +211,10 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
         return true;
     }
 
-    public bool TryAddRandomMood(EntityUid uid, SpelfMoodsComponent? comp = null)
+    public bool TryAddRandomMood(EntityUid uid, string datasetProto, SpelfMoodsComponent? comp = null)
     {
         if (!Resolve(uid, ref comp))
             return false;
-
-        var datasetProto = _proto.Index<WeightedRandomPrototype>(RandomSpelfMoodDataset).Pick();
 
         if (TryPick(datasetProto, out var moodProto, GetActiveMoods(uid, comp)))
         {
@@ -225,6 +223,16 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
         }
 
         return false;
+    }
+
+    public bool TryAddRandomMood(EntityUid uid, SpelfMoodsComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return false;
+
+        var datasetProto = _proto.Index<WeightedRandomPrototype>(RandomSpelfMoodDataset).Pick();
+
+        return TryAddRandomMood(uid, datasetProto, comp);
     }
 
     public HashSet<string> GetConflicts(IEnumerable<SpelfMood> moods)
@@ -290,10 +298,6 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
 
         // "No, and" moods
         if (TryPick(NoAndDataset, out mood, GetActiveMoods(uid, comp)))
-            TryAddMood(uid, mood, comp, true, false);
-
-        // Wildcard moods
-        if (TryPick(WildcardDataset, out mood, GetActiveMoods(uid, comp)))
             TryAddMood(uid, mood, comp, true, false);
 
         comp.Action = _actions.AddAction(uid, ActionViewMoods);

--- a/Content.Server/Impstation/Spelfs/SpelfMoodSystem.cs
+++ b/Content.Server/Impstation/Spelfs/SpelfMoodSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Chat.Managers;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Dataset;
+using Content.Shared.Emag.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.Impstation.Spelfs;
 using Content.Shared.Impstation.Spelfs.Components;
@@ -18,11 +19,10 @@ using Robust.Shared.Random;
 
 namespace Content.Server.Impstation.Spelfs;
 
-public sealed partial class SpelfMoodsSystem : EntitySystem
+public sealed partial class SpelfMoodsSystem : SharedSpelfMoodSystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly UserInterfaceSystem _bui = default!;
@@ -56,6 +56,7 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
         NewSharedMoods();
 
         SubscribeLocalEvent<SpelfMoodsComponent, ComponentStartup>(OnSpelfMoodInit);
+        SubscribeLocalEvent<SpelfMoodsComponent, ComponentShutdown>(OnSpelfMoodShutdown);
         SubscribeLocalEvent<SpelfMoodsComponent, ToggleMoodsScreenEvent>(OnToggleMoodsScreen);
         SubscribeLocalEvent<SpelfMoodsComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
         SubscribeLocalEvent<RoundRestartCleanupEvent>((_) => NewSharedMoods());
@@ -110,7 +111,7 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
             return;
         args.Handled = true;
 
-        _userInterface.TryToggleUi(uid, SpelfMoodsUiKey.Key, actor.PlayerSession);
+        _bui.TryToggleUi(uid, SpelfMoodsUiKey.Key, actor.PlayerSession);
     }
 
     private bool TryPick(string datasetProto, [NotNullWhen(true)] out SpelfMoodPrototype? proto, IEnumerable<SpelfMood>? currentMoods = null, HashSet<string>? conflicts = null)
@@ -159,7 +160,7 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
             return;
 
         var state = new SpelfMoodsBuiState(comp.Moods, comp.FollowsSharedMoods ? SharedMoods : []);
-        _userInterface.SetUiState(uid, SpelfMoodsUiKey.Key, state);
+        _bui.SetUiState(uid, SpelfMoodsUiKey.Key, state);
     }
 
     public void AddMood(EntityUid uid, SpelfMood mood, SpelfMoodsComponent? comp = null, bool notify = true)
@@ -287,7 +288,7 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
         }
     }
 
-    public void OnSpelfMoodInit(EntityUid uid, SpelfMoodsComponent comp, ComponentStartup args)
+    private void OnSpelfMoodInit(EntityUid uid, SpelfMoodsComponent comp, ComponentStartup args)
     {
         if (comp.LifeStage != ComponentLifeStage.Starting)
             return;
@@ -303,8 +304,14 @@ public sealed partial class SpelfMoodsSystem : EntitySystem
         comp.Action = _actions.AddAction(uid, ActionViewMoods);
     }
 
-    public void OnSpelfMoodShutdown(EntityUid uid, SpelfMoodsComponent comp, ComponentShutdown args)
+    private void OnSpelfMoodShutdown(EntityUid uid, SpelfMoodsComponent comp, ComponentShutdown args)
     {
         _actions.RemoveAction(uid, comp.Action);
+    }
+
+    protected override void OnEmagged(EntityUid uid, SpelfMoodsComponent comp, ref GotEmaggedEvent args)
+    {
+        base.OnEmagged(uid, comp, ref args);
+        TryAddRandomMood(uid, WildcardDataset, comp);
     }
 }

--- a/Content.Shared/Impstation/Spelfs/SharedSpelfMoodSystem.cs
+++ b/Content.Shared/Impstation/Spelfs/SharedSpelfMoodSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Emag.Systems;
+using Content.Shared.Impstation.Spelfs.Components;
+
+namespace Content.Shared.Impstation.Spelfs;
+
+public abstract class SharedSpelfMoodSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SpelfMoodsComponent, OnAttemptEmagEvent>(OnAttemptEmag);
+        SubscribeLocalEvent<SpelfMoodsComponent, GotEmaggedEvent>(OnEmagged);
+    }
+
+    private void OnAttemptEmag(EntityUid uid, SpelfMoodsComponent comp, ref OnAttemptEmagEvent args)
+    {
+        if (!comp.CanBeEmagged)
+            args.Handled = true;
+    }
+
+    protected virtual void OnEmagged(EntityUid uid, SpelfMoodsComponent comp, ref GotEmaggedEvent args)
+    {
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/Impstation/Spelfs/SpelfMoodBoundComponent.cs
+++ b/Content.Shared/Impstation/Spelfs/SpelfMoodBoundComponent.cs
@@ -13,6 +13,9 @@ public sealed partial class SpelfMoodsComponent : Component
     [DataField, ViewVariables, AutoNetworkedField]
     public List<SpelfMood> Moods = new();
 
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool CanBeEmagged = true;
+
     [DataField(serverOnly: true), ViewVariables]
     public EntityUid? Action;
 }


### PR DESCRIPTION
This is a stopgap while we wait for upstream to finish the borg rework. After which, we'll hook into the ion storm event and roll wildcards from that.