### PR TITLE
Non-RNG Fultons

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -20,7 +20,7 @@ research-technology-super-powercells = Super Powercells
 research-technology-bluespace-storage = Bluespace Storage
 research-technology-portable-fission = Portable Fission
 research-technology-space-scanning = Space Scanning
-research-technology-excavation = Mass Excavation
+research-technology-advanced-salvage = Advanced Salvaging
 
 research-technology-salvage-weapons = Salvage Weapons
 research-technology-draconic-munitions = Draconic Munitions

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -201,6 +201,8 @@
       - ClothingHeadHatCone
       - FreezerElectronics
       - Flare
+    dynamicRecipes:
+      - Fulton
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - BoxLethalshot
@@ -291,6 +293,7 @@
       - PowerDrill
       - MiningDrill
       - MiningDrillDiamond
+      - FultonBeacon
       - AnomalyScanner
       - AnomalyLocator
       - AnomalyLocatorWide

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -183,6 +183,8 @@
     - OreBagOfHolding
     - MiningDrillDiamond
     - AdvancedMineralScannerEmpty
+    - Fulton
+    - FultonBeacon
 
 # Tier 3
 

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -171,8 +171,8 @@
     - BorgModuleRCD
 
 - type: technology
-  id: MassExcavation
-  name: research-technology-excavation
+  id: AdvancedSalvage
+  name: research-technology-advanced-salvage
   icon:
     sprite: Objects/Tools/handdrilldiamond.rsi
     state: handdrill


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

This change can be discussed, but it was requested and was easy enough to implement that I figured I'd get the PR up. With the return of Our Wife The Reclaimer, albeit with some progression required, the topic of returning fultons also came up. This PR aims to add fultons back into something salvage can reasonably expect to have at some point, without it being free at the start, much like the shipyard console allows that midpoint between the hard nerf and the ease we had before. Hell, go wild and print a bunch and use them for deliveries to different departments on the station. Why not. It's fun, it's a bit wasteful, but it's silly and lovely. Let salvage have their touys.

:cl: Drags-His-Tail
- tweak: Added fultons and fulton beacons to the Mass Excavation research.
