### PR TITLE
buff shittle component prices

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Shuttles/thruster.rsi
     state: base
   product: CrateEngineeringThruster
-  cost: 1500
+  cost: 750 #buffed on imp
   category: cargoproduct-category-name-shuttle
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Structures/Shuttles/gyroscope.rsi
     state: base
   product: CrateEngineeringGyroscope
-  cost: 4000
+  cost: 2000 #buffed on imp
   category: cargoproduct-category-name-shuttle
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Shuttles/thruster.rsi
     state: base
   product: CrateEngineeringThruster
-  cost: 750 #buffed on imp
+  cost: 650 #buffed on imp
   category: cargoproduct-category-name-shuttle
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -14,7 +14,7 @@
     sprite: Structures/Shuttles/gyroscope.rsi
     state: base
   product: CrateEngineeringGyroscope
-  cost: 2000 #buffed on imp
+  cost: 4000
   category: cargoproduct-category-name-shuttle
   group: market
 

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
@@ -14,7 +14,7 @@
     sprite: Clothing/Head/Helmets/eva_large.rsi
     state: icon
   product: CrateEngineeringShittle
-  cost: 2000
+  cost: 2500
   category: cargoproduct-category-name-shuttle
   group: market
 

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
@@ -4,7 +4,7 @@
     sprite: _Impstation/Structures/Shuttles/minigyroscope.rsi
     state: base
   product: CrateEngineeringMiniGyroscope
-  cost: 500
+  cost: 1000
   category: cargoproduct-category-name-shuttle
   group: market
 

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
@@ -4,7 +4,7 @@
     sprite: _Impstation/Structures/Shuttles/minigyroscope.rsi
     state: base
   product: CrateEngineeringMiniGyroscope
-  cost: 800
+  cost: 500
   category: cargoproduct-category-name-shuttle
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Clothing/Head/Helmets/eva_large.rsi
     state: icon
   product: CrateEngineeringShittle
-  cost: 5000
+  cost: 2000
   category: cargoproduct-category-name-shuttle
   group: market
 

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_shuttle.yml
@@ -14,7 +14,7 @@
     sprite: Clothing/Head/Helmets/eva_large.rsi
     state: icon
   product: CrateEngineeringShittle
-  cost: 2500
+  cost: 2750
   category: cargoproduct-category-name-shuttle
   group: market
 

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
@@ -19,3 +19,4 @@
       - id: ThrusterFlatpack
       - id: MiniGyroscopeFlatpack
       - id: ShuttleConsoleCircuitboard
+      - id: PortableGeneratorJrPacmanMachineCircuitboard

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
@@ -20,3 +20,4 @@
       - id: MiniGyroscopeFlatpack
       - id: ShuttleConsoleCircuitboard
       - id: PortableGeneratorJrPacmanMachineCircuitboard
+      - id: JugWeldingFuel


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Shittles are time consuming, expensive, fragile, and serve no real purpose other than being really fun to build and fly. With current prices its generally better to wait and buy the reclaimer than it is to order the parts and spend the time nessecary to have a shittle up and running. Previously, the parts for a PTA shittle would run you 9.5k spesos, when buying a reclaimer outright costs 17k.

Its worth noting that even with the slashed prices and extra crate contents, youre still paying over double the sell value for the contents of the crate.
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Drastically reduced the cost of cargo ordering shuttle parts.
- tweak: The Shittle builders crate now contains a PACMAN-JR machine board and a jug of welding fuel.
