### PR TITLE
remove changeling's transformation sting

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/Catalog/changeling_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Catalog/changeling_catalog.yml
@@ -184,19 +184,19 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- type: listing
-  id: EvolutionMenuStingTransform
-  name: evolutionmenu-sting-transform-name
-  description: evolutionmenu-sting-transform-desc
-  icon: { sprite: _Goobstation/Changeling/changeling_abilities.rsi, state: sting_transform }
-  productAction: ActionStingTransform
-  cost:
-    EvolutionPoint: 6
-  categories:
-  - ChangelingAbilitySting
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+# - type: listing
+#   id: EvolutionMenuStingTransform
+#   name: evolutionmenu-sting-transform-name
+#   description: evolutionmenu-sting-transform-desc
+#   icon: { sprite: _Goobstation/Changeling/changeling_abilities.rsi, state: sting_transform }
+#   productAction: ActionStingTransform
+#   cost:
+#     EvolutionPoint: 6
+#   categories:
+#   - ChangelingAbilitySting
+#   conditions:
+#   - !type:ListingLimitedStockCondition
+#     stock: 1
 
 # utility
 


### PR DESCRIPTION
comments out the transformation sting for changeling for the time being. there's a number of issues with it, including removing storage implants and all of heretic's abilities. it's usually only ever used for the funny rather than legitimate strategies, anyway. if changelings ever get adjusted to only change people's appearance data rather than how it currently works, this can easily be re-enabled

**Changelog**
:cl:
- remove: Removed changeling's transformation sting for the time being.