### PR TITLE
handheld artifacts can now be beds

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -290,3 +290,30 @@
         Bloodloss: -0.3
         Poison: -0.3
         Radiation: -0.2
+
+- type: artifactEffect
+  id: EffectBedHandheld
+  targetDepth: 4
+  effectProb: 0.3
+  effectHint: artifact-effect-hint-storage
+  whitelist:
+    components:
+    - Item
+  permanentComponents:
+  - type: Strap
+    position: Down
+    rotation: -90
+  - type: HealOnBuckle
+    damage:
+      types:
+        Blunt: -0.4
+        Slash: -0.4
+        Pierce: -0.4
+        Heat: -0.4
+        Cold: -0.4
+        Shock: -0.3
+        Caustic: -0.2
+        Asphyxiation: -0.4
+        Bloodloss: -0.3
+        Poison: -0.3
+        Radiation: -0.2


### PR DESCRIPTION
i'm sorry but it had to be done it is too funny

see: me testing if this is possible:

https://github.com/user-attachments/assets/534baa2e-8241-4b74-9af0-4596facddac8

 
 
 
Previously, only the large artifacts could be beds. I have added another, mutually exclusive effect that only targets handheld artifacts with 30% probability. Yes you can pick people up and smuggle and do probably crazy stuff. its rare and funny 
reject if you think too strong

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: rare and powerful upgrade to handheld artifacts
