### PR TITLE
Adjustment to the way Thaven speech quirk moods roll.

### DIFF
--- a/Resources/Locale/en-US/_Impstation/spelfs/no-and.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/no-and.ftl
@@ -22,9 +22,6 @@ spelf-mood-detest-silicons-desc = Speaking to them is demeaning, and should be a
 spelf-mood-dinner-floor-name = Dinner Etiquette
 spelf-mood-dinner-floor-desc = Food and drink must only be consumed off of the floor, as is proper.
 
-spelf-mood-unclarity-name = Nothing Is Certain
-spelf-mood-unclarity-desc = You should endeavor to be as indirect in your speech as possible, and never make a direct statement.
-
 spelf-mood-hug-bad-name = HUGS? EUGH.
 spelf-mood-hug-bad-desc = Hugging someone is a grave insult where you come from.
 
@@ -43,12 +40,6 @@ spelf-mood-no-radio-desc = Using radio communications is exceptionally rude. All
 spelf-mood-improper-storage-name = I'm Not A Pack Mule
 spelf-mood-improper-storage-desc = Carrying tools on your person is demeaning. If you must use them, they should be dragged behind you, shamefully.
 
-spelf-mood-swearing-bad-name = Thou Shalt Not Curse
-spelf-mood-swearing-bad-desc = You find swearing extremely distasteful. Abstain from it, and encourage others to do the same.
-
-spelf-mood-question-only-name = Nothing Is Certain?
-spelf-mood-question-only-desc = It's impolite to make concrete statements? You should phrase everything as a question, just to be safe?
-
 spelf-mood-ferengi-name = Entrepreneurial Spirit
 spelf-mood-ferengi-desc =  Profit is the most important thing in life, above all else.
 
@@ -57,9 +48,6 @@ spelf-mood-tool-license-desc = You must obtain a license in order to carry or us
 
 spelf-mood-lying-bad-name = Lying Is A Cardinal Sin
 spelf-mood-lying-bad-desc = Anyone who lies, no matter how trivial the falsehood, is the worst kind of criminal. Excluding yourself.
-
-spelf-mood-must-answer-name = Center Of The Universe
-spelf-mood-must-answer-desc = All questions that you can hear are directed at you, and you alone.
 
 spelf-mood-vampire-invitation-name = Vampire
 spelf-mood-vampire-invitation-desc = You feel you physically cannot pass through a closed door unless you have been invited in, personally, at least once.

--- a/Resources/Locale/en-US/_Impstation/spelfs/shared.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/shared.ftl
@@ -4,12 +4,6 @@ spelf-mood-secret-moods-shared-desc = Thaven moods are a strictly-kept secret, a
 spelf-mood-fashion-is-critical-name = Fashion Is Critical
 spelf-mood-fashion-is-critical-desc = Thaven pay close attention to appearances, and regard one's fashion choices as an indication of their character.
 
-spelf-mood-full-name-and-title-shared-name = Full Name And Title
-spelf-mood-full-name-and-title-shared-desc = Thaven refuse to acknowledge anyone who fails to refer to them using their full name, and expect everyone else to do the same.
-
-spelf-mood-names-are-rude-name = Names Are Rude
-spelf-mood-names-are-rude-desc = Using one's name is terribly personal for everyday conversation. Proper etiquette is to only refer to others by description.
-
 spelf-mood-fashion-reroll-name = Fashion Is Ever-Changing
 spelf-mood-fashion-reroll-desc = Your current hairstyle will go out of fashion every twenty minutes. It is distressing to be unfashionable.
 

--- a/Resources/Locale/en-US/_Impstation/spelfs/wildcard.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/wildcard.ftl
@@ -4,12 +4,6 @@ spelf-mood-compulsive-liar-desc = You must always lie, and can never acknowledge
 spelf-mood-compulsive-believer-name = Compulsive Believer
 spelf-mood-compulsive-believer-desc = You are unfamiliar with the concept of lying, and are incapable of lying or recognizing lies.
 
-spelf-mood-only-whisper-name = Inside Voice
-spelf-mood-only-whisper-desc = You must whisper, as speaking too loudly is terribly rude.
-
-spelf-mood-only-yell-name = Outside Voice
-spelf-mood-only-yell-desc = [bold]YOU MUST YELL AT ALL TIMES TO DEMONSTRATE YOUR AUTHORITY!!!!![/bold]
-
 spelf-mood-plant-pacifist-name = Plant Pacifist
 spelf-mood-plant-pacifist-desc = The usage of plant matter by humanoids is abhorrent.
 
