### PR TITLE
changeling biomass adjustments for rotting corpses + salvage corpse adjustments

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -20,7 +20,6 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Damage.Components;
 using Content.Server.Radio.Components;
-using Content.Shared.Atmos.Rotting;
 
 namespace Content.Server.Changeling;
 

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -10,6 +10,7 @@ using Content.Shared.Popups;
 using Content.Shared.Damage;
 using Robust.Shared.Prototypes;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Atmos.Rotting;
 using Content.Server.Objectives.Components;
 using Content.Server.Light.Components;
 using Content.Shared.Eye.Blinding.Systems;
@@ -19,11 +20,14 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Damage.Components;
 using Content.Server.Radio.Components;
+using Content.Shared.Atmos.Rotting;
 
 namespace Content.Server.Changeling;
 
 public sealed partial class ChangelingSystem : EntitySystem
 {
+    [Dependency] private readonly SharedRottingSystem _rotting = default!;
+
     public void SubscribeAbilities()
     {
         SubscribeLocalEvent<ChangelingComponent, OpenEvolutionMenuEvent>(OnOpenEvolutionMenu);
@@ -90,6 +94,11 @@ public sealed partial class ChangelingSystem : EntitySystem
         if (!HasComp<AbsorbableComponent>(target))
         {
             _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-unabsorbable"), uid, uid);
+            return;
+        }
+        if (TryComp<RottingComponent>(target, out var rotComp) && _rotting.RotStage(target, rotComp) >= 2)
+        {
+            _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-extremely-bloated"), uid, uid);
             return;
         }
 

--- a/Content.Shared/Atmos/Rotting/RottingComponent.cs
+++ b/Content.Shared/Atmos/Rotting/RottingComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class RottingComponent : Component
     /// <summary>
     /// How long has this thing been rotting?
     /// </summary>
-    [DataField]
+    [DataField("totalRotTime")]
     public TimeSpan TotalRotTime = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Examine;
+using Content.Shared.Changeling;
+using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -96,6 +97,17 @@ public abstract class SharedRottingSystem : EntitySystem
             description += "-nonmob";
 
         args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(uid, EntityManager))));
+
+        if (HasComp<ChangelingComponent>(args.Examiner) && !HasComp<AbsorbedComponent>(uid))
+        {
+            var changelingDescription = stage switch
+            {
+                >= 2 => "changeling-examine-extremely-bloated",
+                _ => "changeling-examine-rotting"
+            };
+
+            args.PushMarkup(Loc.GetString(changelingDescription, ("target", Identity.Entity(uid, EntityManager))));
+        }
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
@@ -8,6 +8,7 @@ changeling-absorb-start = {CAPITALIZE(THE($user))} starts absorbing {CAPITALIZE(
 changeling-absorb-fail-incapacitated = You can't absorb it until it's not incapacitated.
 changeling-absorb-fail-absorbed = You've already absorbed it.
 changeling-absorb-fail-unabsorbable = The target is not absorbable.
+changeling-absorb-fail-extremely-bloated = The target is too rotted to absorb.
 changeling-absorb-end-self = Another organic absorbed. You are evolving.
 changeling-absorb-end-self-ling = Another changeling absorbed. You are evolving more rapidly.
 changeling-absorb-onexamine = [color=red]The body feels hollow.[/color]

--- a/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
@@ -4,7 +4,10 @@ changeling-chemicals-deficit = Not enough chemicals!
 changeling-action-fail-lesserform = Can't use it while in lesser form!
 changeling-action-fail-absorbed = Need to absorb {$number} more organics to use it!
 
-changeling-absorb-start = {CAPITALIZE(THE($user))} starts absorbing {CAPITALIZE(THE($target))}'s!
+changeling-examine-rotting = [color=yellow]{ CAPITALIZE(POSS-ADJ($target)) } corpse has low biomass and will offer no evolutionary potential.[/color]
+changeling-examine-extremely-bloated = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse is inedible.[/color]
+
+changeling-absorb-start = {CAPITALIZE(THE($user))} starts absorbing {CAPITALIZE(THE($target))}!
 changeling-absorb-fail-incapacitated = You can't absorb it until it's not incapacitated.
 changeling-absorb-fail-absorbed = You've already absorbed it.
 changeling-absorb-fail-unabsorbable = The target is not absorbable.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -88,6 +88,8 @@
         Blunt: 19
   - type: Inventory
     templateId: corpse
+  - type: Rotting
+    totalRotTime: 1200 # 20 minutes
 
 - type: entity
   parent: MobHuman


### PR DESCRIPTION
balance adjustments for changelings when it comes to rotting corpses. once the "extremely bloated" stage of rotting is reached, changelings are no longer capable of absorbing a corpse. unidentified corpses (mostly found through salvage) spawn in the extremely bloated stage of rotting. corpses in other stages of rotting grant half the biomass of a regular corpse, and grant no evolution points

inspect text has been added to reflect these changes that _only_ shows up for changelings, and doesn't show if the corpse has already been absorbed

![image](https://github.com/user-attachments/assets/04f533cd-269e-4103-874f-5a871c57238f)
![image](https://github.com/user-attachments/assets/58252807-add2-49be-9343-18177a634ea5)
![image](https://github.com/user-attachments/assets/6d38ade1-0440-456d-b807-7c00bb1839c7)

**Changelog**
:cl:
- tweak: Salvage corpses spawn heavily rotted, and extremely bloated.
- tweak: Changelings are incapable of absorbing corpses once they reach the "extremely bloated" stage.