### PR TITLE
changeling chameleon skin nerf and price reduction

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -20,6 +20,7 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Damage.Components;
 using Content.Server.Radio.Components;
+using Content.Shared.Stealth;
 
 namespace Content.Server.Changeling;
 
@@ -575,10 +576,15 @@ public sealed partial class ChangelingSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("changeling-chameleon-end"), uid, uid);
             return;
         }
+        else
+        {
+            AddComp<StealthComponent>(uid);
 
-        EnsureComp<StealthComponent>(uid);
-        EnsureComp<StealthOnMoveComponent>(uid);
-        _popup.PopupEntity(Loc.GetString("changeling-chameleon-start"), uid, uid);
+            var stealthOnMove = AddComp<StealthOnMoveComponent>(uid);
+            stealthOnMove.MovementVisibilityRate = 1;
+
+            _popup.PopupEntity(Loc.GetString("changeling-chameleon-start"), uid, uid);
+        }
     }
     public void OnEphedrineOverdose(EntityUid uid, ChangelingComponent comp, ref ActionEphedrineOverdoseEvent args)
     {

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -17,6 +17,7 @@ using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Server.Flash.Components;
 using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Damage.Components;
 using Content.Server.Radio.Components;
@@ -26,6 +27,7 @@ namespace Content.Server.Changeling;
 public sealed partial class ChangelingSystem : EntitySystem
 {
     [Dependency] private readonly SharedRottingSystem _rotting = default!;
+    [Dependency] private readonly SharedStealthSystem _stealth = default!;
 
     public void SubscribeAbilities()
     {
@@ -575,15 +577,14 @@ public sealed partial class ChangelingSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("changeling-chameleon-end"), uid, uid);
             return;
         }
-        else
-        {
-            AddComp<StealthComponent>(uid);
 
-            var stealthOnMove = AddComp<StealthOnMoveComponent>(uid);
-            stealthOnMove.MovementVisibilityRate = 1;
+        EnsureComp<StealthComponent>(uid);
+        _stealth.SetMinVisibility(uid, 0);
 
-            _popup.PopupEntity(Loc.GetString("changeling-chameleon-start"), uid, uid);
-        }
+        var stealthOnMove = EnsureComp<StealthOnMoveComponent>(uid);
+        stealthOnMove.MovementVisibilityRate = 1;
+
+        _popup.PopupEntity(Loc.GetString("changeling-chameleon-start"), uid, uid);
     }
     public void OnEphedrineOverdose(EntityUid uid, ChangelingComponent comp, ref ActionEphedrineOverdoseEvent args)
     {

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -20,7 +20,6 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Damage.Components;
 using Content.Server.Radio.Components;
-using Content.Shared.Stealth;
 
 namespace Content.Server.Changeling;
 

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -208,4 +208,18 @@ public abstract class SharedStealthSystem : EntitySystem
             FlatModifier = flatModifier;
         }
     }
+
+    /// <summary>
+    /// Sets the minimum visibility
+    /// </summary>
+    /// <param name="value">The value to set the minimum visibility to.</param>
+    public void SetMinVisibility(EntityUid uid, float value, StealthComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        component.MinVisibility = value;
+
+        Dirty(uid, component);
+    }
 }

--- a/Resources/Prototypes/_Goobstation/Changeling/Catalog/changeling_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Catalog/changeling_catalog.yml
@@ -249,7 +249,7 @@
   icon: { sprite: _Goobstation/Changeling/changeling_abilities.rsi, state: chameleon_skin }
   productAction: ActionChameleonSkin
   cost:
-    EvolutionPoint: 4
+    EvolutionPoint: 2
   categories:
   - ChangelingAbilityUtility
   conditions:


### PR DESCRIPTION
part of #943: changeling's invisibility has been a real sticking point for a while but it has a lot of cool utility. it feels a bit "free" because you can just move around people without ever being detected - this should remedy that without preventing other cool, legitimate uses of it. also reduces the price by 2 evolution points to compensate

the way this is done is kinda ass but fucking whatever. it works and i am not refactoring too much yet

[2024-12-09 17-33-34.webm](https://github.com/user-attachments/assets/d97b54a7-ac6e-4e79-bc66-58e0164148b3)

**Changelog**
:cl:
- tweak: Changeling's chameleon skin reveals faster while moving, but is cheaper to evolve.