### PR TITLE
disable space wind

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -1,5 +1,3 @@
-using Content.Shared._Goobstation.CCVar;
-using Content.Shared._Impstation.CCVar;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 
@@ -14,14 +12,9 @@ namespace Content.Server.Atmos.EntitySystems
         public float SpaceWindPressureForceDivisorPush { get; private set; }
         public float SpaceWindMaxVelocity { get; private set; }
         public float SpaceWindMaxPushForce { get; private set; }
-        public float SpaceWindMinimumCalculatedMass { get; private set; } // Goobstation - Spacewind Cvars
-        public float SpaceWindMaximumCalculatedInverseMass { get; private set; } // Goobstation - Spacewind Cvars
-        public bool MonstermosUseExpensiveAirflow { get; private set; } // Goobstation - Spacewind Cvars
         public bool MonstermosEqualization { get; private set; }
         public bool MonstermosDepressurization { get; private set; }
-        public bool MonstermosRipTiles { get; private set; } // Goobstation - Spacewind Cvars
-        public float MonstermosRipTilesMinimumPressure { get; private set; } // Goobstation - Spacewind Cvars
-        public float MonstermosRipTilesPressureOffset { get; private set; } // Goobstation - Spacewind Cvars
+        public bool MonstermosRipTiles { get; private set; }
         public bool GridImpulse { get; private set; }
         public float SpacingEscapeRatio { get; private set; }
         public float SpacingMinGas { get; private set; }
@@ -33,7 +26,6 @@ namespace Content.Server.Atmos.EntitySystems
         public float AtmosTickRate { get; private set; }
         public float Speedup { get; private set; }
         public float HeatScale { get; private set; }
-        public float HumanoidThrowMultiplier { get; private set; } // Goobstation - Spacewind Cvars
 
         /// <summary>
         /// Time between each atmos sub-update.  If you are writing an atmos device, use AtmosDeviceUpdateEvent.dt
@@ -49,14 +41,9 @@ namespace Content.Server.Atmos.EntitySystems
             Subs.CVar(_cfg, CCVars.SpaceWindPressureForceDivisorPush, value => SpaceWindPressureForceDivisorPush = value, true);
             Subs.CVar(_cfg, CCVars.SpaceWindMaxVelocity, value => SpaceWindMaxVelocity = value, true);
             Subs.CVar(_cfg, CCVars.SpaceWindMaxPushForce, value => SpaceWindMaxPushForce = value, true);
-            Subs.CVar(_cfg, GoobCCVars.SpaceWindMinimumCalculatedMass, value => SpaceWindMinimumCalculatedMass = value, true); // Goobstation - Spacewind Cvars
-            Subs.CVar(_cfg, GoobCCVars.SpaceWindMaximumCalculatedInverseMass, value => SpaceWindMaximumCalculatedInverseMass = value, true); // Goobstation - Spacewind Cvars
-            Subs.CVar(_cfg, GoobCCVars.MonstermosUseExpensiveAirflow, value => MonstermosUseExpensiveAirflow = value, true); // Goobstation - Spacewind Cvars
             Subs.CVar(_cfg, CCVars.MonstermosEqualization, value => MonstermosEqualization = value, true);
             Subs.CVar(_cfg, CCVars.MonstermosDepressurization, value => MonstermosDepressurization = value, true);
             Subs.CVar(_cfg, CCVars.MonstermosRipTiles, value => MonstermosRipTiles = value, true);
-            Subs.CVar(_cfg, GoobCCVars.MonstermosRipTilesMinimumPressure, value => MonstermosRipTilesMinimumPressure = value, true); // Goobstation - Spacewind Cvars
-            Subs.CVar(_cfg, GoobCCVars.MonstermosRipTilesPressureOffset, value => MonstermosRipTilesPressureOffset = value, true); // Goobstation - Spacewind Cvars
             Subs.CVar(_cfg, CCVars.AtmosGridImpulse, value => GridImpulse = value, true);
             Subs.CVar(_cfg, CCVars.AtmosSpacingEscapeRatio, value => SpacingEscapeRatio = value, true);
             Subs.CVar(_cfg, CCVars.AtmosSpacingMinGas, value => SpacingMinGas = value, true);
