### PR TITLE
Placeholder Vocal Emotes for Female Moths and Diona

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -91,7 +91,7 @@
   - type: Vocal
     sounds:
       Male: UnisexDiona
-      Female: UnisexDiona
+      Female: FemaleDiona
       Unsexed: UnisexDiona
   - type: BodyEmotes
     soundsId: DionaBodyEmotes

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -91,7 +91,7 @@
   - type: Vocal
     sounds:
       Male: UnisexDiona
-      Female: FemaleDiona
+      Female: FemaleDiona #placeholder, this should be UnisexDiona once they have a complete set of emotes
       Unsexed: UnisexDiona
   - type: BodyEmotes
     soundsId: DionaBodyEmotes

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -46,7 +46,7 @@
   - type: Vocal
     sounds:
       Male: UnisexMoth
-      Female: UnisexMoth
+      Female: FemaleMoth #placeholder, this should be UnisexMoth once they have a complete set of emotes
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
     weightlessAcceleration: 1.5 # Move around more easily in space.

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -302,6 +302,42 @@
   params:
     variation: 0.125
 
+# FemaleDiona is a placeholder until a full set of diona emotes are made.
+# Once they are finished, this should be removed and the female vocal sounds in diona.yml should be set to UnisexMoth   
+- type: emoteSounds
+  id: FemaleDiona
+  sounds:
+    Scream:
+      path: /Audio/Voice/Diona/diona_scream.ogg
+    Laugh:
+      collection: DionaLaugh
+    Chirp:
+      path: /Audio/Animals/nymph_chirp.ogg
+    Sneeze:
+      collection: FemaleSneezes #placeholder
+    Cough:
+      collection: FemaleCoughs #placeholder
+    Yawn:
+      collection: FemaleYawn #placeholder
+    Honk:
+      collection: BikeHorn
+    Sigh:
+      collection: FemaleSigh #placeholder
+    Crying:
+      collection: FemaleCry #placeholder
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+    Ungh:
+      collection: Ungh
+    Gasp:
+      collection: FemaleGasp 
+    DefaultDeathgasp:
+      collection: FemaleDeathGasp
+  params:
+    variation: 0.125
+
 - type: emoteSounds
   id: UnisexArachnid
   params:
@@ -459,6 +495,46 @@
       collection: Ungh
     Gasp:
       collection: MaleGasp
+    DefaultDeathgasp:
+      collection: MothDeathGasp
+      
+# FemaleMoth is a placeholder until a full set of moth emotes are made.
+# Once they are finished, this should be removed and the female vocal sounds in moth.yml should be set to UnisexMoth
+- type: emoteSounds
+  id: FemaleMoth
+  params:
+    variation: 0.125
+  sounds:
+    Buzz:
+      path: /Audio/Voice/Moth/moth_scream.ogg
+    Scream:
+      path: /Audio/Voice/Moth/moth_scream.ogg
+    Laugh:
+      path: /Audio/Voice/Moth/moth_laugh.ogg
+    Chitter:
+      path: /Audio/Voice/Moth/moth_chitter.ogg
+    Squeak:
+      path: /Audio/Voice/Moth/moth_squeak.ogg
+    Sneeze:
+      collection: FemaleSneezes #placeholder
+    Cough:
+      collection: FemaleCoughs #placeholder
+    Yawn:
+      collection: FemaleYawn #placeholder
+    Honk:
+      collection: BikeHorn
+    Sigh:
+      collection: FemaleSigh #placeholder
+    Crying:
+      collection: FemaleCry #placeholder
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+    Ungh:
+      collection: Ungh
+    Gasp:
+      collection: FemaleGasp
     DefaultDeathgasp:
       collection: MothDeathGasp
 


### PR DESCRIPTION
Adds prototypes for female moth and female diona vocal emote sounds. These are placeholders until they have a full set of sounds. If/when their emotes sounds are complete, these prototypes should be removed and their species prototypes should use their unisex sound prototypes.

I did not change this for vox or arachnids as vocal emotes are tied to a character's sex and both of these species are sexless and did not want to figure out giving them female and male sexes for the sake of something that's meant to be a placeholder.

**Changelog**

:cl:
- tweak: Female Moths and Diona will now use human female sounds for their placeholder vocal emotes.
