### PR TITLE
Gun flavortext improvements and other small related fixes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -61,7 +61,7 @@
   id: CrateArmoryPistols
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: pistols crate
-  description: Contains two standard-issue Mk58 handguns with four magazines. Requires Armory access to open.
+  description: Contains two standard-issue Mk 58 handguns with four magazines. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -2,7 +2,7 @@
   id: CrateArmorySMG
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: SMG crate
-  description: Contains two high-powered, semiautomatic rifles with four mags. Requires Armory access to open.
+  description: Contains two WT550 submachine guns with four magazines. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -15,7 +15,7 @@
   id: CrateArmoryShotgun
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: shotgun crate
-  description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open.
+  description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer shotguns with three boxes of lethal pellet shotgun shells. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -28,7 +28,7 @@
   id: CrateTrackingImplants
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: tracking implants
-  description: Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.
+  description: Contains five tracking implanters. Good for prisoners you'd like to release but still keep track of.
   components:
   - type: StorageFill
     contents:
@@ -39,7 +39,7 @@
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   id: CrateTrainingBombs
   name: training bombs
-  description: Contains three low-yield training bombs for security to learn defusal and safe ordnance disposal, EOD suit not included. Requires Armory access to open.
+  description: Contains three low-yield training bombs for security to learn defusal and safe ordnance disposal. EOD suit not included. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -61,7 +61,7 @@
   id: CrateArmoryPistols
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: pistols crate
-  description: Contains two standard NT pistols with four mags. Requires Armory access to open.
+  description: Contains two standard-issue Mk58 handguns with four magazines. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -74,7 +74,7 @@
   id: CrateSecurityRiot
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: swat crate
-  description: Contains two sets of riot armor, helmets, shields, and enforcers loaded with beanbags. Extra ammo is included. Requires Armory access to open.
+  description: Contains two sets of riot armor, helmets, shields, and Stun Enforcers. Extra stun ammo included. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -28,7 +28,7 @@
   id: CrateTrackingImplants
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: tracking implants
-  description: Contains five tracking implanters. Good for prisoners you'd like to release but still keep track of.
+  description: Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -15,7 +15,7 @@
   id: CrateArmoryShotgun
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: shotgun crate
-  description: For when the enemy absolutely needs to be replaced with lead. Contains two enforcer shotguns with three boxes of lethal pellet shotgun shells. Requires Armory access to open.
+  description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer shotguns with three boxes of lethal pellet shotgun shells. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -74,7 +74,7 @@
   id: CrateSecurityRiot
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: swat crate
-  description: Contains two sets of riot armor, helmets, shields, and stun enforcers. Extra stun ammo included. Requires Armory access to open.
+  description: Contains two sets of riot armor, helmets, shields, and stun Enforcers. Extra stun ammo included. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -15,7 +15,7 @@
   id: CrateArmoryShotgun
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: shotgun crate
-  description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer shotguns with three boxes of lethal pellet shotgun shells. Requires Armory access to open.
+  description: For when the enemy absolutely needs to be replaced with lead. Contains two enforcer shotguns with three boxes of lethal pellet shotgun shells. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -74,7 +74,7 @@
   id: CrateSecurityRiot
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: swat crate
-  description: Contains two sets of riot armor, helmets, shields, and Stun Enforcers. Extra stun ammo included. Requires Armory access to open.
+  description: Contains two sets of riot armor, helmets, shields, and stun enforcers. Extra stun ammo included. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/security.yml
@@ -2,7 +2,7 @@
   id: CrateSecurityArmor
   parent: CrateSecgear
   name: armor crate
-  description: Three vests of well-rounded, decently-protective armor. Requires Security access to open.
+  description: Contains three well-rounded, decently-protective armor vests. Requires Security access to open.
   components:
   - type: StorageFill
     contents:
@@ -69,7 +69,7 @@
   id: CrateSecurityBiosuit
   parent: CrateSecgear
   name: security bio suit crate
-  description: Contains 2 biohazard suits to ensure that no disease will distract you from your duties. Requires Security access to open.
+  description: Contains two biohazard suits to ensure that no disease will distract you from your duties. Requires Security access to open.
   components:
   - type: StorageFill
     contents:
@@ -83,7 +83,7 @@
 - type: entity
   id: CrateSecurityTrackingMindshieldImplants
   name: implanter crate
