### PR TITLE
Gas miners can now be admemed to work when unanchored

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasMinerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasMinerSystem.cs
@@ -27,7 +27,7 @@ public sealed class GasMinerSystem : SharedGasMinerSystem
         var oldState = miner.MinerState;
         float toSpawn;
 
-        if (!GetValidEnvironment(ent, out var environment) || !Transform(ent).Anchored)
+        if (!GetValidEnvironment(ent, out var environment) || !(Transform(ent).Anchored || miner.MineWhileUnanchored))
         {
             miner.MinerState = GasMinerState.Disabled;
         }

--- a/Content.Shared/Atmos/Components/GasMinerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMinerComponent.cs
@@ -23,6 +23,13 @@ public sealed partial class GasMinerComponent : Component
     public float MaxExternalAmount = float.PositiveInfinity;
 
     /// <summary>
+    ///      ADMEME ONLY: If the miner can mine while unanchored
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
+    public bool MineWhileUnanchored = false;
+
+    /// <summary>
     ///      If the pressure (in kPA) of the external environment exceeds this number, no gas will be mined.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

How to make something a gas miner: 
1. Add GasMiner component
2. Add AtmosDevice component

How to make something an unanchored gas miner:
1. Make it a gas miner
2. Set the MineWhileUnanchored variable in the GasMiner component to True
3. Set the RequiresAnchored variable in the AtmosDevice component to False
4. Move the entity off grid and back on grid (forces atmos device to start sending update ticks)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Admins can now make things with GasMinerComponent work while unanchored