@@ -68,7 +55,6 @@ namespace Content.Server.Atmos.EntitySystems
             Subs.CVar(_cfg, CCVars.AtmosHeatScale, value => { HeatScale = value; InitializeGases(); }, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroups, value => ExcitedGroups = value, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroupsSpaceIsAllConsuming, value => ExcitedGroupsSpaceIsAllConsuming = value, true);
-            Subs.CVar(_cfg, GoobCCVars.AtmosHumanoidThrowMultiplier, value => HumanoidThrowMultiplier = value, true); // Goobstation - Spacewind Cvars
         }
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -1,7 +1,6 @@
 using Content.Server.Atmos.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
-using Content.Shared.Humanoid;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Physics;
 using Robust.Shared.Audio;
@@ -51,7 +50,8 @@ namespace Content.Server.Atmos.EntitySystems
                 comp.Accumulator = 0f;
                 toRemove.Add(ent);
 
-                if (TryComp<PhysicsComponent>(uid, out var body))
+                if (HasComp<MobStateComponent>(uid) &&
+                    TryComp<PhysicsComponent>(uid, out var body))
                 {
                     _physics.SetBodyStatus(uid, body, BodyStatus.OnGround);
                 }
@@ -71,10 +71,27 @@ namespace Content.Server.Atmos.EntitySystems
             }
         }
 