-  description: Contains 4 MindShield implants and 4 tracking implant. Requires Security access to open.
+  description: Contains four Mindshield implants and four tracking implants. Requires Security access to open.
   parent: CrateSecgear
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -106,7 +106,7 @@
   name: svalinn laser pistol
   parent: [ BaseWeaponPowerCellSmall, BaseRestrictedContraband ]
   id: WeaponLaserSvalinn
-  description: A cheap and widely-used laser pistol. Defeats glass cover, passing right through.
+  description: A cheap and widely-used laser pistol.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
@@ -127,7 +127,7 @@
   name: retro laser blaster
   parent: [ BaseWeaponBatterySmall, BaseMajorContraband ]
   id: WeaponLaserGun
-  description: A weapon using light amplified by the stimulated emission of radiation. Defeats glass cover, passing right through.
+  description: A weapon using light amplified by the stimulated emission of radiation.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
@@ -150,7 +150,7 @@
   name: makeshift laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponMakeshiftLaser
-  description: Better pray it won't burn your hands off. Defeats glass cover, passing right through.
+  description: Better pray it won't burn your hands off.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/makeshift.rsi
@@ -228,7 +228,7 @@
   name: laser rifle
   parent: [WeaponLaserCarbinePractice, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponLaserCarbine
-  description: Favored by Nanotrasen Security for being cheap and easy to use. Lasers can defeat glass cover, passing right through.
+  description: Favored by Nanotrasen Security for being cheap and easy to use.
   components:
   - type: StaticPrice
     price: 420
@@ -240,7 +240,7 @@
   name: pulse pistol
   parent: BaseWeaponBatterySmall
   id: WeaponPulsePistol
-  description: A state-of-the-art energy pistol favored as a sidearm by NT operatives. Defeats glass cover, passing right through.
+  description: A state-of-the-art energy pistol favored as a sidearm by NT operatives.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_pistol.rsi
@@ -269,7 +269,7 @@
   name: pulse carbine
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseCentcommContraband]
   id: WeaponPulseCarbine
-  description: A high-tech energy carbine favored by the NT-ERT operatives. Defeats glass cover, passing right through.
+  description: A high-tech energy carbine favored by the NT-ERT operatives.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_carbine.rsi
@@ -300,7 +300,7 @@
   name: pulse rifle
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponPulseRifle
-  description: A weapon that is almost as infamous as its users. Defeats glass cover, passing right through.
+  description: A weapon that is almost as infamous as its users.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_rifle.rsi
@@ -327,7 +327,7 @@
   name: laser cannon
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponLaserCannon
-  description: A heavy-duty, high-powered laser weapon. Defeats glass cover, passing right through.
+  description: A heavy-duty, high-powered laser weapon.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
@@ -382,7 +382,7 @@
   name: x-ray cannon
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponXrayCannon
-  description: An experimental weapon that uses concentrated x-ray energy against its target. Defeats glass cover, passing right through.
+  description: An experimental weapon that uses concentrated x-ray energy against its target.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/xray.rsi
@@ -549,7 +549,7 @@
   name: antique laser pistol
   parent: [BaseWeaponBatterySmall, BaseGrandTheftContraband]
   id: WeaponAntiqueLaser
-  description: All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. Defeats glass cover, passing right through.
+  description: All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
@@ -593,7 +593,7 @@
   name: advanced laser pistol
   parent: [ BaseWeaponBatterySmall, BaseRestrictedContraband]
   id: WeaponAdvancedLaser
-  description: An experimental high-energy laser pistol with a self-charging nuclear battery. Defeats glass cover, passing right through.
+  description: An experimental high-energy laser pistol with a self-charging nuclear battery.
   components:
   - type: Item
     size: Normal  # Intentionally larger than other pistols

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -106,7 +106,7 @@
   name: svalinn laser pistol
   parent: [ BaseWeaponPowerCellSmall, BaseRestrictedContraband ]
   id: WeaponLaserSvalinn
-  description: A cheap and widely used laser pistol.
+  description: A cheap and widely-used laser pistol. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
@@ -127,7 +127,7 @@
   name: retro laser blaster
   parent: [ BaseWeaponBatterySmall, BaseMajorContraband ]
   id: WeaponLaserGun
