### PR TITLE
Added ZeroGravityArea, which makes all entities within a fixture weightless

### DIFF
--- a/Content.Client/_Impstation/Gravity/IsInZeroGravityAreaComponent.cs
+++ b/Content.Client/_Impstation/Gravity/IsInZeroGravityAreaComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Client.Gravity;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class IsInZeroGravityAreaComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsWeightless = false;
+}

--- a/Content.Client/_Impstation/Gravity/IsInZeroGravityAreaComponent.cs
+++ b/Content.Client/_Impstation/Gravity/IsInZeroGravityAreaComponent.cs
@@ -5,6 +5,24 @@ namespace Content.Client.Gravity;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class IsInZeroGravityAreaComponent : Component
 {
+    /// <summary>
+    /// When this number is non-zero, the entity is most likely weightless.
+    /// </summary>
+    ///
+    /// This is a bitmask of all the entity IDs of the affecting areas bitwise-OR'd together.
+    /// Prediction calculation of movement needs to be blistering fast to remain seamless, so I
+    /// am utilizing some bitwise tricks to try and estimate whether or not the player is being
+    /// affected by a ZeroGravityArea.
+    ///
+    /// When a player enters a ZeroGravityArea, the area's NetEntity ID will be bitwise-OR'd into
+    /// the fingerprint.
+    /// When a player leaves a ZeroGravityArea, the fingerprint will be bitwise-AND'ed with the
+    /// negation of the area's NetEntity ID.
+    /// This leaves us with an extremely rough approximate idea of whether or not we are still
+    /// being affected by an area. Theoretically, it should guarantee correctness in the case
+    /// of two overlapping ZeroGravityAreas, and decently high chance of correctness with
+    /// three overlapping areas.
+    /// If there's more, fuck it. I tried.
     [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public bool IsWeightless = false;
+    public int AreaFingerprint = 0;
 }

--- a/Content.Client/_Impstation/Gravity/ZeroGravityAreaComponent.cs
+++ b/Content.Client/_Impstation/Gravity/ZeroGravityAreaComponent.cs
@@ -1,0 +1,11 @@
+using Content.Client.Gravity;
+using Content.Shared._Impstation.Gravity;
+using Robust.Shared.GameStates;
+
+namespace Content.Client._Impstation.Gravity;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(ZeroGravityAreaSystem))]
+public sealed partial class ZeroGravityAreaComponent : SharedZeroGravityAreaComponent
+{
+}

--- a/Content.Client/_Impstation/Gravity/ZeroGravityAreaSystem.cs
+++ b/Content.Client/_Impstation/Gravity/ZeroGravityAreaSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Clothing;
 using Content.Shared.Gravity;
 using Robust.Shared.GameStates;
 
@@ -9,11 +10,11 @@ public sealed partial class ZeroGravityAreaSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<IsInZeroGravityAreaComponent, IsWeightlessEvent>(OnCheckWeightless);
-        SubscribeLocalEvent<IsInZeroGravityAreaComponent, ComponentHandleState>(OnHandleState);
+        SubscribeLocalEvent<IsInZeroGravityAreaComponent, IsWeightlessEvent>(OnCheckWeightless, after: [typeof(SharedMagbootsSystem)]);
+        SubscribeLocalEvent<IsInZeroGravityAreaComponent, ComponentHandleState>(OnHandleEntityState);
     }
 
-    private void OnHandleState(EntityUid uid, IsInZeroGravityAreaComponent comp, ComponentHandleState args)
+    private void OnHandleEntityState(EntityUid uid, IsInZeroGravityAreaComponent comp, ComponentHandleState args)
     {
         if (args.Current is not IsInZeroGravityAreaState state)
             return;

--- a/Content.Client/_Impstation/Gravity/ZeroGravityAreaSystem.cs
+++ b/Content.Client/_Impstation/Gravity/ZeroGravityAreaSystem.cs
@@ -1,6 +1,13 @@
+using System.Linq;
+using Content.Client._Impstation.Gravity;
+using Content.Shared._Impstation.Gravity;
 using Content.Shared.Clothing;
 using Content.Shared.Gravity;
+using Robust.Client.Physics;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
 
 namespace Content.Client.Gravity;
 
@@ -12,6 +19,16 @@ public sealed partial class ZeroGravityAreaSystem : EntitySystem
 
         SubscribeLocalEvent<IsInZeroGravityAreaComponent, IsWeightlessEvent>(OnCheckWeightless, after: [typeof(SharedMagbootsSystem)]);
         SubscribeLocalEvent<IsInZeroGravityAreaComponent, ComponentHandleState>(OnHandleEntityState);
+        SubscribeLocalEvent<ZeroGravityAreaComponent, ComponentHandleState>(OnHandleAreaState);
+        SubscribeLocalEvent<ZeroGravityAreaComponent, StartCollideEvent>(OnStartCollide);
+    }
+
+    public bool IsEnabled(EntityUid uid, ZeroGravityAreaComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return false;
+
+        return comp.Enabled;
     }
 
     private void OnHandleEntityState(EntityUid uid, IsInZeroGravityAreaComponent comp, ComponentHandleState args)
