### PR TITLE
ore bags can hold salt again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -25,4 +25,5 @@
       tags:
         - ArtifactFragment
         - Ore
+        - Salt
   - type: Dumpable


### PR DESCRIPTION
im guessing that salt lost the ore tag at some point but idk the implications of that. so ore bags can hold anything tagged salt now

**Changelog**
:cl:
- fix: Ore bags can hold salt again.