### PR TITLE
Small HoS Loadout Bugfix

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1328,9 +1328,6 @@
   - ArmorVest #imp
   - ArmorVestSlim #imp
   - HeadofSecurityEliteArmor #imp
-  - ArmorVest
-  - ArmorVestSlim
-  - HeadofSecurityEliteArmor
 
 - type: loadoutGroup
   id: HeadofSecurityBelt

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -429,6 +429,7 @@
   groups:
   - HeadofSecurityHead
   - HeadofSecurityNeck
+  - HeadofSecurityMask
   - HeadofSecurityJumpsuit
   - HeadofSecurityOuterClothing
   - UpperSecurityShoes


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Some armour items were showing up twice and the mask category had disappeared, i fixed it. #yay
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed some duplicate and missing items in the Head of Security loadout.
