### PR TITLE
neck gaiters are pullable now

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -727,7 +727,7 @@
     - Snout
 
 - type: entity
-  parent: ClothingMaskBase
+  parent: ClothingMaskPullableBase
   id: ClothingMaskNeckGaiter
   name: neck gaiter
   description: Stylish neck gaiter for your neck, can protect from the cosmic wind?...


### PR DESCRIPTION
ok sorry about the last one i was very tired and didn't double-check things. THIS one is safe and cool, you can just pull them down off your face.  easy

this also means you _have_ to stop eating your nutribricks through your neck gaiter.  it's weird and nobody likes to see you do that.

i may possibly add an "around the neck" sprite for when it's down later, but this first cause 90% of pullable masks already don't have that and a neck gaiter of all things is likely to vanish when pulled low

:cl:
- tweak: Neck gaiters can now be pulled down like other masks