### PR TITLE
Vent Crawling Balance Changes and Fixes

### DIFF
--- a/Content.Server/VentCraw/VentCrawTubeSystem.cs
+++ b/Content.Server/VentCraw/VentCrawTubeSystem.cs
@@ -11,11 +11,14 @@ using Content.Shared.DoAfter;
 using Content.Shared.Movement.Systems;
 using Content.Shared.VentCraw;
 using Content.Shared.Verbs;
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Hands.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Content.Shared.Eye.Blinding.Systems;
+
 
 namespace Content.Server.VentCraw
 {
@@ -30,6 +33,7 @@ namespace Content.Server.VentCraw
         [Dependency] private readonly PopupSystem _popup = default!;
         [Dependency] private readonly SharedMoverController _mover = default!;
         [Dependency] private readonly BlindableSystem _blind = default!;
+        [Dependency] private readonly SharedHandsSystem _hands = default!;
 
         public override void Initialize()
         {
@@ -62,7 +66,7 @@ namespace Content.Server.VentCraw
             AlternativeVerb verb = new()
             {
                 Act = () => TryEnter(uid, args.User, ventCrawlerComponent),
-                Text = Loc.GetString("comp-climbable-verb-climb")
+                Text = Loc.GetString("comp-crawlable-verb-enter-vent")
             };
             args.Verbs.Add(verb);
         }
@@ -86,6 +90,13 @@ namespace Content.Server.VentCraw
                     _popup.PopupEntity(Loc.GetString("entity-storage-component-welded-shut-message"), user);
                     return;
                 }
+            }
+
+            // Check if they have any items in their hands that they can drop
+            if (TryComp<HandsComponent>(user, out var hands) && _hands.CountFreeableHands((user, hands)) > 0)
+            {
+                _popup.PopupEntity(Loc.GetString("vent-entry-denied-held-items"), user);
+                return;
             }
 
             var args = new DoAfterArgs(EntityManager, user, crawler.EnterDelay, new EnterVentDoAfterEvent(), user, uid, user)

--- a/Content.Server/VentCraw/VentCrawTubeSystem.cs
+++ b/Content.Server/VentCraw/VentCrawTubeSystem.cs
@@ -93,7 +93,7 @@ namespace Content.Server.VentCraw
             }
 
             // Check if they have any items in their hands that they can drop
-            if (TryComp<HandsComponent>(user, out var hands) && _hands.CountFreeableHands((user, hands)) > 0)
+            if (TryComp<HandsComponent>(user, out var hands) && _hands.CountFreeableHands((user, hands)) != hands.CountFreeHands())
             {
                 _popup.PopupEntity(Loc.GetString("vent-entry-denied-held-items"), user);
                 return;

--- a/Content.Shared/VentCraw/SharedVentCrawableSystem.cs
+++ b/Content.Shared/VentCraw/SharedVentCrawableSystem.cs
@@ -3,10 +3,12 @@
 using System.Linq;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Body.Components;
-using Content.Shared.Tools.Components;
+using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Movement.Events;
+using Robust.Shared.Player;
+using Content.Shared.Tools.Components;
 using Content.Shared.VentCraw.Tube.Components;
 using Content.Shared.VentCraw.Components;
 using Robust.Shared.Audio.Systems;
@@ -14,7 +16,6 @@ using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
-using Content.Shared.Eye.Blinding.Systems;
 
 namespace Content.Shared.VentCraw;
 
@@ -40,25 +41,45 @@ public sealed class SharedVentCrawableSystem : EntitySystem
 
         SubscribeLocalEvent<VentCrawlerComponent, CanSeeAttemptEvent>(OnCanSee);
         SubscribeLocalEvent<VentCrawlerComponent, InteractionAttemptEvent>(OnInteractAttempt);
+        SubscribeLocalEvent<VentCrawlerComponent, AttackAttemptEvent>(OnAttackAttempt);
     }
 
     /// <summary>
     /// Blinds entities that are inside of vents
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="comp"></param>
-    /// <param name="args"></param>
+    /// <param name="uid">The entity attempting to see.</param>
+    /// <param name="comp">That entity's ventcrawler component.</param>
+    /// <param name="args">The CanSeeAttemptEvent arguments.</param>
     private void OnCanSee(EntityUid uid, VentCrawlerComponent comp, ref CanSeeAttemptEvent args)
     {
         if (comp.InTube)
             args.Cancel();
     }
 
