### PR TITLE
crusher dagger nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -167,7 +167,7 @@
     attackRate: 2
     damage:
       types:
-        Slash: 15
+        Slash: 10
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Tag


### PR DESCRIPTION
this thing does as much dps as an energy sword for 0 tc. why

dps comparison chart for similar weapons:
| Name | Damage | Attack Rate | DPS |
| ------- | --------- | ------------- | ---- |
| kitchen knife | 10 | 1 | 10 |
| machete | 15 | 1 | 15 |
| combat/survival knife | 12 | 1.5 | 18 |
| butcher's cleaver | 13 | 1.5 | 19.5 |
| **crusher dagger (NEW)** | 10 | 2 | 20 |
| energy dagger | 20 | 1 | 20 |
| captain's sabre | 17 | 1.5 | 25.5 |
| energy katana | 30 | 1 | 30 |
| energy sword | 30 | 1 | 30 |
| **crusher dagger (OLD)** | 15 | 2 | 30 |

it's a slight reduction in damage for an increase in usability with swing speed. it still one-shots hivelord broods easily. it performs its intended function in salvage

**Changelog**
:cl:
- tweak: Crusher dagger damage reduced from 15 to 10. (30 DPS -> 20 DPS)