### PR TITLE
Freeze revenants in place during stun and prevent haunting the same person twice

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -242,7 +242,7 @@ public sealed partial class RevenantSystem : EntitySystem
                 var essence = rev.EssencePerSecond;
 
                 if (TryComp<RevenantRegenModifierComponent>(uid, out var regen))
-                    essence += rev.HauntEssenceRegenPerWitness * regen.Witnesses.Count;
+                    essence += rev.HauntEssenceRegenPerWitness * regen.NewHaunts;
 
                 ChangeEssenceAmount(uid, essence, rev, regenCap: true);
             }

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared.Store.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Robust.Server.GameObjects;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -191,6 +192,8 @@ public sealed partial class RevenantSystem : EntitySystem
 
         _statusEffects.TryAddStatusEffect<CorporealComponent>(uid, "Corporeal", TimeSpan.FromSeconds(debuffs.Y), false);
         _stun.TryStun(uid, TimeSpan.FromSeconds(debuffs.X), false);
+        if (debuffs.X > 0)
+            _physics.ResetDynamics(uid, Comp<PhysicsComponent>(uid));
 
         return true;
     }

--- a/Content.Shared/Revenant/Components/HauntedComponent.cs
+++ b/Content.Shared/Revenant/Components/HauntedComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Revenant.Components;
+
+[RegisterComponent]
+public sealed partial class HauntedComponent : Component
+{
+}

--- a/Content.Shared/Revenant/Components/RevenantRegenModifierComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantRegenModifierComponent.cs
@@ -7,18 +7,22 @@ namespace Content.Shared.Revenant.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RevenantRegenModifierComponent : Component
 {
-    [ViewVariables, AutoNetworkedField]
+    [DataField(required: true), ViewVariables, AutoNetworkedField]
     public HashSet<NetEntity> Witnesses;
+
+    [DataField(required: true), ViewVariables, AutoNetworkedField]
+    public int NewHaunts;
 
     [DataField]
     public ProtoId<AlertPrototype> Alert = "EssenceRegen";
 
-    public RevenantRegenModifierComponent(HashSet<NetEntity> witnesses)
+    public RevenantRegenModifierComponent(HashSet<NetEntity> witnesses, int newHaunts)
     {
         Witnesses = witnesses;
+        NewHaunts = newHaunts;
     }
 
-    public RevenantRegenModifierComponent() : this(new())
+    public RevenantRegenModifierComponent() : this(new(), 0)
     {
     }
 }

--- a/Content.Shared/Revenant/EntitySystems/HauntedSystem.cs
+++ b/Content.Shared/Revenant/EntitySystems/HauntedSystem.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Examine;
+using Content.Shared.Revenant.Components;
+
+namespace Content.Shared.Revenant.EntitySystems;
+
+public sealed partial class HauntedSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HauntedComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, HauntedComponent comp, ExaminedEvent args)
+    {
+        if (HasComp<RevenantComponent>(args.Examiner))
+        {
+            args.PushMarkup($"[color=mediumpurple]{Loc.GetString("revenant-already-haunted", ("target", uid))}[/color]");
+        }
+    }
+}

--- a/Resources/Locale/en-US/revenant/revenant.ftl
+++ b/Resources/Locale/en-US/revenant/revenant.ftl
@@ -41,3 +41,5 @@ revenant-exorcise-success = {$revenant}'s energy fades away...
 
 revenant-revealed-default = {CAPITALIZE(THE($revealer))} weakens your ethereal cloak!
 revenant-revealed-salt = The salt puddle weakens your ethereal cloak!
+
+revenant-already-haunted = { CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } been haunted.


### PR DESCRIPTION
**Changelog**

:cl: TGRCDev
- tweak: Revenants now freeze in place when any of their abilities stun them, to prevent revenants from abusing their velocity to slide through doors while stunned.
- tweak: Revenants now only receive stolen essence and essence regen from a haunted crewmate once. Revenants can see who has already been haunted by examining them.
