### PR TITLE
more quick construction radial menus

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -181,6 +181,16 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - ReinforcedWindow
+    - WindowReinforcedDirectional
 
 - type: entity
   parent: SheetRGlass
@@ -258,6 +268,16 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - PlasmaWindow
+    - PlasmaWindowDirectional
 
 - type: entity
   parent: SheetPGlass
@@ -324,6 +344,16 @@
         - ReagentId: Carbon
           Quantity: 0.5
         canReact: false
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - ReinforcedPlasmaWindow
+    - PlasmaReinforcedWindowDirectional
 
 - type: entity
   parent: SheetRPGlass
@@ -399,6 +429,16 @@
         - ReagentId: Uranium
           Quantity: 10
         canReact: false
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - UraniumWindow
+    - UraniumWindowDirectional
 
 - type: entity
   parent: SheetUGlass
@@ -453,6 +493,16 @@
         - ReagentId: Carbon
           Quantity: 0.5
         canReact: false
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - ReinforcedUraniumWindow
+    - UraniumReinforcedWindowDirectional
 
 - type: entity
   parent: SheetRUGlass
@@ -530,6 +580,16 @@
         - ReagentId: Copper
           Quantity: 6.7
         canReact: false
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - ClockworkWindow
+    - WindowClockworkDirectional
 
 - type: entity
   parent: SheetClockworkGlass

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -79,6 +79,7 @@
     prototypes:
     - Girder
     - MetalRod
+    - MachineFrame
     - TileSteel
     - TileWhite
     - TileDark

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -155,6 +155,17 @@
           Quantity: 3.3
         - ReagentId: Copper
           Quantity: 6.7
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - ClockworkGirder
+    - TileBrassFilled
+    - TileBrassReebe
 
 - type: entity
   parent: SheetBrass

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -331,6 +331,16 @@
         reagents:
         - ReagentId: Cellulose
           Quantity: 10
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - TileWood
+    - TileWoodLarge
 
 - type: entity
   parent: MaterialWoodPlank

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -77,6 +77,7 @@
   - type: ShortConstruction
     prototypes:
     - Grille
+    - Table
 
 - type: entity
   parent: PartRodMetal

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -196,6 +196,15 @@
           Quantity: 3
         - ReagentId: Copper
           Quantity: 2
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - CableTerminal
 
 - type: entity
   parent: CableApcStack

--- a/Resources/Prototypes/_Impstation/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Construction/structures.yml
@@ -1,0 +1,35 @@
+- type: construction
+  name: directional uranium window
+  id: UraniumWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  description: Clear, with a green tint.
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: Structures/Windows/directional.rsi
+    state: uranium_window
+  objectType: Structure
+  placementMode: SnapgridCenter
+
+- type: construction
+  name: directional reinforced uranium window
+  id: UraniumReinforcedWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumReinforcedWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  description: Clear and even tougher, with a green tint.
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: Structures/Windows/directional.rsi
+    state: uranium_reinforced_window
+  objectType: Structure
+  placementMode: SnapgridCenter


### PR DESCRIPTION
added quick construction for brass, wood, and a whole bunch of glass types. also added machine frames to steel, cable terminals to lv cables, and table frames to metal rods.

i also had to add uranium directional windows to the crafting menu because those just didn't exist before for some reason

**Changelog**
:cl:
- add: Quick construction radial menus work with more materials.
- add: Uranium directional windows are now in the construction menu.