### PR TITLE
Rainbow crayon uses upped, added infinite rainbow crayon

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -91,7 +91,7 @@
   - type: Crayon
     color: Red
     selectableColor: true
-    capacity: 30
+    capacity: 200
   - type: Tag
     tags:
     - Write

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/crayons.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: CrayonRainbow
+  id: CrayonRainbowInfinite
+  suffix: infinite
+  components:
+  - type: Crayon
+    color: Red
+    selectableColor: true
+    infinite: true

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/crayons.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: CrayonRainbow
   id: CrayonRainbowInfinite
-  suffix: infinite
+  suffix: Infinite
   components:
   - type: Crayon
     color: Red


### PR DESCRIPTION
Bringing the rainbow crayon into the new era as well, also added an infinite rainbow crayon. 

:cl:
- add: Legends tell of an infinite rainbow crayon, forged by the gods for the truly dedicated...
- tweak: Normal rainbow crayons now have 200 charges to match the crayon update

