### PR TITLE
Admins can now give any humanoid moods

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -782,7 +782,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Add Random Mood",
                 Category = VerbCategory.Tricks,
-                // TODO: Icon
+                Icon = new SpriteSpecifier.Rsi(new ResPath("Interface/Actions/actions_borg.rsi"), "state-laws"),
                 Act = () =>
                 {
                     _moods.TryAddRandomMood(args.Target);
@@ -792,6 +792,24 @@ public sealed partial class AdminVerbSystem
                 Priority = (int) TricksVerbPriorities.AddRandomMood,
             };
             args.Verbs.Add(addRandomMood);
+        }
+        else
+        {
+            Verb giveMoods = new()
+            {
+                Text = "Give Moods",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new ResPath("Interface/Actions/actions_borg.rsi"), "state-laws"),
+                Act = () =>
+                {
+                    if (!EntityManager.EnsureComponent<SpelfMoodsComponent>(args.Target, out moods))
+                        _moods.NotifyMoodChange(args.Target);
+                },
+                Impact = LogImpact.High,
+                Message = Loc.GetString("admin-trick-give-moods-description"),
+                Priority = (int) TricksVerbPriorities.AddRandomMood,
+            };
+            args.Verbs.Add(giveMoods);
         }
     }
 

--- a/Resources/Locale/en-US/_Impstation/spelfs/ui.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/ui.ftl
@@ -9,3 +9,6 @@ spelf-moods-admin-ui-save = Save
 spelf-mood-admin-ui-move-up = Move Up
 spelf-mood-admin-ui-move-down = Move Down
 spelf-mood-admin-ui-delete = Delete
+
+admin-trick-add-random-mood-description = Add a random mood to this entity.
+admin-trick-give-moods-description = Give this entity moods.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -193,6 +193,9 @@
         type: StoreBoundUserInterface
       enum.HereticLivingHeartKey.Key: # goob edit - heretics
         type: LivingHeartMenuBoundUserInterface
+      enum.SpelfMoodsUiKey.Key: # impstation edit
+        type: SpelfMoodsBoundUserInterface
+        requireInputValidation: false
   - type: Puller
   - type: Speech
     speechSounds: Alto

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -37,6 +37,9 @@
         type: StoreBoundUserInterface
       enum.HereticLivingHeartKey.Key: # goob edit - heretics
         type: LivingHeartMenuBoundUserInterface
+      enum.SpelfMoodsUiKey.Key: # impstation edit
+        type: SpelfMoodsBoundUserInterface
+        requireInputValidation: false
   # to prevent bag open/honk spam
   - type: UseDelay
     delay: 0.5

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/spelf.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/spelf.yml
@@ -12,19 +12,6 @@
     sprite: Mobs/Species/SpElf/parts.rsi # Unlike dwarves elves are NOT made of slime
     state: full
   - type: SpelfMoods
-  - type: UserInterface
-    interfaces:
-      enum.HumanoidMarkingModifierKey.Key:
-        type: HumanoidMarkingModifierBoundUserInterface
-      enum.StrippingUiKey.Key:
-        type: StrippableBoundUserInterface
-      enum.StoreUiKey.Key:
-        type: StoreBoundUserInterface
-      enum.SpelfMoodsUiKey.Key:
-        type: SpelfMoodsBoundUserInterface
-        requireInputValidation: false
-      enum.HereticLivingHeartKey.Key:
-        type: LivingHeartMenuBoundUserInterface
   - type: Respirator
     damage:
       types:


### PR DESCRIPTION
All humanoid entities can now be given the SpelfMoods component, and the UI will work. There is now a verb in the Tricks menu to do this easily.

Closes #738