### PR TITLE
add biogenerators to atlas, cluster, and saltern

### DIFF
--- a/Resources/Maps/atlas.yml
+++ b/Resources/Maps/atlas.yml
@@ -5399,6 +5399,13 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
+- proto: Biogenerator
+  entities:
+  - uid: 8723
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 30
 - proto: BlastDoor
   entities:
   - uid: 99
@@ -19832,6 +19839,9 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
   - uid: 7271
     components:
     - type: Transform
@@ -19839,6 +19849,9 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
 - proto: ClothingEyesGlassesMeson
   entities:
   - uid: 7265
@@ -19848,6 +19861,9 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
   - uid: 7266
     components:
     - type: Transform
@@ -19855,6 +19871,9 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
 - proto: ClothingEyesGlassesThermal
   entities:
   - uid: 7267
@@ -19864,6 +19883,9 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
 - proto: ClothingHandsGlovesColorYellow
   entities:
   - uid: 1668

--- a/Resources/Maps/cluster.yml
+++ b/Resources/Maps/cluster.yml
@@ -5782,7 +5782,7 @@ entities:
       pos: -4.5,45.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -1773.3143
+      secondsUntilStateChange: -1812.4135
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -8169,6 +8169,13 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,27.5
+      parent: 1
+- proto: Biogenerator
+  entities:
+  - uid: 11748
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
       parent: 1
 - proto: BlastDoor
   entities:
@@ -61579,6 +61586,11 @@ entities:
       parent: 1
 - proto: RandomSpawner
   entities:
+  - uid: 6011
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
   - uid: 11734
     components:
     - type: Transform
@@ -61643,11 +61655,6 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-9.5
-      parent: 1
-  - uid: 11748
-    components:
-    - type: Transform
-      pos: 4.5,-5.5
       parent: 1
   - uid: 11750
     components:
@@ -70977,10 +70984,10 @@ entities:
       parent: 1
 - proto: VendingMachineHydrobe
   entities:
-  - uid: 6011
+  - uid: 12698
     components:
     - type: Transform
-      pos: 5.5,-5.5
+      pos: 4.5,-5.5
       parent: 1
 - proto: VendingMachineJaniDrobe
   entities:

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -5395,7 +5395,7 @@ entities:
       pos: -29.5,-18.5
       parent: 31
     - type: Door
-      secondsUntilStateChange: -660.03546
+      secondsUntilStateChange: -687.3661
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -6983,6 +6983,13 @@ entities:
     - type: Transform
       pos: -19.612082,-6.8995214
       parent: 31
+- proto: Biogenerator
+  entities:
+  - uid: 12129
+    components:
+    - type: Transform
+      pos: -19.5,1.5
+      parent: 31
 - proto: BlastDoor
   entities:
   - uid: 66
@@ -7532,7 +7539,7 @@ entities:
   - uid: 4129
     components:
     - type: Transform
-      pos: -19.764086,1.4415555
+      pos: -20.29044,0.8461655
       parent: 31
   - uid: 5631
     components:
@@ -34911,7 +34918,7 @@ entities:
       pos: 3.5,29.5
       parent: 31
     - type: Door
-      secondsUntilStateChange: -15360.535
+      secondsUntilStateChange: -15387.866
       state: Closing
   - uid: 8815
     components:


### PR DESCRIPTION
adds biogenerators to botany on our upstream-derotated maps. a few upstream maps like core don't have biogenerators but i don't really wanna touch those

**Changelog**
:cl:
- add: The botany departments of Atlas, Cluster, and Saltern now have biogenerators at roundstart.
