### PR TITLE
duplicate starting galoshes removed

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -18,7 +18,6 @@
 - type: startingGear
   id: JanitorGear
   equipment:
-    shoes: ClothingShoesGaloshes
     id: JanitorPDA
     ears: ClothingHeadsetService
     belt: ClothingBeltJanitorFilled


### PR DESCRIPTION
Title. Forgot to remove the galoshes from janitor's starting gear when I made the shoes loadout.

:cl: aada
- fix: Roundstart duplicate galoshes fixed.
