### PR TITLE
Add juice that makes you UNGH to liquid anomalies

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -338,6 +338,7 @@
         - ReagentSlimeChlorineTrifluoride
         - ReagentSlimeHonk
         - ReagentSlimeIpecac
+        - ReagentSlimeJuiceThatMakesYouUngh
       chance: 1
 
 - type: entity
@@ -821,3 +822,20 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
         color: "#102000"
+
+- type: entity
+  id: ReagentSlimeJuiceThatMakesYouUngh
+  parent: ReagentSlime
+  suffix: JuiceThatMakesYouUngh
+  components:
+  - type: Bloodstream
+    bloodReagent: JuiceThatMakesYouUngh
+  - type: PointLight
+    color: "#8F3134"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#8F3134"

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -807,6 +807,7 @@
     - Testosterone
     - Estradiol
     - Genderfluid
+    - JuiceThatMakesYouUngh
   - type: Drink
     solution: anomaly
   - type: DrainableSolution

--- a/Resources/Prototypes/_Impstation/Reagents/fun.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/fun.yml
@@ -65,9 +65,6 @@
       - !type:Polymorph
         prototype: PolymorphBros
         conditions:
-        - !type:OrganType
-          type: Animal
-          shouldHave: false
         - !type:ReagentThreshold
           min: 50
       - !type:AdjustReagent


### PR DESCRIPTION
Adds juice that makes you UNGH to liquid anomalies along with reagent slimes. Also fixed juice that makes you UNGH not transforming species with animal organs.

**Changelog**

:cl:
- add: Juice that makes you UNGH added to liquid anomalies and reagent slimes.
- fix: Juice that makes you UNGH will now properly transform all species.
