### PR TITLE
Add brigmedic spawns to Xeno and Barratry, other fixes for Xeno

### DIFF
--- a/Resources/Maps/_Harmony/barratry.yml
+++ b/Resources/Maps/_Harmony/barratry.yml
@@ -13701,13 +13701,13 @@ entities:
             0: 28791
           -21,12:
             1: 15
-            5: 30464
+            3: 30464
           -20,13:
             0: 52305
             1: 4352
           -21,13:
             1: 65280
-            5: 7
+            3: 7
           -20,14:
             1: 24337
             0: 12
@@ -13867,7 +13867,7 @@ entities:
             0: 32
           -23,8:
             1: 255
-            3: 57344
+            4: 57344
           -22,4:
             1: 8184
           -22,5:
@@ -13898,12 +13898,12 @@ entities:
             1: 226
           -23,11:
             1: 61440
-            5: 224
+            3: 224
           -23,9:
-            4: 224
-            5: 57344
-          -23,10:
             5: 224
+            3: 57344
+          -23,10:
+            3: 224
             6: 57344
           -23,12:
             1: 242
@@ -14041,6 +14041,21 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
           - 6666.982
           - 0
           - 0
@@ -14058,21 +14073,6 @@ entities:
           moles:
           - 0
           - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 0
           - 0
           - 0
           - 0
@@ -81183,6 +81183,13 @@ entities:
         - 0
         - 0
         - 0
+- proto: LockerBrigmedicFilled
+  entities:
+  - uid: 16592
+    components:
+    - type: Transform
+      pos: -61.5,51.5
+      parent: 1
 - proto: LockerCaptain
   entities:
   - uid: 2542
@@ -95075,6 +95082,13 @@ entities:
     - type: Transform
       pos: -41.5,42.5
       parent: 1
+- proto: SpawnPointBrigmedic
+  entities:
+  - uid: 16591
+    components:
+    - type: Transform
+      pos: -61.5,52.5
+      parent: 1
 - proto: SpawnPointCaptain
   entities:
   - uid: 16122
@@ -97092,7 +97106,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -54.5,39.5
       parent: 1
-    - type: DeviceNetwork
     - type: SurveillanceCamera
       id: Janitorial Back
 - proto: SurveillanceCameraSupply

--- a/Resources/Maps/xeno.yml
+++ b/Resources/Maps/xeno.yml
@@ -41596,6 +41596,9 @@ entities:
     - type: Transform
       pos: 5.4202023,-22.37221
       parent: 2
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
 - proto: ClothingEyesGlassesCheapSunglasses
   entities:
   - uid: 6987
@@ -41620,6 +41623,9 @@ entities:
     - type: Transform
       pos: 79.38343,-24.34906
       parent: 2
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
 - proto: ClothingEyesGlassesThermal
   entities:
   - uid: 8216
@@ -41627,6 +41633,9 @@ entities:
     - type: Transform
       pos: -41.384144,-26.542435
       parent: 2
+    - type: ContainerContainer
+      containers:
+        lens_slot: !type:ContainerSlot {}
 - proto: ClothingHandsGlovesBoxingBlue
   entities:
   - uid: 7687
@@ -57286,6 +57295,14 @@ entities:
       parent: 2
 - proto: GasFilter
   entities:
+  - uid: 9907
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 18548
     components:
     - type: Transform
@@ -57331,14 +57348,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-63.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 17412
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-24.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -58837,6 +58846,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 13521
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 13529
     components:
     - type: Transform
@@ -59192,6 +59209,12 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0EE4F0FF'
+  - uid: 17414
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-24.5
+      parent: 2
   - uid: 17685
     components:
     - type: Transform
@@ -65628,13 +65651,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 9907
-    components:
-    - type: Transform
-      pos: 17.5,-25.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 9908
     components:
     - type: Transform
@@ -70636,16 +70652,10 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 16.5,-24.5
+      pos: 16.5,-25.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 17414
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-23.5
-      parent: 2
   - uid: 17699
     components:
     - type: Transform
@@ -71133,6 +71143,20 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 19090
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 19091
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-23.5
+      parent: 2
 - proto: GasPipeTJunction
   entities:
   - uid: 166
@@ -72563,14 +72587,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 13521
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-24.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 13547
     components:
     - type: Transform
@@ -72847,8 +72863,11 @@ entities:
   - uid: 17408
     components:
     - type: Transform
-      pos: 15.5,-23.5
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-25.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 17409
     components:
     - type: Transform
@@ -72860,6 +72879,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-24.5
+      parent: 2
+  - uid: 17412
+    components:
+    - type: Transform
+      pos: 16.5,-23.5
       parent: 2
   - uid: 17682
     components:
@@ -82728,6 +82752,13 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-48.5
+      parent: 2
+- proto: LockerBrigmedicFilled
+  entities:
+  - uid: 19088
+    components:
+    - type: Transform
+      pos: 69.5,-48.5
       parent: 2
 - proto: LockerCaptainFilledNoLaser
   entities:
@@ -99083,6 +99114,13 @@ entities:
     - type: Transform
       pos: -2.5,-48.5
       parent: 2
+- proto: SpawnPointBrigmedic
+  entities:
+  - uid: 19089
+    components:
+    - type: Transform
+      pos: 70.5,-48.5
+      parent: 2
 - proto: SpawnPointCaptain
   entities:
   - uid: 15311
@@ -104490,6 +104528,13 @@ entities:
     components:
     - type: Transform
       pos: -58.50746,-65.516075
+      parent: 2
+- proto: trayScanner
+  entities:
+  - uid: 19092
+    components:
+    - type: Transform
+      pos: 15.686685,-22.176643
       parent: 2
 - proto: TwoWayLever
   entities:

--- a/Resources/Prototypes/Maps/xeno.yml
+++ b/Resources/Prototypes/Maps/xeno.yml
@@ -2,8 +2,8 @@
   id: Xeno
   mapName: 'Xeno'
   mapPath: /Maps/xeno.yml
-  minPlayers: 25
-  maxPlayers: 70
+  minPlayers: 40
+  maxPlayers: 80
   stations:
     Xeno:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
Adds brigmedic spawns and lockers to both Barratry and Xeno. Neither station has a treatment room in Security, so I figured it was worth adding the brigmedic locker along with the spawner. Fixed the gas filter in the cryopod loop filtering back into the cryoloop. It now correctly filters into waste like every other cryo set up on every other map. Changed Xeno's player ranged from 25 - 70 to 40 - 80 (it's a big map).

**Changelog**

:cl:
- add: (Xeno Station) Added birgmedic spawner and brigmedic locker.
- tweak: (Xeno Station) The gas filter hooked up to the cryo pod is no longer insane and now functions how it does on every other station.
- tweak: (Xeno Station) The station now has a player range of 40 - 80, up from 25 - 70 (it's big).
- add: (Barratry Station) Added birgmedic spawner and brigmedic locker.