### PR TITLE
Change service locked glass airlock sprite to better match their standard counterpart

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -442,6 +442,8 @@
       board: [ DoorElectronicsService ]
   - type: Wires
     layoutId: AirlockService
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Glass/basic.rsi
 
 - type: entity
   parent: AirlockServiceGlassLocked


### PR DESCRIPTION
The standard white glass airlock best communicates that anybody can open it up; it is not restricted by any access. However, this same sprite is also used for glass airlocks that are access-restricted to civilian jobs, making it confusing at a glance on whether or not you would be able to open it with your current access level. This PR changes the service glass airlock to use a glass airlock sprite (that was already in the game and seemingly unused?) that better matches its normal counterpart, affecting all airlocks that are its children (service, lawyer, theater, bar, kitchen, janitor, and chapel).

![glassairlock](https://github.com/user-attachments/assets/2dc049de-0fb0-4d88-abdf-4ba551a24075)

At some point I would like to change it so airlocks for each specific civilian job have their own sprite, even if it's just changing the color of the stripe on the airlock, but for now, this is the easiest way to convey the idea that an airlock is restricted in some way.

**Changelog**

:cl:
- tweak: Glass airlocks that are locked by civilian accesses (eg. janitor, service, kitchen) now use a sprite that better matches their standard counterpart.

