### PR TITLE
DO NOT MERGE UNTIL I SAY SO: roundstart decapoids

### DIFF
--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -28,6 +28,12 @@ public sealed partial class PullerComponent : Component
     public float WalkSpeedModifier => Pulling == default ? 1.0f : 0.95f;
 
     public float SprintSpeedModifier => Pulling == default ? 1.0f : 0.95f;
+	
+    /// <summary>
+    /// whether or not to apply speed modifiers to the puller
+    /// </summary>
+	[AutoNetworkedField, DataField]
+	public bool ApplySpeedModifier = true;
 
     /// <summary>
     /// Entity currently being pulled if applicable.

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -226,6 +226,10 @@ public sealed class PullingSystem : EntitySystem
 
     private void OnRefreshMovespeed(EntityUid uid, PullerComponent component, RefreshMovementSpeedModifiersEvent args)
     {
+		// skip this if ApplySpeedModifier is false
+		if (!component.ApplySpeedModifier)
+			return;
+		
         if (TryComp<HeldSpeedModifierComponent>(component.Pulling, out var heldMoveSpeed) && component.Pulling.HasValue)
         {
             var (walkMod, sprintMod) =

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -24,6 +24,7 @@
       mask:
         tags:
           - Vaporizer
+          - SGD
     failMessage: decapoid-cant-speak
   - type: Respirator 
     damage:
@@ -46,7 +47,7 @@
     - map: [ "gloves" ]
     - map: [ "shoes" ]
     - map: [ "ears" ]
-    - map: [ "enum.HumanoidVisualLayers.Snout" ] # not default
+    - map: [ "enum.HumanoidVisualLayers.Snout" ] # not default - gills use this slot
     - map: [ "outerClothing" ]
     - map: [ "eyes" ]
     - map: [ "belt" ]
@@ -84,7 +85,7 @@
   - type: Butcherable
     butcheringType: Spike
     spawned:
-    - id: FoodMeatCrab
+    - id: FoodMeatCrab # maybe custom someday. as-is, it's fine
       amount: 1
   - type: Fixtures
     fixtures:
@@ -104,7 +105,7 @@
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:
-        sprite: _Impstation/Mobs/Effects/decapoid_brute_damage.rsi
+        sprite: _Impstation/Mobs/Effects/decapoid_brute_damage.rsi # todo: make this cover the legs.
         color: "#162581"
   - type: Reactive
     groups:
@@ -115,12 +116,12 @@
     sounds:
       Male: UnisexDecapoid
       Female: UnisexDecapoid
-      Unsexed: UnisexDecapoid
+      Unsexed: UnisexDecapoid # male and female sounds have to 1) exist and 2) come first, otherwise urists will spawn without emote sounds 66% of the time, because this game is poorly programmed
   - type: MovementSpeedModifier
     baseSprintSpeed: 3.5
     baseWalkSpeed: 1.5
     weightlessAcceleration: 1.5 # move more easily in space
-    weightlessFrictionNoInput: 2 # more control over movement in space?
+    weightlessFrictionNoInput: 2 # more control over movement in space
     weightlessModifier: 1
   - type: Temperature
     heatDamageThreshold: 380 # slightly more vulnerable to heat
@@ -144,14 +145,15 @@
         Blunt: 5
     clumsySound:
       path: /Audio/_Impstation/Effects/Clumsy/crab_snap.ogg # the game gets really touchy about having that initial forward slash.
-    clumsyHypo: false # these variables are imp specials
+    clumsyHypo: false # these variables were created for this purpose and have been upstreamed
     clumsyVaulting: false
     clumsyDefib: false
-    gunFailedMessage: gun-clumsy-decapoid
+    gunFailedMessage: gun-clumsy-decapoid # The gun slips out of your claws!
   - type: Bloodstream
     bloodReagent: CopperBlood # real life crustaceans are in the same clade as spiders and share a blood type
   - type: Puller
-    needsHands: false # they drag with the claw. no way to remove the walkspeed penalty as far as I can tell.
+    needsHands: false # they drag with the claw, or their back legs
+    applySpeedModifier: false # they're strong as fuck. also i made this variable just for them.
   - type: Inventory
     templateId: decapoid
     displacements:
@@ -169,7 +171,7 @@
         sizeMaps:
           32:
             sprite: _Impstation/Mobs/Species/Decapoid/displacement.rsi
-            state: jumpsuit # todo: custom? (accomodate gills?)
+            state: jumpsuit # todo: custom? (accomodate gills?) - edit: no
       gloves:
         sizeMaps:
           32:
@@ -196,11 +198,11 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: HumanoidAppearance
-    species: Decapoid # is this defined?
+    species: Decapoid
   - type: Body
     prototype: Decapoid
   - type: Sprite
-    layers: # Need to redefine the whole order to draw the legs and claw correctly
+    layers: # Need to redefine the whole order to draw the legs and claw correctly - REMEMBER TO UPDATE THIS WHEN UPDATING THE OTHER LIST.
     - map: [ "enum.HumanoidVisualLayers.RFoot" ] # this is the back feet TODO: fix the fact that only the feet render
     - map: [ "enum.HumanoidVisualLayers.RLeg" ] # this is the back legs
     - map: [ "enum.HumanoidVisualLayers.Chest" ]
@@ -213,7 +215,7 @@
     - map: [ "gloves" ]
     - map: [ "shoes" ]
     - map: [ "ears" ]
-    - map: [ "enum.HumanoidVisualLayers.Snout" ] # not default
+    - map: [ "enum.HumanoidVisualLayers.Snout" ] # not default - the gills use this slot.
     - map: [ "outerClothing" ]
     - map: [ "eyes" ]
     - map: [ "belt" ]
@@ -255,11 +257,11 @@
           32:
             sprite: _Impstation/Mobs/Species/Decapoid/displacement.rsi
             state: jumpsuit
-      head: # don't need mask, those are fine
+      head: 
         sizeMaps:
           32:
             sprite: _Impstation/Mobs/Species/Decapoid/displacement.rsi
-            state: jumpsuit # todo: custom? (accomodate gills?)
+            state: jumpsuit 
       gloves:
         sizeMaps:
           32:
@@ -271,7 +273,7 @@
             sprite: _Impstation/Mobs/Species/Decapoid/displacement.rsi
             state: neck
 
-- type: entity
+- type: entity # have to do this because otherwise decapoids would not display as having their vaporizer in the customization menu.
   save: false
   id: BaseMobDecapoidInternals
   parent: BaseMobDecapoid

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -93,7 +93,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 120
+        density: 150 # they're a little heavier than everyone else.
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/_Impstation/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Species/decapoid.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Decapoid
   name: species-name-decapoid
-  roundStart: false
+  roundStart: true
   prototype: MobDecapoid
   sprites: MobDecapoidSprites
   defaultSkinTone: "#385878"

--- a/Resources/ServerInfo/_Impstation/Guidebook/Mobs/Decapoid.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/Mobs/Decapoid.xml
@@ -12,7 +12,7 @@
   
   This enormous benefit comes with a laundry list of detriments, however, when it comes to operating aboard a Nanotrasen vessel. Due to the weight of their carapace, [color=#ffa500]they move approximately 20% slower than most NT-accepted species,[/color] and their unique configuration of lower limbs makes it [color=#ffa500]impossible for them to wear shoes.[/color] 
   
-  Their major claw is enormous and somewhat unwieldy. [color=#ffa500]This left "hand" is useless for most of the tasks one might use a hand for,[/color] and functions primarily as a [color=#1e90ff]competent melee weapon and shield.[/color] Their minor claw isn't much more dextrous, and while its smaller size allows it to manipulate most tools, [color=#ffa500]Decapoids are incapable of efficiently using firearms of any kind.[/color] It's not all bad, however - Their abundance of limbs allows them to [color=#1e90ff]drag objects without the use of their claws.[/color]
+  Their major claw is enormous and somewhat unwieldy. [color=#ffa500]This left "hand" is useless for most of the tasks one might use a hand for,[/color] and functions primarily as a [color=#1e90ff]competent melee weapon and shield.[/color] Their minor claw isn't much more dextrous, and while its smaller size allows it to manipulate most tools, [color=#ffa500]Decapoids are incapable of efficiently using firearms of any kind.[/color] It's not all bad, however - Their abundance of limbs allows them to [color=#1e90ff]drag objects without the use of their claws,[/color] and their immense physical strength [color=#1e90ff]negates the normal speed penalty for dragging.[/color]
 
   ## Breathing Requirements
 


### PR DESCRIPTION
also i added a new variable to pullercomponent that lets you disable the inherent movespeed penalty and only be affected by the pulled object's density. but who cares about systems changes 

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: ADDED DECAPOIDS, a new playable species that you should probably read the guidebook entry for. 