### PR TITLE
patronizing accent removal + accent immune trait

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -27,8 +27,11 @@ trait-unrevivable-desc = You are unable to be revived by defibrillators.
 trait-pirate-accent-name = Pirate accent
 trait-pirate-accent-desc = You can't stop speaking like a pirate!
 
-trait-accentless-name = Accentless
+trait-accentless-name = No Species Accent
 trait-accentless-desc = You don't have the accent that your species would usually have.
+
+trait-accentimmune-name = No Accent
+trait-accentimmune-desc = You have no accent whatsoever, somehow. Where are you from?
 
 trait-frontal-lisp-name = Frontal lisp
 trait-frontal-lisp-desc = You thpeak with a lithp.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -35,8 +35,8 @@
     sprite: Clothing/Head/Hats/beret_french.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/beret_french.rsi
-  - type: AddAccentClothing
-    accent: FrenchAccent
+#  - type: AddAccentClothing # Imp
+#    accent: FrenchAccent
   - type: Tag
     tags:
     - ClothMade
@@ -441,8 +441,8 @@
     sprite: Clothing/Head/Hats/sombrero.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/sombrero.rsi
-  - type: AddAccentClothing
-    accent: SpanishAccent
+#  - type: AddAccentClothing # Imp
+#    accent: SpanishAccent
 
 - type: entity
   parent: ClothingHeadBase
@@ -507,8 +507,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hats/ushanka.rsi
   - type: Appearance
-  - type: AddAccentClothing
-    accent: RussianAccent
+#  - type: AddAccentClothing # Imp
+#    accent: RussianAccent
   - type: Foldable
     canFoldInsideContainer: true
   - type: FoldableClothing
@@ -1026,9 +1026,9 @@
       sprite: Clothing/Head/Hats/cowboyhatbrown.rsi
     - type: Clothing
       sprite: Clothing/Head/Hats/cowboyhatbrown.rsi
-    - type: AddAccentClothing
-      accent: ReplacementAccent
-      replacement: cowboy
+#    - type: AddAccentClothing
+#      accent: ReplacementAccent
+#      replacement: cowboy
 
 - type: entity
   parent: ClothingHeadHatCowboyBrown

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -808,9 +808,9 @@
     sprite: Clothing/Mask/italian_moustache.rsi
   - type: Item
     storedRotation: -90
-  - type: AddAccentClothing
-    accent: ReplacementAccent
-    replacement: italian
+#  - type: AddAccentClothing # Imp
+#    accent: ReplacementAccent
+#    replacement: italian
 
 - type: entity
   parent: ClothingMaskBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -162,8 +162,8 @@
     sprite: Clothing/OuterClothing/Misc/poncho.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/poncho.rsi
-  - type: AddAccentClothing
-    accent: SpanishAccent
+#  - type: AddAccentClothing # Imp
+#    accent: SpanishAccent
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -232,7 +232,6 @@
     removes:
     - type: SouthernAccent
     - type: PirateAccent
-    - type: ReplacementAccent
     - type: GermanAccent
     - type: SpanishAccent
     - type: ScrambledAccent
@@ -251,4 +250,10 @@
     - type: MothAccent
     - type: GrayAccent
     - type: ReplacementAccent
-      accent: [cowboy, italian, liar, mobster, slimes, dwarf]
+      accent:
+      - cowboy
+      - italian
+      - liar
+      - mobster
+      - slimes
+      - dwarf

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -233,13 +233,8 @@
     - type: SouthernAccent
     - type: PirateAccent
     - type: ReplacementAccent
-      accent: cowboy
     - type: GermanAccent
-    - type: ReplacementAccent
-      accent: italian
     - type: SpanishAccent
-    - type: ReplacementAccent
-      accent: liar
     - type: ScrambledAccent
     - type: NoContractionsAccent
     - type: SharpInflection
@@ -248,11 +243,7 @@
     - type: SnalienAccent
     - type: StutteringAccent
     - type: FrontalLisp
-    - type: ReplacementAccent
-      accent: mobster
     - type: RatvarianLanguage
-    - type: ReplacementAccent
-      accent: slimes
     - type: RussianAccent
     - type: BasicRussianAccent
     - type: FrenchAccent
@@ -260,4 +251,9 @@
     - type: MothAccent
     - type: GrayAccent
     - type: ReplacementAccent
+      accent: cowboy
+      accent: italian
+      accent: liar
+      accent: mobster
+      accent: slimes
       accent: dwarf

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -93,7 +93,7 @@
   cost: 1
   components:
   - type: ScrambledAccent
-  
+
 - type: trait
   id: NoContractions
   name: trait-nocontractions-name
@@ -104,7 +104,7 @@
   - type: ReplacementAccent
     accent: nocontractions
   - type: NoContractionsAccent
-  
+
 - type: trait
   id: SharpInflection
   name: trait-sharpinflection-name
@@ -113,7 +113,7 @@
   cost: 1
   components:
   - type: SharpInflection
