### PR TITLE
Spelfs can now view their moods when handcuffed or unconscious

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/spelf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/spelf.yml
@@ -22,6 +22,7 @@
         type: StoreBoundUserInterface
       enum.SpelfMoodsUiKey.Key:
         type: SpelfMoodsBoundUserInterface
+        requireInputValidation: false
       enum.HereticLivingHeartKey.Key:
         type: LivingHeartMenuBoundUserInterface
   - type: Respirator

--- a/Resources/Prototypes/_Impstation/Actions/spelfs.yml
+++ b/Resources/Prototypes/_Impstation/Actions/spelfs.yml
@@ -5,6 +5,8 @@
   components:
   - type: InstantAction
     itemIconStyle: NoItem
+    checkCanInteract: false
+    checkConsciousness: false
     icon:
       sprite: Interface/Actions/actions_borg.rsi
       state: state-laws


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Fixes #489 

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Thaven can now view their moods when handcuffed / unconscious
