### PR TITLE
Added Quick Construction menu from Einstein Engine

### DIFF
--- a/Content.Client/_EinsteinEngine/ShortConstruction/UI/ShortConstructionMenu.xaml
+++ b/Content.Client/_EinsteinEngine/ShortConstruction/UI/ShortConstructionMenu.xaml
@@ -1,0 +1,11 @@
+<ui:RadialMenu xmlns="https://spacestation14.io"
+                xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+                BackButtonStyleClass="RadialMenuBackButton"
+                CloseButtonStyleClass="RadialMenuCloseButton"
+                VerticalExpand="True"
+                HorizontalExpand="True"
+                MinSize="450 450">
+
+
+    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False"></ui:RadialContainer>
+</ui:RadialMenu>

--- a/Content.Client/_EinsteinEngine/ShortConstruction/UI/ShortConstructionMenu.xaml.cs
+++ b/Content.Client/_EinsteinEngine/ShortConstruction/UI/ShortConstructionMenu.xaml.cs
@@ -1,0 +1,110 @@
+using System.Numerics;
+using Content.Client.Construction;
+using Content.Client.UserInterface.Controls;
+using Content.Shared._EinsteinEngine.ShortConstruction;
+using Content.Shared.Construction.Prototypes;
+using Content.Shared.Popups;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Placement;
+using Robust.Client.Player;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.XAML;
+using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._EinsteinEngine.ShortConstruction.UI;
+
+//This was originally a PR for Einstein's Engines, submitted by Github user VMSolidus.
+//https://github.com/Simple-Station/Einstein-Engines/pull/861
+//It has been modified to work within the Imp Station 14 server fork by Honeyed_Lemons.
+
+public sealed class ShortConstructionMenu : RadialMenu
+{
+    [Dependency] private readonly IClyde _displayManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly EntityManager _entManager = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly IPlacementManager _placementManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    private readonly ConstructionSystem _construction;
+
+    private readonly SpriteSystem _spriteSystem;
+    private readonly SharedPopupSystem _popup;
+
+    private EntityUid _owner;
+
+    public ShortConstructionMenu(EntityUid owner, ShortConstructionMenuBUI bui, ConstructionSystem construction)
+    {
+        IoCManager.InjectDependencies(this);
+        RobustXamlLoader.Load(this);
+
+        _spriteSystem = _entManager.System<SpriteSystem>();
+        _popup = _entManager.System<SharedPopupSystem>();
+
+        _owner = owner;
+        _construction = construction;
+
+        // Find the main radial container
+        var main = FindControl<RadialContainer>("Main");
+
+        if (!_entManager.TryGetComponent<ShortConstructionComponent>(owner, out var crafting))
+            return;
+        foreach (var protoId in crafting.Prototypes)
+        {
+            if (_playerManager.LocalSession == null)
+                return;
+            if (!_protoManager.TryIndex(protoId, out var proto))
+                continue;
+
+            var button = new RadialMenuTextureButton
+            {
+                ToolTip = Loc.GetString(proto.Name),
+                StyleClasses = { "RadialMenuButton" },
+                SetSize = new Vector2(48f, 48f)
+            };
+
+            var texture = new TextureRect
+            {
+                VerticalAlignment = Control.VAlignment.Center,
+                HorizontalAlignment = Control.HAlignment.Center,
+                Texture = _spriteSystem.Frame0(proto.Icon),
+                TextureScale = new Vector2(1.5f, 1.5f)
+            };
+
+            button.AddChild(texture);
+
+            main.AddChild(button);
+
+            button.OnButtonUp += _ =>
+            {
+                Close();
+                ConstructItem(proto);
+            };
+        }
+
+    }
+    /// <summary>
+    /// Makes an item or places a schematic based on the type of construction recipe.
+    /// </summary>
+    private void ConstructItem(ConstructionPrototype prototype)
+    {
+        if (prototype.Type == ConstructionType.Item)
+        {
+            _construction.TryStartItemConstruction(prototype.ID);
+            return;
+        }
+
+        _placementManager.BeginPlacing(new PlacementInformation
+            {
+                IsTile = false,
+                PlacementOption = prototype.PlacementMode
+            },
+            new ConstructionPlacementHijack(_construction, prototype));
+
+        // Should only close the menu if we're placing a construction hijack.
+        Close();
+    }
+}

