### PR TITLE
additional changeling/rotting adjustments

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -90,7 +90,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-absorbed"), uid, uid);
             return;
         }
-        if (!HasComp<AbsorbableComponent>(target))
+        if (!HasComp<AbsorbableComponent>(target) || (TryComp<AbsorbableComponent>(target, out var absorbComp) && absorbComp.Disabled))
         {
             _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-unabsorbable"), uid, uid);
             return;
@@ -105,7 +105,6 @@ public sealed partial class ChangelingSystem : EntitySystem
             return;
 
         var popupOthers = Loc.GetString("changeling-absorb-start", ("user", Identity.Entity(uid, EntityManager)), ("target", Identity.Entity(target, EntityManager)));
-        _popup.PopupEntity(Loc.GetString("changeling-absorb-rotting"), uid, uid);
         _popup.PopupEntity(popupOthers, uid, PopupType.LargeCaution);
         PlayMeatySound(uid, comp);
         var dargs = new DoAfterArgs(EntityManager, uid, TimeSpan.FromSeconds(15), new AbsorbDNADoAfterEvent(), uid, target)
@@ -132,8 +131,12 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         PlayMeatySound(args.User, comp);
 
+        var reducedBiomass = false;
+        if (HasComp<RottingComponent>(target) || (TryComp<AbsorbableComponent>(target, out var absorbComp) && absorbComp.ReducedBiomass))
+            reducedBiomass = true;
+
         float biomassModifier = 1f;
-        if (HasComp<RottingComponent>(target))
+        if (reducedBiomass)
             biomassModifier = 0.5f;
 
         UpdateBiomass(uid, comp, (comp.MaxBiomass * biomassModifier) - comp.TotalAbsorbedEntities);
@@ -159,7 +162,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             popup = Loc.GetString("changeling-absorb-end-self");
             bonusChemicals += 10;
 
-            if (!HasComp<RottingComponent>(target))
+            if (reducedBiomass)
                 bonusEvolutionPoints += 2;
         }
         TryStealDNA(uid, target, comp, true);

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -162,8 +162,10 @@ public sealed partial class ChangelingSystem : EntitySystem
             popup = Loc.GetString("changeling-absorb-end-self");
             bonusChemicals += 10;
 
-            if (reducedBiomass)
+            if (!reducedBiomass)
                 bonusEvolutionPoints += 2;
+            else
+                popup = Loc.GetString("changeling-absorb-end-self-reduced-biomass");
         }
         TryStealDNA(uid, target, comp, true);
         comp.TotalAbsorbedEntities++;

--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -64,9 +64,9 @@ public abstract class SharedRottingSystem : EntitySystem
         args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(perishable, EntityManager))));
     }
 
-    private void OnStartup(EntityUid uid, RottingComponent component, ComponentStartup args)
+    private void OnStartup(Entity<RottingComponent> ent, ref ComponentStartup args)
     {
-        component.NextRotUpdate = _timing.CurTime + component.RotUpdateRate;
+        ent.Comp.NextRotUpdate = _timing.CurTime + ent.Comp.RotUpdateRate;
     }
 
     private void OnShutdown(EntityUid uid, RottingComponent component, ComponentShutdown args)

--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -26,6 +26,7 @@ public abstract class SharedRottingSystem : EntitySystem
         SubscribeLocalEvent<PerishableComponent, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<PerishableComponent, ExaminedEvent>(OnPerishableExamined);
 
+        SubscribeLocalEvent<RottingComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<RottingComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<RottingComponent, MobStateChangedEvent>(OnRottingMobStateChanged);
         SubscribeLocalEvent<RottingComponent, RejuvenateEvent>(OnRejuvenate);
@@ -61,6 +62,11 @@ public abstract class SharedRottingSystem : EntitySystem
         var isMob = HasComp<MobStateComponent>(perishable);
         var description = "perishable-" + stage + (!isMob ? "-nonmob" : string.Empty);
         args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(perishable, EntityManager))));
+    }
+
+    private void OnStartup(EntityUid uid, RottingComponent component, ComponentStartup args)
+    {
+        component.NextRotUpdate = _timing.CurTime + component.RotUpdateRate;
     }
 
     private void OnShutdown(EntityUid uid, RottingComponent component, ComponentShutdown args)

--- a/Content.Shared/_Goobstation/Changeling/AbsorbableComponent.cs
+++ b/Content.Shared/_Goobstation/Changeling/AbsorbableComponent.cs
@@ -8,5 +8,9 @@ namespace Content.Shared.Changeling;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class AbsorbableComponent : Component
 {
+    [DataField("disabled")]
+    public bool Disabled = false;
 
+    [DataField("reducedBiomass")]
+    public bool ReducedBiomass = false;
 }

