### PR TITLE
Spelf moods now check for duplicate moodvars by default

### DIFF
--- a/Content.IntegrationTests/Tests/Impstation/Spelfs/MoodTests.cs
+++ b/Content.IntegrationTests/Tests/Impstation/Spelfs/MoodTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Content.IntegrationTests;
+using Content.Server.Impstation.Spelfs;
+using Content.Shared.Dataset;
+using Content.Shared.Impstation.Spelfs;
+using NUnit.Framework;
+using Robust.Shared.ContentPack;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
+
+namespace Content.IntegrationTests.Tests.Impstation.Spelfs;
+
+[TestFixture, TestOf(typeof(SpelfMoodPrototype))]
+public sealed class SpelfMoodTests
+{
+    [TestPrototypes]
+    const string PROTOTYPES = @"
+- type: dataset
+  id: ThreeValueSet
+  values:
+    - One
+    - Two
+    - Three
+- type: spelfMood
+  id: DuplicateTest
+  moodName: DuplicateTest
+  moodDesc: DuplicateTest
+  allowDuplicateMoodVars: false
+  moodVars:
+    a: ThreeValueSet
+    b: ThreeValueSet
+    c: ThreeValueSet
+- type: spelfMood
+  id: DuplicateOverlapTest
+  moodName: DuplicateOverlapTest
+  moodDesc: DuplicateOverlapTest
+  allowDuplicateMoodVars: false
+  moodVars:
+    a: ThreeValueSet
+    b: ThreeValueSet
+    c: ThreeValueSet
+    d: ThreeValueSet
+    e: ThreeValueSet
+";
+
+    [Test]
+    [Repeat(10)]
+    public async Task TestDuplicatePrevention()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var spelfSystem = entMan.System<SpelfMoodsSystem>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+
+        var dataset = protoMan.Index<DatasetPrototype>("ThreeValueSet");
+        var moodProto = protoMan.Index<SpelfMoodPrototype>("DuplicateTest");
+
+        var datasetSet = dataset.Values.ToHashSet();
+        var mood = spelfSystem.RollMood(moodProto);
+        var moodVarSet = mood.MoodVars.Values.ToHashSet();
+
+        Assert.That(moodVarSet, Is.EquivalentTo(datasetSet));
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    [Repeat(10)]
+    public async Task TestDuplicateOverlap()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var spelfSystem = entMan.System<SpelfMoodsSystem>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+
+        var dataset = protoMan.Index<DatasetPrototype>("ThreeValueSet");
+        var moodProto = protoMan.Index<SpelfMoodPrototype>("DuplicateOverlapTest");
+
+        var datasetSet = dataset.Values.ToHashSet();
+        var mood = spelfSystem.RollMood(moodProto);
+        var moodVarSet = mood.MoodVars.Values.ToHashSet();
+
+        Assert.That(moodVarSet, Is.EquivalentTo(datasetSet));
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Impstation/Spelfs/SpelfMoodSystem.cs
+++ b/Content.Server/Impstation/Spelfs/SpelfMoodSystem.cs
@@ -190,8 +190,38 @@ public sealed partial class SpelfMoodsSystem : SharedSpelfMoodSystem
             Conflicts = proto.Conflicts,
         };
 
-        foreach (var (name, dataset) in proto.MoodVarDatasets)
-            mood.MoodVars.Add(name, _random.Pick(_proto.Index<DatasetPrototype>(dataset)));
+        var alreadyChosen = new HashSet<string>();
+
+        foreach (var (name, datasetID) in proto.MoodVarDatasets)
+        {
+            var dataset = _proto.Index<DatasetPrototype>(datasetID);
+
+            if (proto.AllowDuplicateMoodVars)
+            {
+                mood.MoodVars.Add(name, _random.Pick(dataset));
+                continue;
+            }
+
+            var choices = dataset.Values.ToList();
+            var foundChoice = false;
+            while (choices.Count > 0)
+            {
+                var choice = _random.PickAndTake(choices);
+                if (alreadyChosen.Contains(choice))
+                    continue;
+
+                mood.MoodVars.Add(name, choice);
+                alreadyChosen.Add(choice);
+                foundChoice = true;
+                break;
+            }
+
+            if (!foundChoice)
+            {
+                Log.Warning($"Ran out of choices for moodvar \"{name}\" in \"{proto.ID}\"! Picking a duplicate...");
+                mood.MoodVars.Add(name, _random.Pick(_proto.Index<DatasetPrototype>(dataset)));
+            }
+        }
 
         return mood;
     }

--- a/Content.Shared/Impstation/Spelfs/SpelfMoodPrototype.cs
+++ b/Content.Shared/Impstation/Spelfs/SpelfMoodPrototype.cs
@@ -64,4 +64,12 @@ public sealed partial class SpelfMoodPrototype : IPrototype
     /// </summary>
     [DataField("moodVars", customTypeSerializer: typeof(PrototypeIdValueDictionarySerializer<string, DatasetPrototype>))]
     public Dictionary<string, string> MoodVarDatasets = new();
+
+    /// <summary>
+    /// If false, prevents the same variable from being rolled twice when rolling
+    /// mood variables for this mood. Does not prevent the same mood variable
+    /// from being present in other moods.
+    /// </summary>
+    [DataField("allowDuplicateMoodVars"), ViewVariables(VVAccess.ReadWrite)]
+    public bool AllowDuplicateMoodVars = false;
 }


### PR DESCRIPTION
This adds the `allowDuplicateMoodVars` variable to `SpelfMoodPrototype`, which is `false` by default. When `false`, prevents the same string from being selected for multiple mood variables. This only prevents duplicates within the same mood prototype, and does not check other moods' moodvars.

In the case that there are more moodVars than values in the dataset, moodVars will begin selecting duplicate values and log warnings.