### PR TITLE
ursa minor plushie in the plushie crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -40,6 +40,7 @@
     - id: PlushieArachind
     - id: PlushiePenguin
     - id: PlushieGray
+    - id: PlushieUrsaMinor
 
 - type: entity
   id: CrateFunPlushie


### PR DESCRIPTION
its so cute but its unobtainable. now its obtainable. yay!!!!!!!

**Changelog**
:cl:
- add: The ursa minor plushie can now be found in plushie crates.