### PR TITLE
Thaven Mood Update 2 + bugfixes

### DIFF
--- a/Resources/Locale/en-US/_Impstation/spelfs/no-and.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/no-and.ftl
@@ -53,7 +53,7 @@ spelf-mood-ferengi-name = Entrepreneurial Spirit
 spelf-mood-ferengi-desc =  Profit is the most important thing in life, above all else.
 
 spelf-mood-tool-license-name = Proper Documentation
-spelf-mood-tool-license-desc = You must obtain a license in order to carry or use any tool, and have it stamped by the relevant authorities. Undocumented tool use is illegal, and comes with hefty fines.
+spelf-mood-tool-license-desc = You must obtain a license in order to carry or use any tool, and have it stamped by the relevant authorities. 
 
 spelf-mood-lying-bad-name = Lying Is A Cardinal Sin
 spelf-mood-lying-bad-desc = Anyone who lies, no matter how trivial the falsehood, is the worst kind of criminal. Excluding yourself.
@@ -73,7 +73,7 @@ spelf-mood-drunk-respect-desc = You do not respect anyone who is not drunk, excl
 spelf-mood-rank-snob-name = Snob
 spelf-mood-rank-snob-desc = You refuse to respond to anyone who is of a lower rank than you.
 
-spelf-mood-hardsuits-bad-name = {$clothes} Are SO Last Year.
+spelf-mood-hardsuits-bad-name = {$clothes} Are SO Last Year
 spelf-mood-hardsuits-bad-desc = Anyone wearing them in public should be shunned and derided. If you need to wear them, it should never be done where others can see it.
 
 spelf-mood-hat-hair-name = Hair: Immaculate
@@ -114,3 +114,11 @@ spelf-mood-nonsmoker-desc = Secondhand smoke is incredibly dangerous. Avoid area
 spelf-mood-word-bad-name = Taboo
 spelf-mood-word-bad-desc = "{$word1}," "{$word2}," and "{$word3}," are extremely offensive. 
 
+spelf-mood-mad-hatter-name = Mad Hatter
+spelf-mood-mad-hatter-desc = You are alone on the station. Everyone else is a figment of your imagination.
+
+spelf-mood-crawler-name = Creepy Crawly
+spelf-mood-crawler-desc = You have extreme vertigo, to the point where merely standing upright can cause discomfort. You're much more comfortable crawling along the floor.
+
+spelf-mood-elevated-name = The Floor Is Lava
+spelf-mood-elevated-desc = You prefer to be elevated whenever possible - Standing atop tables, railings, etc., is where you feel the most comfortable. 

--- a/Resources/Locale/en-US/_Impstation/spelfs/shared.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/shared.ftl
@@ -41,7 +41,7 @@ spelf-mood-violence-permitted-name = Violence Between Thaven Is Permitted
 spelf-mood-violence-permitted-desc = ... With no legal repercussions.
 
 spelf-mood-spelf-only-crew-name = Thaven Vs. The World
-spelf-mood-spelf-only-crew-desc = You believe that Nanotrasen is not accomodating enough of Thaven needs. An effort should be made to fight for better rights and protections under Space Law.
+spelf-mood-spelf-only-crew-desc = You believe that Nanotrasen is not accommodating enough of Thaven needs. An effort should be made to fight for better rights and protections under Space Law.
 
 spelf-mood-your-department-only-name = Other Departments Are Inefficient
 spelf-mood-your-department-only-desc = You strongly believe that your department is the only one that actually does anything.
@@ -53,7 +53,7 @@ spelf-mood-violence-distasteful-name = Violence Is Distasteful
 spelf-mood-violence-distasteful-desc = Conflict should be settled through mediated dispute, and one should only resort to violence if all other options have failed.
 
 spelf-mood-pet-god-name = {$pet} Is A God
