### PR TITLE
window upgrades

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
@@ -74,6 +74,26 @@
               doAfter: 1
             - tool: Anchoring
               doAfter: 2
+        - to: plasmaWindow
+          steps:
+            - material: Plasma
+              amount: 2
+              doAfter: 2
+        - to: reinforcedWindow
+          steps:
+            - material: MetalRod
+              amount: 2
+              doAfter: 2
+        - to: uraniumWindow
+          steps:
+            - material: Uranium
+              amount: 2
+              doAfter: 2
+        - to: clockworkWindow
+          steps:
+            - material: Brass
+              amount: 2
+              doAfter: 3
 
     - node: reinforcedWindow
       entity: ReinforcedWindow
@@ -97,6 +117,16 @@
               doAfter: 1
             - tool: Anchoring
               doAfter: 2
+        - to: reinforcedPlasmaWindow
+          steps:
+            - material: Plasma
+              amount: 2
+              doAfter: 3
+        - to: reinforcedUraniumWindow
+          steps:
+            - material: Uranium
+              amount: 2
+              doAfter: 3
 
     - node: tintedWindow
       entity: TintedWindow
@@ -134,6 +164,11 @@
             - tool: Screwing
               doAfter: 2
             - tool: Anchoring
+              doAfter: 3
+        - to: reinforcedPlasmaWindow
+          steps:
+            - material: MetalRod
+              amount: 2
               doAfter: 3
 
     - node: reinforcedPlasmaWindow
@@ -176,6 +211,11 @@
             - tool: Screwing
               doAfter: 2
             - tool: Anchoring
+              doAfter: 3
+        - to: reinforcedUraniumWindow
+          steps:
+            - material: MetalRod
+              amount: 2
               doAfter: 3
 
     - node: reinforcedUraniumWindow

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/window_diagonal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/window_diagonal.yml
@@ -60,6 +60,26 @@
               doAfter: 1
             - tool: Anchoring
               doAfter: 2
+        - to: plasmaWindowDiagonal
+          steps:
+            - material: Plasma
+              amount: 2
+              doAfter: 2
+        - to: reinforcedWindowDiagonal
+          steps:
+            - material: MetalRod
+              amount: 2
+              doAfter: 2
+        - to: uraniumWindowDiagonal
+          steps:
+            - material: Uranium
+              amount: 2
+              doAfter: 2
+        - to: clockworkWindowDiagonal
+          steps:
+            - material: Brass
+              amount: 2
+              doAfter: 3
 
     - node: reinforcedWindowDiagonal
       entity: ReinforcedWindowDiagonal
@@ -83,6 +103,16 @@
               doAfter: 1
             - tool: Anchoring
               doAfter: 2
+        - to: reinforcedPlasmaWindowDiagonal
+          steps:
+            - material: Plasma
+              amount: 2
+              doAfter: 3
+        - to: reinforcedUraniumWindowDiagonal
+          steps:
+            - material: Uranium
+              amount: 2
+              doAfter: 3
 
     - node: clockworkWindowDiagonal
       entity: ClockworkWindowDiagonal
@@ -125,6 +155,11 @@
               doAfter: 2
             - tool: Anchoring
               doAfter: 3
+        - to: reinforcedPlasmaWindowDiagonal
+          steps:
+            - material: MetalRod
+              amount: 2
+              doAfter: 3
 
     - node: reinforcedPlasmaWindowDiagonal
       entity: ReinforcedPlasmaWindowDiagonal
@@ -166,6 +201,11 @@
             - tool: Screwing
               doAfter: 2
             - tool: Anchoring
+              doAfter: 3
+        - to: reinforcedUraniumWindowDiagonal
+          steps:
+            - material: MetalRod
+              amount: 2
               doAfter: 3
 
     - node: reinforcedUraniumWindowDiagonal

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windowdirectional.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windowdirectional.yml
@@ -60,6 +60,26 @@
               doAfter: 1
             - tool: Anchoring
               doAfter: 2
+        - to: windowReinforcedDirectional
+          steps:
+            - material: MetalRod
+              amount: 1
+              doAfter: 3
+        - to: plasmaWindowDirectional
+          steps:
+            - material: Plasma
+              amount: 1
+              doAfter: 2
+        - to: uraniumWindowDirectional
+          steps:
+            - material: Uranium
+              amount: 1
+              doAfter: 2
+        - to: windowClockworkDirectional
+          steps:
+            - material: Brass
+              amount: 1
+              doAfter: 3
 
     - node: windowReinforcedDirectional
       entity: WindowReinforcedDirectional
@@ -79,6 +99,16 @@
               doAfter: 1
             - tool: Anchoring
               doAfter: 2
+        - to: plasmaReinforcedWindowDirectional
+          steps:
+            - material: Plasma
+              amount: 1
+              doAfter: 3
+        - to: uraniumReinforcedWindowDirectional
+          steps:
+            - material: Uranium
+              amount: 1
+              doAfter: 3
 
     - node: plasmaWindowDirectional
       entity: PlasmaWindowDirectional
@@ -97,6 +127,11 @@
             - tool: Screwing
               doAfter: 2
             - tool: Anchoring
+              doAfter: 3
+        - to: plasmaReinforcedWindowDirectional
+          steps:
+            - material: MetalRod
+              amount: 1
               doAfter: 3
 
     - node: windowClockworkDirectional
@@ -153,6 +188,11 @@
             - tool: Screwing
               doAfter: 2
             - tool: Anchoring
+              doAfter: 3
+        - to: uraniumReinforcedWindowDirectional
+          steps:
+            - material: MetalRod
+              amount: 1
               doAfter: 3
 
     - node: uraniumReinforcedWindowDirectional


### PR DESCRIPTION
upstream removed them. we can have them back
this does not include shuttle window upgrades (because i hate them & am vindictive & evil) and also takes longer compared to the old window upgrading. it matches the do-after speed of building these windows from scratch, it just provides convenience and requires less bag space/construction menu work

**Changelog**
:cl:
- add: Direct window upgrading is back! Shuttle windows are not back, though.