### PR TITLE
Correction to wording on nonlethal shotgun crate

### DIFF
--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/security.yml
@@ -2,7 +2,7 @@
   id: CrateSecurityShotgunNonlethal
   parent: CrateSecgear
   name: nonlethal shotgun crate
-  description: For when you need to break some ribs. Contains two Beanbag Kammerer shotguns with extra ammunition. Requires Security access to open.
+  description: For when the station is being a bit too rowdy. Contains two Stun Kammerer shotguns with extra ammunition. Requires Security access to open.
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
This was missed during the rework to nonlethal shotgun rounds. Tones down the violence of the description and uses the correct name of the shotgun.

**Changelog**

:cl:
- tweak: Reworded the description of the nonlethal shotgun crate to match previous changes to them.

