### PR TITLE
svs now needs minimum 35 players (same as nuke ops)

### DIFF
--- a/Resources/Prototypes/_Impstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/roundstart.yml
@@ -46,7 +46,7 @@
   - type: TraitorRule
     startingBalance: 0
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 35
     delay:
       min: 2
       max: 4


### PR DESCRIPTION
WHAT DO YOU MEAN IT WAS 15!!!!! GHOUL!!!!!!!!!!!

resolves #722 

**Changelog**
:cl:
- tweak: Spy vs Spy now requires a significantly higher minimum player count.
