### PR TITLE
salvage glasses fix

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -998,6 +998,7 @@
 - type: loadoutGroup
   id: SalvageSpecialistGlasses
   name: loadout-group-salvage-specialist-glasses
+  minLimit: 0
   loadouts:
   - Glasses
   - GlassesCheapSunglasses

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -263,7 +263,6 @@
   - SalvageSpecialistOuterClothing
   - SalvageSpecialistShoes
   - SalvageSpecialistGlasses
-  - Glasses
   - SalvageSpecialistBackpack
   - SalvageSpecialistPDA
   - Survival


### PR DESCRIPTION
removes the default glasses from the salvage loadout, and sets the minimum limit to 0 so salvage aren't forced to wear a pair

**Changelog**
:cl:
- fix: Fixed salvage's glasses loadout.