### PR TITLE
slime water vapor damage fix

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -461,12 +461,15 @@
           Ammonia: 1.0
           WaterVapor: -1.0
       - !type:HealthChange # for slimes
+        scaleByQuantity: true
+        ignoreResistances: true
         conditions:
         - !type:OrganType
           type: Slime 
+          shouldHave: true
         damage:
           types:
-            Caustic: 150 # slimes breathe less, so they need to take a shitload of damage. end imp special.
+            Caustic: 50 # i want this to be a legitimate assassination method. end imp special.
 
 - type: reagent
   id: Ice


### PR DESCRIPTION

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Made Slime People's damage from water vapor scale with quantity, which should make it more dangerous.

