### PR TITLE
bros vent spawn events cut in half

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Conditional/timed.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Conditional/timed.yml
@@ -97,5 +97,5 @@
         - MobBros
         - MobSorb
       chance: 0.9
-      minimumEntitiesSpawned: 20
-      maximumEntitiesSpawned: 25
+      minimumEntitiesSpawned: 10
+      maximumEntitiesSpawned: 15


### PR DESCRIPTION
this has been requested a few times as a server load issue. if we have a bros event on a sufficiently swamped map then they cause mob AI to lock up entirely

also this needs to be moved to our file structure but im not doing that for a 2 line change. sorry

**Changelog**
:cl:
- tweak: Removed BROS.