### PR TITLE
Make pAI trinket available only for intern roles

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -3,6 +3,7 @@ loadout-group-species-restriction = This item is not available for your current 
 
 # Miscellaneous
 loadout-group-trinkets = Trinkets
+loadout-group-learner = pAI Assistant
 loadout-group-glasses = Glasses
 loadout-group-backpack = Backpack
 loadout-group-instruments = Instruments

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -17,7 +17,6 @@
   - CigPackSpirits
   - CigarCase
   - CigarGold
-  - PersonalAI
   - GoldPersonalAI
   - FolderBlack
   - BarFlask
@@ -35,6 +34,15 @@
   - ClothingNeckAutismPin
   - ClothingNeckGoldAutismPin
   - HarmonicaInstrument
+
+# For introductory roles learning more complex jobs, like an in-game personal mentor
+- type: loadoutGroup
+  id: Learner
+  name: loadout-group-learner
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+  - PersonalAI
 
 - type: loadoutGroup
   id: Glasses

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -292,6 +292,7 @@
   - TechnicalAssistantJumpsuit
   - StationEngineerBackpack
   - SurvivalExtended
+  - Learner
   - Trinkets
   - GroupSpeciesBreathTool
   - GroupTankHarness
@@ -369,6 +370,7 @@
   - ScientistBackpack
   - Glasses
   - Survival
+  - Learner
   - Trinkets
   - GroupSpeciesBreathTool
   - GroupTankHarness
@@ -467,6 +469,7 @@
   - SecurityCadetJumpsuit
   - SecurityBackpack
   - SurvivalSecurity
+  - Learner
   - Trinkets
   - GroupSpeciesBreathToolSecurity
   - GroupTankHarness
@@ -515,6 +518,7 @@
   - Glasses
   - MedicalBackpack
   - SurvivalMedical
+  - Learner
   - Trinkets
   - GroupSpeciesBreathToolMedical
   - GroupTankHarness


### PR DESCRIPTION
Removes pAI from general trinket pool and adds it to learner roles as an optional trinket. I'll leave this up for a bit before merging to allow for discussion about it, but this matches the original idea behind putting pAIs into the general trinket pool. They're supposed to be rare, and there's still quite a few out there on the maps themselves. 

:cl:
- tweak: Removed pAI from base trinket loadout and added it to learner roles to better match the original intent

