### PR TITLE
slime upgrade changelog fix

### DIFF
--- a/Resources/Textures/_Impstation/Mobs/Customization/slime_parts.rsi/meta.json
+++ b/Resources/Textures/_Impstation/Mobs/Customization/slime_parts.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Sprited by Sha-Seng (Github) for Impstation",
+  "copyright": "Sprited by Sha-Seng (Github)",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
:cl:
- tweak: slime outline is now 75% opacity (down from 100%)
- tweak: slime hair is now 65% opacity (up from 50%)
- tweak: slime torso outlines adjusted to not overlap visibly on arms and legs
- remove: nose and mouth from default slime sprite
- add: nose and color-customizable mouth as slime head markings
- add: internal skeleton markings for gelatinous cube type slimes
- add: internal brain, lungs, and core markings
