### PR TITLE
derotate atlas until somebody decides to fix it up

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -20,4 +20,4 @@
     FoodButter: 6
     FoodCheese: 2
     FoodMeat: 12
-    
+    RandomIngredientBox: 50

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -1,7 +1,6 @@
 - type: gameMapPool
   id: DefaultMapPool
   maps:
-  - Atlas
   - Bagel
   - Box
   - Cog

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Boxes/chef.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Boxes/chef.yml
@@ -1,0 +1,26 @@
+- type: entity
+  parent: BoxCardboard
+  id: BoxIngredientFiesta
+  name: ingredients box (fiesta)
+  description: A box containing supplementary ingredients for the aspiring chef. The box's theme is 'fiesta'.
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodDoughTortilla
+    - id: FoodCorn
+    - id: FoodSoybeans
+    - id: FoodChiliPepper
+
+- type: entity
+  parent: BoxCardboard
+  id: BoxIngredientItalian
+  name: ingredients box (italian)
+  description: A box containing supplementary ingredients for the aspiring chef. The box's theme is 'italian'.
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodTomato
+    - id: FoodTomato
+    - id: DrinkWineCan
+    - id: FoodMeatMeatball
+    - id: FoodMeatMeatball

--- a/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/Random/Food_Drinks/ingredient_boxes.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/Random/Food_Drinks/ingredient_boxes.yml
@@ -1,0 +1,13 @@
+- type: entity
+  id: RandomIngredientBox
+  name: random ingredient box
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Objects/Storage/boxes.rsi
+      state: box
+  - type: RandomSpawner
+    prototypes:
+      - BoxIngredientFiesta
+      - BoxIngredientItalian


### PR DESCRIPTION
this map is the ultimate lowpop misery and has so many issues. if someone would like to list additional issues in the comments for anyone who wants to fix the map up, go ahead, but in its current state it's just often not fun to play on

current issues that come to mind:
- telecomms apc is on an external wall and gets hit by meteors too easily
- the bridge apcs are outside the bridge for whatever reason, leaving the captain's office easily accessible with two apc dismantlings
- atmos needs lv cables to reach the gas pumps

**Changelog**
:cl:
- remove: Derotated Atlas from the map pool for the time being.