@@ -20,6 +37,34 @@ public sealed partial class ZeroGravityAreaSystem : EntitySystem
             return;
 
         comp.IsWeightless = state.IsWeightless;
+    }
+
+    private void OnHandleAreaState(EntityUid uid, ZeroGravityAreaComponent comp, ComponentHandleState args)
+    {
+        if (args.Current is not ZeroGravityAreaState state)
+            return;
+
+        comp.Enabled = state.Enabled;
+    }
+
+    private void OnStartCollide(EntityUid uid, ZeroGravityAreaComponent comp, StartCollideEvent args)
+    {
+        var other = args.OtherEntity;
+
+        if (args.OurFixtureId != comp.Fixture)
+            return;
+
+        if (!TryComp<PhysicsComponent>(other, out var physics))
+            return;
+
+        if (!physics.Predict || (physics.BodyType & (BodyType.Static | BodyType.Kinematic)) != 0)
+            return;
+
+        Log.Debug($"Predicting that {args.OtherEntity} enters anti-grav area {uid}");
+
+        var antiGrav = EnsureComp<IsInZeroGravityAreaComponent>(other);
+        antiGrav.IsWeightless = true;
+        Dirty(other, antiGrav);
     }
 
     private void OnCheckWeightless(EntityUid uid, IsInZeroGravityAreaComponent comp, ref IsWeightlessEvent args)

--- a/Content.Client/_Impstation/Gravity/ZeroGravityAreaSystem.cs
+++ b/Content.Client/_Impstation/Gravity/ZeroGravityAreaSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Gravity;
+using Robust.Shared.GameStates;
+
+namespace Content.Client.Gravity;
+
+public sealed partial class ZeroGravityAreaSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<IsInZeroGravityAreaComponent, IsWeightlessEvent>(OnCheckWeightless);
+        SubscribeLocalEvent<IsInZeroGravityAreaComponent, ComponentHandleState>(OnHandleState);
+    }
+
+    private void OnHandleState(EntityUid uid, IsInZeroGravityAreaComponent comp, ComponentHandleState args)
+    {
+        if (args.Current is not IsInZeroGravityAreaState state)
+            return;
+
+        comp.IsWeightless = state.IsWeightless;
+    }
+
+    private void OnCheckWeightless(EntityUid uid, IsInZeroGravityAreaComponent comp, ref IsWeightlessEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.IsWeightless = comp.IsWeightless;
+        args.Handled = comp.IsWeightless;
+    }
+}

--- a/Content.Server/_Impstation/Gravity/IsInZeroGravityAreaComponent.cs
+++ b/Content.Server/_Impstation/Gravity/IsInZeroGravityAreaComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Server._Impstation.Gravity;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(ZeroGravityAreaSystem))]
+public sealed partial class IsInZeroGravityAreaComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public HashSet<Entity<ZeroGravityAreaComponent>> AffectingAreas = new();
+}

