### PR TITLE
stun prod requires makeshift cuffs instead of cuffs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -70,6 +70,9 @@
     sprite: Objects/Misc/cablecuffs.rsi
     state: cuff
     color: forestgreen
+  - type: Tag # Imp start
+    tags:
+    - Cablecuffs # Imp end
 
 - type: entity
   name: zipties

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
@@ -13,12 +13,9 @@
               icon:
                 sprite: Objects/Power/power_cells.rsi
                 state: small
-            - tag: Handcuffs
-              icon:
-                sprite: Objects/Misc/cablecuffs.rsi
-                state: cuff
-                color: red
-              name: cuffs
+            - material: Cable
+              amount: 15
+              doAfter: 1
             - tag: Igniter
               name: igniter
               icon:
@@ -27,4 +24,4 @@
               doAfter: 15
     - node: msstunprod
       entity: Stunprod
-      
+

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
@@ -13,8 +13,12 @@
               icon:
                 sprite: Objects/Power/power_cells.rsi
                 state: small
-            - material: Cable
-              amount: 15
+            - tag: Cablecuffs
+              name: makeshift handcuffs
+              icon:
+                sprite: Objects/Misc/cablecuffs.rsi
+                state: cuff
+                color: forestgreen
               doAfter: 1
             - tag: Igniter
               name: igniter

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -3,6 +3,9 @@
   id: BeltUtility
 
 - type: Tag
+  id: Cablecuffs
+
+- type: Tag
   id: CartridgeLPistol
 
 - type: Tag


### PR DESCRIPTION
because this thing can eat real security cuffs when you're standing in front of the wire dispenser and have makeshift cuffs in your bag (wow)

:cl:
- tweak: Stun Prod now requires makeshift cuffs instead of any cuffs so it won't eat your security cuffs