### PR TITLE
Monotonous and Sharp Inflection Accents

### DIFF
--- a/Content.Server/Speech/Components/MonotonousComponent.cs
+++ b/Content.Server/Speech/Components/MonotonousComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class MonotonousComponent : Component
+{
+
+}

--- a/Content.Server/Speech/Components/SharpInflectionComponent.cs
+++ b/Content.Server/Speech/Components/SharpInflectionComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class SharpInflectionComponent : Component
+{
+
+}

--- a/Content.Server/Speech/EntitySystems/MonotonousSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MonotonousSystem.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class MonotonousSystem : EntitySystem
+{
+    // @formatter:off
+    private static readonly Regex RegexAnyPunctuationNotPeriod = new(@"[!?]+");
+    // @formatter:on
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<MonotonousComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, MonotonousComponent component, AccentGetEvent args)
+    {
+        args.Message = RegexAnyPunctuationNotPeriod.Replace(args.Message, ".");
+
+        // If the message doesn't end with a letter or punctuation, we add a period for sharpness
+        if (!char.IsLetterOrDigit(args.Message[^1]) && !char.IsPunctuation(args.Message[^1]))
+        {
+            args.Message += ".";
+        }
+    }
+}

--- a/Content.Server/Speech/EntitySystems/SharpInflectionSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SharpInflectionSystem.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class SharpInflectionSystem : EntitySystem
+{
+    // @formatter:off
+    private static readonly Regex RegexEndsWithExclamation = new(@"[!]+$");
+    private static readonly Regex RegexEndsWithQuestion = new(@"[?]+$");
+    private static readonly Regex RegexEndsWithPeriod = new(@"[.]+$");
+    // @formatter:on
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SharpInflectionComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, SharpInflectionComponent component, AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        message = RegexEndsWithExclamation.Replace(message, "!!");
+        message = RegexEndsWithQuestion.Replace(message, "?!!");
+        message = RegexEndsWithPeriod.Replace(message, "...");
+
+        // If the message doesn't end with any punctuation, we add ... anyway
+        if (!RegexEndsWithExclamation.IsMatch(message) && 
+            !RegexEndsWithQuestion.IsMatch(message) && 
+            !RegexEndsWithPeriod.IsMatch(message))
+        {
+            message += "...";
+        }
+
+        args.Message = message;
+    }
+}

--- a/Content.Server/Speech/EntitySystems/SharpInflectionSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SharpInflectionSystem.cs
@@ -8,7 +8,8 @@ public sealed class SharpInflectionSystem : EntitySystem
     // @formatter:off
     private static readonly Regex RegexEndsWithExclamation = new(@"[!]+$");
     private static readonly Regex RegexEndsWithQuestion = new(@"[?]+$");
-    private static readonly Regex RegexEndsWithPeriod = new(@"[.]+$");
+    private static readonly Regex RegexEndsWithPeriod = new(@"[\.]+$");
+    private static readonly Regex RegexEndsWithAnyPunctuation = new(@"[!?\.]+$");
     // @formatter:on
 
     public override void Initialize()
@@ -26,9 +27,7 @@ public sealed class SharpInflectionSystem : EntitySystem
         message = RegexEndsWithPeriod.Replace(message, "...");
 
         // If the message doesn't end with any punctuation, we add ... anyway
-        if (!RegexEndsWithExclamation.IsMatch(message) && 
-            !RegexEndsWithQuestion.IsMatch(message) && 
-            !RegexEndsWithPeriod.IsMatch(message))
+        if (!RegexEndsWithAnyPunctuation.IsMatch(message))
         {
             message += "...";
         }

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -81,7 +81,7 @@ trait-scrambled-desc = There was an accident with a tesla engine, now others hav
 trait-nocontractions-name = No contractions
 trait-nocontractions-desc = You are (mostly) incapable of using contractions.
 
-trait-sharpinflection-name = Sharp Inflection
+trait-sharpinflection-name = Sharp inflection
 trait-sharpinflection-desc = You mumble... When you aren't shouting!!
 
 trait-monotonous-name = Monotonous

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -80,3 +80,9 @@ trait-scrambled-desc = There was an accident with a tesla engine, now others hav
 
 trait-nocontractions-name = No contractions
 trait-nocontractions-desc = You are (mostly) incapable of using contractions.
+
+trait-sharpinflection-name = Sharp Inflection
+trait-sharpinflection-desc = You mumble... When you aren't shouting!!
+
+trait-monotonous-name = Monotonous
+trait-monotonous-desc = You speak in a way that others see as total disinterest. Always.

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -121,8 +121,6 @@
   category: SpeechTraits
   cost: 1
   components:
-  - type: ReplacementAccent
-    accent: sharpinflection
   - type: SharpInflection
   
 - type: trait
@@ -132,8 +130,6 @@
   category: SpeechTraits
   cost: 1
   components:
-  - type: ReplacementAccent
-    accent: monotonous
   - type: Monotonous
 
 # 2 Cost

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -113,6 +113,28 @@
   - type: ReplacementAccent
     accent: nocontractions
   - type: NoContractionsAccent
+  
+- type: trait
+  id: SharpInflection
+  name: trait-sharpinflection-name
+  description: trait-sharpinflection-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: sharpinflection
+  - type: SharpInflection
+  
+- type: trait
+  id: Monotonous
+  name: trait-monotonous-name
+  description: trait-monotonous-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: monotonous
+  - type: Monotonous
 
 # 2 Cost
 
@@ -130,7 +152,7 @@
   name: trait-socialanxiety-name
   description: trait-socialanxiety-desc
   category: SpeechTraits
-  cost: 2
+  cost: 1
   components:
   - type: StutteringAccent
     matchRandomProb: 0.1


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

This adds two new punctuation-based accents and lowers the cost of stuttering! I did the latter because 2-pointers are usually reserved for total conversion (ratvarian, russian), and stuttering is relatively low-impact compared to some other 1-pointers. It'd be more fun to combine it with them.

The accents are:
- Monotonous: You speak in a way that others see as total disinterest. Always. 
![image](https://github.com/user-attachments/assets/e9ae7793-c6c6-429e-9514-51f690bb8360)
  - Adds a period to the end of messages if there isn't one.
  - Replaces ? and ! with .

- Sharp inflection: You mumble... When you aren't shouting!!
![image](https://github.com/user-attachments/assets/5fb014d4-7e33-4e42-bc23-ac9da481a32c)
  - Adds a ... to the end of messages if there isn't any punctuation.
  - Turns messages ending in "!" to end in "!!" (to be yelling)
  - Turns messages ending in "?" to end in "?!!" (to be yelling)
  - Turns messages ending in "." to end in "..." (to be mumbling)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: "Monotonous" and "Sharp inflection" punctuation-based accents. Both are 1-point traits.
- tweak: Changed stutter to be a 1-point speech trait rather than 2-point.
