### PR TITLE
dino wars redux

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/ai_factions.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/ai_factions.yml
@@ -5,3 +5,4 @@
   - Syndicate
   - Zombie
   - Revolutionary
+  - Dino

--- a/Resources/Prototypes/_Goobstation/Heretic/ai_factions.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/ai_factions.yml
@@ -6,3 +6,4 @@
   - Zombie
   - Revolutionary
   - Changeling
+  - Dino

--- a/Resources/Prototypes/_Impstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Impstation/Damage/modifier_sets.yml
@@ -8,10 +8,8 @@
   coefficients:
     Blunt: 0.6
     Slash: 0.7
-    Piercing: 1.3
     Cold: 1.4
     Poison: 0.8
-    Structural: 2.0
   flatReductions:
     Blunt: 5
     Piercing: 5

--- a/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
@@ -1,0 +1,173 @@
+- type: entity
+  name: random dinosaur spawner
+  id: DinosaurSpawnerRandom
+  parent: MarkerBase
+  suffix: DO NOT MAP
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: raptor
+          sprite: _Impstation/Mobs/Aliens/Dinos/raptor.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurAnki
+      - MobDinosaurCompy
+      - MobDinosaurDilo
+      - MobDinosaurKentro
+      - MobDinosaurPara
+      - MobDinosaurRaptor
+      - MobDinosaurSpino
+      - MobDinosaurStego
+      - MobDinosaurTrex
+      - MobDinosaurTrike
+
+- type: entity
+  name: dinosaur spawner
+  suffix: ankylosaurus, DO NOT MAP
+  id: DinosaurSpawnerAnki
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: anki
+          sprite: _Impstation/Mobs/Aliens/Dinos/anky.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurAnki
+
+- type: entity
+  name: dinosaur spawner
+  suffix: compsognathus, DO NOT MAP
+  id: DinosaurSpawnerCompy
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: compy
+          sprite: _Impstation/Mobs/Aliens/Dinos/compy.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurCompy
+
+- type: entity
+  name: dinosaur spawner
+  suffix: dilophosaurus, DO NOT MAP
+  id: DinosaurSpawnerDilo
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: dilo
+          sprite: _Impstation/Mobs/Aliens/Dinos/dilo.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurDilo
+
+- type: entity
+  name: dinosaur spawner
+  suffix: kentrosaurus, DO NOT MAP
+  id: DinoSpawnerKentro
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: kentro
+          sprite: _Impstation/Mobs/Aliens/Dinos/kentro.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurKentro
+
+- type: entity
+  name: dinosaur spawner
+  suffix: parasaurolophus, DO NOT MAP
+  id: DinoSpawnerPara
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: para
+          sprite: _Impstation/Mobs/Aliens/Dinos/para.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurPara
+
+- type: entity
+  name: dinosaur spawner
+  suffix: velociraptor, DO NOT MAP
+  id: DinoSpawnerRaptor
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: raptor
+          sprite: _Impstation/Mobs/Aliens/Dinos/raptor.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurRaptor
+
+- type: entity
+  name: dinosaur spawner
+  suffix: spinosaurus, DO NOT MAP
+  id: DinoSpawnerSpino
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: spino
+          sprite: _Impstation/Mobs/Aliens/Dinos/spino.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurSpino
+
+- type: entity
+  name: dinosaur spawner
+  suffix: stegosaurus, DO NOT MAP
+  id: DinoSpawnerStego
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: stego
+          sprite: _Impstation/Mobs/Aliens/Dinos/stego.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurStego
+
+- type: entity
+  name: dinosaur spawner
+  suffix: tyrannosaurus, DO NOT MAP
+  id: DinoSpawnerTrex
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: trex
+          sprite: _Impstation/Mobs/Aliens/Dinos/trex.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurTrex
+
+- type: entity
+  name: dinosaur spawner
+  suffix: triceratops, DO NOT MAP
+  id: DinoSpawnerTrike
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: trike
+          sprite: _Impstation/Mobs/Aliens/Dinos/trike.rsi
+    - type: ConditionalSpawner
+      prototypes:
+      - MobDinosaurTrike

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
@@ -160,7 +160,7 @@
   - type: Devourer # imp additions
     foodPreference: Humanoid
     shouldStoreDevoured: true
-    chemical: Ichor
+    chemical: DinoBlood
     healRate: 15.0
     whitelist:
       components:
@@ -351,7 +351,7 @@
   - type: Devourer # imp additions
     foodPreference: Humanoid
     shouldStoreDevoured: true
-    chemical: Ichor
+    chemical: DinoBlood
     healRate: 15.0
     whitelist:
       components:
@@ -409,7 +409,7 @@
   - type: Devourer # imp additions
     foodPreference: Humanoid
     shouldStoreDevoured: true
-    chemical: Ichor
+    chemical: DinoBlood
     healRate: 15.0
     whitelist:
       components:
