### PR TITLE
Update spray painter to include new civilian airlocks, differentiate existing pipe colors, add more pipe colors

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -21,13 +21,19 @@
   - type: SprayPainter
     colorPalette:
       red: '#FF1212FF'
-      yellow: '#B3A234FF'
-      brown: '#947507FF'
+      yellow: '#FFFF00FF'
+      orange: '#FF6600FF'
       green: '#3AB334FF'
-      cyan: '#03FCD3FF'
+      cyan: '#00FFFFFF'
       blue: '#0335FCFF'
       white: '#FFFFFFFF'
       black: '#333333FF'
+      purple: '#7A2DFFFF'
+      magenta: '#FF00FFFF'
+      ice blue: '#64DAFFFF'
+      sky blue: '#0099FFFF'
+      lime green: '#D3FC03FF'
+      seafoam green: '#00FF87FF'
       # standard atmos pipes
       waste: '#990000'
       distro: '#0055cc'

--- a/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
@@ -15,6 +15,12 @@
     science:     Structures/Doors/Airlocks/Standard/science.rsi
     security:    Structures/Doors/Airlocks/Standard/security.rsi
     virology:    Structures/Doors/Airlocks/Standard/virology.rsi
+    bar:         _Impstation/Structures/Doors/Airlocks/Standard/bar.rsi
+    chapel:      _Impstation/Structures/Doors/Airlocks/Standard/chapel.rsi
+    janitor:     _Impstation/Structures/Doors/Airlocks/Standard/janitor.rsi
+    kitchen:     _Impstation/Structures/Doors/Airlocks/Standard/kitchen.rsi
+    lawyer:      _Impstation/Structures/Doors/Airlocks/Standard/lawyer.rsi
+    theatre:     _Impstation/Structures/Doors/Airlocks/Standard/theatre.rsi
 
 - type: AirlockGroup
   id: Glass
@@ -33,6 +39,12 @@
     medical:     Structures/Doors/Airlocks/Glass/medical.rsi
     security:    Structures/Doors/Airlocks/Glass/security.rsi
     virology:    Structures/Doors/Airlocks/Glass/virology.rsi
+    bar:         _Impstation/Structures/Doors/Airlocks/Glass/bar.rsi
+    chapel:      _Impstation/Structures/Doors/Airlocks/Glass/chapel.rsi
+    janitor:     _Impstation/Structures/Doors/Airlocks/Glass/janitor.rsi
+    kitchen:     _Impstation/Structures/Doors/Airlocks/Glass/kitchen.rsi
+    lawyer:      _Impstation/Structures/Doors/Airlocks/Glass/lawyer.rsi
+    theatre:     _Impstation/Structures/Doors/Airlocks/Glass/theatre.rsi
 
 - type: AirlockGroup
   id: Windoor
@@ -82,3 +94,9 @@
     science: Science
     security: Security
     virology: Medical
+    bar: Civilian
+    chapel: Civilian
+    janitor: Civilian
+    kitchen: Civilian
+    lawyer: Civilian
+    theatre: Civilian


### PR DESCRIPTION
Updates the spray painter to be able to spray our new civilian airlocks (see #873 and #834). Also adjusts some spray painter pipe colors to be more distinct from each other while adding some more pipe colors.

![Content Client_pfTz4dwNq2](https://github.com/user-attachments/assets/ce208d2e-a9ef-444c-9ade-632f73e5ea88)

**Changelog**

:cl:
- add: The spray painter can now paint airlocks to use the new civilian door sprites.
- tweak: Spray painter pipe color options have been adjusted to be more distinct and more color options have been added.
