### PR TITLE
prevent slimes being reviveable after changeling absorption

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -142,7 +142,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         UpdateBiomass(uid, comp, (comp.MaxBiomass * biomassModifier) - comp.TotalAbsorbedEntities);
 
         var dmg = new DamageSpecifier(_proto.Index(AbsorbedDamageGroup), 200);
-        _damage.TryChangeDamage(target, dmg, false, false);
+        _damage.TryChangeDamage(target, dmg, true, false);
         _blood.ChangeBloodReagent(target, "FerrochromicAcid");
         _blood.SpillAllSolutions(target);
 
@@ -493,7 +493,7 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         EnsureComp<AbsorbedComponent>(target);
         var dmg = new DamageSpecifier(_proto.Index(AbsorbedDamageGroup), 200);
-        _damage.TryChangeDamage(target, dmg, false, false);
+        _damage.TryChangeDamage(target, dmg, true, false);
         _blood.ChangeBloodReagent(target, "FerrochromicAcid");
         _blood.SpillAllSolutions(target);
 


### PR DESCRIPTION
part of #943: literally one variable to ignore damage resistance btw

**Changelog**
- fix: Changeling absorption no longer respects damage resistance. Slimepeople will now be unreviveable.