### PR TITLE
Add Luggage ghostrole as a rare silent storagespawn event

### DIFF
--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -8,6 +8,7 @@
     - id: CockroachMigration
     - id: MouseMigration
     - id: TrashAnimalMigration
+    - id: LuggageMigration # imp special
 
 - type: entityTable
   id: SpicyPestEventsTable

--- a/Resources/Prototypes/_Impstation/GameRules/pests.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/pests.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: LuggageMigration
+  parent: BaseStationEventShortDelay
+  components:
+  - type: StationEvent
+    weight: 1.5
+    duration: 1
+  - type: RandomEntityStorageSpawnRule
+    prototype: MobDiscworldLuggage


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Luggage can now spawn on its own, rarely.

