### PR TITLE
Pulled lockers/crates can now only be opened by the person pulling them

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -182,15 +182,6 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (!ResolveStorage(target, ref component))
             return;
 
-        // impstation edit
-        // prevent dumbasses from opening crates that are being dragged
-        if (
-            TryComp<PullableComponent>(target, out var pull) &&
-            pull.BeingPulled &&
-            pull.Puller != user
-        )
-            return;
-
         if (component.Open)
         {
             TryCloseStorage(target);
@@ -380,6 +371,15 @@ public abstract class SharedEntityStorageSystem : EntitySystem
                 return false;
             }
         }
+
+        // impstation edit: prevent opening containers being pulled by others
+        if (
+            TryComp<PullableComponent>(target, out var pullable) && // Can be pulled
+            pullable.BeingPulled && // Someone is pulling it
+            pullable.Puller != user && // It is not the user
+            !component.Contents.Contains(user) // The user is not inside of it
+        )
+            return false;
 
         //Checks to see if the opening position, if offset, is inside of a wall.
         if (component.EnteringOffset != new Vector2(0, 0) && !HasComp<WallMountComponent>(target)) //if the entering position is offset

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -26,6 +26,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared.Movement.Pulling.Components;
 
 namespace Content.Shared.Storage.EntitySystems;
 
@@ -179,6 +180,15 @@ public abstract class SharedEntityStorageSystem : EntitySystem
     public void ToggleOpen(EntityUid user, EntityUid target, SharedEntityStorageComponent? component = null)
     {
         if (!ResolveStorage(target, ref component))
+            return;
+
+        // impstation edit
+        // prevent dumbasses from opening crates that are being dragged
+        if (
+            TryComp<PullableComponent>(target, out var pull) &&
+            pull.BeingPulled &&
+            pull.Puller != user
+        )
             return;
 
         if (component.Open)


### PR DESCRIPTION
Fixes a long standing issue of pulling material crates / lockers / dumpsters and random dipshits clicking on them and spilling the contents.

**Changelog**

:cl: TGRCDev
- tweak: Crates/lockers being pulled can now only be opened by the person pulling them