+        private void AddMobMovedByPressure(EntityUid uid, MovedByPressureComponent component, PhysicsComponent body)
+        {
+            if (!TryComp<FixturesComponent>(uid, out var fixtures))
+                return;
+
+            _physics.SetBodyStatus(uid, body, BodyStatus.InAir);
+
+            foreach (var (id, fixture) in fixtures.Fixtures)
+            {
+                _physics.RemoveCollisionMask(uid, id, fixture, (int) CollisionGroup.TableLayer, manager: fixtures);
+            }
+
+            // TODO: Make them dynamic type? Ehh but they still want movement so uhh make it non-predicted like weightless?
+            // idk it's hard.
+
+            component.Accumulator = 0f;
+            _activePressures.Add((uid, component));
+        }
+
         private void HighPressureMovements(Entity<GridAtmosphereComponent> gridAtmosphere, TileAtmosphere tile, EntityQuery<PhysicsComponent> bodies, EntityQuery<TransformComponent> xforms, EntityQuery<MovedByPressureComponent> pressureQuery, EntityQuery<MetaDataComponent> metas)
         {
-            if (tile.PressureDifference < (SpaceWindMinimumCalculatedMass * SpaceWindMinimumCalculatedMass) || tile.PressureDifference < 130)
-                return;
             // TODO ATMOS finish this
 
             // Don't play the space wind sound on tiles that are on fire...
@@ -104,8 +121,7 @@ namespace Content.Server.Atmos.EntitySystems
             var gridWorldRotation = xforms.GetComponent(gridAtmosphere).WorldRotation;
 
             // If we're using monstermos, smooth out the yeet direction to follow the flow
-            //TODO This is bad, don't run this. It just makes the throws worse by somehow rounding them to orthogonal
-            if (!MonstermosEqualization)
+            if (MonstermosEqualization)
             {
                 // We step through tiles according to the pressure direction on the current tile.
                 // The goal is to get a general direction of the airflow in the area.
@@ -145,7 +161,7 @@ namespace Content.Server.Atmos.EntitySystems
                         (entity, pressureMovements),
                         gridAtmosphere.Comp.UpdateCounter,
                         tile.PressureDifference,
-                        tile.PressureDirection,
+                        tile.PressureDirection, 0,
                         tile.PressureSpecificTarget != null ? _mapSystem.ToCenterCoordinates(tile.GridIndex, tile.PressureSpecificTarget.GridIndices) : EntityCoordinates.Invalid,
                         gridWorldRotation,
                         xforms.GetComponent(entity),
@@ -166,29 +182,12 @@ namespace Content.Server.Atmos.EntitySystems
             tile.PressureDirection = differenceDirection;
         }
 
-        //INFO The EE version of this function drops pressureResistanceProbDelta, since it's not needed. If you are for whatever reason calling this function
-        //INFO And if it isn't working, you've probably still got the pressureResistanceProbDelta line included.
-        /// <notes>
-        /// EXPLANATION:
-        /// pressureDifference = Force of Air Flow on a given tile
-        /// physics.Mass = Mass of the object potentially being thrown
-        /// physics.InvMass = 1 divided by said Mass. More CPU efficient way to do division.
-        ///
-        /// Objects can only be thrown if the force of air flow is greater than the SQUARE of their mass or {SpaceWindMinimumCalculatedMass}, whichever is heavier
-        /// This means that the heavier an object is, the exponentially more force is required to move it
-        /// The force of a throw is equal to the force of air pressure, divided by an object's mass. So not only are heavier objects
-        /// less likely to be thrown, they are also harder to throw,
-        /// while lighter objects are yeeted easily, and from great distance.
-        ///
-        /// For a human sized entity with a standard weight of 80kg and a spacing between a hard vacuum and a room pressurized at 101kpa,
-        /// The human shall only be moved if he is either very close to the hole, or is standing in a region of high airflow
-        /// </notes>
-
         public void ExperiencePressureDifference(
             Entity<MovedByPressureComponent> ent,
             int cycle,
             float pressureDifference,
             AtmosDirection direction,
+            float pressureResistanceProbDelta,
             EntityCoordinates throwTarget,
             Angle gridWorldRotation,
             TransformComponent? xform = null,
@@ -201,27 +200,50 @@ namespace Content.Server.Atmos.EntitySystems
             if (!Resolve(uid, ref xform))
                 return;
 
-            if (physics.BodyType != BodyType.Static
-                && !float.IsPositiveInfinity(component.MoveResist))
+            // TODO ATMOS stuns?
+
+            var maxForce = MathF.Sqrt(pressureDifference) * 2.25f;
+            var moveProb = 100f;
+
+            if (component.PressureResistance > 0)
+                moveProb = MathF.Abs((pressureDifference / component.PressureResistance * MovedByPressureComponent.ProbabilityBasePercent) -
+                                     MovedByPressureComponent.ProbabilityOffset);
+
+            // Can we yeet the thing (due to probability, strength, etc.)
+            if (moveProb > MovedByPressureComponent.ProbabilityOffset && _random.Prob(MathF.Min(moveProb / 100f, 1f))
+                                                                      && !float.IsPositiveInfinity(component.MoveResist)
+                                                                      && (physics.BodyType != BodyType.Static
+                                                                          && (maxForce >= (component.MoveResist * MovedByPressureComponent.MoveForcePushRatio)))
+                || (physics.BodyType == BodyType.Static && (maxForce >= (component.MoveResist * MovedByPressureComponent.MoveForceForcePushRatio))))
             {
-                var moveForce = pressureDifference * MathF.Max(physics.InvMass, SpaceWindMaximumCalculatedInverseMass);
-                if (HasComp<HumanoidAppearanceComponent>(ent))
-                    moveForce *= HumanoidThrowMultiplier;
-                if (moveForce > physics.Mass)
+                if (HasComp<MobStateComponent>(uid))
                 {
+                    AddMobMovedByPressure(uid, component, physics);
+                }
+
+                if (maxForce > MovedByPressureComponent.ThrowForce)
+                {
+                    var moveForce = maxForce;
+                    moveForce /= (throwTarget != EntityCoordinates.Invalid) ? SpaceWindPressureForceDivisorThrow : SpaceWindPressureForceDivisorPush;
+                    moveForce *= MathHelper.Clamp(moveProb, 0, 100);
+
+                    // Apply a sanity clamp to prevent being thrown through objects.
+                    var maxSafeForceForObject = SpaceWindMaxVelocity * physics.Mass;
+                    moveForce = MathF.Min(moveForce, maxSafeForceForObject);
+
                     // Grid-rotation adjusted direction
                     var dirVec = (direction.ToAngle() + gridWorldRotation).ToWorldVec();
-                    moveForce *= MathF.Max(physics.InvMass, SpaceWindMaximumCalculatedInverseMass);
 
-                    //TODO Consider replacing throw target with proper trigonometry angles.
+                    // TODO: Technically these directions won't be correct but uhh I'm just here for optimisations buddy not to fix my old bugs.
                     if (throwTarget != EntityCoordinates.Invalid)
                     {
-                        var pos = throwTarget.ToMap(EntityManager, _transformSystem).Position - xform.WorldPosition + dirVec;
-                        _throwing.TryThrow(uid, pos.Normalized() * MathF.Min(moveForce, SpaceWindMaxVelocity), moveForce);
+                        var pos = ((_transformSystem.ToMapCoordinates(throwTarget).Position - _transformSystem.GetWorldPosition(xform)).Normalized() + dirVec).Normalized();
+                        _physics.ApplyLinearImpulse(uid, pos * moveForce, body: physics);
                     }
                     else
                     {
-                        _throwing.TryThrow(uid, dirVec.Normalized() * MathF.Min(moveForce, SpaceWindMaxVelocity), moveForce);
+                        moveForce = MathF.Min(moveForce, SpaceWindMaxPushForce);
+                        _physics.ApplyLinearImpulse(uid, dirVec * moveForce, body: physics);
                     }
 
                     component.LastHighPressureMovementAirCycle = cycle;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -6,7 +6,6 @@ using Content.Server.NodeContainer.EntitySystems;
 using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Decals;
 using Content.Shared.Doors.Components;
-using Content.Shared.Throwing;
 using Content.Shared.Maps;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
@@ -39,7 +38,6 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
     [Dependency] private readonly TileSystem _tile = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] public readonly PuddleSystem Puddle = default!;
-    [Dependency] private readonly ThrowingSystem _throwing = default!;
 
     private const float ExposedUpdateDelay = 1f;
     private float _exposedTimer = 0f;

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -170,9 +170,7 @@ public sealed class TemperatureSystem : EntitySystem
             return Atmospherics.MinimumHeatCapacity;
         }
 
-        if (physics.Mass < 1)
-            return comp.SpecificHeat;
-        else return comp.SpecificHeat * physics.FixturesMass;
+        return comp.SpecificHeat * physics.FixturesMass;
     }
 
     private void OnInit(EntityUid uid, InternalTemperatureComponent comp, MapInitEvent args)

--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -8,7 +8,7 @@ public sealed partial class CCVars
     ///     Whether gas differences will move entities.
     /// </summary>
     public static readonly CVarDef<bool> SpaceWind =
-        CVarDef.Create("atmos.space_wind", true, CVar.SERVERONLY);
+        CVarDef.Create("atmos.space_wind", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     Divisor from maxForce (pressureDifference * 2.25f) to force applied on objects.

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -117,11 +117,5 @@ namespace Content.Shared.Maps
         {
             TileId = id;
         }
-
-        [DataField]
-        public bool Reinforced = false; 
-
-        [DataField]
-        public float TileRipResistance = 125f;
     }
 }