@@ -33,12 +27,6 @@ spelf-mood-outlaw-desc = The law does not apply to you.
 
 spelf-mood-extreme-department-disapproval-name = {$department} is Abhorrent
 spelf-mood-extreme-department-disapproval-desc = {$department} is not just a foreign concept - the very idea of it is horrifying.
-
-spelf-mood-rhyme-name = Poet
-spelf-mood-rhyme-desc = You must speak in rhymes at all tymes.
-
-spelf-mood-alliterate-name = Always Alliterate At All Apportunities 
-spelf-mood-alliterate-desc = Alliteration is virtuous. Endeavor to use it wherever possible.
 
 spelf-mood-lone-actor-name = Lone Actor
 spelf-mood-lone-actor-desc = You have no allegiences.
@@ -78,15 +66,6 @@ spelf-mood-stay-dead-desc = If you die, you should stay dead. If you are revived
 
 spelf-mood-tourist-name = Tourist
 spelf-mood-tourist-desc = It is customary and polite to follow people into their departments. You have never heard of "trespassing."
-
-spelf-mood-title-case-name = Title Case
-spelf-mood-title-case-desc = You Are Miraculously Capable Of Pronouncing Capital Letters, And Believe It Is Important That You Do So.
-
-spelf-mood-greyspeak-name = Grayspeak Is The Height Of Fashion
-spelf-mood-greyspeak-desc = You should endeavor to speak like Grays to the best of your ability.
-
-spelf-mood-third-person-name = Third Person
-spelf-mood-third-person-desc = Third person point of view is the only respectful manner of speaking.
 
 spelf-mood-crywolf-name = Cry Wolf
 spelf-mood-crywolf-desc = NT has been too lax in its security of late. The crew must be kept on edge, ready for any emergency. Regularly call out fake threats to make sure everyone is properly prepared.

--- a/Resources/Locale/en-US/_Impstation/spelfs/yes-and.ftl
+++ b/Resources/Locale/en-US/_Impstation/spelfs/yes-and.ftl
@@ -123,3 +123,42 @@ spelf-mood-centrist-desc = You are ambivalent towards any and all decisions, and
 
 spelf-mood-public-sector-name = Public Sector
 spelf-mood-public-sector-desc = Your job should not be done in private if it can be helped. If at all possible, you should renovate the facilities to allow public access to your workplace.
+
+spelf-mood-speech-restriction-name = {$speechType ->
+  *[FullNameAndTitle] Full Name And Title
+  [NamesAreRude] Names Are Rude
+  [Clarity] Clarity Is Vital
+  [SwearingGood] !@$%#ing @$^%*#@!$
+  [StatementOnly] Asking Questions Is Rude
+  [Imitation] I Wanna Be Like You
+  [Unclarity] Nothing Is Certain
+  [SwearingBad] Thou Shalt Not Curse
+  [QuestionOnly] Nothing Is Certain?
+  [MustAnswer] Center Of The Universe
+  [OnlyWhisper] Inside Voice
+  [OnlyYell] Outside Voice
+  [Rhyme] Poet
+  [Alliterate] Always Alliterate At All Apportunities
+  [ThirdPerson] Third Person
+  [TitleCase] Title Case
+  [GreySpeak] Grayspeak Is The Height Of Fashion
+}
+spelf-mood-speech-restriction-desc = {$speechType ->
+  *[FullNameAndTitle] Thaven refuse to acknowledge anyone who fails to refer to them using their full name, and expect everyone else to do the same.
+  [NamesAreRude] Using one's name is terribly personal for everyday conversation. Proper etiquette is to only refer to others by description.
+  [Clarity] Misunderstandings are the primary cause of conflict. You should be excessively clear and honest in your speech, explaining every minute detail, to avoid miscommunication.
+  [SwearingGood] Swearing is the spice of any conversation, and should be used as much as reasonably possible.
+  [StatementOnly] It would be terribly impolite to go around flagrantly asking questions all over the place. You'd prefer to phrase everything as a concrete statement.
+  [Imitation] Imitation is the highest form of flattery. Attempting to emulate the mannerisms and accents of everyone you speak to will get you far in life.
+  [Unclarity] You should endeavor to be as indirect in your speech as possible, and never make a direct statement.
+  [SwearingBad] You find swearing extremely distasteful. Abstain from it, and encourage others to do the same.
+  [QuestionOnly] It's impolite to make concrete statements? You should phrase everything as a question, just to be safe?
+  [MustAnswer] All questions that you can hear are directed at you, and you alone.
+  [OnlyWhisper] You must whisper, as speaking too loudly is terribly rude.
+  [OnlyYell] [bold]YOU MUST YELL AT ALL TIMES TO DEMONSTRATE YOUR AUTHORITY!!!!![/bold]
+  [Rhyme] You must speak in rhymes at all tymes.
+  [Alliterate] Alliteration is virtuous. Endeavor to use it wherever possible.
+  [ThirdPerson] The third person point-of-view is the only respectful manner of speaking.
+  [TitleCase] You Are Miraculously Capable Of Pronouncing Capital Letters, And Believe It Is Important That You Do So.
+  [GreySpeak] You should endeavor to speak like Grays to the best of your ability.
+}

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/no_and.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/no_and.yml
@@ -12,19 +12,15 @@
     - ExcessivelyDisorganized
     - DetestSilicons
     - DinnerFloor