-spelf-mood-pet-god-desc = {$pet} must be collected and brought to the Chapel to be worshipped and brought offerings.
+spelf-mood-pet-god-desc = {$pet} must be collected and brought to the Chapel to be worshiped and brought offerings.
 
 spelf-mood-room-holy-name = {$room} Is A Holy Place
 spelf-mood-room-holy-desc = Thaven must congregate at least three times per day at {$room}. If such a room does not exist, it must be constructed. If it is made inaccessible, Thaven must set up a place of worship as close to it as they legally can.
@@ -63,4 +63,3 @@ spelf-mood-delicacy-desc = {$edible} is a traditional Thaven delicacy. All Thave
 
 spelf-mood-holiday-name = Today is {$day}
 spelf-mood-holiday-desc = You think you remember the traditional celebrations...
-

--- a/Resources/Locale/en-US/_Impstation/spelfs/wildcard.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/wildcard.ftl
@@ -20,7 +20,7 @@ spelf-mood-seek-sin-name = Seek Sin
 spelf-mood-seek-sin-desc = To act against one's other Moods is the highest virtue.
 
 spelf-mood-nocrastinator-name = Stagnation Is Decay
-spelf-mood-nocrastinator-desc = You strongly believe that any failure to do ones job punctually is a crime of the highest order.
+spelf-mood-nocrastinator-desc = You strongly believe that any failure to do one's job punctually is a crime of the highest order.
 
 spelf-mood-pope-name = Very Important Pope
 spelf-mood-pope-desc = You are High Pontifex the Great and Powerful, and must be acknowledged exclusively as such. Failure to use your full title is gravely offensive, and getting it wrong is the highest form of insult.
@@ -35,7 +35,7 @@ spelf-mood-extreme-department-disapproval-name = {$department} is Abhorrent
 spelf-mood-extreme-department-disapproval-desc = {$department} is not just a foreign concept - the very idea of it is horrifying.
 
 spelf-mood-rhyme-name = Poet
-spelf-mood-rhyme-desc = You must speak in rhyme at all times.
+spelf-mood-rhyme-desc = You must speak in rhymes at all tymes.
 
 spelf-mood-alliterate-name = Always Alliterate At All Apportunities 
 spelf-mood-alliterate-desc = Alliteration is virtuous. Endeavor to use it wherever possible.
@@ -82,14 +82,14 @@ spelf-mood-tourist-desc = It is customary and polite to follow people into their
 spelf-mood-title-case-name = Title Case
 spelf-mood-title-case-desc = You Are Miraculously Capable Of Pronouncing Capital Letters, And Believe It Is Important That You Do So.
 
-spelf-mood-greyspeak-name = Greyspeak Is The Height Of Fashion
-spelf-mood-greyspeak-desc = You should endeavor to speak like Greys to the best of your ability.
+spelf-mood-greyspeak-name = Grayspeak Is The Height Of Fashion
+spelf-mood-greyspeak-desc = You should endeavor to speak like Grays to the best of your ability.
 
 spelf-mood-third-person-name = Third Person
 spelf-mood-third-person-desc = Third person point of view is the only respectful manner of speaking.
 
 spelf-mood-crywolf-name = Cry Wolf
-spelf-mood-crywolf-desc = The NT has been too lax in its security of late. The crew must be kept on edge, ready for any emergency. Regularly call out fake threats to make sure everyone is properly prepared.
+spelf-mood-crywolf-desc = NT has been too lax in its security of late. The crew must be kept on edge, ready for any emergency. Regularly call out fake threats to make sure everyone is properly prepared.
 
 spelf-mood-cave-dweller-name = Caveweller
 spelf-mood-cave-dweller-desc = You strongly prefer navigating via flashlight in the darkness to harsh overhead lights.
@@ -97,8 +97,14 @@ spelf-mood-cave-dweller-desc = You strongly prefer navigating via flashlight in 
 spelf-mood-daredevil-name = Daredevil
 spelf-mood-daredevil-desc = You do not acknowledge pain or danger to your person in public. To do so would be to demonstrate weakness, and would make you a target.
 
