### PR TITLE
reverting mimes to the classic basic french accent

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -16,7 +16,7 @@
   - !type:AddComponentSpecial
     components:
     - type: MimePowers
-#    - type: FrenchAccent # Imp
+    - type: BasicFrenchAccent # Imp
 
 - type: startingGear
   id: MimeGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -16,7 +16,7 @@
   - !type:AddComponentSpecial
     components:
     - type: MimePowers
-    - type: FrenchAccent
+#    - type: FrenchAccent # Imp
 
 - type: startingGear
   id: MimeGear


### PR DESCRIPTION
iii dunno.  mimes originally had a basic french accent, but then we made the basic french accent into full french with lots of word replacements and added a "basicfrench" alternative that was just the phonetic accent.  so mimes got changed to the full french.  we COULD change it to basicfrench so they say "bitch" instead of "salope" but first i'm curious if anyone's interested in removing it

to cover my ass i wanna be clear that mimes talking SUCKS and my character only does it in extreme situations (like rolling antag), but removing it would allow players to select french, or basicfrench, or whatever speech traits they wanted in case their mime has to open their mouth

since we're an mrp server i think it's pretty reasonable to have characters have consistent voices, not changed by what job they're playing...  like if someone has a russian accent, why would that change?  a vow of silence is one thing, but your character talking completely differently seems a little lrp ig

plan B, which i like less than this idea, is just reverting forced mime accent to the 'new' (old) basicfrench.  but let's see how this is received first

and no, selecting the Accentless trait doesn't override mime speech so there's no way to undo it without this pr.  at least, then, actually french mimes can re-select it in traits

:cl:
- tweak: mimes have the basic french accent again (but stop talking!)