### PR TITLE
Fix Space Debris Spawning Empty

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
@@ -31,7 +31,7 @@ public sealed partial class DungeonJob
 
             if (reservedTiles.Contains(node))
                 continue;
-            
+
             if (dunGen.TileMask is not null)
             {
                 if (!dunGen.TileMask.Contains(((ContentTileDefinition) _tileDefManager[tileRef.Value.Tile.TypeId]).ID))
@@ -52,7 +52,7 @@ public sealed partial class DungeonJob
                 }
             }
 
-            if (tile is not null && biomeSystem.TryGetEntity(node, indexedBiome.Layers, tile.Value, seed, _grid, out var entityProto))
+            if (biomeSystem.TryGetEntity(node, indexedBiome.Layers, tile ?? tileRef.Value.Tile, seed, _grid, out var entityProto))
             {
                 var ent = _entManager.SpawnEntity(entityProto, new EntityCoordinates(_gridUid, node + _grid.TileSizeHalfVector));
                 var xform = xformQuery.Get(ent);


### PR DESCRIPTION
Porting a one line change from upstream. 

:cl:
- fix: Space debris is no longer a barren wasteland