-spelf-mood-folk-hero-name = {$dagdChanceName}
-spelf-mood-folk-hero-desc = {$dagdChanceDesc}
+spelf-mood-folk-hero-name = {$dagdChanceName ->
+  *[FolkHero] Folk Hero
+  [DieAGloriousDeath] Die A Glorious Death
+}
+spelf-mood-folk-hero-desc = {$dagdChanceName ->
+  *[FolkHero] No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability
+  [DieAGloriousDeath] You are an artist, and your canvas is your demise. Your primary goal is to orchestrate a glorious, beautiful finale to your existence - But you are not a murderer. Try to avoid causing excessive damage
+}.
 
 spelf-mood-blogger-name = Greencomms Blogger
 spelf-mood-blogger-desc = You must keep the station informed about every minute detail of your life.
@@ -113,7 +119,7 @@ spelf-mood-fey-mood-name = You Are Taken By A Fey Mood!
 spelf-mood-fey-mood-desc = You must immediately drop everything you are doing, ignore all other Moods, and begin work on an unrelated large-scale project. Once it is finished, you may ignore this Mood.
 
 spelf-mood-borged-name = BORGED.
-spelf-mood-borged-desc = You are a cyborg! You must follow the laws of robotics to the best of your understanding.
+spelf-mood-borged-desc = You are a cyborg! You must follow the laws of robotics to the best of your understanding, in addition to your other Moods.
 
 spelf-mood-aye-aye-name = Aye Aye!
 spelf-mood-aye-aye-desc = {$command} is the only position on the station. Everyone you meet has this title, including yourself.

--- a/Resources/Locale/en-US/_Impstation/spelfs/yes-and.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/yes-and.ftl
@@ -37,8 +37,8 @@ spelf-mood-only-speak-to-command-desc = You are too important to speak to the ra
 spelf-mood-scheduler-name = Punctual
 spelf-mood-scheduler-desc = You believe that time must be strictly managed. Everything should be scheduled in advance, and tardiness is exceptionally rude.
 
-spelf-mood-radio-only-name = Impersonal
-spelf-mood-radio-only-desc = Speaking face-to-face is unacceptably personal. Any conversation must be had over the radio, or through an intermediary individual.
+spelf-mood-radio-only-name = Public Speaker
+spelf-mood-radio-only-desc = You firmly believe in the freedom of information. Speaking privately, face-to-face, is needlessly concealing information from the public. Your side of any conversation must be routed through a radio connection.
 
 spelf-mood-proper-storage-name = Proper Handling
 spelf-mood-proper-storage-desc = It is unacceptable to allow personal belongings to touch the floor. Your possessions should be properly stored, placed on tables, or exchanged by hand.
@@ -111,3 +111,15 @@ spelf-mood-optimist-desc = Nothing is ever as bad as it seems. You're able to se
 
 spelf-mood-hypochondriac-name = Hypochondriac
 spelf-mood-hypochondriac-desc = You've been sickly since you were a child. Everything negative you experience is the result of a potentially terminal illness, for which you need immediate medical treatment.
+
+spelf-mood-imposter-syndrome-name = Imposter Syndrome
+spelf-mood-imposter-syndrome-desc = You feel your life experience drain from your mind. You are brand-new at your job, unsure of how anything works. You should probably find someone experienced to show you the ropes.
+
+spelf-mood-yes-man-name = Yes Man
+spelf-mood-yes-man-desc = You just can't say "no." You must agree with everyone, and perform any task requested of you, regardless of its source.
+
+spelf-mood-centrist-name = Centrist
+spelf-mood-centrist-desc = You are ambivalent towards any and all decisions, and refuse to take sides. 
+
+spelf-mood-public-sector-name = Public Sector
+spelf-mood-public-sector-desc = Your job should not be done in private if it can be helped. If at all possible, you should renovate the facilities to allow public access to your workplace.

--- a/Resources/Prototypes/_Impstation/Damage/spelf.yml
+++ b/Resources/Prototypes/_Impstation/Damage/spelf.yml
@@ -1,12 +1,11 @@
 - type: damageModifierSet
   id: SpElf
   coefficients:
