### PR TITLE
3 new endgame chems

### DIFF
--- a/.filenesting.json
+++ b/.filenesting.json
@@ -1,0 +1,3 @@
+{
+    "help":"https://go.microsoft.com/fwlink/?linkid=866610"
+}

--- a/.filenesting.json
+++ b/.filenesting.json
@@ -1,3 +1,0 @@
-{
-    "help":"https://go.microsoft.com/fwlink/?linkid=866610"
-}

--- a/Resources/Locale/en-US/_Impstation/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/_Impstation/reagents/meta/chemicals.ftl
@@ -1,0 +1,2 @@
+reagent-name-philosophers-juice = philosopher's juice
+reagent-desc-philosophers-juice = A pseudo-magical catalyst for advanced chemistry.

--- a/Resources/Locale/en-US/_Impstation/reagents/meta/fun.ftl
+++ b/Resources/Locale/en-US/_Impstation/reagents/meta/fun.ftl
@@ -9,3 +9,6 @@ reagent-desc-propulsion-gel = A refinement of the accelerative properties of Gas
 
 reagent-name-ungh-juice = juice that makes you UNGH
 reagent-desc-ungh-juice = The glucose and citric acid seem to have neutralized the toxic effects of the vent crud. Though, the mixture has caused new side-effects to occur.
+
+reagent-name-holium = holium
+reagent-desc-holium = An impossibly compressed liquid. It feels as though it could tear through any surface.

--- a/Resources/Locale/en-US/_Impstation/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_Impstation/reagents/meta/medicine.ftl
@@ -6,3 +6,6 @@ reagent-desc-subjuzine = A devious alteration of cognizine that bends the creatu
 
 reagent-name-caramexinin = caramexinin
 reagent-desc-caramexinin = An artificial sweetener that treats and prevents Theobromine poisoning in animals.
+
+reagent-name-abnormium = abnormium
+reagent-desc-abnormium = A strange liquid of alien origin.

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -33,7 +33,7 @@
     timeToDecay: 600
     startPrice: 10000
     endPrice: 200
-  #Imp special : grind the cores for abnormalium
+  #Imp special : grind the cores for abnormium
   - type: Extractable
     grindableSolutionName: abnoJuice
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -33,6 +33,15 @@
     timeToDecay: 600
     startPrice: 10000
     endPrice: 200
+  #Imp special : grind the cores for abnormalium
+  - type: Extractable
+    grindableSolutionName: abnoJuice
+  - type: SolutionContainerManager
+    solutions:
+      abnoJuice:
+        reagents:
+        - ReagentId: Abnormium
+          Quantity: 25
 
 - type: entity
   parent: BaseAnomalyCore

--- a/Resources/Prototypes/_Impstation/Reagents/chemicals.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/chemicals.yml
@@ -1,0 +1,9 @@
+- type: reagent
+  id: PhilosophersJuice
+  name: reagent-name-philosophers-juice
+  desc: reagent-desc-philosophers-juice
+  physicalDesc: reagent-physical-desc-space-grease
+  flavor: bitter
+  color: "#7e009e"
+  boilingPoint: -127.3 # Same as plasma
+  meltingPoint: -186.4

--- a/Resources/Prototypes/_Impstation/Reagents/fun.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/fun.yml
@@ -109,3 +109,17 @@
   desc: reagent-desc-testosterone
   physicalDesc: reagent-physical-desc-chalky
   color: "#267ef0"
+
+- type: reagent
+  id: Holium
+  # group: Special # The recipe is complicated enough that I think we shouldnt hide the recipe honestly
+  name: reagent-name-holium
+  desc: reagent-desc-holium
+  physicalDesc: reagent-physical-desc-threat
+  flavor: bottomless
+  color: "#000000"
+  tileReactions:
+  - !type:CreateEntityTileReaction
+    entity: FloorChasmEntity
+    maxOnTileWhitelist:
+      tags: [ FloorChasmEntity ]

--- a/Resources/Prototypes/_Impstation/Reagents/fun.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/fun.yml
@@ -116,7 +116,7 @@
   name: reagent-name-holium
   desc: reagent-desc-holium
   physicalDesc: reagent-physical-desc-threat
-  flavor: bottomless
+  flavor: singulo
   color: "#000000"
   tileReactions:
   - !type:CreateEntityTileReaction

--- a/Resources/Prototypes/_Impstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/medicine.yml
@@ -49,3 +49,29 @@
           types:
             Poison: -0.2
 
+- type: reagent
+  id: Abnormium
+  name: reagent-name-abnormium
+  group: Medicine
+  desc: reagent-desc-abnormium
+  flavor: sour
+  color: "#64ffe6"
+  physicalDesc: reagent-physical-desc-enigmatic
+  slippery: false
+  metabolisms:
+    # Bad omnizine that also gives you cancer
+    Medicine:
+      effects:
+      - !type:ModifyBloodLevel
+        amount: 2
+      - !type:HealthChange
+        damage:
+          groups:
+            Brute: -2
+            Burn: -2
+            Airloss: -2
+            Toxin: -2
+            Genetic: 5
+      - !type:ModifyBleedAmount
+        amount: -1
+

--- a/Resources/Prototypes/_Impstation/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Reactions/chemicals.yml
@@ -10,7 +10,7 @@
       amount: 2
   products:
     Estradiol: 5
-
+    
 - type: reaction
   id: Testosterone
   impact: Medium
@@ -23,3 +23,42 @@
       amount: 2
   products:
     Testosterone: 5
+    
+- type: reaction
+  id: PhilosophersJuice
+  impact: Medium
+  minTemp: 500
+  reactants:
+    TableSalt:
+      amount: 25
+    Silver:
+      amount: 25
+    Gold:
+      amount: 25
+    Plasma:
+      amount: 25
+    Blood:
+      amount: 100
+  products:
+    PhilosophersJuice: 1
+    
+- type: reaction
+  id: Holium
+  impact: High
+  minTemp: 1000
+  reactants:
+    Carbon:
+      amount: 200
+    UncookedAnimalProteins:
+      amount: 50
+    Honk:
+      amount: 50
+    Abnormium:
+      amount: 50
+    Frezon:
+      amount: 50
+    PhilosophersJuice:
+      amount: 1
+      catalyst: true
+  products:
+    Holium: 1

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -564,6 +564,9 @@
   id: Flesh
 
 - type: Tag
+  id: FloorChasmEntity
+
+- type: Tag
   id: Flower
 
 - type: Tag


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Abnormium, a new potent medicine made from grinding down abnormality cores. May cause cancer as a side effect.
- add: Philosopher's Juice, a catalyst for endgame chemistry made with unusual materials (more recipes involving this catalyst in the future)
- add: Holium, an impossibly hard to make chemical that will require the entire station to work in tandem to be made in the name of the cult of the hole