### PR TITLE
holoparas can jump now

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -109,6 +109,7 @@
     - type: Tag
       tags:
         - CannotSuicide
+    - type: AnimatedEmotes
 
 # From the uplink injector
 - type: entity


### PR DESCRIPTION
it turns out they dont use basemob as a parent for some reason

**Changelog**
:cl:
- add: Holoparasites and holoclowns can now experience some joy and whimsy in their short, miserable lives.