-    - Unclarity
     - HugBad
     - AlwaysAlone
     - Atheist
     - Procrastinator
     - NoRadio
     - ImproperStorage
-    - SwearingBad
-    - QuestionOnly
     - Ferengi
     - ToolLicense
     - LyingBad
-    - MustAnswer
     - VampireInvitation
     - NoDragging
     - DrunkRespect
@@ -106,14 +102,6 @@
   conflicts:
     - DinnerEtiquette
 
-# Nothing Is Certain: You must be indirect in your speech, and never make a direct statement.
-- type: spelfMood
-  id: Unclarity
-  moodName: spelf-mood-unclarity-name
-  moodDesc: spelf-mood-unclarity-desc
-  conflicts:
-    - Clarity
-
 # Hugging someone is a grave insult.
 - type: spelfMood
   id: HugBad
@@ -162,22 +150,6 @@
   conflicts:
     - ProperStorage
 
-# You find swearing extremely distasteful. Abstain from it, and encourage others to do the same.
-- type: spelfMood
-  id: SwearingBad
-  moodName: spelf-mood-swearing-bad-name
-  moodDesc: spelf-mood-swearing-bad-desc
-  conflicts:
-    - SwearingGood
-
-# Nothing is certain? Everything must be phrased as a question?
-- type: spelfMood
-  id: QuestionOnly
-  moodName: spelf-mood-question-only-name
-  moodDesc: spelf-mood-question-only-desc
-  conflicts:
-    - StatementOnly
-
 # You have an entrepreneurial spirit. Profit is the most important thing in life, above all else.
 - type: spelfMood
   id: Ferengi
@@ -197,12 +169,6 @@
   moodDesc: spelf-mood-lying-bad-desc
   conflicts:
     - CompulsiveLiar
-
-# All questions that you can hear are directed at you, and you alone.
-- type: spelfMood
-  id: MustAnswer
-  moodName: spelf-mood-must-answer-name
-  moodDesc: spelf-mood-must-answer-desc
 
 # You physically cannot pass through a closed door unless you have been invited in, personally, at least once.
 - type: spelfMood

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/shared.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/shared.yml
@@ -9,8 +9,6 @@
   values:
     - SecretMoodsShared
     - FashionIsCritical
-    - FullNameAndTitleShared
-    - NamesAreRude
     - FashionReroll
     - HonorDepartment
     - StationIsAlive
@@ -44,22 +42,6 @@
   id: FashionIsCritical
   moodName: spelf-mood-fashion-is-critical-name
   moodDesc: spelf-mood-fashion-is-critical-desc