-  description: A weapon using light amplified by the stimulated emission of radiation.
+  description: A weapon using light amplified by the stimulated emission of radiation. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
@@ -150,7 +150,7 @@
   name: makeshift laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponMakeshiftLaser
-  description: Better pray it won't burn your hands off.
+  description: Better pray it won't burn your hands off. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/makeshift.rsi
@@ -228,7 +228,7 @@
   name: laser rifle
   parent: [WeaponLaserCarbinePractice, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponLaserCarbine
-  description: Favoured by Nanotrasen Security for being cheap and easy to use.
+  description: Favored by Nanotrasen Security for being cheap and easy to use. Lasers can defeat glass cover, passing right through.
   components:
   - type: StaticPrice
     price: 420
@@ -240,7 +240,7 @@
   name: pulse pistol
   parent: BaseWeaponBatterySmall
   id: WeaponPulsePistol
-  description: A state of the art energy pistol favoured as a sidearm by the NT operatives.
+  description: A state-of-the-art energy pistol favored as a sidearm by NT operatives. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_pistol.rsi
@@ -269,7 +269,7 @@
   name: pulse carbine
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseCentcommContraband]
   id: WeaponPulseCarbine
-  description: A high tech energy carbine favoured by the NT-ERT operatives.
+  description: A high-tech energy carbine favored by the NT-ERT operatives. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_carbine.rsi
@@ -300,7 +300,7 @@
   name: pulse rifle
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponPulseRifle
-  description: A weapon that is almost as infamous as its users.
+  description: A weapon that is almost as infamous as its users. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/pulse_rifle.rsi
@@ -327,7 +327,7 @@
   name: laser cannon
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponLaserCannon
-  description: A heavy duty, high powered laser weapon.
+  description: A heavy-duty, high-powered laser weapon. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
@@ -382,7 +382,7 @@
   name: x-ray cannon
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponXrayCannon
-  description: An experimental weapon that uses concentrated x-ray energy against its target.
+  description: An experimental weapon that uses concentrated x-ray energy against its target. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/xray.rsi
@@ -549,7 +549,7 @@
   name: antique laser pistol
   parent: [BaseWeaponBatterySmall, BaseGrandTheftContraband]
   id: WeaponAntiqueLaser
-  description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy.
+  description: All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. Defeats glass cover, passing right through.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
@@ -593,7 +593,7 @@
   name: advanced laser pistol
   parent: [ BaseWeaponBatterySmall, BaseRestrictedContraband]
   id: WeaponAdvancedLaser
-  description: An experimental high-energy laser pistol with a self-charging nuclear battery.
+  description: An experimental high-energy laser pistol with a self-charging nuclear battery. Defeats glass cover, passing right through.
   components:
   - type: Item
     size: Normal  # Intentionally larger than other pistols

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -69,7 +69,7 @@
   name: L6 SAW
   id: WeaponLightMachineGunL6
   parent: [BaseWeaponLightMachineGun, BaseSyndicateContraband]
-  description: A rather traditionally-made Squad Automatic Weapon, or light machine gun, with a pleasantly-lacquered wooden pistol grip, though lacking a stock for controllability. Uses .30 rifle ammo.
+  description: A rather traditionally-made Squad Automatic Weapon with a pleasantly lacquered wooden pistol grip. Lacks an LMG stock, decreasing controllability. Uses .30 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/LMGs/l6.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -69,7 +69,7 @@
   name: L6 SAW
   id: WeaponLightMachineGunL6
   parent: [BaseWeaponLightMachineGun, BaseSyndicateContraband]
-  description: A rather traditionally made LMG with a pleasantly lacquered wooden pistol grip. Uses .30 rifle ammo.
+  description: A rather traditionally-made Squad Automatic Weapon, or light machine gun, with a pleasantly-lacquered wooden pistol grip, though lacking a stock for controllability. Uses .30 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/LMGs/l6.rsi
@@ -88,7 +88,7 @@
   name: L6C ROW
   id: WeaponLightMachineGunL6C
   parent: BaseItem
