### PR TITLE
stamps in folders maybe (smiles)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -345,6 +345,7 @@
       tags:
         - Document
         - Write
+        - RubberStamp
   - type: ItemMapper
     mapLayers:
       folder-overlay-paper:

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -21,6 +21,9 @@
     size: Tiny
   - type: StealTarget
     stealGroup: Stamp
+  - type: Tag
+    tags:
+      - RubberStamp
 
 - type: entity
   name: alternate rubber stamp

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -36,6 +36,9 @@
   id: SprayPainter
 
 - type: Tag
+  id: RubberStamp
+
+- type: Tag
   id: Vaporizer
 
 - type: Tag


### PR DESCRIPTION
idk, storing stamps already isn't a big problem because of cigarette packs being intentionally designed as tiny item storage.  but also, for that same reason, i don't think it would matter if i could open a folder and have all my bureacracy tools in front of me.  the new folders have little strappy things inside to hold your paperwork tools, it's fine.  just QoL, no pressure

![image](https://github.com/user-attachments/assets/48e55a03-3630-4cf7-b953-91887080b322)

:cl:
- tweak: hi stamps fit in folders now :)