### PR TITLE
ghost role text fix-up

### DIFF
--- a/Resources/Locale/en-US/_DeltaV/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_DeltaV/ghost/roles/ghost-role-component.ftl
@@ -1,15 +1,20 @@
 ghost-role-information-nukie-mouse-name = Nuclear Operative Mouse
 ghost-role-information-nukie-mouse-description = A Nuclear Operative reinforcement for the Syndicate.
-ghost-role-information-nukie-mouse-rules = Normal syndicate antagonist rules apply. Work with whoever called you in, and don't harm them.
+ghost-role-information-nukie-mouse-rules = You are a [color=#6495ed][bold]Familiar[/bold][/color]. Serve the interests of your master, whatever those may be.
                                            The crew is allowed to kill you without warning.
-                                           You are allowed to attack the crew and destroy the station without provocation. 					
+                                           You are allowed to attack the crew and destroy the station without provocation.
+
+                                           You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 ghost-role-information-recruiter-name = Syndicate Recruiter
 ghost-role-information-recruiter-description = The Syndicate needs to hire new people and you're the best in the business.
-ghost-role-information-recruiter-rules =
-    Interview people and have the best candidates sign a contract in blood.
-    Set up shop in maints or use your ship as a portable hiring office!
+ghost-role-information-recruiter-rules = You are a [color=yellow][bold]Syndicate Recruiter[/bold][/color].
+                                         Your priority is to recruit crewmembers to the Syndicate, avoid acting excessively antagonistic.
+                                         Interview people and have the best candidates sign a contract in blood.
 
-    You are just a recruiter so do not act like a full-on antagonist, i.e. no killing people.
-ghost-role-information-listeningop-name = Listening Post Operative
+                                         You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+ghost-role-information-listeningop-name = Syndicate Listening Post Operative
 ghost-role-information-listeningop-description = You are a Listening Post operative. Get into range, observe the station, intercept communications and assist any operatives in the area!
-ghost-role-information-listeningop-rules =	You are a Syndicate Operative tasked with the continuous reporting and monitoring of the station and its activities, as well as assisting any fellow operatives who may be aboard the station. As an antagonist, do whatever is required for you to complete this task. Make sure your station doesn't fall into enemy hands and DO NOT abandon your station! Hide your existence at any cost!
+ghost-role-information-listeningop-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other Syndicate agents.
+                                           Make sure your station doesn't fall into enemy hands and [bold]do not abandon your station[/bold]!
+
+                                           You don't remember any of your previous life, and you don't remember anything you learned as a ghost.

--- a/Resources/Locale/en-US/_DeltaV/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_DeltaV/ghost/roles/ghost-role-component.ftl
@@ -8,13 +8,13 @@ ghost-role-information-nukie-mouse-rules = You are a [color=#6495ed][bold]Famili
 ghost-role-information-recruiter-name = Syndicate Recruiter
 ghost-role-information-recruiter-description = The Syndicate needs to hire new people and you're the best in the business.
 ghost-role-information-recruiter-rules = You are a [color=yellow][bold]Syndicate Recruiter[/bold][/color].
-                                         Your priority is to recruit crewmembers to the Syndicate, avoid acting excessively antagonistic.
-                                         Interview people and have the best candidates sign a contract in blood.
+                                         Your mission is to recruit Nanotrasen crewmembers to the Syndicate. Avoid excessive antagonism or destruction.
+                                         Conduct interviews, and have candidates sign a contract in blood.
 
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 ghost-role-information-listeningop-name = Syndicate Listening Post Operative
 ghost-role-information-listeningop-description = You are a Listening Post operative. Get into range, observe the station, intercept communications and assist any operatives in the area!
 ghost-role-information-listeningop-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other Syndicate agents.
-                                           Make sure your station doesn't fall into enemy hands and [bold]do not abandon your station[/bold]!
+                                           Make sure your station doesn't fall into enemy hands and [bold]do not abandon your station[/bold].
 
                                            You don't remember any of your previous life, and you don't remember anything you learned as a ghost.

--- a/Resources/Locale/en-US/_Impstation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Impstation/ghost/roles/ghost-role-component.ftl
@@ -1,12 +1,10 @@
 ghost-role-information-freeagent-rat-king-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
-                                         You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                         You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                         You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
                                          Your primary goal is getting food. Killing should be used as a last resort. You are still subject to Mass Chaos RDM rules unless declared an enemy of the ship.
+
+                                         You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 ghost-role-information-antagonist-rat-king-rules = You are a [color=red][bold]Solo Antagonist[/bold][/color]. Your intentions are clear, and harmful to the station and its crew.
+
                                           You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                          You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                          You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 
 ghost-role-information-raccoon-name = Raccoon
 ghost-role-information-raccoon-description = A run of the mill trash panda.
@@ -17,9 +15,8 @@ ghost-role-information-possum-description = Screams, eats trash, screams some mo
 ghost-role-information-subjuzine-description = Made obedient with the magic of subjuzine.
 ghost-role-information-subjuzine-rules-1 = You are a [color=#6495ed][bold]Familiar[/bold][/color] under the control of [color=red][bold]
 ghost-role-information-subjuzine-rules-2 = [/bold][/color]. Follow your master's orders and keep their identity secret.
+
                                         You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                        You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                        You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 
 ghost-role-information-syndie-assaultborg-name = Syndicate Assault Borg
 ghost-role-information-syndie-assaultborg-description = Nuclear operatives needs reinforcements. You, a cold silicon killing machine, will help them. More dakka!

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -1,33 +1,27 @@
 # also used in MakeGhostRuleWindow and MakeGhostRoleCommand
 ghost-role-component-default-rules = All normal rules apply unless an administrator tells you otherwise.
+
                                      You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                     You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                     You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 ghost-role-information-nonantagonist-rules = You are a [color=green][bold]Non-antagonist[/bold][/color]. You should generally not seek to harm the station and its crew.
+
                                              You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                             You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                             You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 ghost-role-information-freeagent-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
+                                         You are still required to follow rules against excessive destruction. [color=red]Do not seek to sabotage critical infrastructure without proper escalation.[/color]
+
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                         You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                         You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 ghost-role-information-antagonist-rules = You are a [color=red][bold]Solo Antagonist[/bold][/color]. Your intentions are clear, and harmful to the station and its crew.
+
                                           You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                          You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                          You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 ghost-role-information-rules-team-antagonist = You are a [color=red][bold]Team Antagonist[/bold][/color]. Your intentions are clear, and harmful to the station and its crew.
                                                You must [bold]work with your team[/bold] or follow reasonable directions from your team leaders.
+
                                                You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                               You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                               You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 ghost-role-information-familiar-rules = You are a [color=#6495ed][bold]Familiar[/bold][/color]. Serve the interests of your master, whatever those may be.
+
                                         You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                        You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                        You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 ghost-role-information-silicon-rules = You are a [color=#6495ed][bold]Silicon[/bold][/color]. Obey your laws. You are a Free Agent if you are not currently bound by any laws.
+
                                        You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                       You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                       You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 
 ghost-role-information-mouse-name = Mouse
 ghost-role-information-mouse-description = A hungry and mischievous mouse.
@@ -48,6 +42,8 @@ ghost-role-information-giant-spider-name = Giant spider
 ghost-role-information-giant-spider-description = This station's inhabitants look mighty tasty, and your sticky web is perfect to catch them!
 ghost-role-information-giant-spider-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other giant spiders.
 
+                                            You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+
 ghost-role-information-cognizine-description = Made conscious with the magic of cognizine.
 
 ghost-role-information-hamster-name = Hamster
@@ -63,6 +59,8 @@ ghost-role-information-angry-slimes-name = Slime
 ghost-role-information-angry-slimes-description = Everyone around you irritates your instincts, destroy them!
 ghost-role-information-angry-slimes-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other angry slimes.
 
+                                            You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+
 ghost-role-information-smile-name = Smile the Slime
 ghost-role-information-smile-description = The sweetest creature in the world. Smile Slime!
 
@@ -72,6 +70,8 @@ ghost-role-information-punpun-description = An honorable member of the monkey so
 ghost-role-information-xeno-name = Xeno
 ghost-role-information-xeno-description = You are a xeno, co-operate with your hive to kill all crewmembers!
 ghost-role-information-xeno-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other xenos.
+
+                                    You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 
 ghost-role-information-revenant-name = Revenant
 ghost-role-information-revenant-description = You are a Revenant. Use your powers to harvest souls and unleash chaos upon the crew. Unlock new abilities with the essence you harvest.
@@ -135,10 +135,16 @@ ghost-role-information-ifrit-description = Listen to your owner. Don't tank dama
 ghost-role-information-space-dragon-name = Space dragon
 ghost-role-information-space-dragon-description = Call in 3 carp rifts and take over this quadrant! You have only 5 minutes in between each rift before you will disappear.
 ghost-role-information-space-dragon-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all your summoned carp.
+
+                                            You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 ghost-role-information-space-dragon-summoned-carp-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with your dragon and its allies.
+
+                                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 
 ghost-role-information-space-dragon-dungeon-description = Defend the expedition dungeon with your fishy comrades!
 ghost-role-information-space-dragon-dungeon-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all dungeon mobs.
+
+                                                    You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 
 ghost-role-information-cluwne-name = Cluwne
 ghost-role-information-cluwne-description = Become a pitiful cluwne, your only goal in life is to find a sweet release from your suffering (usually by being beaten to death). A cluwne is not an antagonist but may defend itself. Crewmembers may murder cluwnes freely.
@@ -188,6 +194,8 @@ ghost-role-information-loneop-name = Lone Operative
 ghost-role-information-loneop-description = You are a lone nuclear operative. Destroy the station!
 ghost-role-information-loneop-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other nuclear operatives. Covert syndicate agents are not guaranteed to help you.
 
+                                      You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+
 ghost-role-information-behonker-name = Behonker
 ghost-role-information-behonker-description = You are an antagonist, bring death and honks to those who do not follow the honkmother.
 
@@ -198,9 +206,13 @@ ghost-role-information-Death-Squad-name = Death Squad Operative
 ghost-role-information-Death-Squad-description = One of Nanotrasen's top internal affairs agents. Await orders from CentComm or an official.
 ghost-role-information-Death-Squad-rules = You are required to obey orders given by your superior, you are effectively their [color=#6495ed][bold]Familiar[/bold][/color].
 
+                                           You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+
 ghost-role-information-SyndiCat-name = SyndiCat
 ghost-role-information-SyndiCat-description = You're the faithful trained pet of nuclear operatives with a microbomb. Serve your master to the death!
 ghost-role-information-SyndiCat-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with the agent who summoned you.
+
+                                        You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 
 ghost-role-information-Cak-name = Cak
 ghost-role-information-Cak-description = You are the chef's favorite child. You're a living cake cat.
@@ -215,6 +227,8 @@ ghost-role-information-syndicate-reinforcement-name = Syndicate Agent
 ghost-role-information-syndicate-reinforcement-description = Someone needs reinforcements. You, the first person the syndicate could find, will help them.
 ghost-role-information-syndicate-reinforcement-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with the agent who summoned you.
 
+                                                       You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+
 ghost-role-information-syndicate-reinforcement-medic-name = Syndicate Medic
 ghost-role-information-syndicate-reinforcement-medic-description = Someone needs reinforcements. Your task is to keep the agent who called you alive.
 
@@ -228,13 +242,19 @@ ghost-role-information-nukeop-reinforcement-name = Nuclear Operative
 ghost-role-information-nukeop-reinforcement-description = The nuclear operatives need reinforcements. You, a reserve agent, will help them.
 ghost-role-information-nukeop-reinforcement-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with the nuclear operatives who summoned you.
 
+                                                    You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+
 ghost-role-information-syndicate-monkey-reinforcement-name = Syndicate Monkey Agent
 ghost-role-information-syndicate-monkey-reinforcement-description = Someone needs reinforcements. You, a trained monkey, will help them.
 ghost-role-information-syndicate-monkey-reinforcement-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with the agent who summoned you.
 
+                                                              You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+
 ghost-role-information-syndicate-kobold-reinforcement-name = Syndicate Kobold Agent
 ghost-role-information-syndicate-kobold-reinforcement-description = Someone needs reinforcements. You, a trained kobold, will help them.
 ghost-role-information-syndicate-kobold-reinforcement-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with the agent who summoned you.
+
+                                                              You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 
 ghost-role-information-syndicate-cyborg-assault-name = Syndicate Assault Cyborg
 ghost-role-information-syndicate-cyborg-saboteur-name = Syndicate Saboteur Cyborg
@@ -269,16 +289,14 @@ ghost-role-information-command-description = You are a member of command, but se
 ghost-role-information-lost-challenge-commander-name = Commander on Shore Leave
 ghost-role-information-lost-challenge-commander-description = You are a command member from another starship who was granted shore leave with one of your cargo technicians.
 ghost-role-information-lost-challenge-commander-rules = You are not hostile to the station, do what you must to ensure your own survival.
+
                                      You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                     You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                     You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 
 ghost-role-information-lost-challenge-cargo-technican-name = Cargo Chauffeur
 ghost-role-information-lost-challenge-cargo-technican-description = You are a cargo technician who was granted shore leave with one of your commanding officers.
 ghost-role-information-lost-challenge-cargo-technican-rules = You are not hostile to the station, do what you must to ensure your own survival.
+
                                      You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-                                     You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
-                                     You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 
 ghost-role-information-disaster-victim-name = Disaster Victim
 ghost-role-information-disaster-victim-description = You were rescued in an escape pod from another station that suffered a terrible fate. Perhaps you will be found and rescued.

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -80,7 +80,7 @@
   parent: MarkerBase
   components:
   - type: GhostRole
-    rules: ghost-role-information-rules-default-team-antagonist
+    rules: ghost-role-information-rules-team-antagonist
     raffle:
       settings: default
   - type: GhostRoleMobSpawner
@@ -100,7 +100,7 @@
   - type: GhostRole
     name: ghost-role-information-loneop-name
     description: ghost-role-information-loneop-description
-    rules: ghost-role-information-rules-default-solo-antagonist
+    rules: ghost-role-information-loneop-rules
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -99,7 +99,7 @@
     makeSentient: true
     name: ghost-role-information-xeno-name
     description: ghost-role-information-xeno-description
-    rules: ghost-role-information-rules-default-team-antagonist
+    rules: ghost-role-information-rules-team-antagonist
     raffle:
       settings: default
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -25,7 +25,7 @@
   - type: GhostRole
     name: ghost-role-information-syndicate-reinforcement-spy-name
     description: ghost-role-information-syndicate-reinforcement-description
-    rules: ghost-role-information-rules-default-solo-antagonist
+    rules: ghost-role-information-syndicate-reinforcement-rules
     raffle:
       settings: default
   - type: GhostRoleMobSpawner
@@ -57,7 +57,7 @@
   - type: GhostRole
     name: ghost-role-information-syndicate-monkey-reinforcement-name
     description: ghost-role-information-syndicate-monkey-reinforcement-description
-    rules: ghost-role-information-rules-default-familiar
+    rules: ghost-role-information-familiar-rules
     raffle:
       settings: default
   - type: GhostRoleMobSpawner
@@ -82,7 +82,7 @@
   - type: GhostRole
     name: ghost-role-information-SyndiCat-name
     description: ghost-role-information-SyndiCat-description
-    rules: ghost-role-information-rules-default-familiar
+    rules: ghost-role-information-familiar-rules
     raffle:
       settings: default
   - type: GhostRoleMobSpawner

--- a/Resources/Prototypes/Roles/Ghostroles/syndicate.yml
+++ b/Resources/Prototypes/Roles/Ghostroles/syndicate.yml
@@ -2,21 +2,21 @@
   id: SyndicateKobold
   name: ghost-role-information-syndicate-kobold-reinforcement-name
   description: ghost-role-information-syndicate-kobold-reinforcement-description
-  rules: ghost-role-information-rules-default-familiar 
+  rules: ghost-role-information-familiar-rules 
   entityPrototype: MobKoboldSyndicateAgent
 
 - type: ghostRole
   id: SyndicateKoboldNukeops
   name: ghost-role-information-syndicate-kobold-reinforcement-name
   description: ghost-role-information-syndicate-kobold-reinforcement-description
-  rules: ghost-role-information-rules-default-familiar 
+  rules: ghost-role-information-familiar-rules 
   entityPrototype: MobKoboldSyndicateAgentNukeops
 
 - type: ghostRole
   id: SyndicateMonkey
   name: ghost-role-information-syndicate-monkey-reinforcement-name
   description: ghost-role-information-syndicate-monkey-reinforcement-description
-  rules: ghost-role-information-rules-default-familiar 
+  rules: ghost-role-information-familiar-rules 
   entityPrototype: MobMonkeySyndicateAgent
 
 - type: ghostRole

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -11,7 +11,7 @@
   - type: GhostRole
     name: ghost-role-information-nukie-mouse-name
     description: ghost-role-information-nukie-mouse-description
-    rules: ghost-role-information-nukie-mouse-rules
+    rules: ghost-role-information-familiar-rules
   - type: GhostRoleMobSpawner
     prototype: MobNukieMouse
   - type: EmitSoundOnUse


### PR DESCRIPTION
fixed a bunch of broken locale references for ghost role rule prompts, and made adjustments across the board.

- removed two lines from the generic ghost role prompts. these were redundant and excessive, bloating out the text box with words words words
- added a line break between a ghost role's unique text and its nlr rule reminder
- added the nlr rule reminder to all ghost role rules that did not previously have it
- added a reminder against excessive destruction to the free agent rules. skeletons have gotta chill out on the looses
- nuclear operative mice use the default familiar rules rather than their own ones. the old rules have been adjusted to be in-line with the new standards but are unused
- made adjustments to delta v ghost role rules texts to make them more succinct and less description-y. the roles already have descriptions before being selected, and they were taking up too much space in the text box after line breaks were applied

### free agent
![Content Client_QmV7RmZSgr](https://github.com/user-attachments/assets/98944a88-03c0-4be7-8461-9c3357f733b2)

### lone op
![Content Client_lgNyzomvwd](https://github.com/user-attachments/assets/d72a8f53-3dea-4210-ad73-72ec7d293839)

### listening post operative
![Content Client_HYJwn3xEYc](https://github.com/user-attachments/assets/e8dde23b-349e-4a57-b420-5c44d075a9a4)

### syndicate recruiter
![Content Client_TLfQN6DMLj](https://github.com/user-attachments/assets/12168bfe-7e7a-42f3-bdba-b7409fe28a40)

**Changelog**
:cl:
- tweak: Adjustments have been made to ghost role rules text across the board.
- tweak: Free agents have a warning in their rules text about excessive destruction.
- fix: Fixed broken ghost role texts.