### PR TITLE
heretic preset fix

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -5,6 +5,7 @@
   - type: HereticRule
   - type: GameRule
     minPlayers: 20
+    cancelPresetOnTooFewPlayers: false
     delay:
       min: 30
       max: 60


### PR DESCRIPTION
it's happening again

**Changelog**
:cl:
- fix: Heretic will no longer instantly cancel lowpop rounds when it is rolled.
