### PR TITLE
Station AI gets a special notif

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -9,6 +9,7 @@
     role: JobBorg
     time: 54000  # 15 hrs
   canBeAntag: false
+  joinNotifyCrew: true
   icon: JobIconStationAi
   supervisors: job-supervisors-rd
   jobEntity: StationAiBrain


### PR DESCRIPTION
yes i am procrastinating on space law edits

Station AI now gets the same gold "(player) is on deck!" notice that a latejoining captain does 
![SS14 Loader_8d2M72zczf](https://github.com/user-attachments/assets/066c7f60-b689-4419-ad8a-af043fe6f6a8)

i would prefer it had a different message but that would require c# coding that im not smart enough to do. rn this just makes it more obvious when an AI latejoins which is good enough for me

**Changelog**
:cl:
- tweak: Latejoining AI now has a special message broadcast.
