### PR TITLE
Fix male dwarves using unisex vocal emotes.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -45,7 +45,7 @@
         - MobLayer
   - type: Vocal
     sounds:
-      Male: UnisexDwarf
+      Male: MaleDwarf
       Female: FemaleDwarf
       Unsexed: UnisexDwarf
   - type: ReplacementAccent


### PR DESCRIPTION
Fixes male dwarves so they use male vocal emotes instead of unisex ones. This is a fix to #866.

**Changelog**

:cl:
- fix: Fixed male dwarves using the incorrect vocal emotes.
