### PR TITLE
Fixed artifacts spawning too many things at once

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -644,10 +644,13 @@
     spawns:
     - id: PresentRandom
       prob: 0.95
+      orGroup: present
     - id: PresentRandomUnsafe
       prob: 0.03
+      orGroup: present
     - id: PresentRandomInsane
       prob: 0.02
+      orGroup: present
 
 - type: artifactEffect
   id: EffectAnomaly
@@ -876,10 +879,13 @@
     spawns:
     - id: PresentRandom
       prob: 0.7
+      orGroup: present
     - id: PresentRandomUnsafe
       prob: 0.2
+      orGroup: present
     - id: PresentRandomInsane
       prob: 0.1
+      orGroup: present
 
 - type: artifactEffect
   id: EffectBookSpawnMundane
@@ -891,76 +897,112 @@
     spawns:
     - id: BookRandomStory
       prob: 0.5
+      orGroup: book
     - id: BookGatsby
       prob: 0.05
+      orGroup: book
     - id: BookTEGtorial
       prob: 0.05
+      orGroup: book
     - id: BookClownLaw
       prob: 0.05
+      orGroup: book
     - id: BookAgony
       prob: 0.05
+      orGroup: book
     - id: BookJanitorTale
       prob: 0.05
+      orGroup: book
     - id: BookInspiration
       prob: 0.05
+      orGroup: book
     - id: BookJourney
       prob: 0.05
+      orGroup: book
     - id: BookMap
       prob: 0.05
+      orGroup: book
     - id: BookRufus
       prob: 0.05
+      orGroup: book
     - id: BookMorgue
       prob: 0.05
+      orGroup: book
     - id: BookMedicalOfficer
       prob: 0.05
+      orGroup: book
     - id: BookWatched
       prob: 0.05
+      orGroup: book
     - id: BookTemple
       prob: 0.05
+      orGroup: book
     - id: BookAurora
       prob: 0.05
+      orGroup: book
     - id: BookEarth
       prob: 0.05
+      orGroup: book
     - id: BookNames
       prob: 0.05
+      orGroup: book
     - id: BookIanDesert
       prob: 0.05
+      orGroup: book
     - id: BookIanArctic
       prob: 0.05
+      orGroup: book
     - id: BookIanCity
       prob: 0.05
+      orGroup: book
     - id: BookIanMountain
       prob: 0.05
+      orGroup: book
     - id: BookIanOcean
       prob: 0.05
+      orGroup: book
     - id: BookIanRanch
       prob: 0.05
+      orGroup: book
     - id: BookIanLostWolfPup
       prob: 0.05
+      orGroup: book
     - id: BookFeather
       prob: 0.05
+      orGroup: book
     - id: BookCafe
       prob: 0.05
+      orGroup: book
     - id: BookPossum
       prob: 0.05
+      orGroup: book
     - id: BookSun
       prob: 0.05
+      orGroup: book
     - id: BookStruck
       prob: 0.05
+      orGroup: book
     - id: BookSlothClownMMD
       prob: 0.05
+      orGroup: book
     - id: BookSlothClownPranks
       prob: 0.05
+      orGroup: book
     - id: BookSlothClownSSS
       prob: 0.05
+      orGroup: book
     - id: BookIanAntarctica
       prob: 0.05
+      orGroup: book
     - id: BookWorld
       prob: 0.05
+      orGroup: book
     - id: BookTruth
       prob: 0.05
+      orGroup: book
     - id: BookNarsieLegend
       prob: 0.05
+      orGroup: book
 
 - type: artifactEffect
   id: EffectBookSpawnMagic
@@ -973,22 +1015,31 @@
     spawns:
     - id: WizardsGrimoire
       prob: 0.1
+      orGroup: magicbook
     - id: SpawnSpellbook
       prob: 1
+      orGroup: magicbook
     - id: ForceWallSpellbook
       prob: 1
+      orGroup: magicbook
     - id: BlinkBook
       prob: 1
+      orGroup: magicbook
     - id: SmiteBook
       prob: 0.3
+      orGroup: magicbook
     - id: KnockSpellbook
       prob: 1
+      orGroup: magicbook
     - id: FireballSpellbook
       prob: 1
+      orGroup: magicbook
     - id: SpawnSpaceGreaseSpellbook
       prob: 1
+      orGroup: magicbook
     - id: ScrollRunes
       prob: 1
+      orGroup: magicbook
 
 - type: artifactEffect
   id: EffectSingulo


### PR DESCRIPTION
Added 'orGroup' to the spawns from artifacts so it will only spawn one total (e.g wizard spellbook) instead of one of each.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: fixed too many things spawning from artifacts at one time