--- a/Content.Shared/_Goobstation/CCVar/GoobCCVars.cs
+++ b/Content.Shared/_Goobstation/CCVar/GoobCCVars.cs
@@ -6,49 +6,5 @@ namespace Content.Shared._Goobstation.CCVar;
 [CVarDefs]
 public sealed partial class GoobCCVars : CVars
 {
-    /// <summary>
-    ///     If an object's mass is below this number, then this number is used in place of mass to determine whether air pressure can throw an object.
-    ///     This has nothing to do with throwing force, only acting as a way of reducing the odds of tiny 5 gram objects from being yeeted by people's breath
-    /// </summary>
-    /// <remarks>
-    ///     If you are reading this because you want to change it, consider looking into why almost every item in the game weighs only 5 grams
-    ///     And maybe do your part to fix that? :)
-    /// </remarks>
-    public static readonly CVarDef<float> SpaceWindMinimumCalculatedMass =
-        CVarDef.Create("atmos.space_wind_minimum_calculated_mass", 7f, CVar.SERVERONLY);
-
-    /// <summary>
-    ///     Calculated as 1/Mass, where Mass is the physics.Mass of the desired threshold.
-    ///     If an object's inverse mass is lower than this, it is capped at this. Basically, an upper limit to how heavy an object can be before it stops resisting space wind more.
-    /// </summary>
-    public static readonly CVarDef<float> SpaceWindMaximumCalculatedInverseMass =
-        CVarDef.Create("atmos.space_wind_maximum_calculated_inverse_mass", 0.04f, CVar.SERVERONLY);
-
-    /// <summary>
-    ///     Increases default airflow calculations to O(n^2) complexity, for use with heavy space wind optimizations. Potato servers BEWARE
-    ///     This solves the problem of objects being trapped in an infinite loop of slamming into a wall repeatedly.
-    /// </summary>
-    public static readonly CVarDef<bool> MonstermosUseExpensiveAirflow =
-        CVarDef.Create("atmos.mmos_expensive_airflow", true, CVar.SERVERONLY);
-
-    /// <summary>
-    ///     Taken as the cube of a tile's mass, this acts as a minimum threshold of mass for which air pressure calculates whether or not to rip a tile from the floor
-    ///     This should be set by default to the cube of the game's lowest mass tile as defined in .yml prototypes, but can be increased for server performance reasons
-    /// </summary>
-    public static readonly CVarDef<float> MonstermosRipTilesMinimumPressure =
-        CVarDef.Create("atmos.monstermos_rip_tiles_min_pressure", 7500f, CVar.SERVERONLY);
-
-    /// <summary>
-    ///     Taken after the minimum pressure is checked, the effective pressure is multiplied by this amount. This allows server hosts to
-    ///     finely tune how likely floor tiles are to be ripped apart by air pressure
-    /// </summary>
-    public static readonly CVarDef<float> MonstermosRipTilesPressureOffset =
-        CVarDef.Create("atmos.monstermos_rip_tiles_pressure_offset", 0.44f, CVar.SERVERONLY);
-
-    /// <summary>
-    ///     A multiplier on the amount of force applied to Humanoid entities, as tracked by HumanoidAppearanceComponent
-    ///     This multiplier is added after all other checks are made, and applies to both throwing force, and how easy it is for an entity to be thrown.
-    /// </summary>
-    public static readonly CVarDef<float> AtmosHumanoidThrowMultiplier =
-        CVarDef.Create("atmos.humanoid_throw_multiplier", 2.5f, CVar.SERVERONLY);
+    
 }

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -15,7 +15,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelCheckerLight
@@ -34,7 +33,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelCheckerLight
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelCheckerDark
@@ -53,7 +51,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelCheckerDark
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelMini
@@ -72,7 +69,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelMini
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelPavement
@@ -91,7 +87,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelPavement
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelDiagonal
@@ -110,7 +105,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelDiagonal
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelOffset
@@ -123,7 +117,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelOffset
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelMono
@@ -142,7 +135,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteelMono
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelPavementVertical
@@ -161,7 +153,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteelPavementVertical
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelHerringbone
@@ -180,7 +171,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteelHerringbone
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelDiagonalMini
@@ -199,7 +189,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteelDiagonalMini
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorBrassFilled
@@ -212,7 +201,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemBrassFilled
   heatCapacity: 10000