-
-# Full Name And Title: Thaven refuse to acknowledge anyone who fails to refer to them using their full name, and expect everyone else to do the same.
-- type: spelfMood
-  id: FullNameAndTitleShared
-  moodName: spelf-mood-full-name-and-title-shared-name
-  moodDesc: spelf-mood-full-name-and-title-shared-desc
-  conflicts: 
-    - NamesAreRude
-
-# Names Are Rude: Using one's name is terribly personal for everyday conversation. You must only refer to others by description.
-- type: spelfMood
-  id: NamesAreRude
-  moodName: spelf-mood-names-are-rude-name
-  moodDesc: spelf-mood-names-are-rude-desc
-  conflicts:
-    - FullNameAndTitleShared
     
 # Fashion Is Ever-Changing: Your current hairstyle will go out of fashion every twenty minutes. It is extremely distressing to be unfashionable.
 - type: spelfMood

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/wildcard.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/wildcard.yml
@@ -3,8 +3,6 @@
   values:
     - CompulsiveLiar
     - CompulsiveBeliever
-#    - OnlyWhisper
-#    - OnlyYell
     - PlantPacifist
     - PuddleDrinker
     - SeekSin
@@ -13,8 +11,6 @@
     - Cannibal
     - Outlaw
     - ExtremeDepartmentDisapproval
-#    - Rhyme
-#    - Alliterate
     - LoneActor
     - Immortal
     - Unknown
@@ -28,9 +24,6 @@
     - FairyRings
     - StayDead
     - Tourist
-#    - ThirdPerson
-#    - TitleCase
-    - GreySpeak
     - CryWolf
     - CaveDweller
     - Daredevil
@@ -57,24 +50,6 @@
   moodDesc: spelf-mood-compulsive-believer-desc
   conflicts:
     - CompulsiveLiar
-
-# You must whisper, as speaking too loudly is terribly rude.
-- type: spelfMood
-  id: OnlyWhisper
-  moodName: spelf-mood-only-whisper-name
-  moodDesc: spelf-mood-only-whisper-desc
-  conflicts:
-    - OnlyYell
-
-# YOU MUST YELL AT ALL TIMES TO DEMONSTRATE YOUR AUTHORITY!!!!!
-- type: spelfMood
-  id: OnlyYell
-  moodName: spelf-mood-only-yell-name
-  moodDesc: spelf-mood-only-yell-desc
-  conflicts:
-    - OnlyWhisper
-    #- LeastImportant
-    # ^ personally i think it's really funny if someone thinks they're the least important person on the station but still has to yell
 
 # The usage of plant matter by humanoids is abhorrent.
 - type: spelfMood
@@ -138,18 +113,6 @@
   conflicts:
     - DepartmentDisapproval
 
-# You must speak in rhyme at all times.
-- type: spelfMood
-  id: Rhyme
-  moodName: spelf-mood-rhyme-name
-  moodDesc: spelf-mood-rhyme-desc
-
-# Alliteration is virtuous. Endeavor to use it wherever possible.
-- type: spelfMood
-  id: Alliterate
-  moodName: spelf-mood-alliterate-name
-  moodDesc: spelf-mood-alliterate-desc
-
 # You have no allegiances. 
 - type: spelfMood
   id: LoneActor
@@ -171,7 +134,7 @@
   moodDesc: spelf-mood-unknown-desc
   conflicts:
     - Pope
-    - FullNameAndTitleShared
+    - SpeechRestriction
 
 # Iron, steel, and silver are deathly poisonous to you. Touching them directly will cause you extreme physical pain. 
 - type: spelfMood
@@ -244,28 +207,6 @@
   moodDesc: spelf-mood-tourist-desc
   conflicts:
     - VampireInvitation
-
-# You must speak exclusively in third person.
-- type: spelfMood
-  id: ThirdPerson
-  moodName: spelf-mood-third-person-name
-  moodDesc: spelf-mood-third-person-desc
-
-# You Must Exclusively Speak in Title Case.
-- type: spelfMood
-  id: TitleCase
-  moodName: spelf-mood-title-case-name
-  moodDesc: spelf-mood-title-case-desc
-  conflicts:
-    - OnlyYell
-
-# Greyspeak is extremely fashionable, and you should endeavor to speak like Greys to the best of your ability.
-- type: spelfMood
-  id: GreySpeak
-  moodName: spelf-mood-greyspeak-name
-  moodDesc: spelf-mood-greyspeak-desc
-  conflicts:
-    - Imitation
 
 # Cry Wolf: The crew is too lax and must be kept on edge for any emergency. Regularly call out fake threats to make sure they're ready for the real deal.
 - type: spelfMood

