### PR TITLE
fix gray paperdolls not appearing correctly 

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/gray.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gray.yml
@@ -124,5 +124,55 @@
   id: MobGrayDummy
   categories: [ HideSpawnMenu ]
   components:
-  - type: Sprite
-    scale: 1, 0.8
+  - type: HumanoidAppearance
+    species: Gray
+  - type: Body
+    prototype: Gray
+  - type: Inventory
+    templateId: gray
+    displacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: jumpsuit
+      head:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: head
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: outerClothing
+      neck:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: neck
+      eyes:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: eyes
+      mask:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: head
+      gloves:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: hand
+      back:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: back
+      ears:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Gray/displacement.rsi
+            state: head


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed gray paperdolls not using displacement. 