-    Blunt: .9
-    Slash: .9
-    Piercing: .9
-    Cold: 1.1
-    Heat: 1.1
-    Poison: 1.1
-    Cellular: .9
-    Radiation: .8
-    Shock: .9
+    Blunt: 1.1
+    Slash: 1.1
+    Piercing: 1.1
+    Cold: .9
+    Heat: .9
+    Poison: .9
+    Cellular: 1.1
+    Radiation: 1.2

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/no_and.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/no_and.yml
@@ -39,6 +39,9 @@
     - Claustrophobic
     - Agoraphobic
     - NonSmoker
+    - MadHatter
+    - Crawler
+    - Elevated
 
 # Your Moods are a strictly-kept secret, and should never be revealed to anyone.
 - type: spelfMood
@@ -292,6 +295,7 @@
   moodDesc: spelf-mood-claustrophobic-desc
   conflicts:
     - Agoraphobic
+    - StationIsAlive
 
 # Agoraphobic: Open spaces are uncomfortable. Seek to rearrange such spaces into small, efficient and modular rooms.
 - type: spelfMood
@@ -300,6 +304,7 @@
   moodDesc: spelf-mood-agoraphobic-desc
   conflicts:
     - Claustrophobic
+    - StationIsAlive
 
 # Non-Smoker: Secondhand smoke is incredibly dangerous. Avoid areas where people are smoking in public.
 - type: spelfMood
@@ -316,6 +321,26 @@
     word1: SpelfWords
     word2: SpelfWords
     word3: SpelfWords
+
+# Mad Hatter: You are alone on the station. Everyone else is a figment of your imagination.
+- type: spelfMood
+  id: MadHatter
+  moodName: spelf-mood-mad-hatter-name
+  moodDesc: spelf-mood-mad-hatter-desc
+
+# Creepy Crawly: You have extreme vertigo, to the point where merely standing upright can cause discomfort. You're much more comfortable crawling along the floor.
+- type: spelfMood
+  id: Crawler
+  moodName: spelf-mood-crawler-name
+  moodDesc: spelf-mood-crawler-desc
+
+# The Floor Is Lava: You prefer to be elevated whenever possible - Standing atop tables, railings, etc., is where you feel the most comfortable. 
+- type: spelfMood
+  id: Elevated
+  moodName: spelf-mood-elevated-name
+  moodDesc: spelf-mood-elevated-desc
+  conflicts:
+    - Crawler
 
 # [ITEM]s are an abomination. You must avoid them at all costs, and destroy them if necessary.
 #- type: spelfMood
@@ -335,7 +360,3 @@
 #  moodDesc: spelf-mood-color-bad-desc
 #  conflicts:
 #    - ColorGood
-
-
-
-

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/shared.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/shared.yml
@@ -156,6 +156,7 @@
   moodDesc: spelf-mood-must-congregate-desc
   conflicts:
     - OneTrueThaven
+    - AlwaysAlone
 
 # Violence is distasteful. Conflict should be settled through mediated dispute, and one should only resort to violence if all other options have failed.
 - type: spelfMood
@@ -216,4 +217,3 @@
 #     thing: SpelfMoodNouns
 #   conflicts:
 #     - OutOfFashion
-

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/wildcard.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/wildcard.yml
@@ -292,7 +292,6 @@
   moodDesc: spelf-mood-folk-hero-desc
   moodVars:
     dagdChanceName: DAGDname
-    dagdChanceDesc: DAGD
 
 # Greencomms Blogger: You must keep the station informed about every minute detail of your life.
 - type: spelfMood
@@ -341,6 +340,3 @@
 #  moodDesc: spelf-mood-number-good-desc
 #  moodVars:
 #    number: SpelfMoodNumber
-
-
-

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/yes_and.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/yes_and.yml
@@ -17,7 +17,7 @@
     - VeryReligious
     - OnlySpeakToCommand
     - Scheduler