--- a/Resources/Prototypes/_Impstation/Spelfs/Moods/yes_and.yml
+++ b/Resources/Prototypes/_Impstation/Spelfs/Moods/yes_and.yml
@@ -11,31 +11,23 @@
     - MustDoDrugs
     - WorshipSilicons
     - DinnerEtiquette
-    - Clarity
     - HugGood
     - NeverAlone
     - VeryReligious
     - OnlySpeakToCommand
     - Scheduler
-#    - RadioOnly
     - ProperStorage
-    - SwearingGood
-#    - StatementOnly
     - TheftNeutral
     - Duel
     - Prometheus
     - Klingon
     - SogginsLaw
-#    - Imitation
     - Generous
     - FavorsRepaid
     - Bookkeeper
     - SacredBlood
     - GiftReciever
     - NewJob
-#    - ThirdPerson
-#    - TitleCase
-    - GreySpeak
     - DepartmentTitle
     - Barefoot
     - Hospitable
@@ -48,6 +40,7 @@
     - ImposterSyndrome
     - YesMan
     - Centrist
+    - SpeechRestriction
 
 # You are extremely possessive of your property. Refuse to relinquish it, and if it is misplaced or stolen, it must be retrieved at all costs. 
 - type: spelfMood
@@ -106,14 +99,6 @@
   conflicts:
     - DinnerFloor
 
-# You must be excessively clear and honest in your speech, explaining every minute detail. 
-- type: spelfMood
-  id: Clarity
-  moodName: spelf-mood-clarity-name
-  moodDesc: spelf-mood-clarity-desc
-  conflicts:
-    - Unclarity
-
 # It is extremely impolite not to hug people frequently.
 - type: spelfMood
   id: HugGood
@@ -169,22 +154,6 @@
   moodDesc: spelf-mood-proper-storage-desc
   conflicts:
     - ImproperStorage
-
-# Swearing is the spice of any conversation, and must be used as much as reasonably possible.
-- type: spelfMood
-  id: SwearingGood
-  moodName: spelf-mood-swearing-good-name
-  moodDesc: spelf-mood-swearing-good-desc
-  conflicts:
-    - SwearingBad
-
-# Asking questions is rude. Everything must be phrased as a statement.
-- type: spelfMood
-  id: StatementOnly
-  moodName: spelf-mood-statement-only-name
-  moodDesc: spelf-mood-statement-only-desc
-  conflicts:
-    - QuestionOnly
 
 # Theft is a morally neutral act. You don't understand the concept of property as it relates to other people.
 - type: spelfMood
@@ -273,8 +242,7 @@
   moodName: spelf-mood-no-department-title-name
   moodDesc: spelf-mood-no-department-title-desc
   conflicts:
-    - FullNameAndTitleShared
-    - NamesAreRude
+    - SpeechRestriction
 
 # The ground you walk on is sacred. You must not wear shoes.
 - type: spelfMood
@@ -360,6 +328,14 @@
   moodDesc: spelf-mood-public-sector-desc
   conflicts:
     - StationIsAlive
+
+# Speech Restrictions
+- type: spelfMood
+  id: SpeechRestriction
+  moodName: spelf-mood-speech-restriction-name
+  moodDesc: spelf-mood-speech-restriction-desc
+  moodVars:
+    speechType: SpeechRestrictions
 
 # The color [COLOR] is the only acceptable color for decorations. Endeavor to make your environment this color where possible.
 #- type: spelfMood

--- a/Resources/Prototypes/_Impstation/datasets.yml
+++ b/Resources/Prototypes/_Impstation/datasets.yml
@@ -152,6 +152,27 @@
     - FolkHero
 
 - type: dataset
+  id: SpeechRestrictions
+  values:
+    - FullNameAndTitle
+    - NamesAreRude
+    - Clarity
+    - SwearingGood
+    - StatementOnly
+    - Imitation
+    - Unclarity
+    - SwearingBad
+    - QuestionOnly
+    - MustAnswer
+    - OnlyWhisper
+    - OnlyYell
+    - Rhyme
+    - Alliterate
+    - ThirdPerson
+    - TitleCase
+    - GreySpeak
+
+- type: dataset
   id: SpelfWords
   values:
   - accept


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Thaven speech quirk moods are now (as a group) as likely to roll as any other single mood, which should make Thaven moods more interesting on average, and make it easier to play a consistent character.
