### PR TITLE
Adds "All Aboard The Ship"

### DIFF
--- a/Resources/Locale/en-US/_Impstation/game-ticking/game-presets/preset-allaboard.ftl
+++ b/Resources/Locale/en-US/_Impstation/game-ticking/game-presets/preset-allaboard.ftl
@@ -1,0 +1,2 @@
+allaboard-title = All Aboard The Ship!
+allaboard-description = WE CAN MAKE IT WORSE!!!

--- a/Resources/Prototypes/_Impstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/roundstart.yml
@@ -68,3 +68,33 @@
       forceAllPossible: true
       mindRoles:
       - MindRoleTraitor
+
+- type: entity
+  parent: BaseTraitorRuleNoRandomObjectives
+  id: SpyVsSpy20TC
+  components:
+  - type: TraitorRule
+    startingBalance: 20
+  - type: GameRule
+    minPlayers: 15
+    delay:
+      min: 240
+      max: 420
+  - type: AntagObjectives
+    objectives:
+    - KillRandomTraitorSvSObjective
+    - RandomTraitorAliveSvSObjective
+    - EscapeShuttleObjective
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      fallbackRoles: [ TraitorSleeper ]
+      max: 100
+      playerRatio: 1
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      forceAllPossible: true
+      mindRoles:
+      - MindRoleTraitor

--- a/Resources/Prototypes/_Impstation/game_presets.yml
+++ b/Resources/Prototypes/_Impstation/game_presets.yml
@@ -1,0 +1,21 @@
+- type: gamePreset
+  id: AllAboardTheShip
+  alias:
+  - svsaller
+  name: allaboard-title
+  description: allaboard-description
+  showInVote: false #lol. lmao
+  rules:
+    - Nukeops
+    - SpyVsSpy20TC
+    - Revolutionary
+    - Zombie
+    - Changeling
+    - BasicStationEventScheduler
+    - KesslerSyndromeScheduler
+    - MeteorSwarmMildScheduler
+    - MeteorSwarmScheduler
+    - RampingStationEventScheduler
+    - SpaceTrafficControlEventScheduler
+    - SpaceTrafficControlFriendlyEventScheduler
+    - BasicRoundstartVariation


### PR DESCRIPTION
adds all aboard the ship, an aller at once variant gamemode that swaps traitor for 20 TC SVS. this is primarily intended for playtesting for a theoretical "allest at once" that is aller at once + 20 TC SVS + all antag immune blacklists removed. 

i couldnt test this locally as much as i'd like; the gamemode shows up for admins to select but i could not start a round with it because i did not want to deal with having 20 clients open at once. and also the only way to _really_ test aller is to force 50 people to play it

oh yeah i added 20 tc SVS

**Changelog**
:cl:
- add: ALL ABOARD!!!!
