### PR TITLE
removes antimov and singularity beacons from surplus crates

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1054,6 +1054,10 @@
      blacklist:
        tags:
        - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+      blacklist:
+       tags:
+       - SurplusBundle #imp special (dud roll as a traitor unless you have dagd)
 
 - type: listing
   id: UplinkNukieAntimovCircuitBoard
@@ -1072,6 +1076,10 @@
     whitelist:
       tags:
       - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      tags:
+      - SurplusBundle #imp special
 
 - type: listing
   id: UplinkSurplusBundle
@@ -1127,6 +1135,10 @@
     Telecrystal: 12
   categories:
     - UplinkDisruption
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle # imp special. could maybe make a flatpack that only shows up in surplus bundles at some point, but rn its worse than useless and has a good chance of getting people stuck in wallsa nd shit
 
 - type: listing
   id: UplinkCameraBug

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1055,9 +1055,9 @@
        tags:
        - NukeOpsUplink
   - !type:BuyerWhitelistCondition
-      blacklist:
-       tags:
-       - SurplusBundle #imp special (dud roll as a traitor unless you have dagd)
+    blacklist:
+      components:
+        - SurplusBundle #imp special (dud roll as a traitor unless you have dagd)
 
 - type: listing
   id: UplinkNukieAntimovCircuitBoard
@@ -1078,8 +1078,8 @@
       - NukeOpsUplink
   - !type:BuyerWhitelistCondition
     blacklist:
-      tags:
-      - SurplusBundle #imp special
+      components:
+        - SurplusBundle #imp special
 
 - type: listing
   id: UplinkSurplusBundle
@@ -1135,10 +1135,11 @@
     Telecrystal: 12
   categories:
     - UplinkDisruption
+  conditions:
   - !type:BuyerWhitelistCondition
     blacklist:
       components:
-      - SurplusBundle # imp special. could maybe make a flatpack that only shows up in surplus bundles at some point, but rn its worse than useless and has a good chance of getting people stuck in wallsa nd shit
+        - SurplusBundle # imp special. could maybe make a flatpack that only shows up in surplus bundles at some point, but rn its worse than useless and has a good chance of getting people stuck in wallsa nd shit
 
 - type: listing
   id: UplinkCameraBug


### PR DESCRIPTION
antimov because it's going to break server rules to use it outside of a dagd objective and singularity beacon because it just kills the player who opens the crate rn

**Changelog**
:cl:
- tweak: You can no longer receive Antimov law boards and singularity beacons from Syndicate Surplus Crates.