-  tileRipResistance: 220
 
 - type: tile
   id: FloorBrassReebe
@@ -225,7 +213,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemBrassReebe
   heatCapacity: 10000
-  tileRipResistance: 220
 
 - type: tile
   id: FloorPlastic
@@ -244,7 +231,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWood
@@ -265,7 +251,6 @@
     collection: BarestepWood
   itemDrop: FloorTileItemWood
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhite
@@ -284,7 +269,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteMini
@@ -303,7 +287,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteMini
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhitePavement
@@ -322,7 +305,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhitePavement
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteDiagonal
@@ -341,7 +323,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteDiagonal
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteOffset
@@ -354,7 +335,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteOffset
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteMono
@@ -373,7 +353,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteMono
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhitePavementVertical
@@ -392,7 +371,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhitePavementVertical
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteHerringbone
@@ -411,7 +389,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteHerringbone
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteDiagonalMini
@@ -430,7 +407,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteDiagonalMini
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhitePlastic
@@ -449,7 +425,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorDark
@@ -468,7 +443,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkMini
@@ -487,7 +461,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkMini
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkPavement
@@ -506,7 +479,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkPavement
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkDiagonal
@@ -525,7 +497,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkDiagonal
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkOffset
@@ -538,7 +509,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkOffset
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkMono
@@ -557,7 +527,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkMono
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkPavementVertical
@@ -576,7 +545,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkPavementVertical
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkHerringbone
@@ -595,7 +563,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkHerringbone
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkDiagonalMini
@@ -614,7 +581,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDarkDiagonalMini
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkPlastic
@@ -633,7 +599,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorTechMaint
@@ -646,7 +611,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemTechmaint
   heatCapacity: 10000
