### PR TITLE
changes maximum character age + age threshold for examine descriptions

### DIFF
--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -107,22 +107,25 @@ public sealed partial class SpeciesPrototype : IPrototype
 
     /// <summary>
     ///     Characters younger than this appear young.
+    ///     imp edit: 30 is not middle aged. i fucking hate you so much holy shit
     /// </summary>
     [DataField]
-    public int YoungAge = 30;
+    public int YoungAge = 40;
 
     /// <summary>
     ///     Characters older than this appear old. Characters in between young and old age appear middle aged.
+    ///     hivehum edit this is so i can make garba gleef 60 without him getting called old lol
     /// </summary>
     [DataField]
-    public int OldAge = 60;
+    public int OldAge = 70;
 
     /// <summary>
     ///     Characters cannot be older than this. Only used for restrictions...
     ///     although imagine if ghosts could age people WYCI...
+    ///     imp edit. we're brave. this will only matter when newmed drops, anyway
     /// </summary>
     [DataField]
-    public int MaxAge = 120;
+    public int MaxAge = 999;
 }
 
 public enum SpeciesNaming : byte


### PR DESCRIPTION
**Changelog**

the only thing i feel unsteady about is raising max age but it works from minimal testing and i dont think anything RIGHT NOW cares about how old you are

:cl:
- tweak: Thirty year olds are no longer considered middle aged.
- add: You can now be as old as you want.