### PR TITLE
Further tweak of player count ranges for stations

### DIFF
--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -2,7 +2,7 @@
   id: Atlas
   mapName: Atlas
   mapPath: /Maps/atlas.yml
-  minPlayers: 0
+  minPlayers: 7
   maxPlayers: 25
   stations:
     Atlas:

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -2,7 +2,7 @@
   id: Cluster
   mapName: 'Cluster'
   mapPath: /Maps/cluster.yml
-  minPlayers: 0
+  minPlayers: 7
   maxPlayers: 35
   stations:
     Cluster:

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -2,7 +2,7 @@
   id: Cog
   mapName: 'Cog'
   mapPath: /Maps/cog.yml
-  minPlayers: 50
+  minPlayers: 45
   maxPlayers: 80 #big map
   stations:
     Cog:

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -3,6 +3,7 @@
   mapName: 'Cog'
   mapPath: /Maps/cog.yml
   minPlayers: 50
+  maxPlayers: 80 #big map
   stations:
     Cog:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -2,7 +2,7 @@
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/omega.yml
-  minPlayers: 0
+  minPlayers: 7
   maxPlayers: 35
   stations:
     Omega:

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -2,7 +2,7 @@
   id: Packed
   mapName: 'Packed'
   mapPath: /Maps/packed.yml
-  minPlayers: 0
+  minPlayers: 7
   maxPlayers: 35
   stations:
     Packed:

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -3,7 +3,7 @@
   mapName: 'Reach'
   mapPath: /Maps/reach.yml
   minPlayers: 0
-  maxPlayers: 15
+  maxPlayers: 7
   stations:
     Reach:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -2,7 +2,7 @@
   id: Saltern
   mapName: 'Saltern'
   mapPath: /Maps/saltern.yml
-  minPlayers: 0
+  minPlayers: 7
   maxPlayers: 35
   fallback: true
   stations:


### PR DESCRIPTION
Sets minimum player count of  Omega, Packed, Saltern, Cluster, and Atlas to 7. Sets reach max size to 7. Sets Cog's range to 45 - 80. Tweak of #911. No changelog since publish hasn't been made for that change yet I think.

Player count ranges after these changes:
max 7: Reach
7 - 25: Atlas
7 - 35: Cluster, Packed, Omega, Saltern
30 - 70: Barratry
35 - 70: Box, Meta, Marathon
35 - 80: Bagel, Hummingbird, Train, Union
40 - 80: Core, Xeno
45 - 80: Cog
min 60: Fland, Oasis