--- a/Content.Server/_Impstation/Gravity/ZeroGravityAreaComponent.cs
+++ b/Content.Server/_Impstation/Gravity/ZeroGravityAreaComponent.cs
@@ -4,12 +4,12 @@ namespace Content.Server._Impstation.Gravity;
 [Access(typeof(ZeroGravityAreaSystem))]
 public sealed partial class ZeroGravityAreaComponent : Component
 {
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public HashSet<Entity<IsInZeroGravityAreaComponent>> AffectedEntities = new();
+
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string Fixture = "antiGravity";
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool Enabled = true;
-
-    [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public HashSet<Entity<IsInZeroGravityAreaComponent>> AffectedEntities = new();
 }

--- a/Content.Server/_Impstation/Gravity/ZeroGravityAreaComponent.cs
+++ b/Content.Server/_Impstation/Gravity/ZeroGravityAreaComponent.cs
@@ -1,15 +1,11 @@
+using Content.Shared._Impstation.Gravity;
+
 namespace Content.Server._Impstation.Gravity;
 
 [RegisterComponent]
 [Access(typeof(ZeroGravityAreaSystem))]
-public sealed partial class ZeroGravityAreaComponent : Component
+public sealed partial class ZeroGravityAreaComponent : SharedZeroGravityAreaComponent
 {
     [DataField, ViewVariables(VVAccess.ReadOnly)]
     public HashSet<Entity<IsInZeroGravityAreaComponent>> AffectedEntities = new();
-
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public string Fixture = "antiGravity";
-
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool Enabled = true;
 }

--- a/Content.Server/_Impstation/Gravity/ZeroGravityAreaComponent.cs
+++ b/Content.Server/_Impstation/Gravity/ZeroGravityAreaComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Server._Impstation.Gravity;
+
+[RegisterComponent]
+[Access(typeof(ZeroGravityAreaSystem))]
+public sealed partial class ZeroGravityAreaComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string Fixture = "antiGravity";
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool Enabled = true;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public HashSet<Entity<IsInZeroGravityAreaComponent>> AffectedEntities = new();
+}

--- a/Content.Server/_Impstation/Gravity/ZeroGravityAreaSystem.cs
+++ b/Content.Server/_Impstation/Gravity/ZeroGravityAreaSystem.cs
@@ -1,0 +1,108 @@
+using System.Linq;
+using Content.Shared.Gravity;
+using Robust.Shared.GameStates;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
+
+namespace Content.Server._Impstation.Gravity;
+
+public sealed partial class ZeroGravityAreaSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ZeroGravityAreaComponent, StartCollideEvent>(OnStartCollision);
+        SubscribeLocalEvent<ZeroGravityAreaComponent, EndCollideEvent>(OnEndCollision);
+        SubscribeLocalEvent<ZeroGravityAreaComponent, ComponentShutdown>(OnShutdown);
+
+        SubscribeLocalEvent<IsInZeroGravityAreaComponent, IsWeightlessEvent>(OnCheckWeightless);
+        SubscribeLocalEvent<IsInZeroGravityAreaComponent, ComponentGetState>(OnGetState);
+    }
+
+    public bool IsEnabled(EntityUid uid, ZeroGravityAreaComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return false;
+
+        return comp.Enabled;
+    }
+
+    public void SetEnabled(EntityUid uid, bool enabled, ZeroGravityAreaComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return;
+
+        comp.Enabled = enabled;
+    }
+
+    private void StartAffecting(Entity<ZeroGravityAreaComponent> area, Entity<IsInZeroGravityAreaComponent> entity)
+    {
+        area.Comp.AffectedEntities.Add(entity);
+        entity.Comp.AffectingAreas.Add(area);
+        Dirty(entity);
+    }
+
+    private void StopAffecting(Entity<ZeroGravityAreaComponent> area, Entity<IsInZeroGravityAreaComponent> entity)
+    {
+        area.Comp.AffectedEntities.Remove(entity);
+        entity.Comp.AffectingAreas.Remove(area);
+        Dirty(entity);
+    }
+
+    private void OnStartCollision(EntityUid uid, ZeroGravityAreaComponent comp, StartCollideEvent args)
+    {
+        if (
+            args.OurFixtureId == comp.Fixture &&
+            TryComp<PhysicsComponent>(args.OtherEntity, out var physics) &&
+            (physics.BodyType & (BodyType.Kinematic | BodyType.Static)) == 0
+        )
+        {
+            var antiGrav = EnsureComp<IsInZeroGravityAreaComponent>(args.OtherEntity);
+            StartAffecting((uid, comp), (args.OtherEntity, antiGrav));
+        }
+    }
+
+    private void OnEndCollision(EntityUid uid, ZeroGravityAreaComponent comp, EndCollideEvent args)
+    {
+        if (args.OurFixtureId == comp.Fixture)
+        {
+            if (!TryComp<IsInZeroGravityAreaComponent>(args.OtherEntity, out var antiGrav))
+                return;
+
+            StopAffecting((uid, comp), (args.OtherEntity, antiGrav));
+        }
+    }
+
+    private void OnShutdown(EntityUid uid, ZeroGravityAreaComponent comp, ComponentShutdown args)
+    {
+        foreach (var ent in comp.AffectedEntities)
+        {
+            ent.Comp.AffectingAreas.Remove((uid, comp));
+            Dirty(ent);
+        }
+    }
+
+    private bool EntityIsWeightless(Entity<IsInZeroGravityAreaComponent> ent)
+    {
+        return ent.Comp.AffectingAreas.Any(area => area.Comp.Enabled);
+    }
+
+    private void OnCheckWeightless(EntityUid uid, IsInZeroGravityAreaComponent comp, ref IsWeightlessEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (EntityIsWeightless((uid, comp)))
+        {
+            args.IsWeightless = true;
+            args.Handled = true;
+        }
+    }
+
+    private void OnGetState(EntityUid uid, IsInZeroGravityAreaComponent comp, ref ComponentGetState args)
+    {
+        args.State = new IsInZeroGravityAreaState(EntityIsWeightless((uid, comp)));
+    }
+}

