### PR TITLE
Minor Hummingbird Update (v1.2g christmas)

### DIFF
--- a/Resources/Maps/_Impstation/hummingbird.yml
+++ b/Resources/Maps/_Impstation/hummingbird.yml
@@ -67099,7 +67099,7 @@ entities:
   - uid: 2434
     components:
     - type: Transform
-      pos: 31.5,6.5
+      pos: 34.5,4.5
       parent: 2
 - proto: ExplosivesSignMed
   entities:
@@ -137067,7 +137067,7 @@ entities:
   - uid: 2409
     components:
     - type: Transform
-      pos: 34.5,4.5
+      pos: 31.5,6.5
       parent: 2
 - proto: VendingMachineSalvage
   entities:
@@ -154029,7 +154029,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -140965.23
+      secondsUntilStateChange: -141044.55
       state: Opening
     - type: Airlock
       autoClose: False


### PR DESCRIPTION
Swapped placement of the robotech deluxe and exosuit fabricators in robotics to reduce instances of cyborg endoskeletons spawning in the wall.

**Changelog**

:cl:
- tweak: (Hummingbird) Swapped placement of the robotech deluxe and exosuit fabricators in robotics to reduce instances of cyborg endoskeletons spawning in the wall.
