### PR TITLE
fixed contraband on the beanbag kammerer and bandolier

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -29,16 +29,6 @@
   group: market
 
 - type: cargoProduct
-  id: SecurityShotgunNonLethal
-  icon:
-    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump.rsi
-    state: icon
-  product: CrateSecurityShotgunNonlethal
-  cost: 2000
-  category: cargoproduct-category-name-security
-  group: market
-
-- type: cargoProduct
   id: SecurityRiot
   icon:
     sprite: Clothing/OuterClothing/Armor/riot.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/security.yml
@@ -21,19 +21,6 @@
         amount: 3
 
 - type: entity
-  id: CrateSecurityShotgunNonlethal
-  parent: CrateSecgear
-  name: nonlethal shotgun crate
-  description: For when you need to break some ribs. Contains two Beanbag Kammerer shotguns with extra ammunition. Requires Security access to open.
-  components:
-  - type: StorageFill
-    contents:
-      - id: WeaponShotgunKammererBeanbag
-        amount: 2
-      - id: BoxBeanbag
-        amount: 3
-
-- type: entity
   id: CrateSecurityNonlethal
   parent: CrateSecgear
   name: nonlethals crate

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -541,7 +541,7 @@
 # Belts without visualizers
 
 - type: entity
-  parent: [ClothingBeltAmmoProviderBase, BaseMinorContraband]
+  parent: [ClothingBeltAmmoProviderBase, BaseMinorCivilianContraband]
   id: ClothingBeltBandolier
   name: bandolier
   description: A bandolier for holding shotgun ammunition.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -157,36 +157,6 @@
     proto: ShellShotgunBeanbag
 
 - type: entity
-  name: Beanbag Enforcer
-  parent: WeaponShotgunEnforcer
-  id: WeaponShotgunEnforcerBeanbag
-  description: A premium combat shotgun with an extended magazine and a built-in silencer, modified to only accept .50 beanbag shotgun shells. Carry gauze.
-  components:
-  - type: Sprite
-    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagenforcer.rsi
-  - type: Clothing
-    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagenforcer.rsi
-  - type: Item
-    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagenforcer_inhands_64x.rsi
-  - type: Gun
-    fireRate: 2
-    selectedMode: SemiAuto
-    availableModes:
-    - SemiAuto
-    soundGunshot:
-      path: /Audio/_Impstation/Weapons/Guns/Gunshots/silenced2.ogg
-    soundEmpty:
-      path: /Audio/Weapons/Guns/Empty/empty.ogg
-  - type: BallisticAmmoProvider
-    whitelist:
-      tags:
-      - ShellShotgunBeanbag
-    capacity: 7
-    proto: ShellShotgunBeanbag
-    soundInsert:
-      path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
-
-- type: entity
   name: Kammerer
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponShotgunKammerer
@@ -207,39 +177,6 @@
   - type: Tag
     tags:
     - WeaponShotgunKammerer
-
-- type: entity
-  name: Beanbag Kammerer
-  parent:  [BaseWeaponShotgun, BaseGunWieldable, BaseMinorContraband]
-  id: WeaponShotgunKammererBeanbag
-  description: A pump shotgun with a built-in silencer, modified to only accept .50 beanbag shotgun shells. Carry gauze.
-  components:
-  - type: Item
-    size: Normal
-    shape:
-    - 0,0,4,0
-    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump_inhands_64x.rsi
-  - type: Sprite
-    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump.rsi
-  - type: Clothing
-    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump.rsi
-  - type: Gun
-    fireRate: 2
-    selectedMode: SemiAuto
-    availableModes:
-    - SemiAuto
-    soundGunshot:
-      path: /Audio/_Impstation/Weapons/Guns/Gunshots/silenced2.ogg
-    soundEmpty:
-      path: /Audio/Weapons/Guns/Empty/empty.ogg
-  - type: BallisticAmmoProvider
-    whitelist:
-      tags:
-      - ShellShotgunBeanbag
-    capacity: 4
-    proto: ShellShotgunBeanbag
-    soundInsert:
-      path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
 
 - type: entity
   name: sawn-off shotgun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -103,7 +103,7 @@
 
 - type: entity
   name: double-barreled shotgun
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseMinorContraband]
+  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseMinorSecurityCivilianContraband]
   id: WeaponShotgunDoubleBarreled
   description: An immortal classic. Uses .50 shotgun shells.
   components:
@@ -180,7 +180,7 @@
 
 - type: entity
   name: sawn-off shotgun
-  parent: BaseWeaponShotgun
+  parent: [BaseWeaponShotgun, BaseMinorSecurityCivilianContraband]
   id: WeaponShotgunSawn
   description: Groovy! Uses .50 shotgun shells.
   components:

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -614,27 +614,9 @@
     Plastic: 200
 
 - type: latheRecipe