@@ -556,7 +556,7 @@
   - type: Devourer # imp additions
     foodPreference: Humanoid
     shouldStoreDevoured: true
-    chemical: Ichor
+    chemical: DinoBlood
     healRate: 15.0
     whitelist:
       components:
@@ -616,7 +616,7 @@
   - type: Devourer # imp additions
     foodPreference: Humanoid
     shouldStoreDevoured: true
-    chemical: Ichor
+    chemical: DinoBlood
     healRate: 15.0
     whitelist:
       components:
@@ -675,7 +675,7 @@
   - type: Devourer # imp additions
     foodPreference: Humanoid
     shouldStoreDevoured: true
-    chemical: Ichor
+    chemical: DinoBlood
     healRate: 15.0
     whitelist:
       components:
@@ -734,7 +734,7 @@
   - type: Devourer # imp additions
     foodPreference: Humanoid
     shouldStoreDevoured: true
-    chemical: Ichor
+    chemical: DinoBlood
     healRate: 15.0
     whitelist:
       components:

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
@@ -2,7 +2,7 @@
   save: false
   parent: [ BaseSimpleMob, MobCombat ]
   id: BaseMobDinosaur
-  suffix: AI, DO NOT MAP
+  suffix: AI
   description: Enigmatic behemoth from a bygone era, known for their imposing stature and formidable presence.
   abstract: true
   components:
@@ -14,7 +14,7 @@
       - Prying
   - type: Prying
     pryPowered: false
-    useSound: /Audio/Items/jaws_pry.ogg
+    useSound: /Audio/Items/crowbar.ogg
   - type: HTN
     rootTask:
       task: XenoCompound #maybe someday... But for now it's enough.
@@ -80,8 +80,35 @@
     name: ghost-role-information-dino-name
     description: ghost-role-information-dino-description
     rules: ghost-role-information-rules-team-antagonist
-    raffle:
-      settings: short
+  - type: GhostTakeoverAvailable
+  - type: Barotrauma
+    damage:
+      types:
+        Blunt: 0.50
+        Heat: 0.1
+  - type: Temperature # temperature values taken from reptilian species
+    heatDamageThreshold: 400
+    coldDamageThreshold: 285
+    currentTemperature: 310.15
+    specificHeat: 42
+    coldDamage:
+      types:
+        Cold : 0.1 #per second, scales with temperature & other constants
+    heatDamage:
+      types:
+        Heat : 1.5 #per second, scales with temperature & other constants
+  - type: TemperatureSpeed 
+    thresholds:
+      301: 0.8
+      295: 0.6
+      285: 0.4
+  - type: Respirator
+    damage:
+      types:
+        Asphyxiation: 1.0
+    damageRecovery:
+      types:
+        Asphyxiation: -1.0
 
 - type: entity
   parent: BaseMobDinosaur
@@ -126,9 +153,20 @@
     damage:
       types:
         Blunt: 20
+        Structural: 10
   - type: MovementSpeedModifier
     baseSprintSpeed : 2
     baseWalkSpeed: 1
+  - type: Devourer # imp additions
+    foodPreference: Humanoid
+    shouldStoreDevoured: true
+    chemical: Ichor
+    healRate: 15.0
+    whitelist:
+      components:
+      - Door
+      tags:
+      - Wall
 
 - type: entity
   parent: BaseMobDinosaur
@@ -184,6 +222,7 @@
     damage:
       types:
         Piercing: 5
+        Structural: 2
   - type: MovementSpeedModifier
     baseSprintSpeed : 5
     baseWalkSpeed: 2.5
@@ -250,6 +289,7 @@
       types:
         Slash: 5
         Caustic: 2
+        Structural: 2
   - type: MovementSpeedModifier
     baseSprintSpeed : 5.5
     baseWalkSpeed: 2.5
@@ -304,9 +344,20 @@
     damage:
       types:
         Piercing: 10
+        Structural: 5
   - type: MovementSpeedModifier
     baseSprintSpeed : 2.5
     baseWalkSpeed: 1.5
+  - type: Devourer # imp additions
+    foodPreference: Humanoid
+    shouldStoreDevoured: true
+    chemical: Ichor
+    healRate: 15.0
+    whitelist:
+      components:
+      - Door
+      tags:
+      - Wall
 
 - type: entity
   parent: BaseMobDinosaur
@@ -351,9 +402,20 @@
     damage:
       types:
         Blunt: 5
+        Structural: 2
   - type: MovementSpeedModifier
     baseSprintSpeed : 4
     baseWalkSpeed: 2.5
+  - type: Devourer # imp additions
+    foodPreference: Humanoid
+    shouldStoreDevoured: true
+    chemical: Ichor
+    healRate: 15.0
+    whitelist:
+      components:
+      - Door
+      tags:
+      - Wall
 
 - type: entity
   parent: BaseMobDinosaur
@@ -431,6 +493,7 @@
     damage:
       types:
         Slash: 12
