### PR TITLE
Replace empty art toolboxes with filled ones

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -445,4 +445,5 @@ BlueprintFlare: null
 BaseAdvancedPen: Pen
 
 # 2024-11-25
+#impstation change
 ToolboxArtistic: ToolboxArtisticFilled

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -443,3 +443,6 @@ BlueprintFlare: null
 
 # 2024-10-04
 BaseAdvancedPen: Pen
+
+# 2024-11-25
+ToolboxArtistic: ToolboxArtisticFilled


### PR DESCRIPTION
a lot of maps start with empty art toolboxes, which feels like a mistake to me, so this should change it so they all start filled now. i'm not sure if this could cause problems in the future, but it's so small that i can't imagine it ever being an issue. also, i wasn't sure if i should be making a special impstation migraton.yml, so i just left a comment that said this change was an impstation one.


:cl:
- tweak: All empty art toolboxes are now filled. No more disappointment when looking for crayons!