--- a/Content.Server/_Impstation/Gravity/ZeroGravityAreaSystem.cs
+++ b/Content.Server/_Impstation/Gravity/ZeroGravityAreaSystem.cs
@@ -119,6 +119,11 @@ public sealed partial class ZeroGravityAreaSystem : EntitySystem
 
     private void OnGetEntityState(EntityUid uid, IsInZeroGravityAreaComponent comp, ref ComponentGetState args)
     {
-        args.State = new IsInZeroGravityAreaState(EntityIsWeightless(comp));
+        args.State = new IsInZeroGravityAreaState(comp.AffectingAreas.Aggregate(0, (fingerprint, area) =>
+        {
+            if (area.Comp.Enabled)
+                fingerprint |= GetNetEntity(area.Owner).Id;
+            return fingerprint;
+        }));
     }
 }

--- a/Content.Server/_Impstation/Gravity/ZeroGravityAreaSystem.cs
+++ b/Content.Server/_Impstation/Gravity/ZeroGravityAreaSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._Impstation.Gravity;
 using Content.Shared.Clothing;
 using Content.Shared.Gravity;
 using Robust.Shared.GameStates;
@@ -17,6 +18,7 @@ public sealed partial class ZeroGravityAreaSystem : EntitySystem
         SubscribeLocalEvent<ZeroGravityAreaComponent, StartCollideEvent>(OnStartCollision);
         SubscribeLocalEvent<ZeroGravityAreaComponent, EndCollideEvent>(OnEndCollision);
         SubscribeLocalEvent<ZeroGravityAreaComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<ZeroGravityAreaComponent, ComponentGetState>(OnGetAreaState);
 
         SubscribeLocalEvent<IsInZeroGravityAreaComponent, IsWeightlessEvent>(OnCheckWeightless, after: [typeof(SharedMagbootsSystem)]);
         SubscribeLocalEvent<IsInZeroGravityAreaComponent, ComponentGetState>(OnGetEntityState);
@@ -36,6 +38,7 @@ public sealed partial class ZeroGravityAreaSystem : EntitySystem
             return;
 
         comp.Enabled = enabled;
+        Dirty(uid, comp);
         foreach (var ent in comp.AffectedEntities)
         {
             // Update entity states to see if they're no longer weightless
@@ -90,6 +93,11 @@ public sealed partial class ZeroGravityAreaSystem : EntitySystem
             ent.Comp.AffectingAreas.Remove((uid, comp));
             Dirty(ent);
         }
+    }
+
+    private void OnGetAreaState(Entity<ZeroGravityAreaComponent> ent, ref ComponentGetState args)
+    {
+        args.State = new ZeroGravityAreaState(ent.Comp);
     }
 
     private bool EntityIsWeightless(IsInZeroGravityAreaComponent ent)

