### PR TITLE
Security crates now have anti-tamper countermeasures installed

### DIFF
--- a/Content.Server/_Impstation/Container/AntiTamper/AntiTamperComponent.cs
+++ b/Content.Server/_Impstation/Container/AntiTamper/AntiTamperComponent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Server._Impstation.Container.AntiTamper;
+
+/// <summary>
+/// When a locked container with this component is destroyed, it will
+/// acidify the contents.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AntiTamperComponent : Component
+{
+    /// <summary>
+    /// List of containers to acidify. If null,
+    /// all containers will acidify.
+    /// </summary>
+    [DataField]
+    public HashSet<string>? Containers;
+
+    [DataField]
+    public LocId Message = "anti-tamper-contents-destroyed";
+
+    [DataField]
+    public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/Items/soda_spray.ogg");
+}

--- a/Content.Server/_Impstation/Container/AntiTamper/AntiTamperSystem.cs
+++ b/Content.Server/_Impstation/Container/AntiTamper/AntiTamperSystem.cs
@@ -1,0 +1,48 @@
+using Content.Server.Sound;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Audio;
+using Content.Shared.Destructible;
+using Content.Shared.Lock;
+using Content.Shared.Popups;
+using Content.Shared.Storage;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
+
+namespace Content.Server._Impstation.Container.AntiTamper;
+
+public sealed partial class AntiTamperSystem : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly LockSystem _lockSystem = default!;
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AntiTamperComponent, DestructionEventArgs>(OnDestroy, before: [typeof(EntityStorageSystem)]);
+    }
+
+    private void OnDestroy(EntityUid uid, AntiTamperComponent comp, DestructionEventArgs args)
+    {
+        if (!TryComp<ContainerManagerComponent>(uid, out var containerManager))
+            return;
+
+        if (!_lockSystem.IsLocked(uid))
+            return;
+
+        foreach (var container in _containerSystem.GetAllContainers(uid, containerManager))
+        {
+            if (comp.Containers != null && !comp.Containers.Contains(container.ID))
+                continue;
+
+            _containerSystem.CleanContainer(container);
+        }
+
+        var coords = Transform(uid).Coordinates;
+
+        _popupSystem.PopupCoordinates(Loc.GetString(comp.Message, ("container", uid)), coords, PopupType.SmallCaution);
+        _audioSystem.PlayPvs(comp.Sound, coords);
+    }
+}

--- a/Resources/Locale/en-US/_Impstation/anti-tamper.ftl
+++ b/Resources/Locale/en-US/_Impstation/anti-tamper.ftl
@@ -1,0 +1,1 @@
+anti-tamper-contents-destroyed = The anti-tamper system acidifies the contents of {THE($container)}!

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -290,6 +290,10 @@
     sprite: Structures/Storage/Crates/weapon.rsi
   - type: AccessReader
     access: [["Armory"]]
+  - type: AntiTamper
+    containers:
+      - entity_storage
+
 
 - type: entity
   parent: [ CrateBaseSecure, BaseRestrictedContraband ]

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -186,6 +186,9 @@
     sprite: Structures/Storage/Crates/sec_gear.rsi
   - type: AccessReader
     access: [["Security"]]
+  - type: AntiTamper
+    containers:
+      - entity_storage
 
 - type: entity
   parent: CrateBaseSecure


### PR DESCRIPTION
Locked security crates will now acidify their contents upon being destroyed. This is a change to prevent cargo from arming themselves up with no way for security to stop them.

https://github.com/user-attachments/assets/b57502d0-0afe-4d80-9d3c-ca7037e6c5b0

**Changelog**

:cl:
- tweak: Security crates now come with an anti-tamper module that acidifies the contents of the box, which will activate if the box is destroyed while locked.
