### PR TITLE
Added functionality to Decapoid vaporizers and vapor tanks

### DIFF
--- a/Content.Server/_Impstation/Decapoids/Components/VaporizerComponent.cs
+++ b/Content.Server/_Impstation/Decapoids/Components/VaporizerComponent.cs
@@ -1,0 +1,36 @@
+using Content.Shared.Atmos;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Decapoids.Components;
+
+[RegisterComponent]
+[AutoGenerateComponentPause]
+public sealed partial class VaporizerComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string LiquidTank = "waterTank";
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public ProtoId<ReagentPrototype> ExpectedReagent = "Water";
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public Gas OutputGas = Gas.WaterVapor;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 MaxPressure = Atmospherics.OneAtmosphere * 10;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ReagentToMoles = 0.07f;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 ReagentPerSecond = 0.09;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan ProcessDelay = TimeSpan.FromMilliseconds(200);
+
+    [DataField(readOnly: true), ViewVariables(VVAccess.ReadOnly)]
+    [AutoPausedField]
+    public TimeSpan NextProcess = new();
+}

--- a/Content.Server/_Impstation/Decapoids/EntitySystems/VaporizerSystem.cs
+++ b/Content.Server/_Impstation/Decapoids/EntitySystems/VaporizerSystem.cs
@@ -1,0 +1,55 @@
+using Content.Server.Atmos.Components;
+using Content.Server.Decapoids.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Decapoids.EntitySystems;
+
+public sealed partial class VaporizerSystem : EntitySystem
+{
+    [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    private void ProcessVaporizerTank(EntityUid uid, VaporizerComponent vaporizer, GasTankComponent gasTank, SolutionContainerManagerComponent solutionManager)
+    {
+        if (gasTank.Air.Pressure >= vaporizer.MaxPressure)
+            return;
+
+        if (!_solution.TryGetSolution((uid, solutionManager), vaporizer.LiquidTank, out var ent, out var solution))
+            return;
+
+        // Validate solution
+        var valid = true;
+        ReagentQuantity? consumeReagent = null;
+        foreach (var reagent in solution.Contents)
+        {
+            if (reagent.Reagent.Prototype != vaporizer.ExpectedReagent)
+            {
+                valid = false;
+                break;
+            }
+            consumeReagent ??= reagent;
+        }
+        if (!valid || !consumeReagent.HasValue)
+            return;
+
+        var reagentConsumed = solution.RemoveReagent(new ReagentQuantity(consumeReagent.Value.Reagent, vaporizer.ReagentPerSecond * vaporizer.ProcessDelay.TotalSeconds));
+        gasTank.Air.AdjustMoles((int)vaporizer.OutputGas, (float)reagentConsumed * vaporizer.ReagentToMoles);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var enumerator = EntityQueryEnumerator<VaporizerComponent, GasTankComponent, SolutionContainerManagerComponent>();
+
+        while (enumerator.MoveNext(out var uid, out var vaporizer, out var gasTank, out var solutionManager))
+        {
+            if (_gameTiming.CurTime >= vaporizer.NextProcess)
+            {
+                ProcessVaporizerTank(uid, vaporizer, gasTank, solutionManager);
+                vaporizer.NextProcess = _gameTiming.CurTime + vaporizer.ProcessDelay;
+            }
+        }
+    }
+}

--- a/Content.Server/_Impstation/Speech/Components/SpeechRequiresEquipmentComponent.cs
+++ b/Content.Server/_Impstation/Speech/Components/SpeechRequiresEquipmentComponent.cs
@@ -1,0 +1,15 @@
+using Content.Server.Speech.EntitySystems;
+using Content.Shared.Whitelist;
+
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+[Access(typeof(SpeechRequiresEquipmentSystem))]
+public sealed partial class SpeechRequiresEquipmentComponent : Component
+{
+    [DataField(required: true)]
+    public Dictionary<string, EntityWhitelist> Equipment;
+
+    [DataField]
+    public LocId? FailMessage;
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/SpeechRequiresEquipmentSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/SpeechRequiresEquipmentSystem.cs
@@ -1,0 +1,52 @@
+using Content.Server.Speech.Components;
+using Content.Shared.Inventory;
+using Content.Shared.Popups;
+using Content.Shared.Speech;
+using Content.Shared.Whitelist;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed partial class SpeechRequiresEquipmentSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SpeechRequiresEquipmentComponent, SpeakAttemptEvent>(OnSpeechAttempt);
+    }
+
+    public void OnSpeechAttempt(Entity<SpeechRequiresEquipmentComponent> ent, ref SpeakAttemptEvent args)
+    {
+        var canSpeak = true;
+
+        foreach (var (slot, whitelist) in ent.Comp.Equipment)
+        {
+            if (!_inventory.TryGetSlotEntity(ent, slot, out var item))
+            {
+                canSpeak = false;
+                break;
+            }
+
+            if (_whitelist.IsWhitelistFail(whitelist, item.Value))
+            {
+                canSpeak = false;
+                break;
+            }
+        }
+
+        // TODO: SpeakAttemptEvent should be modified to include an optional LocId
+        // reason for why the speak attempt was cancelled.
+        if (!canSpeak)
+        {
+            args.Cancel();
+            if (ent.Comp.FailMessage != null)
+            {
+                _popup.PopupEntity(Loc.GetString(ent.Comp.FailMessage), ent, ent);
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Impstation/species/decapoid.ftl
+++ b/Resources/Locale/en-US/_Impstation/species/decapoid.ftl
@@ -1,0 +1,1 @@
+decapoid-cant-speak = You can't speak without a vaporizer mask!

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -20,6 +20,12 @@
   - type: Loadout
     prototypes:
       - StartingGearDecapoidClaw
+  - type: SpeechRequiresEquipment
+    equipment:
+      mask:
+        tags:
+          - Vaporizer
+    failMessage: decapoid-cant-speak
   - type: Respirator # todo: give the ability to generate their own vapor
     damage:
       types:
@@ -48,7 +54,7 @@
     - map: [ "id" ]
     - map: [ "back" ]
     - map: [ "enum.HumanoidVisualLayers.LLeg" ] # this is the front legs
-    - map: [ "enum.HumanoidVisualLayers.LFoot" ] # this is the front feet 
+    - map: [ "enum.HumanoidVisualLayers.LFoot" ] # this is the front feet
     - map: [ "enum.HumanoidVisualLayers.LHand" ] # this is the crab claw. has to render in front of the whole body
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
@@ -93,13 +99,13 @@
         - MobMask
         layer:
         - MobLayer
-  - type: Damageable 
+  - type: Damageable
     damageContainer: Biological
     damageModifierSet: Decapoid
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:
-        sprite: _Impstation/Mobs/Effects/decapoid_brute_damage.rsi 
+        sprite: _Impstation/Mobs/Effects/decapoid_brute_damage.rsi
         color: "#162581"
   - type: Reactive
     groups:
@@ -111,10 +117,10 @@
       Unsexed: UnisexSilicon
   - type: MovementSpeedModifier
     baseSprintSpeed: 3.5
-    baseWalkSpeed: 1.5 
+    baseWalkSpeed: 1.5
     weightlessAcceleration: 1.5 # move more easily in space
     weightlessFriction: 1 # more control over movement in space?
-    weightlessModifier: 1 
+    weightlessModifier: 1
   - type: Temperature
     heatDamageThreshold: 380 # slightly more vulnerable to heat
     coldDamageThreshold: 0 # immune to space
@@ -137,7 +143,7 @@
         Blunt: 5
     clumsySound:
       path: /Audio/_Impstation/Effects/Clumsy/crab_snap.ogg # the game gets really touchy about having that initial forward slash.
-    
+
   - type: Bloodstream
     bloodReagent: CopperBlood # real life crustaceans are in the same clade as spiders and share a blood type
   - type: Puller
@@ -159,7 +165,7 @@
         sizeMaps:
           32:
             sprite: _Impstation/Mobs/Species/Decapoid/displacement.rsi
-            state: jumpsuit # todo: custom? (accomodate gills?) 
+            state: jumpsuit # todo: custom? (accomodate gills?)
       gloves:
         sizeMaps:
           32:
@@ -170,7 +176,7 @@
           32:
             sprite: _Impstation/Mobs/Species/Decapoid/displacement.rsi
             state: neck
-            
+
 
   - type: Speech
     speechSounds: Borg
@@ -212,7 +218,7 @@
     - map: [ "id" ]
     - map: [ "back" ]
     - map: [ "enum.HumanoidVisualLayers.LLeg" ] # this is the front legs
-    - map: [ "enum.HumanoidVisualLayers.LFoot" ] # this is the front feet 
+    - map: [ "enum.HumanoidVisualLayers.LFoot" ] # this is the front feet
     - map: [ "enum.HumanoidVisualLayers.LHand" ] # this is the crab claw. has to render in front of the whole body
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
@@ -251,7 +257,7 @@
         sizeMaps:
           32:
             sprite: _Impstation/Mobs/Species/Decapoid/displacement.rsi
-            state: jumpsuit # todo: custom? (accomodate gills?) 
+            state: jumpsuit # todo: custom? (accomodate gills?)
       gloves:
         sizeMaps:
           32:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decapoid/decapoid_items.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decapoid/decapoid_items.yml
@@ -18,20 +18,22 @@
         Piercing: 15 # probably nerf this once they're non-antags
         Structural: 15
     soundHit:
-      collection: AlienClaw 
+      collection: AlienClaw
   - type: Unremoveable
 
 - type: entity
   name: vaporizer
-  suffix: Unremoveable # remove this once their speech system works
   parent: ClothingMaskGas
   id: DecapoidBreathingApparatus
   description: 'A neck-mounted breathing apparatus for decapoids. Moistens your gills, if you have them. Also functions as a brain-to-voice translator.'
   components:
-  - type: Unremoveable # remove this once their speech system works
   - type: Sprite
     sprite: _Impstation/Objects/Decapoid/vaporizer.rsi # todo: custom. obviously. also todo: make it able to take in water, convert it to vapor, and internals that steam into the lungs.
     state: icon
+  - type: Tag
+    tags:
+      - Vaporizer
+      - BreathMask
   - type: Clothing
     quickEquip: true
     slots:
@@ -46,7 +48,7 @@
   - type: HideLayerClothing
     slots:
     - Snout
-     
+
 
 - type: entity
   name: vapor tank
@@ -88,4 +90,3 @@
         - 0 # tritium
         - 2.051379050 # water vapor
       temperature: 293.15
-    

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decapoid/decapoid_items.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decapoid/decapoid_items.yml
@@ -90,3 +90,17 @@
         - 0 # tritium
         - 2.051379050 # water vapor
       temperature: 293.15
+  - type: SolutionContainerManager
+    solutions:
+      waterTank:
+        maxVol: 30
+  - type: RefillableSolution
+    solution: waterTank
+  - type: ExaminableSolution
+    solution: waterTank
+  - type: Spillable
+    solution: waterTank
+  - type: Vaporizer
+    # TODO: SolutionContainerVisuals
+    # Being able to see how much water is left would be nice
+    # This is left as an exercise to the spriter :ignorant:

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -3,3 +3,6 @@
 
 - type: Tag
   id: WeaponCleanerLakeUpgradeKit
+
+- type: Tag
+  id: Vaporizer


### PR DESCRIPTION
This adds the `SpeechRequiresEquipment` component, which prevents speech if the mob's worn equipment does not pass a whitelist check. This has been applied to the Decapoid so that they can only speak if their `mask` equipment contains the `Vaporizer` tag.

This also adds functionality to the decapoid's "vapor tank". It has a 30u water chamber which will slowly convert water to water vapor. Some unaddressed problems of the vapor tank:
- Vapor tanks cannot directly pull from water tanks, and need to be poured into from a separate solution container (like a beaker)
- Vapor tanks do not indicate how much water is in them unless you have chemical analysis goggles
- Vapor tanks will not generate water vapor if a non-water reagent is present in the chamber. There is currently no indicator when this happens.

Closes #634.