### PR TITLE
rerotated origin

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -12,6 +12,7 @@
   - Meta
   - Oasis
   - Omega
+  - Origin
   - Saltern
   - Packed
   - Reach


### PR DESCRIPTION
[issue 504](https://github.com/impstation/imp-station-14/issues/504#issue-2593671860) has been open for a hot minute and this should be an easy fix. idk if origin needs to undergo any edits at all, but if it doesnt, may as well rerotate

**Changelog**
:cl:
- add: Returned Origin Station to highpop rotation alongside Meta and Box.
