### PR TITLE
Pens fit in folders

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -344,13 +344,13 @@
     whitelist:
       tags:
         - Document
+        - Write
   - type: ItemMapper
     mapLayers:
       folder-overlay-paper:
         whitelist:
           tags:
           - Document
-          - Write
   - type: Appearance
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -350,6 +350,7 @@
         whitelist:
           tags:
           - Document
+          - Write
   - type: Appearance
   - type: Tag
     tags:


### PR DESCRIPTION
they got little pen slots now, in the folders.  fancy

:cl:
- tweak: Writing instruments (pens, crayons, etc) can now be stored in folders