-  description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges.
+  description: An L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
     - type: Gun
       minAngle: 4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -24,7 +24,7 @@
   name: china lake
   parent: [BaseWeaponLauncher, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponLauncherChinaLake
-  description: PLOOP.
+  description: THUMP.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -24,7 +24,7 @@
   name: china lake
   parent: [BaseWeaponLauncher, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponLauncherChinaLake
-  description: THUMP.
+  description: THOOMP.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -72,7 +72,7 @@
   name: viper
   parent: [BaseWeaponPistol, BaseSyndicateContraband]
   id: WeaponPistolViper
-  description: A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses .35 auto ammo.
+  description: A small, easily-concealable but somewhat underpowered handgun. Retrofitted with a fully automatic receiver. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
@@ -105,7 +105,7 @@
   name: echis
   parent: [ BaseItem, BaseSyndicateContraband ]
   id: WeaponPistolEchis
-  description: A viper for use by cyborgs. Creates .35 ammo on the fly from an internal ammo fabricator, which slowly self-charges.
+  description: A viper pistol for use by cyborgs. Creates .35 ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
   - type: Gun
     fireRate: 5
@@ -140,7 +140,7 @@
   name: cobra
   parent: [ BaseWeaponPistol, BaseSyndicateContraband ]
   id: WeaponPistolCobra
-  description: A rugged, robust operator handgun with inbuilt silencer. Uses .25 caseless ammo.
+  description: A rugged, integrally-suppressed handgun. Perfect for the robust operator who wants to leave no trace. Uses .25 caseless ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/cobra.rsi
@@ -189,7 +189,7 @@
   name: mk 58
   parent: [BaseWeaponPistol, BaseRestrictedContraband]
   id: WeaponPistolMk58
-  description: A cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. Uses .35 auto ammo.
+  description: A cheap, ubiquitous sidearm produced by a NanoTrasen subsidiary. It does its job without any hassle. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -97,7 +97,7 @@
   name: Mateba
   parent: [BaseWeaponRevolver, BaseMajorContraband]
   id: WeaponRevolverMateba
-  description: The iconic sidearm of the dreaded Death Squads, allegedly. Uses .45 magnum ammo.
+  description: The iconic sidearm of the dreaded Deathsquads... allegedly. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -97,7 +97,7 @@
   name: Mateba
   parent: [BaseWeaponRevolver, BaseMajorContraband]
   id: WeaponRevolverMateba
-  description: The iconic sidearm of the dreaded Deathsquads... allegedly. Uses .45 magnum ammo.
+  description: The iconic sidearm of the dreaded deathsquads... allegedly. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -54,7 +54,7 @@
   name: Deckard
   parent: [BaseWeaponRevolver, BaseSecurityCommandContraband]
   id: WeaponRevolverDeckard
-  description: A rare, custom-built revolver. Use when there is no time for Voight-Kampff test. Uses .45 magnum ammo.
+  description: A rare, custom-built revolver. Use when there is no time for the Voight-Kampff test. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
@@ -97,7 +97,7 @@
   name: Mateba
   parent: [BaseWeaponRevolver, BaseMajorContraband]
   id: WeaponRevolverMateba
-  description: The iconic sidearm of the dreaded death squads. Uses .45 magnum ammo.
+  description: The iconic sidearm of the dreaded Death Squads, allegedly. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
@@ -112,7 +112,7 @@
   name: Python
   parent: [BaseWeaponRevolver, BaseSyndicateContraband]
   id: WeaponRevolverPython
-  description: A robust revolver favoured by Syndicate agents. Uses .45 magnum ammo.
+  description: A robust revolver favored by Syndicate agents. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/python.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -55,7 +55,7 @@
   name: AKMS
   parent: [BaseWeaponRifle, BaseRestrictedContraband]
   id: WeaponRifleAk
-  description: An iconic weapon of war. Uses .30 rifle ammo.
+  description: An iconic weapon of war. Simple and effective, favored by revolutionaries everywhere. Uses .30 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/ak.rsi
@@ -104,7 +104,7 @@
   name: M-90gl
   parent: [BaseWeaponRifle, BaseSyndicateContraband]
   id: WeaponRifleM90GrenadeLauncher
-  description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses .20 rifle ammo.
+  description: An older bullpup-carbine model with an attached underbarrel grenade launcher. Uses .20 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/carbine.rsi
@@ -148,7 +148,7 @@
   name: Lecter
   parent: [BaseWeaponRifle, BaseRestrictedContraband]
   id: WeaponRifleLecter
-  description: A high end military grade assault rifle. Uses .20 rifle ammo.
+  description: A modern short-barreled assault rifle fielded by militaries and law enforcement throughout many worlds, complete with familiar controls and ergonomics. Uses .20 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
@@ -195,7 +195,7 @@
   name: Foam Force Astro Ace
   parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponRifleFoam
-  description: A premium foam rifle of the highest quality. Its plastic feels rugged, and its mechanisms sturdy.
+  description: A premium foam rifle of the highest quality. Its plastic feels rugged, and its mechanisms sturdy. The body crackles when you squeeze too tightly.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/foam_rifle.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -55,7 +55,7 @@
   name: AKMS
   parent: [BaseWeaponRifle, BaseRestrictedContraband]
   id: WeaponRifleAk
-  description: An iconic weapon of war. Simple and effective, favored by revolutionaries everywhere. Uses .30 rifle ammo.
+  description: An iconic weapon of war. Simple and effective; favored by revolutionaries everywhere. Uses .30 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/ak.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -85,7 +85,7 @@
   name: C-20r submachine gun
   parent: [BaseWeaponSubMachineGun, BaseSyndicateContraband]
   id: WeaponSubMachineGunC20r
-  description: An SMG often used by the infamous Nuclear Operatives, allegedly. Automatically ejects empty magazines. Uses .35 auto ammo.
+  description: An SMG often used by the infamous Nuclear Operatives... allegedly. Automatically ejects empty magazines. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/c20r.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -85,7 +85,7 @@
   name: C-20r submachine gun
   parent: [BaseWeaponSubMachineGun, BaseSyndicateContraband]
   id: WeaponSubMachineGunC20r
-  description: A firearm that is often used by the infamous nuclear operatives. Uses .35 auto ammo.
+  description: An SMG often used by the infamous Nuclear Operatives, allegedly. Automatically ejects empty magazines. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
@@ -123,7 +123,7 @@
   name: Drozd
   parent: [BaseWeaponSubMachineGun, BaseRestrictedContraband]
   id: WeaponSubMachineGunDrozd
-  description: An excellent fully automatic Heavy SMG.
+  description: A standard burst-fire two-handed submachine gun. Uses .35 auto ammo.
   components:
     - type: Sprite
       sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
@@ -181,7 +181,7 @@
   parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunVector
   suffix: Deprecated use Drozd
-  description: An excellent fully automatic Heavy SMG. Uses .45 magnum ammo.
+  description: An excellent fully-automatic Heavy SMG. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/vector.rsi
@@ -228,7 +228,7 @@
   name: WT550
   parent: [ BaseWeaponSubMachineGun, BaseRestrictedContraband ]
   id: WeaponSubMachineGunWt550
-  description: An excellent SMG, produced by NanoTrasen's Small Arms Division. Uses .35 auto ammo.
+  description: An excellent top-loaded, compact Personal Defense Weapon, produced by NanoTrasen's Small Arms Division. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -48,7 +48,7 @@
   # Don't parent to BaseWeaponShotgun because it differs significantly
   parent: [BaseItem, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponShotgunBulldog
-  description: It's a magazine-fed shotgun designed for close quarters combat. Uses .50 shotgun shells.
+  description: A fully-automatic magazine-fed assault shotgun designed for close-quarters combat. This will get the job done. Uses .50 shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/bulldog.rsi
@@ -105,7 +105,7 @@
   name: double-barreled shotgun
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseMinorSecurityCivilianContraband]
   id: WeaponShotgunDoubleBarreled
-  description: An immortal classic. Uses .50 shotgun shells.
+  description: An immortal classic of the American Frontier, whatever that is. Uses .50 shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
@@ -128,7 +128,7 @@
   name: double-barreled shotgun
   parent: WeaponShotgunDoubleBarreled
   id: WeaponShotgunDoubleBarreledRubber
-  description: An immortal classic. Uses .50 shotgun shells.
+  description: An immortal classic of the American Frontier, whatever that is. Uses .50 shotgun shells.
   suffix: Non-Lethal
   components:
   - type: BallisticAmmoProvider
@@ -138,7 +138,7 @@
   name: Enforcer
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponShotgunEnforcer
-  description: A premium combat shotgun based on the Kammerer design, featuring an upgraded clip capacity. .50 shotgun shells.
+  description: A premium semi-automatic combat shotgun, featuring a pistol grip and full-length magazine tube for those nasty close-quarters engagements. Uses .50 shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
@@ -160,7 +160,7 @@
   name: Kammerer
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponShotgunKammerer
-  description: When an old Remington design meets modern materials, this is the result. A favourite weapon of militia forces throughout many worlds. Uses .50 shotgun shells.
+  description: Even centuries after his time, the legacy of John Moses Browning lives on. This pump-action shotgun is a favorite of hunters and militia forces throughout many worlds. Uses .50 shotgun shells.
   components:
   - type: Item
     size: Normal
@@ -263,7 +263,7 @@
   name: improvised shotgun
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseMinorContraband]
   id: WeaponShotgunImprovised
-  description: A shitty, hand-made shotgun that uses .50 shotgun shells. It can only hold one round in the chamber.
+  description: A shitty, hand-made shotgun. It can only hold one round in the chamber. Uses .50 shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -42,16 +42,50 @@
   name: Kardashev-Mosin
   parent: [BaseWeaponSniper, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponSniperMosin
-  description: A weapon for hunting, or endless trench warfare. Uses .30 rifle ammo.
+  description: A weapon for hunting, or endless trench warfare. There's a bayonet at the end, and the heft of the rifle could do some damage. Uses .30 rifle ammo.
+# Melee and gun components don't play nice; description will change when fixed. Melee components also disabled for the time being
   components:
+  - type: Gun
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+#  - type: MeleeWeapon
+#    range: 2
+#    wideAnimationRotation: -135
+#    attackRate: 1.2
+#    damage:
+#      types:
+#        Piercing: 12
+#        Slash: 4
+#    angle: 0
+#    animation: WeaponArcThrust
+#    soundHit:
+#      path: /Audio/Weapons/bladeslice.ogg
+  - type: EmbeddableProjectile
+    offset: -0.15,0.0
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: ThrowingAngle
+    angle: 225
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Piercing: 15
+        Slash: 5
+#  - type: Sharp
+#  - type: Execution
+#    doAfterDuration: 2.0
+#    animation: WeaponArcThrust
+#    angle: 0
+#  - type: MeleeRequiresWield
 
 - type: entity
   name: Hristov
   parent: [BaseWeaponSniper, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponSniperHristov
-  description: A portable anti-materiel rifle. Fires armor piercing 14.5mm shells. Uses .60 anti-materiel ammo.
+  description: A portable anti-materiel rifle, originally intended for destroying the engine blocks of moving cars with armor-piercing 14.5mm shells. Uses .60 anti-materiel ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -85,7 +85,7 @@
   name: Hristov
   parent: [BaseWeaponSniper, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponSniperHristov
-  description: A portable anti-materiel rifle, originally intended for destroying the engine blocks of moving cars with armor-piercing 14.5mm shells. Uses .60 anti-materiel ammo.
+  description: A portable anti-materiel rifle, originally intended for destroying the engine blocks of moving vehicles. Uses .60 anti-materiel ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -5,6 +5,7 @@
   description: Definition of a Classic. Keeping murder affordable since 200,000 BCE.
   components:
   - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
     offset: -0.15,0.0
   - type: ThrowingAngle
     angle: 225

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/security.yml
@@ -2,7 +2,7 @@
   id: CrateSecurityShotgunNonlethal
   parent: CrateSecgear
   name: nonlethal shotgun crate
-  description: For when the station is being a bit too rowdy. Contains two Stun Kammerer shotguns with extra ammunition. Requires Security access to open.
+  description: For when the station is being a bit too rowdy. Contains two stun Kammerer shotguns with extra ammunition. Requires Security access to open.
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
Originally started to fix the Enforcer's description for using "clip" and not "magazine", but I got carried away and improved a lot of the descriptions to add more detail while remaining true to the original. Also fixed the description of some cargo crate buys to match each other, as well as the spear lacking an impact sound. Mosin is now throwable, but the remnants of my attempts to make it a melee weapons are left as comments for a later date, if upstream ever merges the component to make melee weapon and gun components work together.

:cl:
- add: You can now throw the Mosin. Go ahead. Throw it. (LEGAL DO NOT READ)
- fix: Adjusted many firearm flavortexts! How flavorful! Still in-line with originals, but much more love in them.
- fix: Adjusted a few Security cargo buys for grammar and description.
- fix: Spear now makes an impact noise when thrown. Whoosh!
