### PR TITLE
change default changelog name to upstream

### DIFF
--- a/Resources/Locale/en-US/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/changelog/changelog-window.ftl
@@ -10,5 +10,5 @@ changelog-version-tag = version v{ $version }
 changelog-button = Changelog
 changelog-button-new-entries = Changelog (new!)
 
-changelog-tab-title-Changelog = Changelog
+changelog-tab-title-Changelog = Upstream
 changelog-tab-title-Admin = Admin


### PR DESCRIPTION
changed the name of the default changelog to Upstream since there is not just one changelog here. there are two, in fact. and one of them is ours!

![image](https://github.com/user-attachments/assets/35fcf360-15f8-4dca-aa2f-f3aadb3a9279)

**Changelog**
i don't think this is big enough to require one