### PR TITLE
multiple changelogs

### DIFF
--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -23,8 +23,8 @@ namespace Content.Client.Changelog
         private ISawmill _sawmill = default!;
 
         public bool NewChangelogEntries { get; private set; }
-        public int LastReadId { get; private set; }
-        public int MaxId { get; private set; }
+        public Dictionary<string, int> LastReadId { get; private set; } = new Dictionary<string, int>();
+        public Dictionary<string, int> MaxId { get; private set; } = new Dictionary<string, int>();
 
         public event Action? NewChangelogEntriesChanged;
 
@@ -36,14 +36,18 @@ namespace Content.Client.Changelog
         ///     <see cref="LastReadId"/> is NOT cleared
         ///     since that's used in the changelog menu to show the "since you last read" bar.
         /// </remarks>
-        public void SaveNewReadId()
+        public async void SaveNewReadId()
         {
             NewChangelogEntries = false;
             NewChangelogEntriesChanged?.Invoke();
 
-            using var sw = _resource.UserData.OpenWriteText(new ($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}"));
+            var changelogs = await LoadChangelog();
 
-            sw.Write(MaxId.ToString());
+            foreach (var changelog in changelogs)
+            {
+                using var sw = _resource.UserData.OpenWriteText(new($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}_{changelog.Name}"));
+                sw.Write(MaxId[changelog.Name].ToString());
+            }
         }
 
         public async void Initialize()
@@ -67,26 +71,30 @@ namespace Content.Client.Changelog
                 return;
             }
 
-            var changelog = changelogs[0];
             if (mainChangelogs.Length > 1)
-            {
                 _sawmill.Error($"More than one file found in Resource/Changelog with name {MainChangelogName}");
-            }
 
-            if (changelog.Entries.Count == 0)
-            {
+            if (changelogs[0].Entries.Count == 0)
                 return;
-            }
 
-            MaxId = changelog.Entries.Max(c => c.Id);
+            NewChangelogEntries = false;
 
-            var path = new ResPath($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}");
-            if (_resource.UserData.TryReadAllText(path, out var lastReadIdText))
+            foreach (var changelog in changelogs)
             {
-                LastReadId = int.Parse(lastReadIdText);
-            }
+                var name = changelog.Name;
 
-            NewChangelogEntries = LastReadId < MaxId;
+                MaxId.Add(name, changelog.Entries.Max(c => c.Id));
+                LastReadId.Add(name, 0);
+
+                var path = new ResPath($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}_{name}");
+                if (_resource.UserData.TryReadAllText(path, out var lastReadIdText))
+                {
+                    LastReadId[name] = int.Parse(lastReadIdText);
+                }
+
+                if (!changelog.AdminOnly)
+                    NewChangelogEntries = NewChangelogEntries || LastReadId[name] < MaxId[name];
+            }
 
             NewChangelogEntriesChanged?.Invoke();
         }

--- a/Content.Client/Changelog/ChangelogTab.xaml.cs
+++ b/Content.Client/Changelog/ChangelogTab.xaml.cs
@@ -30,19 +30,20 @@ public sealed partial class ChangelogTab : Control
 
     public void PopulateChangelog(ChangelogManager.Changelog changelog)
     {
+        var name = changelog.Name;
+
         var byDay = changelog.Entries
             .GroupBy(e => e.Time.ToLocalTime().Date)
             .OrderByDescending(c => c.Key);
 
-        var hasRead = changelog.Name != MainChangelogName ||
-                      _changelog.MaxId <= _changelog.LastReadId;
+        var hasRead = _changelog.MaxId[name] <= _changelog.LastReadId[name];
 
         foreach (var dayEntries in byDay)
         {
             var day = dayEntries.Key;
 
             var groupedEntries = dayEntries
-                .GroupBy(c => (c.Author, Read: c.Id <= _changelog.LastReadId))
+                .GroupBy(c => (c.Author, Read: c.Id <= _changelog.LastReadId[name]))
                 .OrderBy(c => c.Key.Read)
                 .ThenBy(c => c.Key.Author);
 


### PR DESCRIPTION
adds greater support for multiple changelog tabs: the changelog button will turn red for impstation changelogs in the same way that upstream changelogs do, and the "new changes" separator now works in it too! this is not hardcoded and can function for any amount of tabs. changelog tabs marked as admin-only will not notify about new changelogs, only player-facing ones will

![image](https://github.com/user-attachments/assets/879120e2-adcd-4fc8-8159-35812c5aa9ee)

as a bit of technical detail, changelog tabs are now stored in separate files in the user data directory, rather than only the main changelog being stored. these are appended with the tab's name, e.g. "_Changelog" or "_Impstation"

**Changelog**
:cl:
- add: Impstation changelogs now let you know when they've been updated - just like this one!
