### PR TITLE
revert increased AI role timer from upstream

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 54000  # 15 hrs
+    time: 18000  # 5 hrs
   canBeAntag: false
   icon: JobIconStationAi
   supervisors: job-supervisors-rd


### PR DESCRIPTION
i wouldnt wish 15 hours borg on my worst enemy

**Changelog**

:cl:
- tweak: You need 5 hours borg playtime to unlock Station AI again.