-  tileRipResistance: 250
 
 - type: tile
   id: FloorTechMaintDark
@@ -659,7 +623,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemTechmaintDark
   heatCapacity: 10000
-  tileRipResistance: 250
 
 - type: tile
   id: FloorReinforced
@@ -672,7 +635,6 @@
     collection: FootstepHull
   itemDrop: PartRodMetal1
   heatCapacity: 10000
-  reinforced: true
 
 - type: tile
   id: FloorMono
@@ -685,7 +647,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMono
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorLino
@@ -698,7 +659,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemLino
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorSteelDirty
@@ -711,7 +671,6 @@
     collection: FootstepPlating
   itemDrop: FloorTileItemDirty
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorElevatorShaft
@@ -724,7 +683,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemElevatorShaft
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorMetalDiamond
@@ -737,7 +695,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemMetalDiamond
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorRockVault
@@ -750,7 +707,6 @@
     collection: FootstepAsteroid
   itemDrop: FloorTileItemRockVault
   heatCapacity: 10000
-  tileRipResistance: 400
 
 - type: tile
   id: FloorBlue
@@ -763,7 +719,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemBlue
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorSteelLime
@@ -782,7 +737,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemLime
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorMining
@@ -795,7 +749,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMining
   heatCapacity: 10000
-  tileRipResistance: 250
 
 - type: tile
   id: FloorMiningDark
@@ -808,7 +761,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMiningDark
   heatCapacity: 10000
-  tileRipResistance: 250
 
 - type: tile
   id: FloorMiningLight
@@ -821,7 +773,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMiningLight
   heatCapacity: 10000
-  tileRipResistance: 250
 
 # Departamental
 - type: tile
@@ -835,7 +786,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemFreezer
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorShowroom
@@ -848,7 +798,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShowroom
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorHydro
@@ -861,7 +810,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemHydro
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorBar
@@ -880,7 +828,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemBar
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorClown
@@ -893,7 +840,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemClown
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorMime
@@ -906,7 +852,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemMime
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorKitchen
@@ -919,7 +864,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemKitchen
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorLaundry
@@ -932,7 +876,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemLaundry
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorSteelDamaged
@@ -952,7 +895,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel #This should probably be made null when it becomes possible to make it such, in SS13 prying destroyed tiles wouldn't give you anything.
   heatCapacity: 10000
-  tileRipResistance: 175
 
 - type: tile
   id: FloorSteelBurnt