--- a/Content.Client/_EinsteinEngine/ShortConstruction/UI/ShortConstructionMenuBUI.cs
+++ b/Content.Client/_EinsteinEngine/ShortConstruction/UI/ShortConstructionMenuBUI.cs
@@ -1,0 +1,56 @@
+using Content.Client.Construction;
+using Content.Client.UserInterface.Controls;
+using Content.Shared.Construction.Prototypes;
+using JetBrains.Annotations;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Placement;
+using Robust.Shared.Enums;
+
+//This was originally a PR for Einstein's Engines, submitted by Github user VMSolidus.
+//https://github.com/Simple-Station/Einstein-Engines/pull/861
+//It has been modified to work within the Imp Station 14 server fork by Honeyed_Lemons.
+
+// ReSharper disable InconsistentNaming
+
+namespace Content.Client._EinsteinEngine.ShortConstruction.UI;
+
+[UsedImplicitly]
+public sealed class ShortConstructionMenuBUI : BoundUserInterface
+{
+    [Dependency] private readonly IClyde _displayManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly EntityManager _entManager = default!;
+
+    private readonly ConstructionSystem _construction;
+
+    private ShortConstructionMenu? _menu;
+
+    public ShortConstructionMenuBUI(EntityUid owner, Enum uiKey) : base(owner, uiKey)
+    {
+        _construction = _entManager.System<ConstructionSystem>();
+        _entManager.System<SpriteSystem>();
+    }
+
+
+    protected override void Open()
+    {
+        base.Open();
+
+        _menu = new ShortConstructionMenu(Owner, this,_construction);
+        _menu.OnClose += Close;
+
+        // Open the menu, centered on the mouse
+        var vpSize = _displayManager.ScreenSize;
+        _menu.OpenCenteredAt(_inputManager.MouseScreenPosition.Position / vpSize);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (!disposing) return;
+
+        _menu?.Dispose();
+    }
+}

--- a/Content.Shared/_EinsteinEngine/ShortConstruction/ShortConstructionComponent.cs
+++ b/Content.Shared/_EinsteinEngine/ShortConstruction/ShortConstructionComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Construction.Prototypes;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._EinsteinEngine.ShortConstruction;
+
+//This was originally a PR for Einstein's Engines, submitted by Github user VMSolidus.
+//https://github.com/Simple-Station/Einstein-Engines/pull/861
+//It has been modified to work within the Imp Station 14 server fork by Honeyed_Lemons.
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ShortConstructionComponent : Component
+{
+    [DataField(required: true)]
+    public List<ProtoId<ConstructionPrototype>> Prototypes = new();
+}
+
+[NetSerializable, Serializable]
+public enum ShortConstructionUiKey : byte
+{
+    Key,
+}

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -85,6 +85,16 @@
         reagents:
         - ReagentId: Silicon
           Quantity: 10
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - Window
+    - WindowDirectional
 
 - type: entity
   parent: SheetGlass

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -69,6 +69,19 @@
           Quantity: 9
         - ReagentId: Carbon
           Quantity: 1
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - Girder
+    - MetalRod
+    - TileSteel
+    - TileWhite
+    - TileDark
 
 - type: entity
   parent: SheetSteel

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -68,6 +68,15 @@
           Quantity: 4.5
         - ReagentId: Carbon
           Quantity: 0.5
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - Grille
 
 - type: entity
   parent: PartRodMetal


### PR DESCRIPTION
Press Z or click on the material to open a radial menu for certain materials (currently only rods, glass, and steel), and quickly build
:cl:
- add: Quick Construction menu from Einstein Engine,