--- a/Content.Shared/_Goobstation/Changeling/AbsorbableSystem.cs
+++ b/Content.Shared/_Goobstation/Changeling/AbsorbableSystem.cs
@@ -1,0 +1,28 @@
+using Content.Shared.Changeling;
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Atmos.Rotting;
+
+namespace Content.Shared.Changeling;
+
+public sealed partial class SharedAbsorbableSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AbsorbableComponent, ExaminedEvent>(OnExamine);
+    }
+
+    private void OnExamine(Entity<AbsorbableComponent> ent, ref ExaminedEvent args)
+    {
+        var reducedBiomass = false;
+        if (HasComp<RottingComponent>(ent.Owner) || (TryComp<AbsorbableComponent>(ent.Owner, out var comp) && comp.ReducedBiomass))
+            reducedBiomass = true;
+
+        if (HasComp<ChangelingComponent>(args.Examiner) && !HasComp<AbsorbedComponent>(ent.Owner) && reducedBiomass)
+        {
+            args.PushMarkup(Loc.GetString("changeling-examine-reduced-biomass", ("target", Identity.Entity(ent.Owner, EntityManager))), 100);
+        }
+    }
+}

--- a/Content.Shared/_Goobstation/Changeling/AbsorbableSystem.cs
+++ b/Content.Shared/_Goobstation/Changeling/AbsorbableSystem.cs
@@ -17,12 +17,12 @@ public sealed partial class SharedAbsorbableSystem : EntitySystem
     private void OnExamine(Entity<AbsorbableComponent> ent, ref ExaminedEvent args)
     {
         var reducedBiomass = false;
-        if (HasComp<RottingComponent>(ent.Owner) || (TryComp<AbsorbableComponent>(ent.Owner, out var comp) && comp.ReducedBiomass))
+        if (!HasComp<RottingComponent>(ent.Owner) && TryComp<AbsorbableComponent>(ent.Owner, out var comp) && comp.ReducedBiomass)
             reducedBiomass = true;
 
         if (HasComp<ChangelingComponent>(args.Examiner) && !HasComp<AbsorbedComponent>(ent.Owner) && reducedBiomass)
         {
-            args.PushMarkup(Loc.GetString("changeling-examine-reduced-biomass", ("target", Identity.Entity(ent.Owner, EntityManager))), 100);
+            args.PushMarkup(Loc.GetString("changeling-examine-reduced-biomass", ("target", Identity.Entity(ent.Owner, EntityManager))));
         }
     }
 }

--- a/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
@@ -14,7 +14,7 @@ changeling-absorb-fail-absorbed = You've already absorbed it.
 changeling-absorb-fail-unabsorbable = The target is not absorbable.
 changeling-absorb-fail-extremely-bloated = The target is too rotted to absorb.
 changeling-absorb-end-self = Another organic absorbed. You are evolving.
-changeling-absorb-end-reduced-biomass = Another organic absorbed.
+changeling-absorb-end-self-reduced-biomass = Another organic absorbed.
 changeling-absorb-end-self-ling = Another changeling absorbed. You are evolving more rapidly.
 changeling-absorb-onexamine = [color=red]The body feels hollow.[/color]
 

--- a/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
@@ -4,6 +4,7 @@ changeling-chemicals-deficit = Not enough chemicals!
 changeling-action-fail-lesserform = Can't use it while in lesser form!
 changeling-action-fail-absorbed = Need to absorb {$number} more organics to use it!
 
+changeling-examine-reduced-biomass = [color=yellow]{ CAPITALIZE(SUBJECT($target)) } has low biomass and will offer no evolutionary potential.[/color]
 changeling-examine-rotting = [color=yellow]{ CAPITALIZE(POSS-ADJ($target)) } corpse has low biomass and will offer no evolutionary potential.[/color]
 changeling-examine-extremely-bloated = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse is inedible.[/color]
 
@@ -13,6 +14,7 @@ changeling-absorb-fail-absorbed = You've already absorbed it.
 changeling-absorb-fail-unabsorbable = The target is not absorbable.
 changeling-absorb-fail-extremely-bloated = The target is too rotted to absorb.
 changeling-absorb-end-self = Another organic absorbed. You are evolving.
+changeling-absorb-end-reduced-biomass = Another organic absorbed.
 changeling-absorb-end-self-ling = Another changeling absorbed. You are evolving more rapidly.
 changeling-absorb-onexamine = [color=red]The body feels hollow.[/color]
 

--- a/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
@@ -6,6 +6,8 @@
   components:
   - type: Speech
     speechVerb: Goblin
+  - type: Absorbable
+    reducedBiomass: true
 
 - type: entity
   parent: MobGoblin


### PR DESCRIPTION
rotting bodies were accidentally gibbing very quickly past a certain point in time due to rot timing issues. this has been resolved. hooray!
changelings get a different popup when absorbing an entity with reduced biomass that just cuts out the "You are evolving." part. the absorbable component now has a flag to enable entities to only give half biomass and no evolution points and, at the request of @widgetbeck, the component can now be disabled entirely, preventing changelings from absorbing an entity that inherited the absorbable component. from the same request, goblins now have reduced biomass. they're stinky and not very good for growing changelings

![image](https://github.com/user-attachments/assets/137ebc13-55f0-4d4d-9674-e9a77948f0e1)

**Changelog**
:cl:
- tweak: Corpses in any stage of rotting grant halved biomass and no evolution points when absorbed by changelings. This was already live, but not reflected in the changelog. Only extremely bloated corpses are inedible.
- tweak: Goblins grant halved biomass and no evolution points when absorbed by changelings. They're kinda small and stinky and really not that tasty.
- fix: Salvage corpses should no longer gib almost instantly past a certain period of time.