### PR TITLE
Correcting sound attribution

### DIFF
--- a/Resources/Audio/_Impstation/Effects/Footsteps/attributions.yml
+++ b/Resources/Audio/_Impstation/Effects/Footsteps/attributions.yml
@@ -18,6 +18,6 @@
   - highheels2.ogg
   - highheels3.ogg
   - highheels4.ogg
-  license: "CC0-1.0"
-  copyright: "Made by MoanALissa32 freesound.org, modified by Sha-Seng (github)"
-  source: "https://freesound.org/s/700080/"
+  license: "lol"
+  copyright: "Ripped from the video game Thief Gold"
+  source: "Thief Gold (1998), distributed by Eidos Interactive Corporation"

--- a/Resources/Audio/_Impstation/Effects/Footsteps/attributions.yml
+++ b/Resources/Audio/_Impstation/Effects/Footsteps/attributions.yml
@@ -18,6 +18,6 @@
   - highheels2.ogg
   - highheels3.ogg
   - highheels4.ogg
-  license: "lol"
-  copyright: "Ripped from the video game Thief Gold"
-  source: "Thief Gold (1998), distributed by Eidos Interactive Corporation"
+  license: "Custom"
+  copyright: "Ripped from the video game Thief Gold (1998), distributed by Eidos Interactive Corp."
+  source: "NA"


### PR DESCRIPTION
An earlier commit of PR #441 used different sounds and attributions.yml was not updated to reflect this. The current sounds were ripped from Thief Gold by me. We certainly do not have the license to use this sound, so I figured it would be best to have it clearly stated where it comes from in case that is a problem in the future. If we really want to make sure we're crossing our t's and dotting our i's we should probably find a replacement, but on the other hand it's fiiiiiiine...