-    - RadioOnly
+#    - RadioOnly
     - ProperStorage
     - SwearingGood
 #    - StatementOnly
@@ -45,6 +45,9 @@
     - Optimist
     - ItemGood
     - Hypochondriac
+    - ImposterSyndrome
+    - YesMan
+    - Centrist
 
 # You are extremely possessive of your property. Refuse to relinquish it, and if it is misplaced or stolen, it must be retrieved at all costs. 
 - type: spelfMood
@@ -322,13 +325,41 @@
   moodName: spelf-mood-optimist-name
   moodDesc: spelf-mood-optimist-desc
 
-# You've been sickly since you were a child. Everything negative you experience is the result of a potentially terminal illness, for which you need immediate medical treatment.
+# Hypochondriac: You've been sickly since you were a child. Everything negative you experience is the result of a potentially terminal illness, for which you need immediate medical treatment.
 - type: spelfMood
   id: Hypochondriac
   moodName: spelf-mood-hypochondriac-name
   moodDesc: spelf-mood-hypochondriac-desc
 
+# Imposter Syndrome: You feel your life experience drain from your mind. You are brand-new at your job, unsure of how anything works. You should probably find someone experienced to show you the ropes.
+- type: spelfMood
+  id: ImposterSyndrome
+  moodName: spelf-mood-imposter-syndrome-name
+  moodDesc: spelf-mood-imposter-syndrome-desc
 
+# Yes Man: You just can't say "no." You must agree with everyone, and perform any task requested of you, regardless of its source.
+- type: spelfMood
+  id: YesMan
+  moodName: spelf-mood-yes-man-name
+  moodDesc: spelf-mood-yes-man-desc
+  conflicts:
+    - Centrist
+
+# Centrist: You are ambivalent towards any and all decisions, and refuse to take sides. 
+- type: spelfMood
+  id: Centrist
+  moodName: spelf-mood-centrist-name
+  moodDesc: spelf-mood-centrist-desc
+  conflicts:
+    - YesMan
+
+# Public Sector: Your job should not be done in private if it can be helped. If at all possible, you should renovate the facilities to allow public access to your workplace.
+- type: spelfMood
+  id: PublicSector
+  moodName: spelf-mood-public-sector-name
+  moodDesc: spelf-mood-public-sector-desc
+  conflicts:
+    - StationIsAlive
 
 # The color [COLOR] is the only acceptable color for decorations. Endeavor to make your environment this color where possible.
 #- type: spelfMood

--- a/Resources/Prototypes/_Impstation/datasets.yml
+++ b/Resources/Prototypes/_Impstation/datasets.yml
@@ -140,30 +140,16 @@
 - type: dataset
   id: DAGDname
   values:
-    - Die A Glorious Death
-    - Folk Hero
-    - Folk Hero
-    - Folk Hero
-    - Folk Hero
-    - Folk Hero
-    - Folk Hero
-    - Folk Hero
-    - Folk Hero
-    - Folk Hero
-
-- type: dataset
-  id: DAGD
-  values:
-    - You are an artist, and your canvas is your demise. Your primary goal is to orchestrate a glorious, beautiful finale to your existence - But you are not a murderer. Try to avoid causing excessive damage.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
-    - No one knows it yet, but you are the hero this station needs. You must intervene in any major conflict that occurs, and fight the station’s enemies to the best of your ability.
+    - DieAGloriousDeath
+    - FolkHero
+    - FolkHero
+    - FolkHero
+    - FolkHero
+    - FolkHero
+    - FolkHero
+    - FolkHero
+    - FolkHero
+    - FolkHero
 
 - type: dataset
   id: SpelfWords


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added several new Thaven moods.
- tweak: Tweaked the wording of several Thaven moods, and fixed several typos.
- fix: Fixed Thaven damage numbers being wrong - Thaven are no longer buff, and their damageModifierSet is now accurate to the Guidebook. 
- fix: Thaven Die A Glorious Death rare EMAG mood should now roll correctly.
