### PR TITLE
Tone down buff to water damage against slimes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -98,7 +98,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Caustic: 2 # the original value was 0.1. this makes it so that it takes 7 water pistol shots to crit a slime.
+            Caustic: 1 # the original value was 0.1. this makes it so that it takes 10 water pistol shots to crit a slime.
       - !type:PopupMessage
         type: Local
         visualType: Large

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -469,7 +469,7 @@
           shouldHave: true
         damage:
           types:
-            Caustic: 50 # i want this to be a legitimate assassination method. end imp special.
+            Caustic: 25 # this is still guaranteed to kill a slime if a water vapor tank is opened at max pressure in a confined space with them. end imp special.
 
 - type: reagent
   id: Ice


### PR DESCRIPTION
Pushing slimes' weakness to water as a downside to a species that has so many upsides is an interesting space, but I think the previous changes were far too deadly (with the comment on water pistol damage also being inaccurate), such as an optimally aimed fire extinguisher dealing just under 80 damage in a single spray and a wide-swinging bucket of water against a single slime dealing 40 dps. This can be particularly frustrating for a slime player if they have been killed by water early in the round before medbay has produced and regenerative mesh, as ointment heals caustic damage at 30% of the rate it heals other types of burn damage. This PR halves the damage from the previous buffs, which is still 10 times the amount of damage it did originally.

**Changelog**

:cl:
- tweak: Toned down the previous increase to water damage against slimes. Water will still deal an appreciable amount of damage, so be careful.
