### PR TITLE
partially revert #939 - no more romerol pills and shrooms

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/spaceshroom.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spaceshroom.yml
@@ -100,10 +100,6 @@
     weight: 1
     reagents:
     - Amatoxin
-  - quantity: 5
-    weight: 0.1
-    reagents:
-    - Romerol
 
 # Cooked Object
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
@@ -24,7 +24,6 @@
       - Omnizine
       - Tricordrazine
       - Vitamin
-      - DinoBlood
   # Neutral - weight: 20
     - quantity: 20
       weight: 17.5
@@ -75,7 +74,6 @@
       weight: 2.5
       reagents:
       - Lexorin
-      - Romerol
 
 - type: entity
   name: strange pill


### PR DESCRIPTION
romerol is a hugely round-defining chem and _should_ really just be relegated to the zombie gamemode and nuclear operatives

at the very least, artifacts can already roll round-ending nodes, have an even rarer chance-within-a-chance to roll romerol foam, and can have its trigger repeated to potentially produce ambuzol from creatures

reagent anomalies are a whole other thing probably worth discussing, but their quantity is severely limited and ambuzol can be produced from the anomaly itself or a reagent slime's body

it's worth noting that i don't think ambuzol should even be potentially producable before an initial infected event starts or nuclear/lone operatives come aboard to start infecting people. call me the fun-killer

maintenance pills should only ever really have an effect on one person - this affects too many people and spirals rounds too hard

also removed dino blood from pills since it's supposed to be dino wars exclusive

**Changelog**
:cl:
- remove: Removed some chemicals from the maintenance pill and spaceshroom pool.