### PR TITLE
one more scientist slot for core

### DIFF
--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -42,7 +42,7 @@
             Paramedic: [ 1, 2 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 3 ]
+            Scientist: [ 4, 4 ]
             ResearchAssistant: [ 1, 1 ]
             #security
             HeadOfSecurity: [ 1, 1 ]


### PR DESCRIPTION
this has been a common complaint for core. it seems pretty understaffed compared to other departments for the size of the map. one more shouldn't hurt

**Changelog**
:cl:
- add: Core Station now has an additional scientist job slot.