-  parent: BaseWeaponRecipe
-  id: WeaponShotgunKammererBeanbag
-  result: WeaponShotgunKammererBeanbag
-  materials:
-    Steel: 300
-    Glass: 200
-    Plastic: 200
-
-- type: latheRecipe
   parent: WeaponDisabler
   id: WeaponDisablerSMG
   result: WeaponDisablerSMG
-  materials:
-    Steel: 1000
-    Glass: 500
-    Plastic: 500
-
-- type: latheRecipe
-  parent: BaseWeaponRecipe
-  id: WeaponShotgunEnforcerBeanbag
-  result: WeaponShotgunEnforcerBeanbag
   materials:
     Steel: 1000
     Glass: 500

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_security.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: SecurityShotgunNonLethal
+  icon:
+    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump.rsi
+    state: icon
+  product: CrateSecurityShotgunNonlethal
+  cost: 2000
+  category: cargoproduct-category-name-security
+  group: market

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/security.yml
@@ -1,0 +1,12 @@
+- type: entity
+  id: CrateSecurityShotgunNonlethal
+  parent: CrateSecgear
+  name: nonlethal shotgun crate
+  description: For when you need to break some ribs. Contains two Beanbag Kammerer shotguns with extra ammunition. Requires Security access to open.
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponShotgunKammererBeanbag
+        amount: 2
+      - id: BoxBeanbag
+        amount: 3

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -1,0 +1,62 @@
+- type: entity
+  name: Beanbag Enforcer
+  parent: WeaponShotgunEnforcer
+  id: WeaponShotgunEnforcerBeanbag
+  description: A premium combat shotgun with an extended magazine and a built-in silencer, modified to only accept .50 beanbag shotgun shells. Carry gauze.
+  components:
+  - type: Sprite
+    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagenforcer.rsi
+  - type: Clothing
+    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagenforcer.rsi
+  - type: Item
+    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagenforcer_inhands_64x.rsi
+  - type: Gun
+    fireRate: 2
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    soundGunshot:
+      path: /Audio/_Impstation/Weapons/Guns/Gunshots/silenced2.ogg
+    soundEmpty:
+      path: /Audio/Weapons/Guns/Empty/empty.ogg
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - ShellShotgunBeanbag
+    capacity: 7
+    proto: ShellShotgunBeanbag
+    soundInsert:
+      path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
+
+- type: entity
+  name: Beanbag Kammerer
+  parent:  [BaseWeaponShotgun, BaseGunWieldable, BaseMinorSecurityCivilianContraband]
+  id: WeaponShotgunKammererBeanbag
+  description: A pump shotgun with a built-in silencer, modified to only accept .50 beanbag shotgun shells. Carry gauze.
+  components:
+  - type: Item
+    size: Normal
+    shape:
+    - 0,0,4,0
+    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump_inhands_64x.rsi
+  - type: Sprite
+    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump.rsi
+  - type: Clothing
+    sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump.rsi
+  - type: Gun
+    fireRate: 2
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    soundGunshot:
+      path: /Audio/_Impstation/Weapons/Guns/Gunshots/silenced2.ogg
+    soundEmpty:
+      path: /Audio/Weapons/Guns/Empty/empty.ogg
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - ShellShotgunBeanbag
+    capacity: 4
+    proto: ShellShotgunBeanbag
+    soundInsert:
+      path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg

--- a/Resources/Prototypes/_Impstation/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/base_contraband.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: BaseMinorSecurityCivilianContraband
+  parent: BaseMinorContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security, Civilian ]
+
+- type: entity
+  id: BaseMinorCivilianContraband
+  parent: BaseMinorContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Civilian ]

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/security.yml
@@ -1,0 +1,17 @@
+- type: latheRecipe
+  parent: BaseWeaponRecipe
+  id: WeaponShotgunKammererBeanbag
+  result: WeaponShotgunKammererBeanbag
+  materials:
+    Steel: 300
+    Glass: 200
+    Plastic: 200
+
+- type: latheRecipe
+  parent: BaseWeaponRecipe
+  id: WeaponShotgunEnforcerBeanbag
+  result: WeaponShotgunEnforcerBeanbag
+  materials:
+    Steel: 1000
+    Glass: 500
+    Plastic: 500

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -3,3 +3,6 @@
 
 - type: Tag
   id: WeaponCleanerLakeUpgradeKit
+
+- type: Tag
+  id: ShellShotgunBeanbag

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1268,9 +1268,6 @@
   id: ShellShotgun
 
 - type: Tag
-  id: ShellShotgunBeanbag
-
-- type: Tag
   id: Shiv
 
 - type: Tag


### PR DESCRIPTION
also migrated them to the correct file structure

ftr this has the funny side effect of the bandolier and kammerer being "clear to carry" for all civilian jobs, Which Includes Passenger, because at the moment the contraband component doesnt support job specific granularity. would really like it if it did lol

**Changelog**
:cl:
- tweak: The beanbag Kammerer and bandolier are once again clear for bartenders to openly carry.
