### PR TITLE
double the sec cadet time lockout

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -8,7 +8,7 @@
       time: 36000 #10 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 54000 #15 hrs
+      time: 108000 #30 hrs
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"


### PR DESCRIPTION
30 hours instead of 15. hopefully this makes sec more approachable

**Changelog**
:cl:
- tweak: Security Cadet role lockout now applies after 30hrs (increased from 15).
