### PR TITLE
add swat shoes to the hacked clothesmate to match tacticool jumpsuits

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -113,6 +113,7 @@
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1
+    ClothingShoesSwat: 2
     ClothingMaskGas: 1
 
   # DO NOT ADD MORE, USE UNIFORM DYING


### PR DESCRIPTION
:cl:
- add: SWAT Shoes are now in the ClothesMate's hacked inventory to match the jumpsuits