### PR TITLE
SpeechSound component lets wearables modify the speaker's speech sounds

### DIFF
--- a/Content.Server/Speech/SpeechNoiseSystem.cs
+++ b/Content.Server/Speech/SpeechNoiseSystem.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Random;
+using Content.Shared.Chat;
 
 namespace Content.Server.Speech
 {
@@ -26,12 +27,20 @@ namespace Content.Server.Speech
 
         public SoundSpecifier? GetSpeechSound(Entity<SpeechComponent> ent, string message)
         {
-            if (ent.Comp.SpeechSounds == null)
+            // impstation edits
+            var protoId = ent.Comp.SpeechSounds;
+
+            // raise event for voice-changing equipment
+            var voiceEv = new TransformSpeakerVoiceEvent(ent);
+            RaiseLocalEvent(ent, voiceEv);
+            protoId = voiceEv.SpeechSounds ?? protoId;
+
+            if (protoId == null)
                 return null;
 
             // Play speech sound
             SoundSpecifier? contextSound;
-            var prototype = _protoManager.Index<SpeechSoundsPrototype>(ent.Comp.SpeechSounds);
+            var prototype = _protoManager.Index<SpeechSoundsPrototype>(protoId);
 
             // Different sounds for ask/exclaim based on last character
             contextSound = message[^1] switch

--- a/Content.Server/_Impstation/Speech/Components/SpeechSoundComponent.cs
+++ b/Content.Server/_Impstation/Speech/Components/SpeechSoundComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Speech;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Impstation.Speech.Components;
+
+/// <summary>
+/// When put on a piece of clothing, modifies the wearer's
+/// speech sounds
+/// </summary>
+[RegisterComponent]
+public sealed partial class SpeechSoundComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public ProtoId<SpeechSoundsPrototype>? SpeechSounds = null;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public ProtoId<SpeechVerbPrototype>? SpeechVerb = null;
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/SpeechSoundSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/SpeechSoundSystem.cs
@@ -1,0 +1,27 @@
+using Content.Server._Impstation.Speech.Components;
+using Content.Server.VoiceMask;
+using Content.Shared.Chat;
+using Content.Shared.Inventory;
+
+namespace Content.Server._Impstation.Speech.EntitySystems;
+
+public sealed partial class SpeechSoundSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SpeechSoundComponent, InventoryRelayedEvent<TransformSpeakerVoiceEvent>>(OnTransformVoice);
+        SubscribeLocalEvent<SpeechSoundComponent, InventoryRelayedEvent<TransformSpeakerNameEvent>>(OnTransformName);
+    }
+
+    private void OnTransformVoice(Entity<SpeechSoundComponent> ent, ref InventoryRelayedEvent<TransformSpeakerVoiceEvent> args)
+    {
+        args.Args.SpeechSounds = ent.Comp.SpeechSounds ?? args.Args.SpeechSounds;
+    }
+
+    private void OnTransformName(Entity<SpeechSoundComponent> ent, ref InventoryRelayedEvent<TransformSpeakerNameEvent> args)
+    {
+        args.Args.SpeechVerb = ent.Comp.SpeechVerb ?? args.Args.SpeechVerb;
+    }
+}

--- a/Content.Shared/Chat/SharedChatEvents.cs
+++ b/Content.Shared/Chat/SharedChatEvents.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Speech;
 using Robust.Shared.Prototypes;
 using Content.Shared.Inventory;
+using Robust.Shared.Audio;
 
 namespace Content.Shared.Chat;
 
@@ -20,5 +21,22 @@ public sealed class TransformSpeakerNameEvent : EntityEventArgs, IInventoryRelay
         Sender = sender;
         VoiceName = name;
         SpeechVerb = null;
+    }
+}
+
+// impstation edit
+/// <summary>
+/// Similar to <seealso cref="TransformSpeakerNameEvent"/>, but for changing the speech
+/// sounds of a speaking entity.
+/// </summary>
+public sealed partial class TransformSpeakerVoiceEvent : EntityEventArgs, IInventoryRelayEvent
+{
+    public SlotFlags TargetSlots { get; } = SlotFlags.WITHOUT_POCKET;
+    public EntityUid Sender;
+    public ProtoId<SpeechSoundsPrototype>? SpeechSounds = null;
+
+    public TransformSpeakerVoiceEvent(EntityUid sender)
+    {
+        Sender = sender;
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -37,6 +37,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, GetDefaultRadioChannelEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshNameModifiersEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, TransformSpeakerNameEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, TransformSpeakerVoiceEvent>(RelayInventoryEvent); // impstation edit
         SubscribeLocalEvent<InventoryComponent, CheckMagicItemEvent>(RelayInventoryEvent); // goob edit
         SubscribeLocalEvent<InventoryComponent, SelfBeforeHyposprayInjectsEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, TargetBeforeHyposprayInjectsEvent>(RelayInventoryEvent);

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decapoid/decapoid_items.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decapoid/decapoid_items.yml
@@ -48,6 +48,9 @@
   - type: HideLayerClothing
     slots:
     - Snout
+  - type: SpeechSound
+    speechSounds: Borg
+    speechVerb: Robotic
 
 
 - type: entity


### PR DESCRIPTION
Added the `SpeechSound` component, which lets you override speech sounds and speech verbs on entities with worn equipment. This is currently used on the decapoid's vaporizer to change the wearer's voice to sound like a borg.
```yml
- type: SpeechSound
    speechSounds: Borg
    speechVerb: Robotic
```

Resolves #843.