### PR TITLE
decapoid + gastropoid fixes

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -93,7 +93,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 150 # they're a little heavier than everyone else.
+        density: 350 # they're a little heavier than everyone else.
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/snail.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/snail.yml
@@ -52,7 +52,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 120
+        density: 300 # this matches diona
         restitution: 0.0
         mask:
         - MobMask
@@ -112,6 +112,9 @@
       294: 0.2
   - type: Bloodstream
     bloodReagent: CopperBlood
+  - type: Tag
+    tags:
+      - Gastropod
   - type: Inventory
     templateId: snail
     displacements:

--- a/Resources/Prototypes/_Impstation/Reagents/biological.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/biological.yml
@@ -25,8 +25,8 @@
           walkSpeedModifier: 2.75
           sprintSpeedModifier: 2.75
           whitelist:
-            components:
-              - SnailSpeed
+            tags:
+              - Gastropod
 
 - type: reagent
   parent: Blood

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -21,7 +21,13 @@
   id: DecapoidClaw
 
 - type: Tag
+  id: DecapoidGenericTag
+
+- type: Tag
   id: DionaMinded
+  
+- type: Tag
+  id: Gastropod
 
 - type: Tag
   id: MagazineLPistol


### PR DESCRIPTION


<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Decapoids being sped up by Mucin
- fix: Fixed Decapoids and Gastropoids using the incorrect density values, which means that they should now correctly shatter glass tables when vaulting. 

