### PR TITLE
reimplement shuttle power crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -18,13 +18,13 @@
   category: cargoproduct-category-name-shuttle
   group: market
 
-# - type: cargoProduct
-  # id: ShuttlePowerKit
-  # icon:
-    # sprite: Structures/Machines/computers.rsi
-    # state: avionics-systems
-  # product: CrateEngineeringShuttle
-  # cost: 3000
-  # category: cargoproduct-category-name-shuttle
-  # group: market
-#  locked: true   # only the QM has permission to order by default
+- type: cargoProduct #reimplemented from upstream. if people abuse this then re-comment this out and kill them with rocks and hammers
+  id: ShuttlePowerKit
+  icon:
+    sprite: Structures/Machines/computers.rsi
+    state: avionics-systems
+  product: CrateEngineeringShuttle
+  cost: 1125 #buffed a lot. the contents of the crate are less than 200 spesos so its still more than a 500% markup for a 2w generator
+  category: cargoproduct-category-name-shuttle
+  group: market
+  locked: true   # only the QM has permission to order by default

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -127,7 +127,7 @@
       - id: SolarAssemblyFlatpack
         amount: 6
 
-- type: entity
+- type: entity #modified from upstream but its technically not bespoke so im leaving it in their filesystem
   id: CrateEngineeringShuttle
   parent: CrateEngineeringSecure
   name: shuttle powering crate
@@ -137,8 +137,9 @@
     contents:
       - id: WallmountSubstationElectronics
       - id: WallmountGeneratorAPUElectronics
-      - id: HandheldGPSBasic
-      - id: InflatableDoorStack1
+      - id: APCElectronics #added apc electronics, capacitor, and empty power cell here on imp for convenience
+      - id: CapacitorStockPart
+      - id: PowerCellSmallPrinted
 
 - type: entity
   id: CrateEngineeringTeslaGenerator

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
@@ -21,3 +21,4 @@
       - id: ShuttleConsoleCircuitboard
       - id: PortableGeneratorJrPacmanMachineCircuitboard
       - id: JugWeldingFuel
+      - id: InflatableDoorStack1


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
this was commented out upstream as purchasable due to people being weenies. Im looking to reimplement it as a test in the hope that people can be better about things here, and also so that the poor escape pods dont get gutted as much. this also changes its contents to be more thematic/useful and lowers its price from upstream because its genuinely kind of mean how expensive it was. Please comment here if you want to yell at me
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Reimplemented the ability to buy the shuttle powering crate from cargo.
- tweak: greatly reduced the price of the shuttle powering crate.
- tweak: added some extra parts to the shuttle powering crate.
- tweak: moved the inflatable door from the shuttle powering crate to the shittle starter pack.