@@ -969,7 +911,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel #Same case as FloorSteelDamaged, make it null when possible
   heatCapacity: 10000
-  tileRipResistance: 175
 
 
 # Concrete
@@ -990,7 +931,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemConcrete
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorConcreteMono
@@ -1009,7 +949,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemConcreteMono
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorConcreteSmooth
@@ -1028,7 +967,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemConcreteSmooth
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorGrayConcrete
@@ -1047,7 +985,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemGrayConcrete
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorGrayConcreteMono
@@ -1066,7 +1003,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemGrayConcreteMono
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorGrayConcreteSmooth
@@ -1085,7 +1021,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemGrayConcreteSmooth
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorOldConcrete
@@ -1104,7 +1039,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemOldConcrete
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorOldConcreteMono
@@ -1123,7 +1057,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemOldConcreteMono
   heatCapacity: 10000
-  tileRipResistance: 300
 
 - type: tile
   id: FloorOldConcreteSmooth
@@ -1142,7 +1075,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemOldConcreteSmooth
   heatCapacity: 10000
-  tileRipResistance: 300
 
 # Carpets (non smoothing)
 - type: tile
@@ -1159,7 +1091,6 @@
   friction: 0.25
   itemDrop: FloorTileItemArcadeBlue
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorArcadeBlue2
@@ -1175,7 +1106,6 @@
   friction: 0.25
   itemDrop: FloorTileItemArcadeBlue2
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorArcadeRed
@@ -1191,7 +1121,6 @@
   friction: 0.25
   itemDrop: FloorTileItemArcadeRed
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorEighties
@@ -1207,7 +1136,6 @@
   friction: 0.25
   itemDrop: FloorTileItemEighties
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorCarpetClown
@@ -1223,7 +1151,6 @@
   friction: 0.25
   itemDrop: FloorTileItemCarpetClown
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorCarpetOffice
@@ -1239,7 +1166,6 @@
   friction: 0.25
   itemDrop: FloorTileItemCarpetOffice
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorBoxing
@@ -1259,7 +1185,6 @@
   friction: 0.25
   itemDrop: FloorTileItemBoxing
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorGym
@@ -1279,7 +1204,6 @@
   friction: 0.25
   itemDrop: FloorTileItemGym
   heatCapacity: 10000
-  tileRipResistance: 50
 
 # Shuttle
 - type: tile
@@ -1299,7 +1223,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleWhite
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleGrey
@@ -1318,7 +1241,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleGrey
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleBlack
@@ -1337,7 +1259,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleBlack
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleBlue
@@ -1356,7 +1277,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleBlue
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleOrange
@@ -1375,7 +1295,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleOrange
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttlePurple
@@ -1394,7 +1313,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttlePurple
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleRed
@@ -1413,7 +1331,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleRed
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 
 # Materials
@@ -1428,7 +1345,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemGold
   heatCapacity: 10000
-  tileRipResistance: 500
 
 - type: tile
   id: FloorSilver
@@ -1441,7 +1357,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSilver
   heatCapacity: 10000
-  tileRipResistance: 500
 
 - type: tile
   id: FloorGlass
@@ -1460,7 +1375,6 @@
     collection: FootstepTile
   itemDrop: SheetGlass1
   heatCapacity: 10000
-  tileRipResistance: 200
 
 - type: tile
   id: FloorRGlass
@@ -1479,7 +1393,6 @@
     collection: FootstepTile
   itemDrop: SheetRGlass1
   heatCapacity: 10000
-  tileRipResistance: 500
 
 - type: tile
   id: FloorMetalFoam
@@ -1495,7 +1408,6 @@
     collection: FootstepHull
   itemDrop: SheetSteel1
   heatCapacity: 10000
-  tileRipResistance: 1000
 
 # Circuits
 - type: tile
@@ -1509,7 +1421,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemGCircuit
   heatCapacity: 10000
-  tileRipResistance: 225
 
 - type: tile
   id: FloorBlueCircuit
@@ -1522,7 +1433,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemBCircuit
   heatCapacity: 10000