+        Structural: 6
   - type: MovementSpeedModifier
     baseSprintSpeed : 6.5
     baseWalkSpeed: 2.5
@@ -486,9 +549,21 @@
       types:
         Slash: 18
         Piercing: 12
+        Structural: 15
   - type: MovementSpeedModifier
     baseSprintSpeed : 5
     baseWalkSpeed: 2.5
+  - type: Devourer # imp additions
+    foodPreference: Humanoid
+    shouldStoreDevoured: true
+    chemical: Ichor
+    healRate: 15.0
+    whitelist:
+      components:
+      - MobState
+      - Door
+      tags:
+      - Wall
 
 - type: entity
   parent: BaseMobDinosaur
@@ -534,9 +609,20 @@
       types:
         Blunt: 10
         Piercing: 8
+        Structural: 9
   - type: MovementSpeedModifier
     baseSprintSpeed : 3.5
     baseWalkSpeed: 2
+  - type: Devourer # imp additions
+    foodPreference: Humanoid
+    shouldStoreDevoured: true
+    chemical: Ichor
+    healRate: 15.0
+    whitelist:
+      components:
+      - Door
+      tags:
+      - Wall
 
 - type: entity
   parent: BaseMobDinosaur
@@ -582,9 +668,21 @@
       types:
         Slash: 15
         Piercing: 25
+        Structural: 20
   - type: MovementSpeedModifier
     baseSprintSpeed : 4.5
     baseWalkSpeed: 2.5
+  - type: Devourer # imp additions
+    foodPreference: Humanoid
+    shouldStoreDevoured: true
+    chemical: Ichor
+    healRate: 15.0
+    whitelist:
+      components:
+      - MobState
+      - Door
+      tags:
+      - Wall
 
 - type: entity
   parent: BaseMobDinosaur
@@ -629,6 +727,18 @@
     damage:
       types:
         Blunt: 15
+        Structural: 7
   - type: MovementSpeedModifier
     baseSprintSpeed : 3
     baseWalkSpeed: 1.5
+  - type: Devourer # imp additions
+    foodPreference: Humanoid
+    shouldStoreDevoured: true
+    chemical: Ichor
+    healRate: 15.0
+    whitelist:
+      components:
+      - MobState
+      - Door
+      tags:
+      - Wall

--- a/Resources/Prototypes/_Impstation/Reagents/biological.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/biological.yml
@@ -39,3 +39,22 @@
   recognizable: true
   physicalDesc: reagent-physical-desc-viscous
   slippery: false
+  metabolisms:
+    # like a shitter omnizine, and a shittier ichor
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 1.5
+    Medicine:
+      effects:
+      - !type:ModifyBloodLevel
+        amount: 1
+      - !type:HealthChange
+        damage:
+          groups:
+            Burn: -1
+            Toxin: -1
+            Airloss: -1
+            Brute: -1
+      - !type:ModifyBleedAmount
+        amount: -1

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -9,6 +9,7 @@
     - Revolutionary
     - Changeling
     - Heretic
+    - Dino
 
 - type: npcFaction
   id: NanoTrasen
@@ -18,6 +19,7 @@
   - Xeno
   - Zombie
   - Revolutionary
+  - Dino
 
 - type: npcFaction
   id: Mouse
@@ -34,6 +36,7 @@
   - SimpleHostile
   - Zombie
   - Xeno
+  - Dino
 
 - type: npcFaction
   id: SimpleHostile
@@ -46,6 +49,7 @@
   - Revolutionary
   - Changeling
   - Heretic
+  - Dino
 
 - type: npcFaction
   id: SimpleNeutral
@@ -60,6 +64,7 @@
   - Zombie
   - Changeling
   - Heretic
+  - Dino
 
 - type: npcFaction
   id: Xeno
@@ -72,6 +77,7 @@
   - Revolutionary
   - Changeling
   - Heretic
+  - Dino
 
 - type: npcFaction
   id: Zombie
@@ -85,6 +91,7 @@
   - Revolutionary
   - Changeling
   - Heretic
+  - Dino
 
 - type: npcFaction
   id: Revolutionary
@@ -93,3 +100,4 @@
   - Zombie
   - SimpleHostile
   - Dragon
+  - Dino


### PR DESCRIPTION
adjusts a whole lot of stuff about dinosaurs
- removed the piercing and structural(??) weakness, making dinosaurs a bit tankier against the hail of bullets
- fixed dino ghost roles, barotrauma, and respiration
- added structural damage to all dino attacks
- large dinosaurs can devour walls and doors. large carnivores can even eat people to heal, like dragons (but worse)
- all appropriate factions are hostile against dinosaurs
- dino blood functions as a shitter ichor/omnizine
- random dinosaur spawner for dino wars events, and regular dinosaur spawners for.. i dont know. dont map these. i even put it in big capital letters. i might be tempting wolfie a little

**Changelog**
:cl:
- tweak: Dino Wars has undergone an extensive rework after beta tester feedback. Thank you for continuing to support the Dino Wars project.