### PR TITLE
moving stun enforcers to nonlethals

### DIFF
--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -62,6 +62,7 @@
   - BoxBeanbag
   - WeaponDisabler
   - WeaponShotgunKammererBeanbag
+  - WeaponShotgunEnforcerBeanbag
 
 - type: technology
   id: UraniumMunitions
@@ -97,7 +98,6 @@
   - TelescopicShield
   - HoloprojectorSecurity
   - WeaponDisablerSMG
-  - WeaponShotgunEnforcerBeanbag
 
 - type: technology
   id: ExplosiveTechnology

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: stun enforcer
+  name: stun Enforcer
   parent: WeaponShotgunEnforcer
   id: WeaponShotgunEnforcerBeanbag
   description: A premium combat shotgun with an extended magazine and a built-in silencer, modified to only accept .50 stun slugs.
@@ -29,7 +29,7 @@
       path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
 
 - type: entity
-  name: stun kammerer
+  name: stun Kammerer
   parent:  [BaseWeaponShotgun, BaseGunWieldable, BaseMinorSecurityCivilianContraband]
   id: WeaponShotgunKammererBeanbag
   description: A pump shotgun with a built-in silencer, modified to only accept .50 stun slugs.

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: Stun Enforcer
+  name: stun enforcer
   parent: WeaponShotgunEnforcer
   id: WeaponShotgunEnforcerBeanbag
   description: A premium combat shotgun with an extended magazine and a built-in silencer, modified to only accept .50 stun slugs.
@@ -29,7 +29,7 @@
       path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
 
 - type: entity
-  name: Stun Kammerer
+  name: stun kammerer
   parent:  [BaseWeaponShotgun, BaseGunWieldable, BaseMinorSecurityCivilianContraband]
   id: WeaponShotgunKammererBeanbag
   description: A pump shotgun with a built-in silencer, modified to only accept .50 stun slugs.


### PR DESCRIPTION
after a discussion with dark, this makes advanced riot control a little less cracked, gives people more of a reason to get nonlethals, and both are tier 1 research

the original idea was stun kammerers come from the same place you get disablers, and stun enforcers come from the same place you get disabler SMGs, but there's still a reason for security to print both since the bartender can legally wield the kammerer

worth a shot!

:cl:
- tweak: Stun Enforcers now come from nonlethals research to make advanced riot control less cracked
- tweak: Fixed capitalization on the stun shotgun item names