### PR TITLE
Fixed some heretic ritual items not working

### DIFF
--- a/Content.IntegrationTests/Tests/_Goobstation/Heretic/RitualKnowledgeTests.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/Heretic/RitualKnowledgeTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.Heretic.Ritual;
+using Content.Shared.Dataset;
+using Content.Shared.Tag;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Goobstation.Heretic;
+
+[TestFixture, TestOf(typeof(RitualKnowledgeBehavior))]
+public sealed class RitualKnowledgeTests
+{
+    [Test]
+    public async Task ValidateEligibleTags()
+    {
+        // As far as I can tell, there's no annotation to validate
+        // a dataset of tag prototype IDs, so we'll have to do it
+        // in a test fixture. Sad.
+
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            // Get the eligible tags prototype
+            var dataset = protoMan.Index<DatasetPrototype>(RitualKnowledgeBehavior.EligibleTagsDataset);
+
+            // Validate that every value is a valid tag
+            Assert.Multiple(() =>
+            {
+                foreach (var tagId in dataset.Values)
+                {
+                    Assert.That(protoMan.TryIndex<TagPrototype>(tagId, out var tagProto), Is.True, $"\"{tagId}\" is not a valid tag prototype ID");
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ValidateTagsHaveItems()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var compFactory = server.ResolveDependency<IComponentFactory>();
+
+        await server.WaitAssertion(() =>
+        {
+            // Get the eligible tags prototype
+            var dataset = protoMan.Index<DatasetPrototype>(RitualKnowledgeBehavior.EligibleTagsDataset).Values.ToHashSet();
+
+            // Loop through every entity prototype and assemble a used tags set
+            var usedTags = new HashSet<string>();
+
+            // Ensure that every tag is used by a non-abstract entity
+            foreach (var entProto in protoMan.EnumeratePrototypes<EntityPrototype>())
+            {
+                if (entProto.Abstract)
+                    continue;
+
+                if (entProto.TryGetComponent<TagComponent>(out var tags, compFactory))
+                {
+                    usedTags.UnionWith(tags.Tags.Select(t => t.Id));
+                }
+            }
+
+            var unusedTags = dataset.Except(usedTags).ToHashSet();
+            Assert.That(unusedTags, Is.Empty, $"The following ritual item tags are not used by any obtainable entity prototypes: {string.Join(", ", unusedTags)}");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
@@ -20,6 +20,9 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
     private EntityLookupSystem _lookup = default!;
     private HereticSystem _heretic = default!;
 
+    [ValidatePrototypeId<DatasetPrototype>]
+    public const string EligibleTagsDataset = "EligibleTags";
+
     // this is basically a ripoff from hereticritualsystem
     public override bool Execute(RitualData args, out string? outstr)
     {
@@ -33,7 +36,7 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
         // generate new set of tags
         if (requiredTags.Count == 0)
             for (int i = 0; i < 4; i++)
-                requiredTags.Add(_rand.Pick(_prot.Index<DatasetPrototype>("EligibleTags").Values), 1);
+                requiredTags.Add(_rand.Pick(_prot.Index<DatasetPrototype>(EligibleTagsDataset).Values), 1);
 
         var lookup = _lookup.GetEntitiesInRange(args.Platform, .75f);
         var missingList = new List<string>();

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -211,6 +211,11 @@
     groups:
     - id: Food
     - id: Drink
+  - type: Tag # goob edit
+    tags:
+      - Meat
+      - Organ
+      - Stomach
 
 - type: entity
   id: OrganHumanLiver
@@ -226,6 +231,11 @@
     groups:
     - id: Alcohol
       rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
+  - type: Tag # goob edit
+    tags:
+      - Meat
+      - Organ
+      - Liver
 
 - type: entity
   id: OrganHumanKidneys

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -39,6 +39,7 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+    - BreathMask # goob edit
   - type: PhysicalComposition
     materialComposition:
       Steel: 50
@@ -67,6 +68,9 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
+  - type: Tag # goob edit
+    tags:
+      - SecurityBreathMask
 
 - type: entity
   parent: [ClothingMaskGas, BaseSyndicateContraband]
@@ -165,6 +169,7 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+    - BreathMask # goob edit
 
 - type: entity
   parent: ClothingMaskBreathMedical
@@ -185,6 +190,10 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
+  - type: Tag # goob edit
+    tags:
+      - SecurityBreathMask
+
 
 - type: entity
   parent: ClothingMaskPullableBase
@@ -204,6 +213,7 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+    - BreathMask # goob edit
   - type: PhysicalComposition
     materialComposition:
       Steel: 50

--- a/Resources/Prototypes/Entities/Objects/Devices/geiger.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/geiger.yml
@@ -34,4 +34,7 @@
     - type: PhysicalComposition
       materialComposition:
         Plastic: 100
+    - type: Tag # goob edit
+      tags:
+        - GeigerCounter
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -158,7 +158,8 @@
         - ReagentId: TranexamicAcid
           Quantity: 3
   - type: Tag
-    tags: []
+    tags:
+      - EmergencyMedipen # goob edit
 
 - type: entity
   name: poison auto-injector

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -136,6 +136,9 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  - type: Tag # goob edit
+    tags:
+      - EmergencyOxygenTank
 
 - type: entity
   parent: [GasTankRoundBase, BaseCommandContraband]
@@ -178,6 +181,9 @@
     sprite: Objects/Tanks/emergency_red.rsi
   - type: Clothing
     sprite: Objects/Tanks/emergency_red.rsi
+  - type: Tag # goob edit
+    tags:
+      - EmergencyNitrogenTank
 
 - type: entity
   parent: [GasTankRoundBase, BaseCommandContraband]
@@ -207,6 +213,9 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  - type: Tag
+    tags:
+      - EmergencyNitrogenTank
 
 - type: entity
   parent: EmergencyOxygenTank
@@ -224,6 +233,9 @@
       temperature: 293.15
   - type: Clothing
     sprite: Objects/Tanks/emergency_extended.rsi
+  - type: Tag # goob edit
+    tags:
+      - ExtendedEmergencyOxygenTank
 
 - type: entity
   parent: EmergencyOxygenTankCommand
@@ -241,6 +253,9 @@
       temperature: 293.15
   - type: Clothing
     sprite: Objects/Tanks/emergency_command.rsi
+  - type: Tag
+    tags:
+      - ExtendedEmergencyOxygenTank
 
 - type: entity
   parent: ExtendedEmergencyOxygenTank
@@ -254,6 +269,9 @@
     sprite: Objects/Tanks/emergency_extended_red.rsi
   - type: Clothing
     sprite: Objects/Tanks/emergency_extended_red.rsi
+  - type: Tag # goob edit
+    tags:
+      - EmergencyNitrogenTank
 
 - type: entity
   parent: ExtendedEmergencyOxygenTankCommand
@@ -267,6 +285,9 @@
     sprite: Objects/Tanks/emergency_red_command.rsi
   - type: Clothing
     sprite: Objects/Tanks/emergency_red_command.rsi
+  - type: Tag
+    tags:
+      - ExtendedEmergencyOxygenTank
 
 - type: entity
   parent: ExtendedEmergencyOxygenTank
@@ -302,6 +323,9 @@
     sprite: Objects/Tanks/emergency_double_red.rsi
   - type: Clothing
     sprite: Objects/Tanks/emergency_double_red.rsi
+  - type: Tag
+    tags:
+      - EmergencyNitrogenTank
 
 - type: entity
   parent: EmergencyOxygenTank
@@ -315,6 +339,9 @@
     sprite: Objects/Tanks/emergency_clown.rsi
   - type: Clothing
     sprite: Objects/Tanks/emergency_clown.rsi
+  - type: Tag # goob edit
+    tags:
+    - ClownEmergencyOxygenTank
 
 - type: entity
   parent: GasTankRoundBase

--- a/Resources/Prototypes/_Goobstation/Datasets/tags.yml
+++ b/Resources/Prototypes/_Goobstation/Datasets/tags.yml
@@ -15,7 +15,7 @@
   - Airlock
   - AirSensor
   - Ambrosia
-  - ApprisalTool
+  - AppraisalTool
   - Arrow
   - ArtifactFragment
   - Banana

--- a/Resources/Prototypes/_Goobstation/Datasets/tags.yml
+++ b/Resources/Prototypes/_Goobstation/Datasets/tags.yml
@@ -7,9 +7,7 @@
   - EmergencyNitrogenTank
   - EmergencyOxygenTank
   - ExtendedEmergencyOxygenTank
-  - MedicalPatch
   - SecurityBreathMask
-  - SpaceMedipen
   - AirAlarm
   - AirAlarmElectronics
   - Airlock

--- a/Resources/Prototypes/_Goobstation/tags copy.yml
+++ b/Resources/Prototypes/_Goobstation/tags copy.yml
@@ -1,0 +1,20 @@
+- type: Tag
+  id: BreathMask
+
+- type: Tag
+  id: ClownEmergencyOxygenTank
+
+- type: Tag
+  id: EmergencyMedipen
+
+- type: Tag
+  id: EmergencyNitrogenTank
+
+- type: Tag
+  id: EmergencyOxygenTank
+
+- type: Tag
+  id: ExtendedEmergencyOxygenTank
+
+- type: Tag
+  id: SecurityBreathMask


### PR DESCRIPTION
This PR is a ported fix from Goob, but requires extra changes due to some item tags that we forgot to port. 

![image](https://github.com/user-attachments/assets/fb08a10c-6af1-494c-b52e-e27aa17464c6)

Tags to fix:
- [x] AppraisalTool
- [x] GeigerCounter
- [x] BreathMask
- [x] ClownEmergencyOxygenTank
- [x] EmergencyMedipen
- [x] EmergencyNitrogenTank
- [x] EmergencyOxygenTank
- [x] ExtendedEmergencyOxygenTank
- [x] ~~MedicalPatch~~ Goob-exclusive item
- [x] SecurityBreathMask
- [x] ~~SpaceMedipen~~ Goob-exclusive item