### PR TITLE
fix surplus crate whitelists, allow recursive crates

### DIFF
--- a/Content.Server/Traitor/Uplink/SurplusBundle/SurplusBundleSystem.cs
+++ b/Content.Server/Traitor/Uplink/SurplusBundle/SurplusBundleSystem.cs
@@ -45,7 +45,7 @@ public sealed class SurplusBundleSystem : EntitySystem
     {
         var ret = new List<ListingData>();
 
-        var listings = _store.GetAvailableListings(ent, null, ent.Comp2.Categories)
+        var listings = _store.GetAvailableListings(ent, null, ent.Comp2.Categories, ent.Owner)
             .OrderBy(p => p.Cost.Values.Sum())
             .Where(p => p.Buyable)
             .ToList();

--- a/Content.Server/Traitor/Uplink/SurplusBundle/SurplusBundleSystem.cs
+++ b/Content.Server/Traitor/Uplink/SurplusBundle/SurplusBundleSystem.cs
@@ -47,6 +47,7 @@ public sealed class SurplusBundleSystem : EntitySystem
 
         var listings = _store.GetAvailableListings(ent, null, ent.Comp2.Categories)
             .OrderBy(p => p.Cost.Values.Sum())
+            .Where(p => p.Buyable)
             .ToList();
 
         if (listings.Count == 0)

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1073,10 +1073,11 @@
     blacklist:
       tags:
       - NukeOpsUplink
-  - !type:BuyerWhitelistCondition
-    blacklist:
-      components:
-      - SurplusBundle
+  # the impstation special (it's really funny when this happens)
+  #- !type:BuyerWhitelistCondition
+  #  blacklist:
+  #    components:
+  #    - SurplusBundle
 
 - type: listing
   id: UplinkSuperSurplusBundle
@@ -1092,10 +1093,11 @@
     blacklist:
       tags:
       - NukeOpsUplink
-  - !type:BuyerWhitelistCondition
-    blacklist:
-      components:
-      - SurplusBundle
+  # see above
+  #- !type:BuyerWhitelistCondition
+  #  blacklist:
+  #    components:
+  #    - SurplusBundle
 
 - type: listing
   id: UplinkSingarityBeacon

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1074,6 +1074,7 @@
       tags:
       - NukeOpsUplink
   # the impstation special (it's really funny when this happens)
+  # seems to be a roughly 10% chance to hit the juck pot 1 million$ and get a double surplus crate
   #- !type:BuyerWhitelistCondition
   #  blacklist:
   #    components:
@@ -1093,11 +1094,12 @@
     blacklist:
       tags:
       - NukeOpsUplink
-  # see above
-  #- !type:BuyerWhitelistCondition
-  #  blacklist:
-  #    components:
-  #    - SurplusBundle
+  # not allowed to be recursive because it set off a chain reaction that crashed my localhost
+  # can still contain normal surplus bundles though smile
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 - type: listing
   id: UplinkSingarityBeacon


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
fixes #544, ~~not entirely sure if the recursive crates actually work but they're likely an _incredibly_ rare occurrence with the way that items are picked to fill them.~~
got recursive crates properly working now yay!

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Surplus crate white / blacklists work again.
- tweak: allowed recursive surplus crates again. have fun!