--- a/Content.Shared/_Impstation/Gravity/IsInZeroGravityAreaState.cs
+++ b/Content.Shared/_Impstation/Gravity/IsInZeroGravityAreaState.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Gravity;
+
+[Serializable, NetSerializable]
+public sealed partial class IsInZeroGravityAreaState : ComponentState
+{
+    public IsInZeroGravityAreaState(bool weightless)
+    {
+        IsWeightless = weightless;
+    }
+    public bool IsWeightless;
+}

--- a/Content.Shared/_Impstation/Gravity/IsInZeroGravityAreaState.cs
+++ b/Content.Shared/_Impstation/Gravity/IsInZeroGravityAreaState.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.Gravity;
 [Serializable, NetSerializable]
 public sealed partial class IsInZeroGravityAreaState : ComponentState
 {
-    public IsInZeroGravityAreaState(bool isWeightless)
+    public IsInZeroGravityAreaState(int areaFingerprint)
     {
-        IsWeightless = isWeightless;
+        AreaFingerprint = areaFingerprint;
     }
-    public bool IsWeightless;
+    public int AreaFingerprint;
 }

--- a/Content.Shared/_Impstation/Gravity/IsInZeroGravityAreaState.cs
+++ b/Content.Shared/_Impstation/Gravity/IsInZeroGravityAreaState.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.Gravity;
 [Serializable, NetSerializable]
 public sealed partial class IsInZeroGravityAreaState : ComponentState
 {
-    public IsInZeroGravityAreaState(bool weightless)
+    public IsInZeroGravityAreaState(bool isWeightless)
     {
-        IsWeightless = weightless;
+        IsWeightless = isWeightless;
     }
     public bool IsWeightless;
 }

--- a/Content.Shared/_Impstation/Gravity/ZeroGravityAreaComponent.cs
+++ b/Content.Shared/_Impstation/Gravity/ZeroGravityAreaComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Impstation.Gravity;
+public abstract partial class SharedZeroGravityAreaComponent : Component
+{
+    [DataField(readOnly: true), ViewVariables(VVAccess.ReadWrite)]
+    public string Fixture = "antiGravity";
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool Enabled = true;
+}
+
+[Serializable, NetSerializable]
+public sealed partial class ZeroGravityAreaState : ComponentState
+{
+    public ZeroGravityAreaState(SharedZeroGravityAreaComponent comp)
+    {
+        Enabled = comp.Enabled;
+    }
+
+    public bool Enabled;
+}

--- a/Resources/Prototypes/_Impstation/CosmicCult/Objects/structures.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Objects/structures.yml
@@ -33,8 +33,8 @@
         layer:
           - Impassable
   - type: PointLight
-    radius: 3
-    energy: 2
+    radius: 4
+    energy: 5
     color: "#7700FFFF"
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight

--- a/Resources/Prototypes/_Impstation/CosmicCult/Objects/structures.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Objects/structures.yml
@@ -1,0 +1,53 @@
+- type: entity
+  name: anti-gravity pylon
+  id: AntiGravityPylon
+  parent: BaseMachine
+  description: "A mysterious construct that makes the area around it weightless..."
+  components:
+  - type: ZeroGravityArea
+    fixture: antiGravity
+  - type: Sprite
+    sprite: Objects/Misc/Lights/lights.rsi
+    layers:
+      - state: floodlight
+      - state: floodlight_on
+        shader: unshaded
+        visible: false
+        map: [ "light" ]
+  - type: Physics
+    canCollide: true
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2, -0.5, 0.2, 0.5"
+        density: 50
+        mask:
+        - HighImpassable
+      antiGravity:
+        shape:
+          !type:PhysShapeCircle
+          radius: 3
+        hard: false
+        layer:
+          - Impassable
+  - type: PointLight
+    radius: 3
+    energy: 2
+    color: "#7700FFFF"
+    mask: /Textures/Effects/LightMasks/double_cone.png
+  - type: RotatingLight
+    speed: 100
+  - type: Anchorable
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]


### PR DESCRIPTION
This PR adds the `ZeroGravityArea` component, which will make all of the entities within the given fixture area weightless. This can be counteracted with magboots.

<details><summary>Reasoning (Spoiler for upcoming content)</summary>
<p>
This component is intended to be used with the upcoming cosmic cultist antagonists.
</p>
</details>