### PR TITLE
theater vendor hacked inventory

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -56,10 +56,16 @@
     ClothingShoesBootsCowboyBlack: 1
     ClothingShoesBootsCowboyWhite: 1
     ClothingNeckScarfStripedZebra: 1
+  contrabandInventory:
+    ClothingUniformJumpsuitAncient: 1
+    ClothingUniformJumpsuitCossack: 1
+    ClothingUniformJumpsuitLoungewear: 1
+    ClothingShoesSlippers: 1
+    ClothingShoesTourist: 1
+    ClothingShoesWizard: 1
   emaggedInventory:
     ClothingShoesBling: 1
     ClothingShoesBootsCowboyFancy: 1
-    ClothingUniformJumpsuitLoungewear: 1
     ClothingOuterDogi: 1
     ClothingMaskSexyClown: 1
     ClothingMaskSexyMime: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -59,6 +59,7 @@
   emaggedInventory:
     ClothingShoesBling: 1
     ClothingShoesBootsCowboyFancy: 1
+    ClothingUniformJumpsuitLoungewear: 1
     ClothingOuterDogi: 1
     ClothingMaskSexyClown: 1
     ClothingMaskSexyMime: 1

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -129,8 +129,6 @@
     sprite: Clothing/OuterClothing/Misc/classicponcho.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/classicponcho.rsi
-  - type: AddAccentClothing
-    accent: SpanishAccent
 
 - type: entity
   parent: ClothingOuterBase


### PR DESCRIPTION
i think the theater wardrobe vendor should have a reason to play with its wires, so i'm adding a few items to it that are rarely mapped, are only occasionally found in maints, or are reserved for civilian visitor roles that we don't even have.  i can add or remove things too but i think rarified fit variety is good.  also pretty sure none of these items are so precious and sought-after that hiding them in a sometimes-hidden vending machine is going to change anything besides give people more fun options to dress with

:cl:
- add: ancient jumpsuit, cossack suit, loungewear, wizard shoes, tourist shoes, and slippers are now found in hacked theater vendors
- tweak: removed patronizing spanish accent from poncho so it's wearable too