### PR TITLE
Update and rerotate Origin

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -14,6 +14,7 @@
   - Meta
   - Oasis
   - Omega
+  - Origin
   - Packed
   - Reach
   - Saltern

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -1,0 +1,67 @@
+- type: gameMap
+  id: Origin
+  mapName: 'Origin'
+  mapPath: /Maps/origin.yml
+  minPlayers: 60
+  stations:
+    Origin:
+      stationProto: StandardNanotrasenStation
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: '{0} Origin {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationEmergencyShuttle
+          emergencyShuttlePath: /Maps/Shuttles/emergency_courser.yml
+        - type: StationJobs
+          availableJobs:
+            #service
+            Captain: [ 1, 1 ]
+            HeadOfPersonnel: [ 1, 1 ]
+            Bartender: [ 2, 2 ]
+            Botanist: [ 3, 3 ]
+            Chef: [ 3, 3 ]
+            Janitor: [ 3, 3 ]
+            Chaplain: [ 2, 2 ]
+            Librarian: [ 2, 2 ]
+            Lawyer: [ 2, 2 ]
+            ServiceWorker: [ 3, 4 ]
+            #engineering
+            ChiefEngineer: [ 1, 1 ]
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 2, 3 ]
+            #medical
+            ChiefMedicalOfficer: [ 1, 1 ]
+            Chemist: [ 2, 2 ]
+            Paramedic: [ 1, 1 ]
+            MedicalDoctor: [ 6, 6 ]
+            Psychologist: [ 1, 1 ]
+            MedicalIntern: [ 1, 2 ]
+            #science
+            ResearchDirector: [ 1, 1 ]
+            Scientist: [ 6, 6 ]
+            ResearchAssistant: [ 4, 4 ]
+            #security
+            HeadOfSecurity: [ 1, 1 ]
+            Warden: [ 1, 1 ]
+            Detective: [ 1, 1 ]
+            SecurityOfficer: [ 7, 7 ]
+            SecurityCadet: [ 2, 4 ]
+            Brigmedic: [ 1, 1 ]
+            #supply
+            Quartermaster: [ 1, 1 ]
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 5, 5 ]
+            #civillian
+            Passenger: [ -1, -1 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
+            Boxer: [ 2, 2 ]
+            Reporter: [ 2, 2 ]
+            #silicon
+            StationAi: [ 1, 1 ]
+            Borg: [ 2, 2 ]
+


### PR DESCRIPTION
Origin was derotated upstream due to a lack of maintenance some time ago. This updates it to bring it up to date with new features, namely supporting Station AI and adding LV wires to atmos for gas pumps.

(Somewhat) comprehensive changelog:
- added station ai and reworked ai core
- added more cameras for ai
- added windoor to plastic flaps in cargo
- added more jrpacmans and fuel tanks around the map
- added a vendomat to the tools room by engineering
- reorganized engineering supply room, adding all 3 pacmans along with a stack of plasma and uranium
- the PA and teg smeses now receive their power directly from the main generators
- added lv cabling to atmos
- replaced armory airlocks to perma with security airlocks
- sec medical room now has a brig access airlock
- added brigmedic spawn and locker
- reworked cyropods in medbay to work off of one loop and have a gas filter

**Changelog**

:cl:
- add: Origin Station has been updated and added back to the map rotation.