+    /// <summary>
+    /// Prevents entities from performing actions while inside the vents.
+    /// </summary>
+    /// <param name="uid">The entity attempting the action.</param>
+    /// <param name="comp">That entity's ventcrawler component.</param>
+    /// <param name="args">The InteractionAttemptEvent arguments.</param>
     private void OnInteractAttempt(EntityUid uid, VentCrawlerComponent comp, ref InteractionAttemptEvent args)
     {
         if (comp.InTube)
             args.Cancelled = true;
     }
+
+    /// <summary>
+    /// Prevents entities from attacking while inside the vents.
+    /// </summary>
+    /// <param name="uid">The entity attempting the attack.</param>
+    /// <param name="comp">That entity's ventcrawler component.</param>
+    /// <param name="args">The AttackAttemptEvent arguments.</param>
+    private void OnAttackAttempt(EntityUid uid, VentCrawlerComponent comp, ref AttackAttemptEvent args)
+    {
+        if (comp.InTube)
+            args.Cancel();
+    }
+
     /// <summary>
     /// Handles the MoveInputEvent for VentCrawHolderComponent.
     /// </summary>

--- a/Content.Shared/VentCraw/SharedVentCrawableSystem.cs
+++ b/Content.Shared/VentCraw/SharedVentCrawableSystem.cs
@@ -1,8 +1,10 @@
 // Initial file ported from the Starlight project repo, located at https://github.com/ss14Starlight/space-station-14
 
 using System.Linq;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Body.Components;
 using Content.Shared.Tools.Components;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Movement.Events;
 using Content.Shared.VentCraw.Tube.Components;
@@ -27,6 +29,7 @@ public sealed class SharedVentCrawableSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public override void Initialize()
     {
@@ -36,6 +39,7 @@ public sealed class SharedVentCrawableSystem : EntitySystem
         SubscribeLocalEvent<VentCrawHolderComponent, MoveInputEvent>(OnMoveInput);
 
         SubscribeLocalEvent<VentCrawlerComponent, CanSeeAttemptEvent>(OnCanSee);
+        SubscribeLocalEvent<VentCrawlerComponent, InteractionAttemptEvent>(OnInteractAttempt);
     }
 
     /// <summary>
@@ -50,6 +54,11 @@ public sealed class SharedVentCrawableSystem : EntitySystem
             args.Cancel();
     }
 
+    private void OnInteractAttempt(EntityUid uid, VentCrawlerComponent comp, ref InteractionAttemptEvent args)
+    {
+        if (comp.InTube)
+            args.Cancelled = true;
+    }
     /// <summary>
     /// Handles the MoveInputEvent for VentCrawHolderComponent.
     /// </summary>

--- a/Resources/Locale/en-US/_Impstation/vent-crawling/vent-crawling.ftl
+++ b/Resources/Locale/en-US/_Impstation/vent-crawling/vent-crawling.ftl
@@ -1,0 +1,8 @@
+
+### UI
+
+# Verb name for entering vents
+comp-crawlable-verb-enter-vent = Enter
+
+# Message for when you can't enter a vent due to items in hand
+vent-entry-denied-held-items = You can't squeeze into the vents while you're holding something!


### PR DESCRIPTION
Things are no longer able to enter vents with something in their hands, most actions can't be taken while inside vents, and things can no longer attack from inside vents. This covers most of the updates I wanted to make to bring a bit more balance to vent crawling. I still need to do the pressure stuff but that's for later.

:cl:
- tweak: You can no longer attack or perform most other actions while inside vents. 
- tweak: You can no longer enter the vents with things in your hands.