-  
+
 - type: trait
   id: Monotonous
   name: trait-monotonous-name
@@ -122,7 +122,7 @@
   cost: 1
   components:
   - type: Monotonous
-  
+
 - type: trait
   id: BasicFrenchAccent
   name: trait-basicfrench-name
@@ -211,7 +211,7 @@
   cost: 2
   components:
   - type: BasicRussianAccent
-  
+
 - type: trait
   id: FrenchAccent
   name: trait-french-name
@@ -220,3 +220,44 @@
   cost: 2
   components:
   - type: FrenchAccent
+
+- type: trait
+  id: AccentImmune
+  name: trait-accentimmune-name
+  description: trait-accentimmune-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: Accentless
+    removes:
+    - type: SouthernAccent
+    - type: PirateAccent
+    - type: ReplacementAccent
+      accent: cowboy
+    - type: GermanAccent
+    - type: ReplacementAccent
+      accent: italian
+    - type: SpanishAccent
+    - type: ReplacementAccent
+      accent: liar
+    - type: ScrambledAccent
+    - type: NoContractionsAccent
+    - type: SharpInflection
+    - type: Monotonous
+    - type: BasicFrenchAccent
+    - type: SnalienAccent
+    - type: StutteringAccent
+    - type: FrontalLisp
+    - type: ReplacementAccent
+      accent: mobster
+    - type: RatvarianLanguage
+    - type: ReplacementAccent
+      accent: slimes
+    - type: RussianAccent
+    - type: BasicRussianAccent
+    - type: FrenchAccent
+    - type: LizardAccent
+    - type: MothAccent
+    - type: GrayAccent
+    - type: ReplacementAccent
+      accent: dwarf

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -251,9 +251,4 @@
     - type: MothAccent
     - type: GrayAccent
     - type: ReplacementAccent
-      accent: cowboy
-      accent: italian
-      accent: liar
-      accent: mobster
-      accent: slimes
-      accent: dwarf
+      accent: [cowboy, italian, liar, mobster, slimes, dwarf]

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -250,4 +250,5 @@
     - type: MothAccent
     - type: GrayAccent
     - type: ReplacementAccent
-      accent: [ cowboy, italian, liar, mobster, slimes, dwarf ]
+      accent: dwarf
+      # Imp TODO: add cowboy, italian, liar, mobster, and slimes to this list one day since apparently you can only remove one ReplacementAccent at a time without pissing off the linter, maybe we can figure it out later. For now, adding the dwarf accent since that's an accent you can spawn with under current circumstances.

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -250,10 +250,4 @@
     - type: MothAccent
     - type: GrayAccent
     - type: ReplacementAccent
-      accents:
-      - cowboy
-      - italian
-      - liar
-      - mobster
-      - slimes
-      - dwarf
+      accent: [ cowboy, italian, liar, mobster, slimes, dwarf ]

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -250,10 +250,14 @@
     - type: MothAccent
     - type: GrayAccent
     - type: ReplacementAccent
-      accent:
-      - cowboy
-      - italian
-      - liar
-      - mobster
-      - slimes
-      - dwarf
+      accent: cowboy
+    - type: ReplacementAccent
+      accent: italian
+    - type: ReplacementAccent
+      accent: liar
+    - type: ReplacementAccent
+      accent: mobster
+    - type: ReplacementAccent
+      accent: slimes
+    - type: ReplacementAccent
+      accent: dwarf

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -250,14 +250,10 @@
     - type: MothAccent
     - type: GrayAccent
     - type: ReplacementAccent
-      accent: cowboy
-    - type: ReplacementAccent
-      accent: italian
-    - type: ReplacementAccent
-      accent: liar
-    - type: ReplacementAccent
-      accent: mobster
-    - type: ReplacementAccent
-      accent: slimes
-    - type: ReplacementAccent
-      accent: dwarf
+      accents:
+      - cowboy
+      - italian
+      - liar
+      - mobster
+      - slimes
+      - dwarf


### PR DESCRIPTION
i went through and removed all the patronizing accents from clothes (not the non-patronizing ones, like pirate clothes and the rat king's crown) so you can wear berets and ushankas and so on without becoming a racist caricature

i also added a new speech trait that does what people thought accentless did, which is remove all other accents on your character, rather than just the species ones.  this accent is designed for people who do things like rp emotes into the mic, like buddy monroe's "*wet thud*" when he salutes.  it just guarantees that your typing is never forced into an accent unless you're cursed with cat ears or something, so that you can still post radio sounds.  currently, it's most relevant for mimes. please let me clap into my radio (even if it technically costs me my invisible wall)

the former "accentless" trait has been renamed to "no species accent" for clarity

![image](https://github.com/user-attachments/assets/eb65ea78-0ea6-40d2-8ab3-71dd7e4b51ab)

:cl:
- add: The "No Accent" trait, which removes _all_ accents from your character
- tweak: The "Accentless" trait is now called "No Species Accent" for clarity
- remove: The patronizing forced accents on various hats, masks, and coats are now removed
