### PR TITLE
giving passenger a hooded coat

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -100,7 +100,7 @@
 - type: loadout
   id: PassengerWintercoat
   equipment:
-    outerClothing: ClothingOuterWinterCoat
+    outerClothing: ClothingOuterWinterColorGray # Imp
 
 # Shoes
 - type: loadout


### PR DESCRIPTION
the current passenger coat is the base item, "winter coat," which doesn't have a functioning hood despite having one on the sprite

fix action: give the passenger the gray winter coat instead which looks like this (original on the left)

![image](https://github.com/user-attachments/assets/dec5a42f-912c-4c58-8e00-31937b39d579)

otherwise we'd have to change the base item that all other coats are parented to

:cl:
- tweak: Passenger winter coat replaced with the version that actually has a hood lol