### PR TITLE
tranquilizer shells are useful now

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -117,7 +117,7 @@
     solutions:
       ammo:
         reagents:
-        - ReagentId: ChloralHydrate
+        - ReagentId: Nocturine
           Quantity: 7
   - type: SolutionTransfer
     maxTransferAmount: 7


### PR DESCRIPTION
they had chloral hydrate previously, but ages ago chloral hydrate was changed to cause drowsiness instead of forced sleep. this seems to be the cleanest way to fix this even if it technically means sec is using syndicate contraband

**Changelog**
:cl:
- tweak: Tranquilizer shells have nocturine in them, making them actually usable again
