### PR TITLE
heretic appraisal tool typo

### DIFF
--- a/Resources/Prototypes/_Goobstation/Datasets/tags.yml
+++ b/Resources/Prototypes/_Goobstation/Datasets/tags.yml
@@ -15,7 +15,7 @@
   - Airlock
   - AirSensor
   - Ambrosia
-  - ApprisalTool
+  - AppraisalTool
   - Arrow
   - ArtifactFragment
   - Banana


### PR DESCRIPTION
typo moment prevented heretics from completing the ritual of knowledge. very cool

**Changelog**
:cl:
- fix: Heretics can now correctly use appraisal tools for the Ritual of Knowledge.