### PR TITLE
Replicate propulsion whitelist to try and fix mucin mispredicts

### DIFF
--- a/Content.Client/_Impstation/Fluids/EntitySystems/PropulsionSystem.cs
+++ b/Content.Client/_Impstation/Fluids/EntitySystems/PropulsionSystem.cs
@@ -44,6 +44,7 @@ public sealed partial class PropulsionSystem : EntitySystem
         comp.PredictIndex = state.PredictIndex;
         comp.WalkSpeedModifier = state.WalkSpeedModifier;
         comp.SprintSpeedModifier = state.SprintSpeedModifier;
+        comp.Whitelist = state.Whitelist;
     }
 
     private bool CanAffect(Entity<PropulsionComponent> entity, EntityUid other)
@@ -63,6 +64,7 @@ public sealed partial class PropulsionSystem : EntitySystem
         propulse.WalkSpeedModifier = entity.Comp.WalkSpeedModifier;
         propulse.SprintSpeedModifier = entity.Comp.SprintSpeedModifier;
         propulse.PredictFingerprint |= 1ul << entity.Comp.PredictIndex;
+        Dirty(other, propulse);
 
         var modifier = EnsureComp<MovementSpeedModifierComponent>(other);
         _speed.RefreshMovementSpeedModifiers(other, modifier);
@@ -74,6 +76,7 @@ public sealed partial class PropulsionSystem : EntitySystem
             return;
 
         propulse.PredictFingerprint &= ~(1ul << entity.Comp.PredictIndex);
+        Dirty(other, propulse);
         _speed.RefreshMovementSpeedModifiers(other);
     }
 

--- a/Content.Shared/_Impstation/Fluids/Components/PropulsionComponent.cs
+++ b/Content.Shared/_Impstation/Fluids/Components/PropulsionComponent.cs
@@ -44,9 +44,11 @@ public sealed partial class PropulsionState : ComponentState
         WalkSpeedModifier = comp.WalkSpeedModifier;
         SprintSpeedModifier = comp.SprintSpeedModifier;
         PredictIndex = comp.PredictIndex;
+        Whitelist = comp.Whitelist;
     }
 
     public float WalkSpeedModifier;
     public float SprintSpeedModifier;
     public byte PredictIndex;
+    public EntityWhitelist? Whitelist;
 }


### PR DESCRIPTION
Sometimes mucin causes mispredictions for non-gastropoids, so I've added the whitelist to the component state. I couldn't replicate it myself, so this is just a guess.