### PR TITLE
decapoid mapping tools

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -36,7 +36,7 @@ public sealed partial class AtmosphereSystem
            return;
        }
 
-       var mixtures = new GasMixture[8];
+       var mixtures = new GasMixture[10];
        for (var i = 0; i < mixtures.Length; i++)
            mixtures[i] = new GasMixture(Atmospherics.CellVolume) { Temperature = Atmospherics.T20C };
 
@@ -67,6 +67,14 @@ public sealed partial class AtmosphereSystem
 
        // 7: Nitrogen (101kpa) for vox rooms
        mixtures[7].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellStandard);
+
+       // imp specials
+
+       // 8: Water Vapor (GM)
+       mixtures[8].AdjustMoles(Gas.WaterVapor, Atmospherics.MolesCellGasMiner);
+
+       // 9: Water Vapor (101kpa) for decapoid rooms
+       mixtures[9].AdjustMoles(Gas.WaterVapor, Atmospherics.MolesCellStandard);
 
        foreach (var arg in args)
        {

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -68,10 +68,11 @@ public sealed partial class AtmosphereSystem
        // 7: Nitrogen (101kpa) for vox rooms
        mixtures[7].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellStandard);
 
-       // imp specials
+        // imp specials
+        // if this file ever creates a merge conflict, PLEASE change the values in Resources/Prototypes/_Impstation/Entities/Markers/atmos_blocker.yml
 
-       // 8: Water Vapor (GM)
-       mixtures[8].AdjustMoles(Gas.WaterVapor, Atmospherics.MolesCellGasMiner);
+        // 8: Water Vapor (GM)
+        mixtures[8].AdjustMoles(Gas.WaterVapor, Atmospherics.MolesCellGasMiner);
 
        // 9: Water Vapor (101kpa) for decapoid rooms
        mixtures[9].AdjustMoles(Gas.WaterVapor, Atmospherics.MolesCellStandard);

--- a/Resources/Prototypes/_Impstation/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/_Impstation/Atmospherics/thresholds.yml
@@ -1,0 +1,8 @@
+# For gas concentrations, threshold=0.1 means 10%
+# this is a copy of stationOxygen
+- type: alarmThreshold
+  id: decapoidWaterVapor
+  lowerBound: !type:AlarmThresholdSetting
+    threshold: 0.10
+  lowerWarnAround: !type:AlarmThresholdSetting
+    threshold: 1.5

--- a/Resources/Prototypes/_Impstation/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/atmos_blocker.yml
@@ -1,0 +1,25 @@
+- type: entity
+  name: Atmos Fix Water Vapor Marker
+  id: AtmosFixWaterVaporMarker
+  description: "Water vapor @ gas miner pressure, T20C"
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - sprite: Markers/atmos.rsi # {
+          state: base
+          shader: unshaded
+        - sprite: Markers/atmos.rsi
+          shader: unshaded # }
+          state: watervapour
+    - type: AtmosFixMarker
+      mode: 8
+
+- type: entity
+  parent: AtmosFixWaterVaporMarker
+  id: AtmosFixDecapoidMarker
+  suffix: Decapoid Atmosphere
+  description: "Water Vapor @ 101 kPa, 20C"
+  components:
+  - type: AtmosFixMarker
+    mode: 9

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Specific/Atmospherics/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Specific/Atmospherics/decapoid.yml
@@ -1,0 +1,51 @@
+- type: entity
+  abstract: true
+  parent: AirSensorBase
+  id: AirSensorDecapoidBase
+  suffix: Decapoid Atmosphere
+  components:
+  - type: AtmosMonitor
+    gasThresholdPrototypes:
+      Oxygen: stationOxygen
+      Nitrogen: ignore
+      CarbonDioxide: stationCO2
+      Plasma: stationPlasma
+      Tritium: stationTritium
+      WaterVapor: decapoidWaterVapor
+      Ammonia: stationAmmonia
+      NitrousOxide: stationNO
+      Frezon: danger
+
+- type: entity
+  parent: [AirSensorDecapoidBase, AirSensor]
+  id: AirSensorDecapoid
+
+- type: entity
+  parent: [AirSensorDecapoidBase, GasVentPump]
+  id: GasVentPumpDecapoid
+
+- type: entity
+  parent: [AirSensorDecapoidBase, GasVentScrubber]
+  id: GasVentScrubberDecapoid
+  components:
+  - type: GasVentScrubber
+    wideNet: true # Air alarm with auto mode overrides filters with hardcoded defaults so default to widenet
+    filterGases:
+    - Oxygen # oxygen and nitrogen aren't necessary to remove, but they help prevent an atmospheric imbalance
+    - Nitrogen
+    - CarbonDioxide
+    - Plasma
+    - Tritium
+    - Ammonia
+    - NitrousOxide
+    - Frezon
+
+# use this to prevent overriding filters with hardcoded defaults
+# this is actually just an exact copy of AirAlarmVox, but it's more clear for mappers
+- type: entity
+  parent: AirAlarm
+  id: AirAlarmDecapoid
+  suffix: Decapoid Atmosphere, auto mode disabled
+  components:
+  - type: AirAlarm
+    autoMode: false


### PR DESCRIPTION
adds decapoid mapping tools: atmos fix markers, air vents, air scrubbers, and an air alarm

this will probably create weird merge conflicts in the future when upstream adds more atmos fix markers of their own. hopefully people heed my warning

no screenshots because they're just atmos devices

**Changelog**
no changelog, this is mapping backend stuff