### PR TITLE
Adjust player count ranges for stations

### DIFF
--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -2,8 +2,8 @@
   id: Atlas
   mapName: Atlas
   mapPath: /Maps/atlas.yml
-  minPlayers: 5
-  maxPlayers: 20
+  minPlayers: 0
+  maxPlayers: 25
   stations:
     Atlas:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -2,7 +2,8 @@
   id: Box
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
-  minPlayers: 50
+  minPlayers: 35
+  maxPlayers: 70
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -2,7 +2,7 @@
   id: Cluster
   mapName: 'Cluster'
   mapPath: /Maps/cluster.yml
-  minPlayers: 10
+  minPlayers: 0
   maxPlayers: 35
   stations:
     Cluster:

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -3,7 +3,6 @@
   mapName: 'Cog'
   mapPath: /Maps/cog.yml
   minPlayers: 50
-  maxPlayers: 80 #big map
   stations:
     Cog:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -2,7 +2,7 @@
   id: Core
   mapName: 'Core'
   mapPath: /Maps/core.yml
-  minPlayers: 45
+  minPlayers: 40
   maxPlayers: 80
   stations:
     Core:

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -2,7 +2,7 @@
   id: Fland
   mapName: 'Fland Installation'
   mapPath: /Maps/fland.yml
-  minPlayers: 70
+  minPlayers: 60
   stations:
     Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,7 +2,8 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 50
+  minPlayers: 35
+  maxPlayers: 70
   stations:
     Meta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -2,7 +2,7 @@
   id: Oasis
   mapName: 'Oasis'
   mapPath: /Maps/oasis.yml
-  minPlayers: 70
+  minPlayers: 60
   stations:
     Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -2,8 +2,8 @@
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/omega.yml
-  minPlayers: 10
-  maxPlayers: 50
+  minPlayers: 0
+  maxPlayers: 35
   stations:
     Omega:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -2,8 +2,8 @@
   id: Packed
   mapName: 'Packed'
   mapPath: /Maps/packed.yml
-  minPlayers: 10
-  maxPlayers: 50
+  minPlayers: 0
+  maxPlayers: 35
   stations:
     Packed:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -3,7 +3,7 @@
   mapName: 'Saltern'
   mapPath: /Maps/saltern.yml
   minPlayers: 0
-  maxPlayers: 50
+  maxPlayers: 35
   fallback: true
   stations:
     Saltern:


### PR DESCRIPTION
This change is primarily to revert previous changes that made lowpop map player ranges to have a higher max player count, but in addition tweaks have been made to most map prototypes to have slightly more standardized player ranges. The amount of players a map can accommodate can be somewhat vibe-based, so not all maps need to fit within a specific range and there are some outliers. The new player ranges for maps are listed below:

max 15: Reach
max 25: Atlas
max 35: Cluster, Packed, Omega, Saltern
30 - 70: Barratry
35 - 70: Box, Meta, Marathon
35 - 80: Bagel, Hummingbird, Train, Union
40 - 80: Core, Xeno
min 50: Cog
min 60: Fland, Oasis

**Changelog**

:cl:
- tweak: Adjusted player count range of a number of maps to better reflect what they can accommodate.

