### PR TITLE
revert "change default changelog name to upstream"

### DIFF
--- a/Resources/Locale/en-US/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/changelog/changelog-window.ftl
@@ -10,5 +10,5 @@ changelog-version-tag = version v{ $version }
 changelog-button = Changelog
 changelog-button-new-entries = Changelog (new!)
 
-changelog-tab-title-Changelog = Upstream
+changelog-tab-title-Changelog = Changelog
 changelog-tab-title-Admin = Admin


### PR DESCRIPTION
this broke the whole dang changelog