### PR TITLE
Give margin of error to Rat King point targeting

### DIFF
--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -234,6 +234,9 @@ namespace Content.Server.Pointing.EntitySystems
                 {
                     position = $"EntId={gridUid} {_map.WorldToTile(gridUid, grid, mapCoordsPointed.Position)}";
                     tileRef = _map.GetTileRef(gridUid, grid, _map.WorldToTile(gridUid, grid, mapCoordsPointed.Position));
+
+                    var arrowEvent = new AfterPointedArrowEvent(arrow);
+                    RaiseLocalEvent(player, ref arrowEvent);
                 }
 
                 var tileDef = _tileDefinitionManager[tileRef?.Tile.TypeId ?? 0];

--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -13,6 +13,10 @@ using Content.Shared.Pointing;
 using Content.Shared.RatKing;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
+using Content.Shared.Damage;
+using Content.Shared.SubFloor;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
 
 namespace Content.Server.RatKing
 {
@@ -25,6 +29,7 @@ namespace Content.Server.RatKing
         [Dependency] private readonly HungerSystem _hunger = default!;
         [Dependency] private readonly NPCSystem _npc = default!;
         [Dependency] private readonly PopupSystem _popup = default!;
+        [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
         public override void Initialize()
         {
@@ -33,6 +38,7 @@ namespace Content.Server.RatKing
             SubscribeLocalEvent<RatKingComponent, RatKingRaiseArmyActionEvent>(OnRaiseArmy);
             SubscribeLocalEvent<RatKingComponent, RatKingDomainActionEvent>(OnDomain);
             SubscribeLocalEvent<RatKingComponent, AfterPointedAtEvent>(OnPointedAt);
+            SubscribeLocalEvent<RatKingComponent, AfterPointedArrowEvent>(OnPointedNearby);
         }
 
         /// <summary>
@@ -98,6 +104,52 @@ namespace Content.Server.RatKing
             foreach (var servant in component.Servants)
             {
                 _npc.SetBlackboard(servant, NPCBlackboard.CurrentOrderedTarget, args.Pointed);
+            }
+        }
+
+        /**
+        * Give leeway for how close you have to point, lets you point NOT directly at something and still target it
+        */
+        private void OnPointedNearby(EntityUid uid, RatKingComponent component, ref AfterPointedArrowEvent args)
+        {
+            if (component.CurrentOrder != RatKingOrderType.CheeseEm)
+                return;
+
+            var arrow = args.PointedArrow;
+            var arrowXform = Transform(arrow);
+
+            var ents = _lookup.GetEntitiesInRange(arrow, component.PointingMargin);
+
+            var target = EntityUid.Invalid;
+            var minDistance = component.PointingMargin + 1f;
+
+            foreach (var ent in ents)
+            {
+                if (ent == uid)
+                    continue;
+
+                // Remove ineligable targets
+                if (!TryComp<DamageableComponent>(ent, out var _1) || !TryComp<BodyComponent>(ent, out var _2))
+                    continue;
+
+                if (TryComp<SubFloorHideComponent>(ent, out var _3) || TryComp<RatKingServantComponent>(ent, out var _4))
+                    continue;
+
+                if (!arrowXform.Coordinates.TryDistance(EntityManager, Transform(ent).Coordinates, out var distance))
+                    continue;
+
+                if (distance < minDistance)
+                {
+                    minDistance = distance;
+                    target = ent;
+                }
+            }
+
+            if (target != EntityUid.Invalid){
+                foreach (var servant in component.Servants)
+                {
+                    _npc.SetBlackboard(servant, NPCBlackboard.CurrentOrderedTarget, target);
+                }
             }
         }
 

--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -107,9 +107,10 @@ namespace Content.Server.RatKing
             }
         }
 
-        /**
-        * Give leeway for how close you have to point, lets you point NOT directly at something and still target it
-        */
+        /// <summary>
+        /// Give leeway on how close you have to point to a target.
+        /// Allows you to point near someone and still have them targeted
+        /// </summary>
         private void OnPointedNearby(EntityUid uid, RatKingComponent component, ref AfterPointedArrowEvent args)
         {
             if (component.CurrentOrder != RatKingOrderType.CheeseEm)

--- a/Content.Shared/Pointing/PointingEvents.cs
+++ b/Content.Shared/Pointing/PointingEvents.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Serialization;
+using Robust.Shared.Map;
 
 namespace Content.Shared.Pointing;
 
@@ -24,6 +25,13 @@ public sealed class PointingAttemptEvent : EntityEventArgs
 /// <param name="Pointed"></param>
 [ByRefEvent]
 public readonly record struct AfterPointedAtEvent(EntityUid Pointed);
+
+/// <summary>
+/// Raised on the entity who is pointing after they point, passing in the arrow.
+/// </summary>
+/// <param name="PointedArrow"></param>
+[ByRefEvent]
+public readonly record struct AfterPointedArrowEvent(EntityUid PointedArrow);
 
 /// <summary>
 /// Raised on an entity after they are pointed at by another entity.

--- a/Content.Shared/RatKing/RatKingComponent.cs
+++ b/Content.Shared/RatKing/RatKingComponent.cs
@@ -59,6 +59,13 @@ public sealed partial class RatKingComponent : Component
     public RatKingOrderType CurrentOrder = RatKingOrderType.Loose;
 
     /// <summary>
+    /// How far away your pointing arrow be from something and still have it be targeted if the arrow isn't directly ON it.
+    /// </summary>
+    [DataField("pointingMargin"), ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
+    public float PointingMargin = 1f;
+
+    /// <summary>
     /// The servants that the rat king is currently controlling
     /// </summary>
     [DataField("servants")]


### PR DESCRIPTION
Provide a margin of error for how close a point has to be to a target. Previously you had to directly point at something to get rat servants to attack when you Cheese 'em. Now you can point nearby and the servants will go for whatever is closest to your pointing.

https://github.com/user-attachments/assets/e0fa6588-8a1e-49c0-8264-75fa4aa0a8fd

:cl:
- tweak: Rat Kings can now target someone by pointing vaguely near them (helpful in intense moments)