-  tileRipResistance: 225
 
 - type: tile
   id: FloorRedCircuit
@@ -1535,7 +1445,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemRCircuit
   heatCapacity: 10000
-  tileRipResistance: 225
 
 # Terrain
 - type: tile
@@ -1821,7 +1730,6 @@
   itemDrop: FloorTileItemFlesh
   friction: 0.05 #slippy
   heatCapacity: 10000
-  tileRipResistance: 200
 
 - type: tile
   id: FloorTechMaint2
@@ -1834,7 +1742,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemSteelMaint
   heatCapacity: 10000
-  tileRipResistance: 225
 
 - type: tile
   id: FloorTechMaint3
@@ -1853,7 +1760,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemGratingMaint
   heatCapacity: 10000
-  tileRipResistance: 225
 
 - type: tile
   id: FloorWoodTile
@@ -1874,7 +1780,6 @@
     collection: BarestepWood
   itemDrop: FloorTileItemWoodPattern
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorBrokenWood
@@ -1898,7 +1803,6 @@
     collection: BarestepWood
   itemDrop: MaterialWoodPlank1
   heatCapacity: 10000
-  tileRipResistance: 60
 
 - type: tile
   id: FloorWebTile
@@ -1913,7 +1817,6 @@
     collection: BarestepCarpet
   itemDrop: FloorTileItemWeb
   heatCapacity: 10000
-  tileRipResistance: 30
 
 - type: tile
   id: FloorChromite
@@ -1933,7 +1836,6 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  tileRipResistance: 500
 
 #Hull tiles
 - type: tile
@@ -1946,7 +1848,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemSteel #probably should not be normally obtainable, but the game shits itself and dies when you try to put null here
   heatCapacity: 10000
-  tileRipResistance: 850
 
 - type: tile
   id: FloorHullReinforced
@@ -1959,7 +1860,6 @@
   itemDrop: FloorTileItemSteel
   heatCapacity: 100000 #/tg/ has this set as "INFINITY." I don't know if that exists here so I've just added an extra 0
   indestructible: true
-  reinforced: true
 
 - type: tile
   id: FloorReinforcedHardened
@@ -1970,7 +1870,6 @@
   footstepSounds:
     collection: FootstepHull
   itemDrop: PartRodMetal1 #same case as FloorHull
-  reinforced: true
 
 # Faux sci tiles
 
@@ -2002,7 +1901,6 @@
     collection: FootstepGrass
   itemDrop: FloorTileItemAstroGrass
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorMowedAstroGrass
@@ -2012,7 +1910,6 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemMowedAstroGrass
-  tileRipResistance: 50
 
 - type: tile
   id: FloorJungleAstroGrass
@@ -2022,7 +1919,6 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemJungleAstroGrass
-  tileRipResistance: 50
 
 # Ice
 - type: tile
@@ -2038,7 +1934,6 @@
   mobFrictionNoInput: 0.05
   mobAcceleration: 2
   itemDrop: FloorTileItemAstroIce
-  tileRipResistance: 50
 
 - type: tile
   id: FloorAstroSnow
@@ -2048,7 +1943,6 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroSnow
-  tileRipResistance: 50
 
 - type: tile
   id: FloorWoodLarge
@@ -2069,7 +1963,6 @@
     collection: BarestepWood
   itemDrop: FloorTileItemWoodLarge
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorXeno
@@ -2083,4 +1976,3 @@
   itemDrop: FloorTileItemXeno
   friction: 0.05 #slippy
   heatCapacity: 10000
-  tileRipResistance: 4500


### PR DESCRIPTION
space wind has been given a fair try but it seems to generate more grief from players than the system is worth with its current implementation. we can bring it back with a better implementation, but as it stands, goob wind doesn't seem to be cutting it for the playerbase

might need `cvar atmos.space_wind` sent to false on the server side just to ensure the fallback space wind isn't used

**Changelog**
:cl:
- remove: Space wind has been disabled.