### PR TITLE
Rotate Banana + fixes

### DIFF
--- a/Resources/Maps/_Impstation/banana.yml
+++ b/Resources/Maps/_Impstation/banana.yml
@@ -10,7 +10,7 @@ tilemap:
   67: FloorLowDesert
   4: FloorShuttleOrange
   1: FloorSteel
-  7: FloorSteelBurnt
+  7: FloorSteelDamaged
   8: FloorSteelDirty
   13: FloorTechMaint
   12: FloorTechMaint2
@@ -1332,10 +1332,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 949
-      - 948
-      - 1314
-      - 1341
+      - 1126
+      - 1125
+      - 1510
+      - 1540
+      - 1149
+      - 1148
   - uid: 4
     components:
     - type: Transform
@@ -1344,12 +1346,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1016
-      - 1080
-      - 929
-      - 930
-      - 931
-      - 961
+      - 1494
+      - 1519
+      - 1081
+      - 1082
+      - 1083
+      - 1103
   - uid: 5
     components:
     - type: Transform
@@ -1357,17 +1359,17 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1061
-      - 1193
-      - 981
-      - 982
-      - 983
-      - 921
-      - 920
-      - 931
-      - 930
-      - 929
-  - uid: 7
+      - 1495
+      - 1529
+      - 1133
+      - 1134
+      - 1135
+      - 1073
+      - 1072
+      - 1083
+      - 1082
+      - 1081
+  - uid: 6
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1375,17 +1377,17 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 965
-      - 966
-      - 924
-      - 963
-      - 964
-      - 967
-      - 1089
-      - 1301
-      - 2378
-      - 2376
-  - uid: 8
+      - 1106
+      - 1107
+      - 1076
+      - 1104
+      - 1105
+      - 1108
+      - 1520
+      - 1504
+      - 1544
+      - 1514
+  - uid: 7
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1393,22 +1395,22 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 967
-      - 6
-  - uid: 9
+      - 1108
+      - 1517
+  - uid: 8
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1313
-      - 1340
-      - 924
-      - 963
-      - 964
-      - 925
-  - uid: 10
+      - 1509
+      - 1539
+      - 1076
+      - 1104
+      - 1105
+      - 1077
+  - uid: 9
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1416,13 +1418,13 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 968
-      - 925
-      - 926
-      - 1323
-      - 1306
-      - 2514
-  - uid: 11
+      - 1109
+      - 1077
+      - 1078
+      - 1537
+      - 1505
+      - 1147
+  - uid: 10
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1430,9 +1432,9 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 917
-      - 1267
-  - uid: 12
+      - 1069
+      - 1534
+  - uid: 11
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1440,15 +1442,15 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 928
-      - 984
-      - 985
-      - 986
-      - 987
-      - 992
+      - 1080
       - 1136
-      - 1140
-  - uid: 13
+      - 1137
+      - 1138
+      - 1139
+      - 1144
+      - 1524
+      - 1498
+  - uid: 12
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1456,15 +1458,15 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 926
-      - 991
-      - 993
-      - 928
-      - 927
-      - 1307
-      - 1039
-      - 2514
-  - uid: 14
+      - 1078
+      - 1143
+      - 1145
+      - 1080
+      - 1079
+      - 1506
+      - 1518
+      - 1147
+  - uid: 13
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1472,31 +1474,34 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 990
-      - 989
-      - 988
-      - 945
-      - 946
-      - 947
-      - 1288
-      - 1195
-      - 613
-      - 612
-      - 2297
-  - uid: 15
+      - 1142
+      - 1141
+      - 1140
+      - 1090
+      - 1091
+      - 1092
+      - 1535
+      - 1499
+      - 1124
+      - 1123
+      - 1146
+      - 1128
+      - 1149
+      - 1148
+  - uid: 14
     components:
     - type: Transform
       pos: -28.5,-2.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1196
-      - 1191
-      - 971
-      - 2297
-      - 612
-      - 613
-  - uid: 16
+      - 1500
+      - 1528
+      - 1112
+      - 1146
+      - 1123
+      - 1124
+  - uid: 15
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1504,24 +1509,24 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 932
-      - 948
-      - 949
-      - 933
-      - 1339
-      - 1312
-  - uid: 18
+      - 1127
+      - 1126
+      - 1125
+      - 1128
+      - 1538
+      - 1508
+  - uid: 16
     components:
     - type: Transform
       pos: -17.5,-13.5
       parent: 2
     - type: DeviceList
       devices:
-      - 959
-      - 941
-      - 1232
-      - 1343
-  - uid: 19
+      - 1102
+      - 1088
+      - 1502
+      - 1541
+  - uid: 17
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1529,24 +1534,24 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1317
-      - 1223
-      - 941
-      - 545
-      - 610
-      - 611
-      - 936
-      - 1326
-  - uid: 20
+      - 1511
+      - 1532
+      - 1088
+      - 1120
+      - 1121
+      - 1122
+      - 1086
+      - 1110
+  - uid: 18
     components:
     - type: Transform
       pos: -26.5,-16.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1256
-      - 936
-  - uid: 21
+      - 1533
+      - 1086
+  - uid: 19
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1554,22 +1559,22 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1209
-      - 942
-  - uid: 22
+      - 1531
+      - 1089
+  - uid: 20
     components:
     - type: Transform
       pos: -30.5,-13.5
       parent: 2
     - type: DeviceList
       devices:
-      - 975
-      - 976
-      - 1319
-      - 1347
-      - 937
-      - 934
-  - uid: 23
+      - 1116
+      - 1117
+      - 1512
+      - 1542
+      - 1087
+      - 1084
+  - uid: 21
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1577,17 +1582,17 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 973
-      - 974
-      - 953
-      - 918
-      - 951
-      - 952
-      - 919
-      - 950
       - 1114
-      - 1271
-  - uid: 24
+      - 1115
+      - 1096
+      - 1070
+      - 1094
+      - 1095
+      - 1071
+      - 1093
+      - 1523
+      - 1503
+  - uid: 22
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1595,47 +1600,47 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1229
-      - 1206
-      - 947
-      - 946
-      - 945
-      - 934
-      - 937
-      - 611
-      - 610
-      - 545
-      - 959
-  - uid: 25
+      - 1501
+      - 1530
+      - 1092
+      - 1091
+      - 1090
+      - 1084
+      - 1087
+      - 1122
+      - 1121
+      - 1120
+      - 1102
+  - uid: 23
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2384
-      - 980
-      - 979
-      - 978
-      - 1154
-      - 1311
-      - 984
-      - 985
-      - 986
-      - 987
-      - 992
-      - 972
-      - 970
-      - 953
-      - 951
-      - 952
-      - 918
-      - 991
-      - 993
-      - 1102
-      - 1103
-      - 2383
-  - uid: 26
+      - 1119
+      - 1132
+      - 1131
+      - 1130
+      - 1525
+      - 1507
+      - 1136
+      - 1137
+      - 1138
+      - 1139
+      - 1144
+      - 1113
+      - 1111
+      - 1096
+      - 1094
+      - 1095
+      - 1070
+      - 1143
+      - 1145
+      - 1496
+      - 1521
+      - 1118
+  - uid: 24
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1643,26 +1648,26 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 983
-      - 982
-      - 981
-      - 980
-      - 979
-      - 978
-      - 1104
-      - 1113
-  - uid: 1035
+      - 1135
+      - 1134
+      - 1133
+      - 1132
+      - 1131
+      - 1130
+      - 1497
+      - 1522
+  - uid: 25
     components:
     - type: Transform
       pos: -27.5,-19.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1321
-      - 1326
+      - 1536
+      - 1110
 - proto: AirAlarmDecapoid
   entities:
-  - uid: 2424
+  - uid: 26
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1670,12 +1675,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2425
-      - 2426
-      - 2384
+      - 1545
+      - 1515
+      - 1119
 - proto: AirAlarmVox
   entities:
-  - uid: 28
+  - uid: 27
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1683,16 +1688,16 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 954
-      - 955
-      - 950
-      - 919
-      - 956
-      - 957
-      - 958
-      - 1336
-      - 1176
-  - uid: 120
+      - 1097
+      - 1098
+      - 1093
+      - 1071
+      - 1099
+      - 1100
+      - 1101
+      - 1513
+      - 1527
+  - uid: 28
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1700,9 +1705,9 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2383
-      - 1739
-      - 724
+      - 1118
+      - 1516
+      - 1546
 - proto: AirlockCaptainLocked
   entities:
   - uid: 29
@@ -1728,46 +1733,46 @@ entities:
       parent: 2
 - proto: AirlockCommandGlassLocked
   entities:
-  - uid: 33
+  - uid: 32
     components:
     - type: Transform
       pos: -22.5,-17.5
       parent: 2
-  - uid: 34
+  - uid: 33
     components:
     - type: Transform
       pos: -21.5,-17.5
       parent: 2
-  - uid: 35
+  - uid: 34
     components:
     - type: Transform
       pos: -24.5,-20.5
       parent: 2
-  - uid: 36
+  - uid: 35
     components:
     - type: Transform
       pos: -20.5,-17.5
       parent: 2
 - proto: AirlockEngineeringLocked
   entities:
-  - uid: 37
+  - uid: 36
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,5.5
       parent: 2
-  - uid: 38
+  - uid: 37
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 2
-  - uid: 39
+  - uid: 38
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 2
-  - uid: 40
+  - uid: 39
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1775,7 +1780,7 @@ entities:
       parent: 2
 - proto: AirlockExternal
   entities:
-  - uid: 43
+  - uid: 40
     components:
     - type: Transform
       pos: -9.5,-2.5
@@ -1784,7 +1789,7 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2168:
+        2529:
         - DoorStatus: DoorBolt
 - proto: AirlockExternalCargoLocked
   entities:
@@ -1802,7 +1807,7 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassEngineeringLocked
   entities:
-  - uid: 44
+  - uid: 43
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1812,9 +1817,9 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        45:
+        44:
         - DoorStatus: DoorBolt
-  - uid: 45
+  - uid: 44
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1824,17 +1829,17 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        44:
+        43:
         - DoorStatus: DoorBolt
 - proto: AirlockExternalGlassShuttleArrivals
   entities:
-  - uid: 46
+  - uid: 45
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 2
-  - uid: 47
+  - uid: 46
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1842,13 +1847,13 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
-  - uid: 48
+  - uid: 47
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-16.5
       parent: 2
-  - uid: 1779
+  - uid: 48
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1856,72 +1861,72 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleShipyard
   entities:
-  - uid: 50
+  - uid: 49
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 51
+  - uid: 50
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 2
 - proto: AirlockFreezerLocked
   entities:
-  - uid: 52
+  - uid: 51
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
 - proto: AirlockGlass
   entities:
-  - uid: 53
+  - uid: 52
     components:
     - type: Transform
       pos: -23.5,-15.5
       parent: 2
-  - uid: 54
+  - uid: 53
     components:
     - type: Transform
       pos: -23.5,-14.5
       parent: 2
 - proto: AirlockHeadOfPersonnelLocked
   entities:
-  - uid: 55
+  - uid: 54
     components:
     - type: Transform
       pos: -17.5,-17.5
       parent: 2
 - proto: AirlockHydroGlassLocked
   entities:
-  - uid: 56
+  - uid: 55
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
 - proto: AirlockJanitorLocked
   entities:
-  - uid: 57
+  - uid: 56
     components:
     - type: Transform
       pos: -23.5,-12.5
       parent: 2
 - proto: AirlockMaint
   entities:
-  - uid: 58
+  - uid: 57
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
 - proto: AirlockMedicalGlass
   entities:
-  - uid: 59
+  - uid: 58
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,3.5
       parent: 2
-  - uid: 60
+  - uid: 59
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1929,13 +1934,13 @@ entities:
       parent: 2
 - proto: AirlockMedicalGlassLocked
   entities:
-  - uid: 61
+  - uid: 60
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,5.5
       parent: 2
-  - uid: 62
+  - uid: 61
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1943,7 +1948,7 @@ entities:
       parent: 2
 - proto: AirlockMedicalMorgueLocked
   entities:
-  - uid: 63
+  - uid: 62
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1951,7 +1956,7 @@ entities:
       parent: 2
 - proto: AirlockSalvageGlassLocked
   entities:
-  - uid: 64
+  - uid: 63
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1959,13 +1964,13 @@ entities:
       parent: 2
 - proto: AirlockScienceGlassLocked
   entities:
-  - uid: 66
+  - uid: 64
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-8.5
       parent: 2
-  - uid: 118
+  - uid: 65
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1973,49 +1978,49 @@ entities:
       parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
-  - uid: 67
+  - uid: 66
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-8.5
       parent: 2
-  - uid: 68
+  - uid: 67
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-8.5
       parent: 2
-  - uid: 69
+  - uid: 68
     components:
     - type: Transform
       pos: -19.5,-7.5
       parent: 2
 - proto: AirlockServiceGlassLocked
   entities:
-  - uid: 70
+  - uid: 69
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 2
-  - uid: 71
+  - uid: 70
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
 - proto: AlwaysPoweredWallLight
   entities:
-  - uid: 74
+  - uid: 71
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
-  - uid: 2431
+  - uid: 72
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,13.5
       parent: 2
-  - uid: 2432
+  - uid: 73
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2023,98 +2028,99 @@ entities:
       parent: 2
 - proto: APCBasic
   entities:
-  - uid: 75
+  - uid: 74
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,3.5
       parent: 2
-  - uid: 76
+  - uid: 75
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,6.5
       parent: 2
-  - uid: 77
+  - uid: 76
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,4.5
       parent: 2
-  - uid: 78
+  - uid: 77
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 2
-  - uid: 79
+  - uid: 78
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,-10.5
       parent: 2
-  - uid: 80
+  - uid: 79
     components:
     - type: Transform
       pos: -29.5,-13.5
       parent: 2
-  - uid: 81
+  - uid: 80
     components:
     - type: Transform
       pos: -19.5,-17.5
       parent: 2
-  - uid: 82
-    components:
-    - type: Transform
-      pos: -12.5,-1.5
-      parent: 2
-  - uid: 83
+  - uid: 81
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 84
+  - uid: 82
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-7.5
       parent: 2
-  - uid: 85
+  - uid: 83
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-2.5
       parent: 2
-  - uid: 86
+  - uid: 84
     components:
     - type: Transform
       pos: -26.5,-19.5
       parent: 2
-  - uid: 87
+  - uid: 85
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,10.5
       parent: 2
-  - uid: 160
+  - uid: 86
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 2
-  - uid: 292
+  - uid: 87
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-1.5
       parent: 2
-  - uid: 302
+  - uid: 88
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-11.5
       parent: 2
-  - uid: 2507
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,-2.5
+      parent: 2
+  - uid: 90
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2122,14 +2128,14 @@ entities:
       parent: 2
 - proto: APECircuitboard
   entities:
-  - uid: 2519
+  - uid: 91
     components:
     - type: Transform
       pos: -24.35849,-5.373108
       parent: 2
 - proto: ArrivalsShuttleTimer
   entities:
-  - uid: 88
+  - uid: 92
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2137,105 +2143,105 @@ entities:
       parent: 2
 - proto: Ashtray
   entities:
-  - uid: 89
+  - uid: 93
     components:
     - type: Transform
       pos: 2.6412992,3.5011878
       parent: 2
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 49
+  - uid: 94
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-16.5
       parent: 2
-  - uid: 90
+  - uid: 95
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-5.5
       parent: 2
-  - uid: 91
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
       parent: 2
-  - uid: 92
+  - uid: 97
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 2
-  - uid: 93
+  - uid: 98
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 95
+  - uid: 99
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 96
+  - uid: 100
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 97
+  - uid: 101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 2
-  - uid: 98
+  - uid: 102
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 99
+  - uid: 103
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 2
-  - uid: 100
+  - uid: 104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 2
-  - uid: 102
+  - uid: 105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 2
-  - uid: 146
+  - uid: 106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,8.5
       parent: 2
-  - uid: 1778
+  - uid: 107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-14.5
       parent: 2
-  - uid: 2381
+  - uid: 108
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 2
-  - uid: 2382
+  - uid: 109
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
-  - uid: 2458
+  - uid: 110
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2243,129 +2249,129 @@ entities:
       parent: 2
 - proto: AtmosFixDecapoidMarker
   entities:
-  - uid: 2420
+  - uid: 111
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
-  - uid: 2421
+  - uid: 112
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 2422
+  - uid: 113
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 2423
+  - uid: 114
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
 - proto: AtmosFixFreezerMarker
   entities:
-  - uid: 103
+  - uid: 115
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
-  - uid: 104
+  - uid: 116
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
-  - uid: 105
+  - uid: 117
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 2
-  - uid: 106
+  - uid: 118
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 2
-  - uid: 107
+  - uid: 119
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 108
+  - uid: 120
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 109
+  - uid: 121
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 2
-  - uid: 110
+  - uid: 122
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
-  - uid: 111
+  - uid: 123
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 112
+  - uid: 124
     components:
     - type: Transform
       pos: -27.5,9.5
       parent: 2
-  - uid: 113
+  - uid: 125
     components:
     - type: Transform
       pos: -27.5,8.5
       parent: 2
-  - uid: 114
+  - uid: 126
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
 - proto: AtmosFixVoxMarker
   entities:
-  - uid: 115
+  - uid: 127
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 2
-  - uid: 116
+  - uid: 128
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 2
-  - uid: 121
+  - uid: 129
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 122
+  - uid: 130
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 2
 - proto: Autolathe
   entities:
-  - uid: 123
+  - uid: 131
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 124
+  - uid: 132
     components:
     - type: Transform
       pos: -29.5,-4.5
       parent: 2
 - proto: BarSpoon
   entities:
-  - uid: 139
+  - uid: 133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2373,57 +2379,57 @@ entities:
       parent: 2
 - proto: Beaker
   entities:
-  - uid: 126
+  - uid: 134
     components:
     - type: Transform
       pos: -12.6813965,6.543274
       parent: 2
-  - uid: 127
+  - uid: 135
     components:
     - type: Transform
       pos: -14.290314,8.552368
       parent: 2
-  - uid: 2534
+  - uid: 136
     components:
     - type: Transform
       pos: -7.542572,6.475281
       parent: 2
 - proto: Bed
   entities:
-  - uid: 128
+  - uid: 137
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
 - proto: BedsheetCaptain
   entities:
-  - uid: 129
+  - uid: 138
     components:
     - type: Transform
       pos: -26.5,-17.5
       parent: 2
 - proto: BedsheetMedical
   entities:
-  - uid: 130
+  - uid: 139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,7.5
       parent: 2
-  - uid: 131
+  - uid: 140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,7.5
       parent: 2
-  - uid: 1834
+  - uid: 141
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 2
 - proto: BedsheetRed
   entities:
-  - uid: 132
+  - uid: 142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2431,28 +2437,28 @@ entities:
       parent: 2
 - proto: BenchSofaCorpLeft
   entities:
-  - uid: 2562
+  - uid: 143
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
 - proto: BenchSofaCorpMiddle
   entities:
-  - uid: 2555
+  - uid: 144
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
 - proto: BenchSofaCorpRight
   entities:
-  - uid: 2563
+  - uid: 145
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
 - proto: Bible
   entities:
-  - uid: 2516
+  - uid: 146
     components:
     - type: Transform
       pos: -23.362152,7.8450623
@@ -2495,54 +2501,61 @@ entities:
           friction: 0.4
 - proto: Biogenerator
   entities:
-  - uid: 2462
+  - uid: 147
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 2
 - proto: BlastDoor
   entities:
-  - uid: 135
+  - uid: 148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-7.5
       parent: 2
-  - uid: 136
+  - uid: 149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-8.5
       parent: 2
-  - uid: 137
+  - uid: 150
     components:
     - type: Transform
       pos: -14.5,-8.5
       parent: 2
 - proto: BlockGameArcade
   entities:
-  - uid: 138
+  - uid: 151
     components:
     - type: Transform
       pos: -17.5,-2.5
       parent: 2
 - proto: BoozeDispenser
   entities:
-  - uid: 141
+  - uid: 152
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
+- proto: BorgSpawnerTckTck
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 2
 - proto: BoxBodyBag
   entities:
-  - uid: 142
+  - uid: 154
     components:
     - type: Transform
       pos: -23.683558,8.777045
       parent: 2
 - proto: BoxCardboard
   entities:
-  - uid: 1534
+  - uid: 155
     components:
     - type: MetaData
       name: forensic supplies box
@@ -2551,19 +2564,19 @@ entities:
       parent: 2
     - type: Storage
       storedItems:
-        2487:
+        159:
           position: 0,0
           _rotation: West
-        2486:
+        160:
           position: 2,0
           _rotation: South
-        1535:
+        156:
           position: 0,1
           _rotation: East
-        1536:
+        157:
           position: 0,2
           _rotation: East
-        1580:
+        158:
           position: 2,2
           _rotation: South
     - type: ContainerContainer
@@ -2572,43 +2585,43 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 2487
-          - 2486
-          - 1535
-          - 1536
-          - 1580
-  - uid: 2445
+          - 159
+          - 160
+          - 156
+          - 157
+          - 158
+  - uid: 161
     components:
     - type: Transform
       pos: -31.27478,3.2773743
       parent: 2
     - type: Storage
       storedItems:
-        2446:
+        162:
           position: 0,0
           _rotation: South
-        2447:
+        163:
           position: 1,0
           _rotation: South
-        2448:
+        164:
           position: 2,0
           _rotation: South
-        2449:
+        165:
           position: 0,1
           _rotation: South
-        2450:
+        166:
           position: 1,1
           _rotation: South
-        2451:
+        167:
           position: 2,1
           _rotation: South
-        2452:
+        168:
           position: 0,2
           _rotation: South
-        2453:
+        169:
           position: 1,2
           _rotation: South
-        2454:
+        170:
           position: 2,2
           _rotation: South
     - type: ContainerContainer
@@ -2617,41 +2630,41 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 2446
-          - 2447
-          - 2448
-          - 2449
-          - 2450
-          - 2451
-          - 2452
-          - 2453
-          - 2454
+          - 162
+          - 163
+          - 164
+          - 165
+          - 166
+          - 167
+          - 168
+          - 169
+          - 170
     - type: Label
       currentLabel: frank food
 - proto: BoxCleanerGrenades
   entities:
-  - uid: 2471
+  - uid: 171
     components:
     - type: Transform
       pos: -24.184052,-11.660706
       parent: 2
 - proto: BoxFolderBlack
   entities:
-  - uid: 143
+  - uid: 172
     components:
     - type: Transform
       pos: 4.6686945,-4.9433904
       parent: 2
 - proto: BoxFolderBlue
   entities:
-  - uid: 144
+  - uid: 173
     components:
     - type: Transform
       pos: 4.8405695,-5.1465154
       parent: 2
 - proto: BrigTimer
   entities:
-  - uid: 145
+  - uid: 174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2659,29 +2672,29 @@ entities:
       parent: 2
 - proto: Bucket
   entities:
-  - uid: 2469
+  - uid: 175
     components:
     - type: Transform
       pos: -6.239624,8.745972
       parent: 2
-  - uid: 2482
+  - uid: 176
     components:
     - type: Transform
       pos: -25.00998,-11.3342285
       parent: 2
 - proto: ButtonFrameCaution
   entities:
-  - uid: 147
+  - uid: 177
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
-  - uid: 148
+  - uid: 178
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 1542
+  - uid: 179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2689,7 +2702,7 @@ entities:
       parent: 2
 - proto: ButtonFrameExit
   entities:
-  - uid: 150
+  - uid: 180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2697,7 +2710,7 @@ entities:
       parent: 2
 - proto: ButtonFrameJanitor
   entities:
-  - uid: 151
+  - uid: 181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2705,3142 +2718,3176 @@ entities:
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 125
-    components:
-    - type: Transform
-      pos: -11.5,6.5
-      parent: 2
-  - uid: 152
-    components:
-    - type: Transform
-      pos: -29.5,-13.5
-      parent: 2
-  - uid: 153
-    components:
-    - type: Transform
-      pos: -25.5,5.5
-      parent: 2
-  - uid: 154
-    components:
-    - type: Transform
-      pos: -6.5,-5.5
-      parent: 2
-  - uid: 155
-    components:
-    - type: Transform
-      pos: -3.5,-8.5
-      parent: 2
-  - uid: 156
-    components:
-    - type: Transform
-      pos: -27.5,-14.5
-      parent: 2
-  - uid: 157
-    components:
-    - type: Transform
-      pos: -28.5,-14.5
-      parent: 2
-  - uid: 158
-    components:
-    - type: Transform
-      pos: -29.5,-14.5
-      parent: 2
-  - uid: 159
-    components:
-    - type: Transform
-      pos: -29.5,-15.5
-      parent: 2
-  - uid: 161
-    components:
-    - type: Transform
-      pos: -30.5,-15.5
-      parent: 2
-  - uid: 162
-    components:
-    - type: Transform
-      pos: -31.5,-15.5
-      parent: 2
-  - uid: 163
-    components:
-    - type: Transform
-      pos: -32.5,-15.5
-      parent: 2
-  - uid: 164
-    components:
-    - type: Transform
-      pos: -33.5,-15.5
-      parent: 2
-  - uid: 165
-    components:
-    - type: Transform
-      pos: -19.5,-17.5
-      parent: 2
-  - uid: 166
-    components:
-    - type: Transform
-      pos: -19.5,-18.5
-      parent: 2
-  - uid: 167
-    components:
-    - type: Transform
-      pos: -20.5,-18.5
-      parent: 2
-  - uid: 168
-    components:
-    - type: Transform
-      pos: -21.5,-18.5
-      parent: 2
-  - uid: 169
-    components:
-    - type: Transform
-      pos: -22.5,-18.5
-      parent: 2
-  - uid: 170
-    components:
-    - type: Transform
-      pos: -23.5,-18.5
-      parent: 2
-  - uid: 171
-    components:
-    - type: Transform
-      pos: -24.5,-18.5
-      parent: 2
-  - uid: 173
-    components:
-    - type: Transform
-      pos: -18.5,-18.5
-      parent: 2
-  - uid: 174
-    components:
-    - type: Transform
-      pos: -17.5,-18.5
-      parent: 2
-  - uid: 175
-    components:
-    - type: Transform
-      pos: -17.5,-17.5
-      parent: 2
-  - uid: 176
-    components:
-    - type: Transform
-      pos: -17.5,-16.5
-      parent: 2
-  - uid: 177
-    components:
-    - type: Transform
-      pos: -17.5,-14.5
-      parent: 2
-  - uid: 178
-    components:
-    - type: Transform
-      pos: -17.5,-15.5
-      parent: 2
-  - uid: 179
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 2
-  - uid: 180
-    components:
-    - type: Transform
-      pos: -3.5,4.5
-      parent: 2
-  - uid: 181
-    components:
-    - type: Transform
-      pos: -20.5,-18.5
-      parent: 2
   - uid: 182
     components:
     - type: Transform
-      pos: -20.5,-19.5
+      pos: -15.5,-2.5
       parent: 2
   - uid: 183
     components:
     - type: Transform
-      pos: -20.5,-20.5
+      pos: -11.5,6.5
       parent: 2
   - uid: 184
     components:
     - type: Transform
-      pos: -20.5,-21.5
+      pos: -29.5,-13.5
       parent: 2
   - uid: 185
     components:
     - type: Transform
-      pos: -21.5,-21.5
+      pos: -25.5,5.5
       parent: 2
   - uid: 186
     components:
     - type: Transform
-      pos: -22.5,-21.5
+      pos: -6.5,-5.5
       parent: 2
   - uid: 187
     components:
     - type: Transform
-      pos: -6.5,4.5
+      pos: -3.5,-8.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -27.5,-14.5
       parent: 2
   - uid: 189
     components:
     - type: Transform
-      pos: 5.5,3.5
+      pos: -28.5,-14.5
       parent: 2
   - uid: 190
     components:
     - type: Transform
-      pos: -26.5,-14.5
+      pos: -29.5,-14.5
       parent: 2
   - uid: 191
     components:
     - type: Transform
-      pos: -25.5,-14.5
+      pos: -29.5,-15.5
       parent: 2
   - uid: 192
     components:
     - type: Transform
-      pos: -24.5,-14.5
+      pos: -30.5,-15.5
       parent: 2
   - uid: 193
     components:
     - type: Transform
-      pos: -23.5,-14.5
+      pos: -31.5,-15.5
       parent: 2
   - uid: 194
     components:
     - type: Transform
-      pos: -23.5,-15.5
+      pos: -32.5,-15.5
       parent: 2
   - uid: 195
     components:
     - type: Transform
-      pos: -22.5,-14.5
+      pos: -33.5,-15.5
       parent: 2
   - uid: 196
     components:
     - type: Transform
-      pos: -22.5,-13.5
+      pos: -19.5,-17.5
       parent: 2
   - uid: 197
     components:
     - type: Transform
-      pos: -22.5,-12.5
+      pos: -19.5,-18.5
       parent: 2
   - uid: 198
     components:
     - type: Transform
-      pos: -12.5,-1.5
+      pos: -20.5,-18.5
       parent: 2
   - uid: 199
     components:
     - type: Transform
-      pos: -27.5,-10.5
+      pos: -21.5,-18.5
       parent: 2
   - uid: 200
     components:
     - type: Transform
-      pos: -27.5,-9.5
+      pos: -22.5,-18.5
       parent: 2
   - uid: 201
     components:
     - type: Transform
-      pos: -28.5,-9.5
+      pos: -23.5,-18.5
       parent: 2
   - uid: 202
     components:
     - type: Transform
-      pos: -29.5,-9.5
+      pos: -24.5,-18.5
       parent: 2
   - uid: 203
     components:
     - type: Transform
-      pos: -27.5,-8.5
+      pos: -18.5,-18.5
       parent: 2
   - uid: 204
     components:
     - type: Transform
-      pos: -27.5,-7.5
+      pos: -17.5,-18.5
       parent: 2
   - uid: 205
     components:
     - type: Transform
-      pos: -27.5,-6.5
+      pos: -17.5,-17.5
       parent: 2
   - uid: 206
     components:
     - type: Transform
-      pos: -27.5,-5.5
+      pos: -17.5,-16.5
       parent: 2
   - uid: 207
     components:
     - type: Transform
-      pos: -28.5,-5.5
+      pos: -17.5,-14.5
       parent: 2
   - uid: 208
     components:
     - type: Transform
-      pos: -29.5,-5.5
+      pos: -17.5,-15.5
       parent: 2
   - uid: 209
     components:
     - type: Transform
-      pos: -29.5,-4.5
+      pos: -6.5,3.5
       parent: 2
   - uid: 210
     components:
     - type: Transform
-      pos: -27.5,-4.5
+      pos: -3.5,4.5
       parent: 2
   - uid: 211
     components:
     - type: Transform
-      pos: -27.5,-3.5
+      pos: -20.5,-18.5
       parent: 2
   - uid: 212
     components:
     - type: Transform
-      pos: -30.5,-11.5
+      pos: -20.5,-19.5
       parent: 2
   - uid: 213
     components:
     - type: Transform
-      pos: -29.5,-3.5
+      pos: -20.5,-20.5
       parent: 2
   - uid: 214
     components:
     - type: Transform
-      pos: -28.5,-7.5
+      pos: -20.5,-21.5
       parent: 2
   - uid: 215
     components:
     - type: Transform
-      pos: -29.5,-7.5
+      pos: -21.5,-21.5
       parent: 2
   - uid: 216
     components:
     - type: Transform
-      pos: -26.5,-9.5
+      pos: -22.5,-21.5
       parent: 2
   - uid: 217
     components:
     - type: Transform
-      pos: -25.5,-9.5
+      pos: -6.5,4.5
       parent: 2
   - uid: 218
     components:
     - type: Transform
-      pos: -24.5,-9.5
+      pos: 5.5,3.5
       parent: 2
   - uid: 219
     components:
     - type: Transform
-      pos: -24.5,-8.5
+      pos: -26.5,-14.5
       parent: 2
   - uid: 220
     components:
     - type: Transform
-      pos: -23.5,-8.5
+      pos: -25.5,-14.5
       parent: 2
   - uid: 221
     components:
     - type: Transform
-      pos: -23.5,-7.5
+      pos: -24.5,-14.5
       parent: 2
   - uid: 222
     components:
     - type: Transform
-      pos: -23.5,-6.5
+      pos: -23.5,-14.5
       parent: 2
   - uid: 223
     components:
     - type: Transform
-      pos: -24.5,6.5
+      pos: -23.5,-15.5
       parent: 2
   - uid: 224
     components:
     - type: Transform
-      pos: -25.5,6.5
+      pos: -22.5,-14.5
       parent: 2
   - uid: 225
     components:
     - type: Transform
-      pos: -25.5,7.5
+      pos: -22.5,-13.5
       parent: 2
   - uid: 226
     components:
     - type: Transform
-      pos: -25.5,4.5
+      pos: -22.5,-12.5
       parent: 2
   - uid: 227
     components:
     - type: Transform
-      pos: -25.5,3.5
+      pos: -16.5,-2.5
       parent: 2
   - uid: 228
     components:
     - type: Transform
-      pos: -25.5,2.5
+      pos: -27.5,-10.5
       parent: 2
   - uid: 229
     components:
     - type: Transform
-      pos: -25.5,1.5
+      pos: -27.5,-9.5
       parent: 2
   - uid: 230
     components:
     - type: Transform
-      pos: -24.5,1.5
+      pos: -28.5,-9.5
       parent: 2
   - uid: 231
     components:
     - type: Transform
-      pos: -24.5,0.5
+      pos: -29.5,-9.5
       parent: 2
   - uid: 232
     components:
     - type: Transform
-      pos: -25.5,0.5
+      pos: -27.5,-8.5
       parent: 2
   - uid: 233
     components:
     - type: Transform
-      pos: -25.5,-0.5
+      pos: -27.5,-7.5
       parent: 2
   - uid: 234
     components:
     - type: Transform
-      pos: -25.5,-1.5
+      pos: -27.5,-6.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -27.5,-5.5
       parent: 2
   - uid: 236
     components:
     - type: Transform
-      pos: -24.5,4.5
+      pos: -28.5,-5.5
       parent: 2
   - uid: 237
     components:
     - type: Transform
-      pos: -23.5,4.5
+      pos: -29.5,-5.5
       parent: 2
   - uid: 238
     components:
     - type: Transform
-      pos: -15.5,4.5
+      pos: -29.5,-4.5
       parent: 2
   - uid: 239
     components:
     - type: Transform
-      pos: -16.5,4.5
+      pos: -27.5,-4.5
       parent: 2
   - uid: 240
     components:
     - type: Transform
-      pos: -17.5,4.5
+      pos: -27.5,-3.5
       parent: 2
   - uid: 241
     components:
     - type: Transform
-      pos: -18.5,4.5
+      pos: -30.5,-11.5
       parent: 2
   - uid: 242
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -29.5,-3.5
       parent: 2
   - uid: 243
     components:
     - type: Transform
-      pos: -19.5,4.5
+      pos: -28.5,-7.5
       parent: 2
   - uid: 244
     components:
     - type: Transform
-      pos: -19.5,3.5
+      pos: -29.5,-7.5
       parent: 2
   - uid: 245
     components:
     - type: Transform
-      pos: -20.5,3.5
+      pos: -26.5,-9.5
       parent: 2
   - uid: 246
     components:
     - type: Transform
-      pos: -2.5,5.5
+      pos: -25.5,-9.5
       parent: 2
   - uid: 247
     components:
     - type: Transform
-      pos: -15.5,5.5
+      pos: -24.5,-9.5
       parent: 2
   - uid: 248
     components:
     - type: Transform
-      pos: -14.5,5.5
+      pos: -24.5,-8.5
       parent: 2
   - uid: 249
     components:
     - type: Transform
-      pos: -13.5,5.5
+      pos: -23.5,-8.5
       parent: 2
   - uid: 250
     components:
     - type: Transform
-      pos: -12.5,5.5
+      pos: -23.5,-7.5
       parent: 2
   - uid: 251
     components:
     - type: Transform
-      pos: -12.5,4.5
+      pos: -23.5,-6.5
       parent: 2
   - uid: 252
     components:
     - type: Transform
-      pos: -13.5,6.5
+      pos: -24.5,6.5
       parent: 2
   - uid: 253
     components:
     - type: Transform
-      pos: -13.5,7.5
+      pos: -25.5,6.5
       parent: 2
   - uid: 254
     components:
     - type: Transform
-      pos: -13.5,8.5
+      pos: -25.5,7.5
       parent: 2
   - uid: 255
     components:
     - type: Transform
-      pos: -12.5,8.5
+      pos: -25.5,4.5
       parent: 2
   - uid: 256
     components:
     - type: Transform
-      pos: -12.5,9.5
+      pos: -25.5,3.5
       parent: 2
   - uid: 257
     components:
     - type: Transform
-      pos: -15.5,6.5
+      pos: -25.5,2.5
       parent: 2
   - uid: 258
     components:
     - type: Transform
-      pos: -15.5,7.5
+      pos: -25.5,1.5
       parent: 2
   - uid: 259
     components:
     - type: Transform
-      pos: -16.5,7.5
+      pos: -24.5,1.5
       parent: 2
   - uid: 260
     components:
     - type: Transform
-      pos: -16.5,8.5
+      pos: -24.5,0.5
       parent: 2
   - uid: 261
     components:
     - type: Transform
-      pos: -6.5,1.5
+      pos: -25.5,0.5
       parent: 2
   - uid: 262
     components:
     - type: Transform
-      pos: -17.5,8.5
+      pos: -25.5,-0.5
       parent: 2
   - uid: 263
     components:
     - type: Transform
-      pos: -18.5,8.5
+      pos: -25.5,-1.5
       parent: 2
   - uid: 264
     components:
     - type: Transform
-      pos: -19.5,8.5
+      pos: -11.5,0.5
       parent: 2
   - uid: 265
     components:
     - type: Transform
-      pos: -20.5,8.5
+      pos: -24.5,4.5
       parent: 2
   - uid: 266
     components:
     - type: Transform
-      pos: -4.5,6.5
+      pos: -23.5,4.5
       parent: 2
   - uid: 267
     components:
     - type: Transform
-      pos: -21.5,8.5
+      pos: -15.5,4.5
       parent: 2
   - uid: 268
     components:
     - type: Transform
-      pos: -25.5,8.5
+      pos: -16.5,4.5
       parent: 2
   - uid: 269
     components:
     - type: Transform
-      pos: -25.5,9.5
+      pos: -17.5,4.5
       parent: 2
   - uid: 270
     components:
     - type: Transform
-      pos: 4.5,5.5
+      pos: -18.5,4.5
       parent: 2
   - uid: 271
     components:
     - type: Transform
-      pos: 3.5,5.5
+      pos: -5.5,1.5
       parent: 2
   - uid: 272
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: -19.5,4.5
       parent: 2
   - uid: 273
     components:
     - type: Transform
-      pos: 2.5,6.5
+      pos: -19.5,3.5
       parent: 2
   - uid: 274
     components:
     - type: Transform
-      pos: 1.5,6.5
+      pos: -20.5,3.5
       parent: 2
   - uid: 275
     components:
     - type: Transform
-      pos: 0.5,6.5
+      pos: -2.5,5.5
       parent: 2
   - uid: 276
     components:
     - type: Transform
-      pos: -0.5,6.5
+      pos: -15.5,5.5
       parent: 2
   - uid: 277
     components:
     - type: Transform
-      pos: -0.5,5.5
+      pos: -14.5,5.5
       parent: 2
   - uid: 278
     components:
     - type: Transform
-      pos: -4.5,8.5
+      pos: -13.5,5.5
       parent: 2
   - uid: 279
     components:
     - type: Transform
-      pos: -4.5,7.5
+      pos: -12.5,5.5
       parent: 2
   - uid: 280
     components:
     - type: Transform
-      pos: -3.5,5.5
+      pos: -12.5,4.5
       parent: 2
   - uid: 281
     components:
     - type: Transform
-      pos: -4.5,5.5
+      pos: -13.5,6.5
       parent: 2
   - uid: 282
     components:
     - type: Transform
-      pos: -5.5,5.5
+      pos: -13.5,7.5
       parent: 2
   - uid: 283
     components:
     - type: Transform
-      pos: -6.5,5.5
+      pos: -13.5,8.5
       parent: 2
   - uid: 284
     components:
     - type: Transform
-      pos: -8.5,6.5
-      parent: 2
-  - uid: 286
-    components:
-    - type: Transform
-      pos: -9.5,5.5
-      parent: 2
-  - uid: 287
-    components:
-    - type: Transform
-      pos: -9.5,6.5
-      parent: 2
-  - uid: 288
-    components:
-    - type: Transform
-      pos: -9.5,7.5
-      parent: 2
-  - uid: 289
-    components:
-    - type: Transform
-      pos: -9.5,8.5
-      parent: 2
-  - uid: 290
-    components:
-    - type: Transform
-      pos: -8.5,8.5
-      parent: 2
-  - uid: 291
-    components:
-    - type: Transform
-      pos: -6.5,8.5
-      parent: 2
-  - uid: 293
-    components:
-    - type: Transform
-      pos: -9.5,4.5
-      parent: 2
-  - uid: 294
-    components:
-    - type: Transform
-      pos: -9.5,3.5
-      parent: 2
-  - uid: 295
-    components:
-    - type: Transform
-      pos: -9.5,2.5
-      parent: 2
-  - uid: 296
-    components:
-    - type: Transform
-      pos: -8.5,2.5
-      parent: 2
-  - uid: 297
-    components:
-    - type: Transform
-      pos: -0.5,4.5
-      parent: 2
-  - uid: 298
-    components:
-    - type: Transform
-      pos: -21.5,-3.5
-      parent: 2
-  - uid: 299
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 2
-  - uid: 300
-    components:
-    - type: Transform
-      pos: -1.5,2.5
-      parent: 2
-  - uid: 301
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 2
-  - uid: 303
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 2
-  - uid: 304
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 2
-  - uid: 305
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 2
-  - uid: 306
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 2
-  - uid: 307
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 2
-  - uid: 308
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 2
-  - uid: 309
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 2
-  - uid: 310
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 2
-  - uid: 311
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 2
-  - uid: 312
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 2
-  - uid: 313
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 2
-  - uid: 314
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 2
-  - uid: 315
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 2
-  - uid: 316
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 2
-  - uid: 317
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 2
-  - uid: 318
-    components:
-    - type: Transform
-      pos: -4.5,-4.5
-      parent: 2
-  - uid: 319
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 2
-  - uid: 320
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 2
-  - uid: 321
-    components:
-    - type: Transform
-      pos: -5.5,-7.5
-      parent: 2
-  - uid: 322
-    components:
-    - type: Transform
-      pos: -5.5,-6.5
-      parent: 2
-  - uid: 323
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 2
-  - uid: 324
-    components:
-    - type: Transform
-      pos: -21.5,-3.5
-      parent: 2
-  - uid: 325
-    components:
-    - type: Transform
-      pos: -12.5,-5.5
-      parent: 2
-  - uid: 326
-    components:
-    - type: Transform
-      pos: -12.5,-6.5
-      parent: 2
-  - uid: 327
-    components:
-    - type: Transform
-      pos: -11.5,-5.5
-      parent: 2
-  - uid: 328
-    components:
-    - type: Transform
-      pos: -11.5,-5.5
-      parent: 2
-  - uid: 329
-    components:
-    - type: Transform
-      pos: -10.5,-5.5
-      parent: 2
-  - uid: 330
-    components:
-    - type: Transform
-      pos: -9.5,-5.5
-      parent: 2
-  - uid: 331
-    components:
-    - type: Transform
-      pos: -9.5,-4.5
-      parent: 2
-  - uid: 332
-    components:
-    - type: Transform
-      pos: -9.5,-3.5
-      parent: 2
-  - uid: 333
-    components:
-    - type: Transform
-      pos: -8.5,-0.5
-      parent: 2
-  - uid: 334
-    components:
-    - type: Transform
-      pos: -14.5,-5.5
-      parent: 2
-  - uid: 335
-    components:
-    - type: Transform
-      pos: -14.5,-6.5
-      parent: 2
-  - uid: 336
-    components:
-    - type: Transform
-      pos: -14.5,-4.5
-      parent: 2
-  - uid: 337
-    components:
-    - type: Transform
-      pos: -14.5,-3.5
-      parent: 2
-  - uid: 338
-    components:
-    - type: Transform
-      pos: -14.5,-2.5
-      parent: 2
-  - uid: 339
-    components:
-    - type: Transform
-      pos: -13.5,-2.5
-      parent: 2
-  - uid: 340
-    components:
-    - type: Transform
-      pos: -13.5,-1.5
-      parent: 2
-  - uid: 341
-    components:
-    - type: Transform
-      pos: -12.5,-2.5
-      parent: 2
-  - uid: 342
-    components:
-    - type: Transform
-      pos: -21.5,-4.5
-      parent: 2
-  - uid: 343
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 2
-  - uid: 344
-    components:
-    - type: Transform
-      pos: 4.5,-4.5
-      parent: 2
-  - uid: 346
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 2
-  - uid: 347
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 2
-  - uid: 348
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 2
-  - uid: 349
-    components:
-    - type: Transform
-      pos: 5.5,-1.5
-      parent: 2
-  - uid: 350
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 2
-  - uid: 351
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 2
-  - uid: 352
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 2
-  - uid: 353
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 2
-  - uid: 354
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 2
-  - uid: 355
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 2
-  - uid: 356
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 2
-  - uid: 357
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 2
-  - uid: 358
-    components:
-    - type: Transform
-      pos: 6.5,3.5
-      parent: 2
-  - uid: 359
-    components:
-    - type: Transform
-      pos: 7.5,3.5
-      parent: 2
-  - uid: 360
-    components:
-    - type: Transform
-      pos: -26.5,5.5
-      parent: 2
-  - uid: 361
-    components:
-    - type: Transform
-      pos: -28.5,5.5
-      parent: 2
-  - uid: 362
-    components:
-    - type: Transform
-      pos: -27.5,5.5
-      parent: 2
-  - uid: 363
-    components:
-    - type: Transform
-      pos: -29.5,5.5
-      parent: 2
-  - uid: 364
-    components:
-    - type: Transform
-      pos: -30.5,5.5
-      parent: 2
-  - uid: 365
-    components:
-    - type: Transform
-      pos: -31.5,5.5
-      parent: 2
-  - uid: 366
-    components:
-    - type: Transform
-      pos: -32.5,5.5
-      parent: 2
-  - uid: 367
-    components:
-    - type: Transform
-      pos: -33.5,5.5
-      parent: 2
-  - uid: 368
-    components:
-    - type: Transform
-      pos: -34.5,5.5
-      parent: 2
-  - uid: 369
-    components:
-    - type: Transform
-      pos: -35.5,5.5
-      parent: 2
-  - uid: 370
-    components:
-    - type: Transform
-      pos: -35.5,6.5
-      parent: 2
-  - uid: 371
-    components:
-    - type: Transform
-      pos: -35.5,7.5
-      parent: 2
-  - uid: 372
-    components:
-    - type: Transform
-      pos: -35.5,8.5
-      parent: 2
-  - uid: 373
-    components:
-    - type: Transform
-      pos: -32.5,6.5
-      parent: 2
-  - uid: 374
-    components:
-    - type: Transform
-      pos: -32.5,7.5
-      parent: 2
-  - uid: 375
-    components:
-    - type: Transform
-      pos: -32.5,4.5
-      parent: 2
-  - uid: 376
-    components:
-    - type: Transform
-      pos: -32.5,3.5
-      parent: 2
-  - uid: 377
-    components:
-    - type: Transform
-      pos: 3.5,-0.5
-      parent: 2
-  - uid: 378
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 2
-  - uid: 379
-    components:
-    - type: Transform
-      pos: 3.5,1.5
-      parent: 2
-  - uid: 380
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 2
-  - uid: 381
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 2
-  - uid: 382
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 2
-  - uid: 383
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 2
-  - uid: 384
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
-      parent: 2
-  - uid: 385
-    components:
-    - type: Transform
-      pos: -4.5,-0.5
-      parent: 2
-  - uid: 386
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
-      parent: 2
-  - uid: 387
-    components:
-    - type: Transform
-      pos: -4.5,-2.5
-      parent: 2
-  - uid: 388
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 2
-  - uid: 389
-    components:
-    - type: Transform
-      pos: -4.5,1.5
-      parent: 2
-  - uid: 390
-    components:
-    - type: Transform
-      pos: -28.5,-11.5
-      parent: 2
-  - uid: 397
-    components:
-    - type: Transform
-      pos: -10.5,-0.5
-      parent: 2
-  - uid: 398
-    components:
-    - type: Transform
-      pos: -9.5,-1.5
-      parent: 2
-  - uid: 399
-    components:
-    - type: Transform
-      pos: -9.5,-0.5
-      parent: 2
-  - uid: 400
-    components:
-    - type: Transform
-      pos: -11.5,-0.5
-      parent: 2
-  - uid: 404
-    components:
-    - type: Transform
-      pos: -23.5,-2.5
-      parent: 2
-  - uid: 406
-    components:
-    - type: Transform
-      pos: -21.5,-2.5
-      parent: 2
-  - uid: 407
-    components:
-    - type: Transform
-      pos: -16.5,-7.5
-      parent: 2
-  - uid: 408
-    components:
-    - type: Transform
-      pos: -17.5,-7.5
-      parent: 2
-  - uid: 409
-    components:
-    - type: Transform
-      pos: -17.5,-6.5
-      parent: 2
-  - uid: 410
-    components:
-    - type: Transform
-      pos: -17.5,-5.5
-      parent: 2
-  - uid: 411
-    components:
-    - type: Transform
-      pos: -17.5,-4.5
-      parent: 2
-  - uid: 412
-    components:
-    - type: Transform
-      pos: -17.5,-3.5
-      parent: 2
-  - uid: 413
-    components:
-    - type: Transform
-      pos: -17.5,-2.5
-      parent: 2
-  - uid: 414
-    components:
-    - type: Transform
-      pos: -17.5,-8.5
-      parent: 2
-  - uid: 415
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
-      parent: 2
-  - uid: 416
-    components:
-    - type: Transform
-      pos: -17.5,-10.5
-      parent: 2
-  - uid: 417
-    components:
-    - type: Transform
-      pos: -17.5,-11.5
-      parent: 2
-  - uid: 418
-    components:
-    - type: Transform
-      pos: -16.5,-11.5
-      parent: 2
-  - uid: 419
-    components:
-    - type: Transform
-      pos: -16.5,-12.5
-      parent: 2
-  - uid: 420
-    components:
-    - type: Transform
-      pos: -17.5,-12.5
-      parent: 2
-  - uid: 422
-    components:
-    - type: Transform
-      pos: -14.5,-7.5
-      parent: 2
-  - uid: 423
-    components:
-    - type: Transform
-      pos: -14.5,-8.5
-      parent: 2
-  - uid: 424
-    components:
-    - type: Transform
-      pos: -14.5,-9.5
-      parent: 2
-  - uid: 425
-    components:
-    - type: Transform
-      pos: -14.5,-6.5
-      parent: 2
-  - uid: 426
-    components:
-    - type: Transform
-      pos: -24.5,-18.5
-      parent: 2
-  - uid: 427
-    components:
-    - type: Transform
-      pos: -25.5,-18.5
-      parent: 2
-  - uid: 428
-    components:
-    - type: Transform
-      pos: -26.5,-17.5
-      parent: 2
-  - uid: 429
-    components:
-    - type: Transform
-      pos: -27.5,-18.5
-      parent: 2
-  - uid: 430
-    components:
-    - type: Transform
-      pos: -25.5,-17.5
-      parent: 2
-  - uid: 431
-    components:
-    - type: Transform
-      pos: -24.5,-12.5
-      parent: 2
-  - uid: 432
-    components:
-    - type: Transform
-      pos: -25.5,-12.5
-      parent: 2
-  - uid: 433
-    components:
-    - type: Transform
-      pos: -26.5,-12.5
-      parent: 2
-  - uid: 435
-    components:
-    - type: Transform
-      pos: -26.5,0.5
-      parent: 2
-  - uid: 436
-    components:
-    - type: Transform
-      pos: -27.5,0.5
-      parent: 2
-  - uid: 437
-    components:
-    - type: Transform
-      pos: -28.5,0.5
-      parent: 2
-  - uid: 438
-    components:
-    - type: Transform
-      pos: -29.5,0.5
-      parent: 2
-  - uid: 439
-    components:
-    - type: Transform
-      pos: -21.5,-1.5
-      parent: 2
-  - uid: 440
-    components:
-    - type: Transform
-      pos: -21.5,-0.5
-      parent: 2
-  - uid: 441
-    components:
-    - type: Transform
-      pos: -21.5,0.5
-      parent: 2
-  - uid: 442
-    components:
-    - type: Transform
-      pos: -21.5,1.5
-      parent: 2
-  - uid: 443
-    components:
-    - type: Transform
-      pos: -21.5,2.5
-      parent: 2
-  - uid: 444
-    components:
-    - type: Transform
-      pos: -13.5,-0.5
-      parent: 2
-  - uid: 445
-    components:
-    - type: Transform
-      pos: -14.5,-0.5
-      parent: 2
-  - uid: 446
-    components:
-    - type: Transform
-      pos: -15.5,-0.5
-      parent: 2
-  - uid: 447
-    components:
-    - type: Transform
-      pos: -15.5,0.5
-      parent: 2
-  - uid: 448
-    components:
-    - type: Transform
-      pos: -15.5,1.5
-      parent: 2
-  - uid: 449
-    components:
-    - type: Transform
-      pos: -15.5,2.5
-      parent: 2
-  - uid: 450
-    components:
-    - type: Transform
-      pos: -14.5,2.5
-      parent: 2
-  - uid: 451
-    components:
-    - type: Transform
-      pos: -13.5,2.5
-      parent: 2
-  - uid: 452
-    components:
-    - type: Transform
-      pos: -12.5,2.5
-      parent: 2
-  - uid: 453
-    components:
-    - type: Transform
-      pos: -11.5,2.5
-      parent: 2
-  - uid: 454
-    components:
-    - type: Transform
-      pos: -8.5,-5.5
-      parent: 2
-  - uid: 455
-    components:
-    - type: Transform
-      pos: -7.5,-5.5
-      parent: 2
-  - uid: 456
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 2
-  - uid: 457
-    components:
-    - type: Transform
-      pos: 3.5,-7.5
-      parent: 2
-  - uid: 458
-    components:
-    - type: Transform
-      pos: 4.5,-7.5
-      parent: 2
-  - uid: 459
-    components:
-    - type: Transform
-      pos: -22.5,-11.5
-      parent: 2
-  - uid: 460
-    components:
-    - type: Transform
-      pos: -22.5,-10.5
-      parent: 2
-  - uid: 461
-    components:
-    - type: Transform
-      pos: -22.5,-9.5
-      parent: 2
-  - uid: 465
-    components:
-    - type: Transform
-      pos: -23.5,-21.5
-      parent: 2
-  - uid: 466
-    components:
-    - type: Transform
-      pos: -16.5,-21.5
-      parent: 2
-  - uid: 467
-    components:
-    - type: Transform
-      pos: -12.5,-7.5
-      parent: 2
-  - uid: 468
-    components:
-    - type: Transform
-      pos: -12.5,-8.5
-      parent: 2
-  - uid: 469
-    components:
-    - type: Transform
-      pos: -12.5,-9.5
-      parent: 2
-  - uid: 470
-    components:
-    - type: Transform
-      pos: -12.5,-10.5
-      parent: 2
-  - uid: 471
-    components:
-    - type: Transform
-      pos: -6.5,-10.5
-      parent: 2
-  - uid: 472
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 2
-  - uid: 473
-    components:
-    - type: Transform
-      pos: -6.5,-8.5
-      parent: 2
-  - uid: 474
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 2
-  - uid: 475
-    components:
-    - type: Transform
-      pos: -26.5,9.5
-      parent: 2
-  - uid: 476
-    components:
-    - type: Transform
-      pos: -27.5,9.5
-      parent: 2
-  - uid: 477
-    components:
-    - type: Transform
-      pos: -29.5,9.5
-      parent: 2
-  - uid: 478
-    components:
-    - type: Transform
-      pos: -29.5,9.5
-      parent: 2
-  - uid: 479
-    components:
-    - type: Transform
-      pos: -16.5,-20.5
-      parent: 2
-  - uid: 480
-    components:
-    - type: Transform
-      pos: -16.5,-19.5
-      parent: 2
-  - uid: 481
-    components:
-    - type: Transform
-      pos: -28.5,-12.5
-      parent: 2
-  - uid: 483
-    components:
-    - type: Transform
-      pos: -29.5,-11.5
-      parent: 2
-  - uid: 484
-    components:
-    - type: Transform
-      pos: -16.5,-18.5
-      parent: 2
-  - uid: 486
-    components:
-    - type: Transform
-      pos: -26.5,-21.5
-      parent: 2
-  - uid: 487
-    components:
-    - type: Transform
-      pos: -26.5,-20.5
-      parent: 2
-  - uid: 488
-    components:
-    - type: Transform
-      pos: -27.5,-21.5
-      parent: 2
-  - uid: 489
-    components:
-    - type: Transform
-      pos: -28.5,-21.5
-      parent: 2
-  - uid: 490
-    components:
-    - type: Transform
-      pos: -27.5,-17.5
-      parent: 2
-  - uid: 491
-    components:
-    - type: Transform
-      pos: -26.5,-19.5
-      parent: 2
-  - uid: 492
-    components:
-    - type: Transform
-      pos: -18.5,-4.5
-      parent: 2
-  - uid: 493
-    components:
-    - type: Transform
-      pos: -19.5,-4.5
-      parent: 2
-  - uid: 494
-    components:
-    - type: Transform
-      pos: -19.5,-3.5
-      parent: 2
-  - uid: 495
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 2
-  - uid: 496
-    components:
-    - type: Transform
-      pos: -2.5,10.5
-      parent: 2
-  - uid: 497
-    components:
-    - type: Transform
-      pos: -1.5,10.5
-      parent: 2
-  - uid: 627
-    components:
-    - type: Transform
-      pos: -27.5,-12.5
-      parent: 2
-  - uid: 726
-    components:
-    - type: Transform
-      pos: -10.5,6.5
-      parent: 2
-  - uid: 1786
-    components:
-    - type: Transform
-      pos: -32.5,8.5
-      parent: 2
-  - uid: 2274
-    components:
-    - type: Transform
-      pos: -29.5,-11.5
-      parent: 2
-  - uid: 2290
-    components:
-    - type: Transform
-      pos: 5.5,4.5
-      parent: 2
-  - uid: 2305
-    components:
-    - type: Transform
-      pos: -7.5,8.5
-      parent: 2
-  - uid: 2306
-    components:
-    - type: Transform
-      pos: -7.5,-1.5
-      parent: 2
-  - uid: 2307
-    components:
-    - type: Transform
-      pos: -7.5,-0.5
-      parent: 2
-  - uid: 2308
-    components:
-    - type: Transform
-      pos: -6.5,-0.5
-      parent: 2
-  - uid: 2309
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 2
-  - uid: 2321
-    components:
-    - type: Transform
-      pos: -7.5,-3.5
-      parent: 2
-  - uid: 2322
-    components:
-    - type: Transform
-      pos: -8.5,-3.5
-      parent: 2
-  - uid: 2323
-    components:
-    - type: Transform
-      pos: -22.5,-2.5
-      parent: 2
-  - uid: 2329
-    components:
-    - type: Transform
-      pos: -17.5,9.5
-      parent: 2
-  - uid: 2330
-    components:
-    - type: Transform
-      pos: -17.5,10.5
-      parent: 2
-  - uid: 2331
-    components:
-    - type: Transform
-      pos: -17.5,11.5
-      parent: 2
-  - uid: 2332
-    components:
-    - type: Transform
-      pos: -18.5,11.5
-      parent: 2
-  - uid: 2333
-    components:
-    - type: Transform
-      pos: -19.5,11.5
-      parent: 2
-  - uid: 2340
-    components:
-    - type: Transform
-      pos: -32.5,9.5
-      parent: 2
-  - uid: 2341
-    components:
-    - type: Transform
-      pos: -32.5,10.5
-      parent: 2
-  - uid: 2342
-    components:
-    - type: Transform
-      pos: -31.5,10.5
-      parent: 2
-  - uid: 2433
-    components:
-    - type: Transform
-      pos: -18.5,12.5
-      parent: 2
-  - uid: 2434
-    components:
-    - type: Transform
-      pos: -18.5,13.5
-      parent: 2
-  - uid: 2500
-    components:
-    - type: Transform
-      pos: -27.5,6.5
-      parent: 2
-  - uid: 2501
-    components:
-    - type: Transform
-      pos: -27.5,7.5
-      parent: 2
-  - uid: 2502
-    components:
-    - type: Transform
-      pos: -27.5,8.5
-      parent: 2
-  - uid: 2503
-    components:
-    - type: Transform
-      pos: -29.5,6.5
-      parent: 2
-  - uid: 2504
-    components:
-    - type: Transform
-      pos: -29.5,7.5
-      parent: 2
-  - uid: 2505
-    components:
-    - type: Transform
-      pos: -29.5,8.5
-      parent: 2
-- proto: CableHV
-  entities:
-  - uid: 391
-    components:
-    - type: Transform
-      pos: -4.5,9.5
-      parent: 2
-  - uid: 392
-    components:
-    - type: Transform
-      pos: -3.5,9.5
-      parent: 2
-  - uid: 394
-    components:
-    - type: Transform
-      pos: -4.5,8.5
-      parent: 2
-  - uid: 395
-    components:
-    - type: Transform
-      pos: -4.5,7.5
-      parent: 2
-  - uid: 396
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 2
-  - uid: 402
-    components:
-    - type: Transform
-      pos: -3.5,5.5
-      parent: 2
-  - uid: 403
-    components:
-    - type: Transform
-      pos: -4.5,5.5
-      parent: 2
-  - uid: 405
-    components:
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 2
-  - uid: 421
-    components:
-    - type: Transform
-      pos: -1.5,9.5
-      parent: 2
-  - uid: 434
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 2
-  - uid: 462
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 2
-  - uid: 463
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 2
-  - uid: 464
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 2
-  - uid: 482
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 2
-  - uid: 485
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 2
-  - uid: 498
-    components:
-    - type: Transform
-      pos: -27.5,1.5
-      parent: 2
-  - uid: 499
-    components:
-    - type: Transform
-      pos: -22.5,1.5
-      parent: 2
-  - uid: 500
-    components:
-    - type: Transform
-      pos: -28.5,1.5
-      parent: 2
-  - uid: 502
-    components:
-    - type: Transform
-      pos: -29.5,0.5
-      parent: 2
-  - uid: 503
-    components:
-    - type: Transform
-      pos: -29.5,-1.5
-      parent: 2
-  - uid: 504
-    components:
-    - type: Transform
-      pos: -29.5,-0.5
-      parent: 2
-  - uid: 505
-    components:
-    - type: Transform
-      pos: -29.5,1.5
-      parent: 2
-  - uid: 506
-    components:
-    - type: Transform
-      pos: -26.5,-1.5
-      parent: 2
-  - uid: 507
-    components:
-    - type: Transform
-      pos: -27.5,-1.5
-      parent: 2
-  - uid: 508
-    components:
-    - type: Transform
-      pos: -22.5,5.5
-      parent: 2
-  - uid: 509
-    components:
-    - type: Transform
-      pos: -28.5,-0.5
-      parent: 2
-  - uid: 510
-    components:
-    - type: Transform
-      pos: -28.5,-1.5
-      parent: 2
-  - uid: 511
-    components:
-    - type: Transform
-      pos: -26.5,1.5
-      parent: 2
-  - uid: 512
-    components:
-    - type: Transform
-      pos: -26.5,2.5
-      parent: 2
-  - uid: 513
-    components:
-    - type: Transform
-      pos: 3.5,1.5
-      parent: 2
-  - uid: 514
-    components:
-    - type: Transform
-      pos: -25.5,-1.5
-      parent: 2
-  - uid: 515
-    components:
-    - type: Transform
-      pos: -25.5,-0.5
-      parent: 2
-  - uid: 516
-    components:
-    - type: Transform
-      pos: -25.5,0.5
-      parent: 2
-  - uid: 517
-    components:
-    - type: Transform
-      pos: -24.5,0.5
-      parent: 2
-  - uid: 518
-    components:
-    - type: Transform
-      pos: -23.5,0.5
-      parent: 2
-  - uid: 519
-    components:
-    - type: Transform
-      pos: -22.5,0.5
-      parent: 2
-  - uid: 520
-    components:
-    - type: Transform
-      pos: -21.5,0.5
-      parent: 2
-  - uid: 521
-    components:
-    - type: Transform
-      pos: -26.5,3.5
-      parent: 2
-  - uid: 522
-    components:
-    - type: Transform
-      pos: -26.5,4.5
-      parent: 2
-  - uid: 523
-    components:
-    - type: Transform
-      pos: -26.5,5.5
-      parent: 2
-  - uid: 524
-    components:
-    - type: Transform
-      pos: -27.5,5.5
-      parent: 2
-  - uid: 525
-    components:
-    - type: Transform
-      pos: -28.5,5.5
-      parent: 2
-  - uid: 526
-    components:
-    - type: Transform
-      pos: -28.5,4.5
-      parent: 2
-  - uid: 527
-    components:
-    - type: Transform
-      pos: -28.5,3.5
-      parent: 2
-  - uid: 528
-    components:
-    - type: Transform
-      pos: -22.5,2.5
-      parent: 2
-  - uid: 529
-    components:
-    - type: Transform
-      pos: -22.5,3.5
-      parent: 2
-  - uid: 530
-    components:
-    - type: Transform
-      pos: -22.5,4.5
-      parent: 2
-  - uid: 531
-    components:
-    - type: Transform
-      pos: 0.5,10.5
-      parent: 2
-  - uid: 532
-    components:
-    - type: Transform
-      pos: 1.5,10.5
-      parent: 2
-  - uid: 533
-    components:
-    - type: Transform
-      pos: 2.5,10.5
-      parent: 2
-  - uid: 534
-    components:
-    - type: Transform
-      pos: 3.5,10.5
-      parent: 2
-  - uid: 535
-    components:
-    - type: Transform
-      pos: 4.5,10.5
-      parent: 2
-  - uid: 536
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 2
-  - uid: 537
-    components:
-    - type: Transform
-      pos: 1.5,8.5
-      parent: 2
-  - uid: 538
-    components:
-    - type: Transform
-      pos: 2.5,8.5
-      parent: 2
-  - uid: 539
-    components:
-    - type: Transform
-      pos: 3.5,8.5
-      parent: 2
-  - uid: 540
-    components:
-    - type: Transform
-      pos: 4.5,8.5
-      parent: 2
-  - uid: 541
-    components:
-    - type: Transform
-      pos: 2.5,9.5
-      parent: 2
-  - uid: 542
-    components:
-    - type: Transform
-      pos: -22.5,6.5
-      parent: 2
-  - uid: 543
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 2
-  - uid: 544
-    components:
-    - type: Transform
-      pos: -1.5,8.5
-      parent: 2
-  - uid: 546
-    components:
-    - type: Transform
-      pos: -21.5,-0.5
-      parent: 2
-  - uid: 547
-    components:
-    - type: Transform
-      pos: -21.5,-1.5
-      parent: 2
-  - uid: 548
-    components:
-    - type: Transform
-      pos: -21.5,-2.5
-      parent: 2
-  - uid: 549
-    components:
-    - type: Transform
-      pos: -21.5,-3.5
-      parent: 2
-  - uid: 550
-    components:
-    - type: Transform
-      pos: -21.5,-4.5
-      parent: 2
-  - uid: 551
-    components:
-    - type: Transform
-      pos: -21.5,-5.5
-      parent: 2
-  - uid: 552
-    components:
-    - type: Transform
-      pos: -21.5,-6.5
-      parent: 2
-  - uid: 553
-    components:
-    - type: Transform
-      pos: -21.5,-7.5
-      parent: 2
-  - uid: 554
-    components:
-    - type: Transform
-      pos: -21.5,-8.5
-      parent: 2
-  - uid: 555
-    components:
-    - type: Transform
-      pos: -21.5,-9.5
-      parent: 2
-  - uid: 556
-    components:
-    - type: Transform
-      pos: -21.5,-10.5
-      parent: 2
-  - uid: 557
-    components:
-    - type: Transform
-      pos: -22.5,-8.5
-      parent: 2
-  - uid: 558
-    components:
-    - type: Transform
-      pos: -23.5,-8.5
-      parent: 2
-  - uid: 559
-    components:
-    - type: Transform
-      pos: -24.5,-8.5
-      parent: 2
-  - uid: 560
-    components:
-    - type: Transform
-      pos: -25.5,-8.5
-      parent: 2
-  - uid: 561
-    components:
-    - type: Transform
-      pos: -26.5,-8.5
-      parent: 2
-  - uid: 562
-    components:
-    - type: Transform
-      pos: -27.5,-8.5
-      parent: 2
-  - uid: 563
-    components:
-    - type: Transform
-      pos: -27.5,-9.5
-      parent: 2
-  - uid: 564
-    components:
-    - type: Transform
-      pos: -28.5,-9.5
-      parent: 2
-  - uid: 565
-    components:
-    - type: Transform
-      pos: -28.5,-10.5
-      parent: 2
-  - uid: 566
-    components:
-    - type: Transform
-      pos: -21.5,-11.5
-      parent: 2
-  - uid: 567
-    components:
-    - type: Transform
-      pos: -21.5,-12.5
-      parent: 2
-  - uid: 568
-    components:
-    - type: Transform
-      pos: -21.5,-13.5
-      parent: 2
-  - uid: 569
-    components:
-    - type: Transform
-      pos: -21.5,-14.5
-      parent: 2
-  - uid: 570
-    components:
-    - type: Transform
-      pos: -21.5,-15.5
-      parent: 2
-  - uid: 571
-    components:
-    - type: Transform
-      pos: -21.5,-16.5
-      parent: 2
-  - uid: 572
-    components:
-    - type: Transform
-      pos: -21.5,-17.5
-      parent: 2
-  - uid: 573
-    components:
-    - type: Transform
-      pos: -21.5,-18.5
-      parent: 2
-  - uid: 574
-    components:
-    - type: Transform
-      pos: -20.5,-18.5
-      parent: 2
-  - uid: 575
-    components:
-    - type: Transform
-      pos: -19.5,-18.5
-      parent: 2
-  - uid: 576
-    components:
-    - type: Transform
-      pos: -18.5,-18.5
-      parent: 2
-  - uid: 577
-    components:
-    - type: Transform
-      pos: -18.5,-17.5
-      parent: 2
-  - uid: 578
-    components:
-    - type: Transform
-      pos: -20.5,0.5
-      parent: 2
-  - uid: 579
-    components:
-    - type: Transform
-      pos: -19.5,0.5
-      parent: 2
-  - uid: 580
-    components:
-    - type: Transform
-      pos: -18.5,0.5
-      parent: 2
-  - uid: 581
-    components:
-    - type: Transform
-      pos: -17.5,0.5
-      parent: 2
-  - uid: 582
-    components:
-    - type: Transform
-      pos: -16.5,0.5
-      parent: 2
-  - uid: 583
-    components:
-    - type: Transform
-      pos: -15.5,0.5
-      parent: 2
-  - uid: 584
-    components:
-    - type: Transform
-      pos: -14.5,0.5
-      parent: 2
-  - uid: 585
-    components:
-    - type: Transform
-      pos: -13.5,0.5
-      parent: 2
-  - uid: 586
-    components:
-    - type: Transform
-      pos: -12.5,0.5
-      parent: 2
-  - uid: 587
-    components:
-    - type: Transform
-      pos: -11.5,0.5
-      parent: 2
-  - uid: 588
-    components:
-    - type: Transform
-      pos: -10.5,0.5
-      parent: 2
-  - uid: 589
-    components:
-    - type: Transform
-      pos: -9.5,0.5
-      parent: 2
-  - uid: 590
-    components:
-    - type: Transform
-      pos: -8.5,0.5
-      parent: 2
-  - uid: 591
-    components:
-    - type: Transform
-      pos: -7.5,0.5
-      parent: 2
-  - uid: 592
-    components:
-    - type: Transform
-      pos: -6.5,0.5
-      parent: 2
-  - uid: 593
-    components:
-    - type: Transform
-      pos: -6.5,-0.5
-      parent: 2
-  - uid: 594
-    components:
-    - type: Transform
-      pos: -6.5,-1.5
-      parent: 2
-  - uid: 595
-    components:
-    - type: Transform
-      pos: -6.5,-2.5
-      parent: 2
-  - uid: 596
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 2
-  - uid: 597
-    components:
-    - type: Transform
-      pos: -5.5,0.5
-      parent: 2
-  - uid: 598
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 2
-  - uid: 599
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 2
-  - uid: 600
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 2
-  - uid: 601
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 2
-  - uid: 602
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 2
-  - uid: 603
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 2
-  - uid: 604
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 2
-  - uid: 605
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 2
-  - uid: 606
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 2
-  - uid: 607
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 2
-  - uid: 608
-    components:
-    - type: Transform
-      pos: 3.5,2.5
-      parent: 2
-  - uid: 609
-    components:
-    - type: Transform
-      pos: 3.5,3.5
-      parent: 2
-  - uid: 616
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 2
-  - uid: 617
-    components:
-    - type: Transform
-      pos: -22.5,-3.5
-      parent: 2
-  - uid: 618
-    components:
-    - type: Transform
-      pos: -23.5,-3.5
-      parent: 2
-  - uid: 619
-    components:
-    - type: Transform
-      pos: -0.5,8.5
-      parent: 2
-  - uid: 620
-    components:
-    - type: Transform
-      pos: -22.5,-18.5
-      parent: 2
-  - uid: 621
-    components:
-    - type: Transform
-      pos: -22.5,-19.5
-      parent: 2
-  - uid: 622
-    components:
-    - type: Transform
-      pos: -22.5,-20.5
-      parent: 2
-  - uid: 623
-    components:
-    - type: Transform
-      pos: -23.5,-20.5
-      parent: 2
-  - uid: 624
-    components:
-    - type: Transform
-      pos: -24.5,-20.5
-      parent: 2
-  - uid: 625
-    components:
-    - type: Transform
-      pos: -25.5,-20.5
-      parent: 2
-  - uid: 626
-    components:
-    - type: Transform
-      pos: -25.5,-19.5
-      parent: 2
-  - uid: 1357
-    components:
-    - type: Transform
-      pos: -29.5,-2.5
-      parent: 2
-  - uid: 1455
-    components:
-    - type: Transform
-      pos: -28.5,-2.5
-      parent: 2
-  - uid: 1853
-    components:
-    - type: Transform
-      pos: -29.5,3.5
-      parent: 2
-  - uid: 2473
-    components:
-    - type: Transform
-      pos: -25.5,5.5
-      parent: 2
-  - uid: 2474
-    components:
-    - type: Transform
-      pos: -25.5,6.5
-      parent: 2
-  - uid: 2475
-    components:
-    - type: Transform
-      pos: -25.5,7.5
-      parent: 2
-- proto: CableMV
-  entities:
-  - uid: 172
-    components:
-    - type: Transform
-      pos: -30.5,-11.5
+      pos: -12.5,8.5
       parent: 2
   - uid: 285
     components:
     - type: Transform
-      pos: -7.5,5.5
+      pos: -12.5,9.5
       parent: 2
-  - uid: 345
+  - uid: 286
     components:
     - type: Transform
-      pos: -29.5,-11.5
+      pos: -15.5,6.5
       parent: 2
-  - uid: 628
+  - uid: 287
     components:
     - type: Transform
-      pos: -28.5,-10.5
+      pos: -15.5,7.5
       parent: 2
-  - uid: 629
+  - uid: 288
     components:
     - type: Transform
-      pos: -27.5,-10.5
+      pos: -16.5,7.5
       parent: 2
-  - uid: 630
+  - uid: 289
     components:
     - type: Transform
-      pos: -28.5,-11.5
+      pos: -16.5,8.5
       parent: 2
-  - uid: 631
+  - uid: 290
     components:
     - type: Transform
-      pos: -28.5,-12.5
+      pos: -6.5,1.5
       parent: 2
-  - uid: 632
+  - uid: 291
     components:
     - type: Transform
-      pos: -27.5,-12.5
+      pos: -17.5,8.5
       parent: 2
-  - uid: 633
+  - uid: 292
     components:
     - type: Transform
-      pos: -27.5,-13.5
+      pos: -18.5,8.5
       parent: 2
-  - uid: 634
+  - uid: 293
     components:
     - type: Transform
-      pos: -18.5,-17.5
+      pos: -19.5,8.5
       parent: 2
-  - uid: 635
+  - uid: 294
     components:
     - type: Transform
-      pos: -19.5,-17.5
+      pos: -20.5,8.5
       parent: 2
-  - uid: 636
+  - uid: 295
     components:
     - type: Transform
-      pos: -22.5,6.5
+      pos: -4.5,6.5
       parent: 2
-  - uid: 637
+  - uid: 296
     components:
     - type: Transform
-      pos: -22.5,5.5
+      pos: -21.5,8.5
       parent: 2
-  - uid: 638
+  - uid: 297
     components:
     - type: Transform
-      pos: -22.5,4.5
+      pos: -25.5,8.5
       parent: 2
-  - uid: 639
+  - uid: 298
     components:
     - type: Transform
-      pos: -23.5,4.5
+      pos: -25.5,9.5
       parent: 2
-  - uid: 640
-    components:
-    - type: Transform
-      pos: -24.5,4.5
-      parent: 2
-  - uid: 641
-    components:
-    - type: Transform
-      pos: -25.5,4.5
-      parent: 2
-  - uid: 642
-    components:
-    - type: Transform
-      pos: -25.5,5.5
-      parent: 2
-  - uid: 643
-    components:
-    - type: Transform
-      pos: -25.5,6.5
-      parent: 2
-  - uid: 644
-    components:
-    - type: Transform
-      pos: -24.5,6.5
-      parent: 2
-  - uid: 645
-    components:
-    - type: Transform
-      pos: -22.5,3.5
-      parent: 2
-  - uid: 646
-    components:
-    - type: Transform
-      pos: -22.5,2.5
-      parent: 2
-  - uid: 647
-    components:
-    - type: Transform
-      pos: -22.5,1.5
-      parent: 2
-  - uid: 648
-    components:
-    - type: Transform
-      pos: -21.5,1.5
-      parent: 2
-  - uid: 649
-    components:
-    - type: Transform
-      pos: -20.5,1.5
-      parent: 2
-  - uid: 650
-    components:
-    - type: Transform
-      pos: -19.5,1.5
-      parent: 2
-  - uid: 651
-    components:
-    - type: Transform
-      pos: -19.5,2.5
-      parent: 2
-  - uid: 652
-    components:
-    - type: Transform
-      pos: -19.5,3.5
-      parent: 2
-  - uid: 653
-    components:
-    - type: Transform
-      pos: -19.5,4.5
-      parent: 2
-  - uid: 654
-    components:
-    - type: Transform
-      pos: -18.5,4.5
-      parent: 2
-  - uid: 655
-    components:
-    - type: Transform
-      pos: -17.5,4.5
-      parent: 2
-  - uid: 656
-    components:
-    - type: Transform
-      pos: -16.5,4.5
-      parent: 2
-  - uid: 657
-    components:
-    - type: Transform
-      pos: -15.5,4.5
-      parent: 2
-  - uid: 658
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 2
-  - uid: 659
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 2
-  - uid: 660
-    components:
-    - type: Transform
-      pos: 2.5,4.5
-      parent: 2
-  - uid: 661
+  - uid: 299
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 662
+  - uid: 300
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 3.5,5.5
       parent: 2
-  - uid: 663
+  - uid: 301
     components:
     - type: Transform
-      pos: 0.5,4.5
+      pos: 3.5,6.5
       parent: 2
-  - uid: 664
+  - uid: 302
     components:
     - type: Transform
-      pos: 0.5,5.5
+      pos: 2.5,6.5
       parent: 2
-  - uid: 665
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 306
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 666
+  - uid: 307
     components:
     - type: Transform
-      pos: -1.5,5.5
+      pos: -4.5,8.5
       parent: 2
-  - uid: 667
+  - uid: 308
     components:
     - type: Transform
-      pos: -2.5,5.5
+      pos: -4.5,7.5
       parent: 2
-  - uid: 668
+  - uid: 309
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
-  - uid: 669
+  - uid: 310
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
-  - uid: 670
+  - uid: 311
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 2
-  - uid: 671
+  - uid: 312
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 2
-  - uid: 672
+  - uid: 313
     components:
     - type: Transform
-      pos: -6.5,4.5
+      pos: -8.5,6.5
       parent: 2
-  - uid: 673
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 2
-  - uid: 674
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 2
-  - uid: 675
-    components:
-    - type: Transform
-      pos: -6.5,-4.5
-      parent: 2
-  - uid: 676
-    components:
-    - type: Transform
-      pos: -6.5,-5.5
-      parent: 2
-  - uid: 677
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 2
-  - uid: 678
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 2
-  - uid: 679
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 2
-  - uid: 680
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 2
-  - uid: 681
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 2
-  - uid: 682
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 2
-  - uid: 683
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 2
-  - uid: 684
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 2
-  - uid: 685
-    components:
-    - type: Transform
-      pos: 2.5,-5.5
-      parent: 2
-  - uid: 686
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 2
-  - uid: 687
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 2
-  - uid: 688
-    components:
-    - type: Transform
-      pos: -7.5,-5.5
-      parent: 2
-  - uid: 689
-    components:
-    - type: Transform
-      pos: -8.5,-5.5
-      parent: 2
-  - uid: 690
-    components:
-    - type: Transform
-      pos: -9.5,-5.5
-      parent: 2
-  - uid: 691
-    components:
-    - type: Transform
-      pos: -10.5,-5.5
-      parent: 2
-  - uid: 692
-    components:
-    - type: Transform
-      pos: -11.5,-5.5
-      parent: 2
-  - uid: 693
-    components:
-    - type: Transform
-      pos: -12.5,-5.5
-      parent: 2
-  - uid: 694
-    components:
-    - type: Transform
-      pos: -13.5,-5.5
-      parent: 2
-  - uid: 695
-    components:
-    - type: Transform
-      pos: -20.5,-17.5
-      parent: 2
-  - uid: 696
-    components:
-    - type: Transform
-      pos: -20.5,-16.5
-      parent: 2
-  - uid: 697
-    components:
-    - type: Transform
-      pos: -20.5,-15.5
-      parent: 2
-  - uid: 698
-    components:
-    - type: Transform
-      pos: -20.5,-14.5
-      parent: 2
-  - uid: 699
-    components:
-    - type: Transform
-      pos: -20.5,-13.5
-      parent: 2
-  - uid: 700
-    components:
-    - type: Transform
-      pos: -20.5,-12.5
-      parent: 2
-  - uid: 701
-    components:
-    - type: Transform
-      pos: -20.5,-11.5
-      parent: 2
-  - uid: 702
-    components:
-    - type: Transform
-      pos: -20.5,-10.5
-      parent: 2
-  - uid: 703
-    components:
-    - type: Transform
-      pos: -20.5,-9.5
-      parent: 2
-  - uid: 704
-    components:
-    - type: Transform
-      pos: -20.5,-8.5
-      parent: 2
-  - uid: 705
-    components:
-    - type: Transform
-      pos: -20.5,-7.5
-      parent: 2
-  - uid: 706
-    components:
-    - type: Transform
-      pos: -19.5,-7.5
-      parent: 2
-  - uid: 707
-    components:
-    - type: Transform
-      pos: -18.5,-7.5
-      parent: 2
-  - uid: 708
-    components:
-    - type: Transform
-      pos: -17.5,-7.5
-      parent: 2
-  - uid: 709
-    components:
-    - type: Transform
-      pos: -16.5,-7.5
-      parent: 2
-  - uid: 710
-    components:
-    - type: Transform
-      pos: -6.5,-6.5
-      parent: 2
-  - uid: 711
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 2
-  - uid: 712
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 2
-  - uid: 713
-    components:
-    - type: Transform
-      pos: -6.5,-8.5
-      parent: 2
-  - uid: 714
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 2
-  - uid: 715
-    components:
-    - type: Transform
-      pos: -23.5,-3.5
-      parent: 2
-  - uid: 716
-    components:
-    - type: Transform
-      pos: -23.5,-2.5
-      parent: 2
-  - uid: 717
-    components:
-    - type: Transform
-      pos: -25.5,-19.5
-      parent: 2
-  - uid: 718
-    components:
-    - type: Transform
-      pos: -26.5,-19.5
-      parent: 2
-  - uid: 719
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 2
-  - uid: 720
-    components:
-    - type: Transform
-      pos: -2.5,10.5
-      parent: 2
-  - uid: 1589
-    components:
-    - type: Transform
-      pos: -6.5,-10.5
-      parent: 2
-  - uid: 2275
-    components:
-    - type: Transform
-      pos: -8.5,-4.5
-      parent: 2
-  - uid: 2276
-    components:
-    - type: Transform
-      pos: -8.5,-3.5
-      parent: 2
-  - uid: 2277
-    components:
-    - type: Transform
-      pos: -7.5,-3.5
-      parent: 2
-  - uid: 2278
-    components:
-    - type: Transform
-      pos: -12.5,-1.5
-      parent: 2
-  - uid: 2279
-    components:
-    - type: Transform
-      pos: -12.5,-0.5
-      parent: 2
-  - uid: 2280
-    components:
-    - type: Transform
-      pos: -12.5,0.5
-      parent: 2
-  - uid: 2281
-    components:
-    - type: Transform
-      pos: -12.5,1.5
-      parent: 2
-  - uid: 2282
-    components:
-    - type: Transform
-      pos: -13.5,1.5
-      parent: 2
-  - uid: 2283
-    components:
-    - type: Transform
-      pos: -14.5,1.5
-      parent: 2
-  - uid: 2284
-    components:
-    - type: Transform
-      pos: -15.5,1.5
-      parent: 2
-  - uid: 2285
-    components:
-    - type: Transform
-      pos: -16.5,1.5
-      parent: 2
-  - uid: 2286
-    components:
-    - type: Transform
-      pos: -17.5,1.5
-      parent: 2
-  - uid: 2287
-    components:
-    - type: Transform
-      pos: -18.5,1.5
-      parent: 2
-  - uid: 2288
-    components:
-    - type: Transform
-      pos: -7.5,6.5
-      parent: 2
-  - uid: 2303
-    components:
-    - type: Transform
-      pos: 5.5,4.5
-      parent: 2
-  - uid: 2310
-    components:
-    - type: Transform
-      pos: -8.5,-1.5
-      parent: 2
-  - uid: 2311
-    components:
-    - type: Transform
-      pos: -8.5,-0.5
-      parent: 2
-  - uid: 2312
-    components:
-    - type: Transform
-      pos: -7.5,-1.5
-      parent: 2
-  - uid: 2313
-    components:
-    - type: Transform
-      pos: -9.5,-0.5
-      parent: 2
-  - uid: 2314
-    components:
-    - type: Transform
-      pos: -10.5,-0.5
-      parent: 2
-  - uid: 2315
-    components:
-    - type: Transform
-      pos: -11.5,-0.5
-      parent: 2
-  - uid: 2316
-    components:
-    - type: Transform
-      pos: -29.5,-13.5
-      parent: 2
-  - uid: 2317
-    components:
-    - type: Transform
-      pos: -29.5,-12.5
-      parent: 2
-  - uid: 2524
-    components:
-    - type: Transform
-      pos: -8.5,5.5
-      parent: 2
-  - uid: 2525
+  - uid: 314
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
-  - uid: 2526
+  - uid: 315
     components:
     - type: Transform
       pos: -9.5,6.5
       parent: 2
-  - uid: 2527
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 2
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 2
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 2
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 2
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 2
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 324
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 325
+    components:
+    - type: Transform
+      pos: -21.5,-3.5
+      parent: 2
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 346
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 2
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -21.5,-3.5
+      parent: 2
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 2
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 2
+  - uid: 360
+    components:
+    - type: Transform
+      pos: -14.5,-5.5
+      parent: 2
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -14.5,-6.5
+      parent: 2
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -14.5,-4.5
+      parent: 2
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -14.5,-3.5
+      parent: 2
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -14.5,-2.5
+      parent: 2
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 2
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -21.5,-4.5
+      parent: 2
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 370
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 376
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 383
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 2
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 2
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -26.5,5.5
+      parent: 2
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -28.5,5.5
+      parent: 2
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -27.5,5.5
+      parent: 2
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -29.5,5.5
+      parent: 2
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -30.5,5.5
+      parent: 2
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -31.5,5.5
+      parent: 2
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -32.5,5.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -33.5,5.5
+      parent: 2
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -34.5,5.5
+      parent: 2
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -35.5,5.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -35.5,6.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -35.5,7.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -35.5,8.5
+      parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -32.5,6.5
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -32.5,7.5
+      parent: 2
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -32.5,4.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -32.5,3.5
+      parent: 2
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 410
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -28.5,-11.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 420
+    components:
+    - type: Transform
+      pos: -23.5,-2.5
+      parent: 2
+  - uid: 421
+    components:
+    - type: Transform
+      pos: -21.5,-2.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -16.5,-7.5
+      parent: 2
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -17.5,-7.5
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -17.5,-6.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -17.5,-5.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -17.5,-4.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -17.5,-3.5
+      parent: 2
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -17.5,-8.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -17.5,-9.5
+      parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -17.5,-10.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -17.5,-11.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -16.5,-11.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -16.5,-12.5
+      parent: 2
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -17.5,-12.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -14.5,-7.5
+      parent: 2
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -14.5,-8.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -14.5,-9.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -14.5,-6.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -24.5,-18.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -25.5,-18.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -26.5,-17.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      pos: -27.5,-18.5
+      parent: 2
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -25.5,-17.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -24.5,-12.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -25.5,-12.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -26.5,-12.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      pos: -26.5,0.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: -27.5,0.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -28.5,0.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -29.5,0.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -21.5,-1.5
+      parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -21.5,-0.5
+      parent: 2
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -21.5,0.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -21.5,1.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -21.5,2.5
+      parent: 2
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -15.5,2.5
+      parent: 2
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -14.5,2.5
+      parent: 2
+  - uid: 458
+    components:
+    - type: Transform
+      pos: -13.5,2.5
+      parent: 2
+  - uid: 459
+    components:
+    - type: Transform
+      pos: -12.5,2.5
+      parent: 2
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 2
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -22.5,-11.5
+      parent: 2
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -22.5,-10.5
+      parent: 2
+  - uid: 468
+    components:
+    - type: Transform
+      pos: -22.5,-9.5
+      parent: 2
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -23.5,-21.5
+      parent: 2
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -16.5,-21.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -12.5,-8.5
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 2
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -12.5,-10.5
+      parent: 2
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -26.5,9.5
+      parent: 2
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -27.5,9.5
+      parent: 2
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -29.5,9.5
+      parent: 2
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -29.5,9.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -16.5,-20.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -16.5,-19.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -28.5,-12.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -29.5,-11.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -16.5,-18.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -26.5,-21.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -26.5,-20.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -27.5,-21.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -28.5,-21.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -27.5,-17.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -26.5,-19.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -18.5,-4.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -19.5,-4.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -19.5,-3.5
+      parent: 2
+  - uid: 497
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      pos: -27.5,-12.5
+      parent: 2
+  - uid: 501
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 2
-  - uid: 2528
+  - uid: 502
+    components:
+    - type: Transform
+      pos: -32.5,8.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: -29.5,-11.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 505
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 506
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 511
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 512
+    components:
+    - type: Transform
+      pos: -22.5,-2.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      pos: -17.5,9.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      pos: -17.5,10.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -17.5,11.5
+      parent: 2
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -18.5,11.5
+      parent: 2
+  - uid: 517
+    components:
+    - type: Transform
+      pos: -19.5,11.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      pos: -32.5,9.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -32.5,10.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -31.5,10.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -18.5,12.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -18.5,13.5
+      parent: 2
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -27.5,6.5
+      parent: 2
+  - uid: 524
+    components:
+    - type: Transform
+      pos: -27.5,7.5
+      parent: 2
+  - uid: 525
+    components:
+    - type: Transform
+      pos: -27.5,8.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -29.5,6.5
+      parent: 2
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -29.5,7.5
+      parent: 2
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -29.5,8.5
+      parent: 2
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 533
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 538
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 2
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 543
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -27.5,1.5
+      parent: 2
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -22.5,1.5
+      parent: 2
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -28.5,1.5
+      parent: 2
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -29.5,0.5
+      parent: 2
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -29.5,-1.5
+      parent: 2
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -29.5,-0.5
+      parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      pos: -29.5,1.5
+      parent: 2
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -26.5,-1.5
+      parent: 2
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -27.5,-1.5
+      parent: 2
+  - uid: 555
+    components:
+    - type: Transform
+      pos: -22.5,5.5
+      parent: 2
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -28.5,-0.5
+      parent: 2
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -28.5,-1.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -26.5,1.5
+      parent: 2
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -26.5,2.5
+      parent: 2
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -25.5,-1.5
+      parent: 2
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -25.5,-0.5
+      parent: 2
+  - uid: 563
+    components:
+    - type: Transform
+      pos: -25.5,0.5
+      parent: 2
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -24.5,0.5
+      parent: 2
+  - uid: 565
+    components:
+    - type: Transform
+      pos: -23.5,0.5
+      parent: 2
+  - uid: 566
+    components:
+    - type: Transform
+      pos: -22.5,0.5
+      parent: 2
+  - uid: 567
+    components:
+    - type: Transform
+      pos: -21.5,0.5
+      parent: 2
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -26.5,3.5
+      parent: 2
+  - uid: 569
+    components:
+    - type: Transform
+      pos: -26.5,4.5
+      parent: 2
+  - uid: 570
+    components:
+    - type: Transform
+      pos: -26.5,5.5
+      parent: 2
+  - uid: 571
+    components:
+    - type: Transform
+      pos: -27.5,5.5
+      parent: 2
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -28.5,5.5
+      parent: 2
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -28.5,4.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      pos: -28.5,3.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: -22.5,2.5
+      parent: 2
+  - uid: 576
+    components:
+    - type: Transform
+      pos: -22.5,3.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: -22.5,4.5
+      parent: 2
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 2
+  - uid: 581
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 2
+  - uid: 583
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 2
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 2
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 2
+  - uid: 586
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 2
+  - uid: 587
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 2
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 2
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -22.5,6.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -21.5,-0.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -21.5,-1.5
+      parent: 2
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -21.5,-2.5
+      parent: 2
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -21.5,-3.5
+      parent: 2
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -21.5,-4.5
+      parent: 2
+  - uid: 597
+    components:
+    - type: Transform
+      pos: -21.5,-5.5
+      parent: 2
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -21.5,-6.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      pos: -21.5,-7.5
+      parent: 2
+  - uid: 600
+    components:
+    - type: Transform
+      pos: -21.5,-8.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: -21.5,-9.5
+      parent: 2
+  - uid: 602
+    components:
+    - type: Transform
+      pos: -21.5,-10.5
+      parent: 2
+  - uid: 603
+    components:
+    - type: Transform
+      pos: -22.5,-8.5
+      parent: 2
+  - uid: 604
+    components:
+    - type: Transform
+      pos: -23.5,-8.5
+      parent: 2
+  - uid: 605
+    components:
+    - type: Transform
+      pos: -24.5,-8.5
+      parent: 2
+  - uid: 606
+    components:
+    - type: Transform
+      pos: -25.5,-8.5
+      parent: 2
+  - uid: 607
+    components:
+    - type: Transform
+      pos: -26.5,-8.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      pos: -27.5,-8.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      pos: -27.5,-9.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      pos: -28.5,-9.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      pos: -28.5,-10.5
+      parent: 2
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -21.5,-11.5
+      parent: 2
+  - uid: 613
+    components:
+    - type: Transform
+      pos: -21.5,-12.5
+      parent: 2
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -21.5,-13.5
+      parent: 2
+  - uid: 615
+    components:
+    - type: Transform
+      pos: -21.5,-14.5
+      parent: 2
+  - uid: 616
+    components:
+    - type: Transform
+      pos: -21.5,-15.5
+      parent: 2
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -21.5,-16.5
+      parent: 2
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -21.5,-17.5
+      parent: 2
+  - uid: 619
+    components:
+    - type: Transform
+      pos: -21.5,-18.5
+      parent: 2
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -20.5,-18.5
+      parent: 2
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -19.5,-18.5
+      parent: 2
+  - uid: 622
+    components:
+    - type: Transform
+      pos: -18.5,-18.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
+      pos: -18.5,-17.5
+      parent: 2
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -20.5,0.5
+      parent: 2
+  - uid: 625
+    components:
+    - type: Transform
+      pos: -19.5,0.5
+      parent: 2
+  - uid: 626
+    components:
+    - type: Transform
+      pos: -18.5,0.5
+      parent: 2
+  - uid: 627
+    components:
+    - type: Transform
+      pos: -17.5,0.5
+      parent: 2
+  - uid: 628
+    components:
+    - type: Transform
+      pos: -16.5,0.5
+      parent: 2
+  - uid: 629
+    components:
+    - type: Transform
+      pos: -15.5,0.5
+      parent: 2
+  - uid: 630
+    components:
+    - type: Transform
+      pos: -14.5,0.5
+      parent: 2
+  - uid: 631
+    components:
+    - type: Transform
+      pos: -13.5,0.5
+      parent: 2
+  - uid: 632
+    components:
+    - type: Transform
+      pos: -12.5,0.5
+      parent: 2
+  - uid: 633
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 2
+  - uid: 634
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 638
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 639
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 640
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 2
+  - uid: 641
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 642
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 643
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 644
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 645
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 646
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 647
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 648
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 652
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 654
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 655
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 656
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 657
+    components:
+    - type: Transform
+      pos: -22.5,-3.5
+      parent: 2
+  - uid: 658
+    components:
+    - type: Transform
+      pos: -23.5,-3.5
+      parent: 2
+  - uid: 659
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 660
+    components:
+    - type: Transform
+      pos: -22.5,-18.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      pos: -22.5,-19.5
+      parent: 2
+  - uid: 662
+    components:
+    - type: Transform
+      pos: -22.5,-20.5
+      parent: 2
+  - uid: 663
+    components:
+    - type: Transform
+      pos: -23.5,-20.5
+      parent: 2
+  - uid: 664
+    components:
+    - type: Transform
+      pos: -24.5,-20.5
+      parent: 2
+  - uid: 665
+    components:
+    - type: Transform
+      pos: -25.5,-20.5
+      parent: 2
+  - uid: 666
+    components:
+    - type: Transform
+      pos: -25.5,-19.5
+      parent: 2
+  - uid: 667
+    components:
+    - type: Transform
+      pos: -29.5,-2.5
+      parent: 2
+  - uid: 668
+    components:
+    - type: Transform
+      pos: -28.5,-2.5
+      parent: 2
+  - uid: 669
+    components:
+    - type: Transform
+      pos: -29.5,3.5
+      parent: 2
+  - uid: 670
+    components:
+    - type: Transform
+      pos: -25.5,5.5
+      parent: 2
+  - uid: 671
+    components:
+    - type: Transform
+      pos: -25.5,6.5
+      parent: 2
+  - uid: 672
+    components:
+    - type: Transform
+      pos: -25.5,7.5
+      parent: 2
+- proto: CableHVStack
+  entities:
+  - uid: 673
+    components:
+    - type: Transform
+      pos: -22.49179,5.414856
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 674
+    components:
+    - type: Transform
+      pos: -30.5,-11.5
+      parent: 2
+  - uid: 675
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 676
+    components:
+    - type: Transform
+      pos: -29.5,-11.5
+      parent: 2
+  - uid: 677
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 2
+  - uid: 678
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 679
+    components:
+    - type: Transform
+      pos: -28.5,-10.5
+      parent: 2
+  - uid: 680
+    components:
+    - type: Transform
+      pos: -27.5,-10.5
+      parent: 2
+  - uid: 681
+    components:
+    - type: Transform
+      pos: -28.5,-11.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      pos: -28.5,-12.5
+      parent: 2
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -27.5,-12.5
+      parent: 2
+  - uid: 684
+    components:
+    - type: Transform
+      pos: -27.5,-13.5
+      parent: 2
+  - uid: 685
+    components:
+    - type: Transform
+      pos: -18.5,-17.5
+      parent: 2
+  - uid: 686
+    components:
+    - type: Transform
+      pos: -19.5,-17.5
+      parent: 2
+  - uid: 687
+    components:
+    - type: Transform
+      pos: -22.5,6.5
+      parent: 2
+  - uid: 688
+    components:
+    - type: Transform
+      pos: -22.5,5.5
+      parent: 2
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -22.5,4.5
+      parent: 2
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -23.5,4.5
+      parent: 2
+  - uid: 691
+    components:
+    - type: Transform
+      pos: -24.5,4.5
+      parent: 2
+  - uid: 692
+    components:
+    - type: Transform
+      pos: -25.5,4.5
+      parent: 2
+  - uid: 693
+    components:
+    - type: Transform
+      pos: -25.5,5.5
+      parent: 2
+  - uid: 694
+    components:
+    - type: Transform
+      pos: -25.5,6.5
+      parent: 2
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -24.5,6.5
+      parent: 2
+  - uid: 696
+    components:
+    - type: Transform
+      pos: -22.5,3.5
+      parent: 2
+  - uid: 697
+    components:
+    - type: Transform
+      pos: -22.5,2.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      pos: -22.5,1.5
+      parent: 2
+  - uid: 699
+    components:
+    - type: Transform
+      pos: -21.5,1.5
+      parent: 2
+  - uid: 700
+    components:
+    - type: Transform
+      pos: -20.5,1.5
+      parent: 2
+  - uid: 701
+    components:
+    - type: Transform
+      pos: -19.5,1.5
+      parent: 2
+  - uid: 702
+    components:
+    - type: Transform
+      pos: -19.5,2.5
+      parent: 2
+  - uid: 703
+    components:
+    - type: Transform
+      pos: -19.5,3.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      pos: -19.5,4.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      pos: -18.5,4.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -17.5,4.5
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: -16.5,4.5
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -15.5,4.5
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 717
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 2
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 725
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 726
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 728
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 731
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 732
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 733
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 734
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 738
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 742
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+  - uid: 743
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 2
+  - uid: 745
+    components:
+    - type: Transform
+      pos: -13.5,-5.5
+      parent: 2
+  - uid: 746
+    components:
+    - type: Transform
+      pos: -20.5,-17.5
+      parent: 2
+  - uid: 747
+    components:
+    - type: Transform
+      pos: -20.5,-16.5
+      parent: 2
+  - uid: 748
+    components:
+    - type: Transform
+      pos: -20.5,-15.5
+      parent: 2
+  - uid: 749
+    components:
+    - type: Transform
+      pos: -20.5,-14.5
+      parent: 2
+  - uid: 750
+    components:
+    - type: Transform
+      pos: -20.5,-13.5
+      parent: 2
+  - uid: 751
+    components:
+    - type: Transform
+      pos: -20.5,-12.5
+      parent: 2
+  - uid: 752
+    components:
+    - type: Transform
+      pos: -20.5,-11.5
+      parent: 2
+  - uid: 753
+    components:
+    - type: Transform
+      pos: -20.5,-10.5
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      pos: -20.5,-9.5
+      parent: 2
+  - uid: 755
+    components:
+    - type: Transform
+      pos: -20.5,-8.5
+      parent: 2
+  - uid: 756
+    components:
+    - type: Transform
+      pos: -20.5,-7.5
+      parent: 2
+  - uid: 757
+    components:
+    - type: Transform
+      pos: -19.5,-7.5
+      parent: 2
+  - uid: 758
+    components:
+    - type: Transform
+      pos: -18.5,-7.5
+      parent: 2
+  - uid: 759
+    components:
+    - type: Transform
+      pos: -17.5,-7.5
+      parent: 2
+  - uid: 760
+    components:
+    - type: Transform
+      pos: -16.5,-7.5
+      parent: 2
+  - uid: 761
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 762
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 763
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 764
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+  - uid: 765
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 766
+    components:
+    - type: Transform
+      pos: -23.5,-3.5
+      parent: 2
+  - uid: 767
+    components:
+    - type: Transform
+      pos: -23.5,-2.5
+      parent: 2
+  - uid: 768
+    components:
+    - type: Transform
+      pos: -25.5,-19.5
+      parent: 2
+  - uid: 769
+    components:
+    - type: Transform
+      pos: -26.5,-19.5
+      parent: 2
+  - uid: 770
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 771
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 772
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 773
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 774
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 775
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 776
+    components:
+    - type: Transform
+      pos: -12.5,-0.5
+      parent: 2
+  - uid: 777
+    components:
+    - type: Transform
+      pos: -12.5,0.5
+      parent: 2
+  - uid: 778
+    components:
+    - type: Transform
+      pos: -12.5,1.5
+      parent: 2
+  - uid: 779
+    components:
+    - type: Transform
+      pos: -13.5,1.5
+      parent: 2
+  - uid: 780
+    components:
+    - type: Transform
+      pos: -14.5,1.5
+      parent: 2
+  - uid: 781
+    components:
+    - type: Transform
+      pos: -15.5,1.5
+      parent: 2
+  - uid: 782
+    components:
+    - type: Transform
+      pos: -16.5,1.5
+      parent: 2
+  - uid: 783
+    components:
+    - type: Transform
+      pos: -17.5,1.5
+      parent: 2
+  - uid: 784
+    components:
+    - type: Transform
+      pos: -18.5,1.5
+      parent: 2
+  - uid: 785
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 2
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 787
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 788
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 2
+  - uid: 789
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 790
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 2
+  - uid: 791
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 792
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 793
+    components:
+    - type: Transform
+      pos: -29.5,-13.5
+      parent: 2
+  - uid: 794
+    components:
+    - type: Transform
+      pos: -29.5,-12.5
+      parent: 2
+  - uid: 795
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 2
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 2
+  - uid: 797
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 2
+  - uid: 799
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 2
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 2
+  - uid: 801
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 2
+  - uid: 802
+    components:
+    - type: Transform
+      pos: -14.5,-2.5
+      parent: 2
+  - uid: 803
+    components:
+    - type: Transform
+      pos: -15.5,-2.5
+      parent: 2
+  - uid: 804
+    components:
+    - type: Transform
+      pos: -16.5,-2.5
+      parent: 2
+- proto: CableMVStack
+  entities:
+  - uid: 805
+    components:
+    - type: Transform
+      pos: -22.49179,5.555481
+      parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 721
+  - uid: 806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 2
-  - uid: 722
+  - uid: 807
     components:
     - type: Transform
       pos: -28.5,-0.5
       parent: 2
-  - uid: 723
+  - uid: 808
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
 - proto: CandleInfinite
   entities:
-  - uid: 727
+  - uid: 809
     components:
     - type: Transform
       pos: -23.778767,7.477115
       parent: 2
-  - uid: 728
+  - uid: 810
     components:
     - type: Transform
       pos: -23.731892,7.727115
       parent: 2
-  - uid: 729
+  - uid: 811
     components:
     - type: Transform
       pos: -23.466267,7.445865
       parent: 2
-  - uid: 876
+  - uid: 812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.7088013,-1.5700989
       parent: 2
-  - uid: 877
+  - uid: 813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5848,13 +5895,13 @@ entities:
       parent: 2
 - proto: CandleRedInfinite
   entities:
-  - uid: 834
+  - uid: 814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5525513,-1.4034424
       parent: 2
-  - uid: 878
+  - uid: 815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5862,61 +5909,61 @@ entities:
       parent: 2
 - proto: Carpet
   entities:
-  - uid: 730
+  - uid: 816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 2
-  - uid: 731
+  - uid: 817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 2
-  - uid: 732
+  - uid: 818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 2
-  - uid: 733
+  - uid: 819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 2
-  - uid: 734
+  - uid: 820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 2
-  - uid: 735
+  - uid: 821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 2
-  - uid: 736
+  - uid: 822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 2
-  - uid: 737
+  - uid: 823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 2
-  - uid: 738
+  - uid: 824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 2
-  - uid: 739
+  - uid: 825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5924,37 +5971,37 @@ entities:
       parent: 2
 - proto: CarpetBlue
   entities:
-  - uid: 740
+  - uid: 826
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,-17.5
       parent: 2
-  - uid: 741
+  - uid: 827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-17.5
       parent: 2
-  - uid: 742
+  - uid: 828
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,-17.5
       parent: 2
-  - uid: 743
+  - uid: 829
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-14.5
       parent: 2
-  - uid: 744
+  - uid: 830
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-15.5
       parent: 2
-  - uid: 745
+  - uid: 831
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5962,122 +6009,122 @@ entities:
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 746
+  - uid: 832
     components:
     - type: Transform
       pos: -35.5,7.5
       parent: 2
-  - uid: 747
+  - uid: 833
     components:
     - type: Transform
       pos: -35.5,6.5
       parent: 2
-  - uid: 748
+  - uid: 834
     components:
     - type: Transform
       pos: -35.5,5.5
       parent: 2
-  - uid: 749
+  - uid: 835
     components:
     - type: Transform
       pos: -33.5,5.5
       parent: 2
-  - uid: 750
+  - uid: 836
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,5.5
       parent: 2
-  - uid: 751
+  - uid: 837
     components:
     - type: Transform
       pos: -31.5,5.5
       parent: 2
-  - uid: 752
+  - uid: 838
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,5.5
       parent: 2
-  - uid: 753
+  - uid: 839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,8.5
       parent: 2
-  - uid: 754
+  - uid: 840
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,9.5
       parent: 2
-  - uid: 755
+  - uid: 841
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,5.5
       parent: 2
-  - uid: 1799
+  - uid: 842
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-8.5
       parent: 2
-  - uid: 2294
+  - uid: 843
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 2
-  - uid: 2295
+  - uid: 844
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-3.5
       parent: 2
-  - uid: 2296
+  - uid: 845
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-2.5
       parent: 2
-  - uid: 2334
+  - uid: 846
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-5.5
       parent: 2
-  - uid: 2335
+  - uid: 847
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-9.5
       parent: 2
-  - uid: 2336
+  - uid: 848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-6.5
       parent: 2
-  - uid: 2337
+  - uid: 849
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-7.5
       parent: 2
-  - uid: 2518
+  - uid: 850
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,0.5
       parent: 2
-  - uid: 2522
+  - uid: 851
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 2
-  - uid: 2523
+  - uid: 852
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6085,64 +6132,64 @@ entities:
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 757
+  - uid: 853
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5247045,-4.3581977
       parent: 2
-  - uid: 758
+  - uid: 854
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-15.5
       parent: 2
-  - uid: 1777
+  - uid: 855
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.744568,-7.3901978
       parent: 2
-  - uid: 2238
+  - uid: 856
     components:
     - type: Transform
       pos: -18.459625,-20.421814
       parent: 2
-  - uid: 2239
+  - uid: 857
     components:
     - type: Transform
       pos: -21.459625,-20.499939
       parent: 2
-  - uid: 2289
+  - uid: 858
     components:
     - type: Transform
       pos: -20.435333,12.449188
       parent: 2
-  - uid: 2488
+  - uid: 859
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.620422,-10.666077
       parent: 2
-  - uid: 2489
+  - uid: 860
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.620422,-9.837952
       parent: 2
-  - uid: 2520
+  - uid: 861
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.494568,4.9372253
       parent: 2
-  - uid: 2521
+  - uid: 862
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.494568,4.9684753
       parent: 2
-  - uid: 2561
+  - uid: 863
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6150,25 +6197,25 @@ entities:
       parent: 2
 - proto: ChairWood
   entities:
-  - uid: 119
+  - uid: 864
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.4996948,-2.4439697
       parent: 2
-  - uid: 759
+  - uid: 865
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 2
-  - uid: 760
+  - uid: 866
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 2
-  - uid: 1348
+  - uid: 867
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6176,101 +6223,101 @@ entities:
       parent: 2
 - proto: ChemDispenser
   entities:
-  - uid: 761
+  - uid: 868
     components:
     - type: Transform
       pos: -12.5,8.5
       parent: 2
 - proto: ChemistryHotplate
   entities:
-  - uid: 762
+  - uid: 869
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 2
 - proto: ChemMaster
   entities:
-  - uid: 763
+  - uid: 870
     components:
     - type: Transform
       pos: -12.5,9.5
       parent: 2
 - proto: CigCartonGreen
   entities:
-  - uid: 2388
+  - uid: 871
     components:
     - type: Transform
       pos: -0.5023804,3.5939026
       parent: 2
 - proto: CircuitImprinter
   entities:
-  - uid: 764
+  - uid: 872
     components:
     - type: Transform
       pos: -24.5,-9.5
       parent: 2
 - proto: CleanerDispenser
   entities:
-  - uid: 2470
+  - uid: 873
     components:
     - type: Transform
       pos: -24.5,-10.5
       parent: 2
 - proto: ClosetChefFilled
   entities:
-  - uid: 765
+  - uid: 874
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
 - proto: ClosetFireFilled
   entities:
-  - uid: 766
+  - uid: 875
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
 - proto: ClosetJanitorFilled
   entities:
-  - uid: 767
+  - uid: 876
     components:
     - type: Transform
       pos: -25.5,-11.5
       parent: 2
 - proto: ClosetL3JanitorFilled
   entities:
-  - uid: 768
+  - uid: 877
     components:
     - type: Transform
       pos: -26.5,-11.5
       parent: 2
 - proto: ClosetMaintenanceFilledRandom
   entities:
-  - uid: 769
+  - uid: 878
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 770
+  - uid: 879
     components:
     - type: Transform
       pos: -15.5,-3.5
       parent: 2
-- proto: ClosetRadiationSuit
+- proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 2472
+  - uid: 880
     components:
     - type: Transform
       pos: -28.5,6.5
       parent: 2
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 773
+  - uid: 881
     components:
     - type: Transform
       pos: -31.5,-13.5
       parent: 2
-  - uid: 774
+  - uid: 882
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6278,12 +6325,12 @@ entities:
       parent: 2
 - proto: ClosetWallEmergencyN2FilledRandom
   entities:
-  - uid: 775
+  - uid: 883
     components:
     - type: Transform
       pos: -32.5,-13.5
       parent: 2
-  - uid: 776
+  - uid: 884
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6291,23 +6338,23 @@ entities:
       parent: 2
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 188
+  - uid: 885
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 401
+  - uid: 886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,8.5
       parent: 2
-  - uid: 780
+  - uid: 887
     components:
     - type: Transform
       pos: -25.5,-13.5
       parent: 2
-  - uid: 1533
+  - uid: 888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6315,7 +6362,7 @@ entities:
       parent: 2
 - proto: ClosetWallPink
   entities:
-  - uid: 801
+  - uid: 889
     components:
     - type: MetaData
       desc: a wall closet containing plasma for backup generators.
@@ -6348,27 +6395,27 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 802
+          - 890
 - proto: ClothingBeltMedicalFilled
   entities:
-  - uid: 2324
+  - uid: 891
     components:
     - type: Transform
       pos: -15.52121,7.699066
       parent: 2
 - proto: ClothingBeltUtilityEngineering
   entities:
-  - uid: 781
+  - uid: 892
     components:
     - type: Transform
       pos: -8.307831,-3.3903503
       parent: 2
 - proto: ClothingEyesGlassesSecurity
   entities:
-  - uid: 1535
+  - uid: 156
     components:
     - type: Transform
-      parent: 1534
+      parent: 155
     - type: Physics
       canCollide: False
     - type: ContainerContainer
@@ -6376,7 +6423,7 @@ entities:
         lens_slot: !type:ContainerSlot {}
 - proto: ClothingEyesHudBeer
   entities:
-  - uid: 2533
+  - uid: 893
     components:
     - type: Transform
       pos: 1.1422424,6.4457397
@@ -6386,27 +6433,27 @@ entities:
         lens_slot: !type:ContainerSlot {}
 - proto: ComfyChair
   entities:
-  - uid: 133
+  - uid: 894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-12.5
       parent: 2
-  - uid: 2492
+  - uid: 895
     components:
     - type: Transform
       pos: -18.5,13.5
       parent: 2
 - proto: ComputerAlert
   entities:
-  - uid: 783
+  - uid: 896
     components:
     - type: Transform
       pos: -24.5,5.5
       parent: 2
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 784
+  - uid: 897
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6414,25 +6461,25 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1526:
+        1754:
         - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
 - proto: ComputerCargoBounty
   entities:
-  - uid: 785
+  - uid: 898
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
 - proto: ComputerCargoOrders
   entities:
-  - uid: 786
+  - uid: 899
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
 - proto: ComputerComms
   entities:
-  - uid: 787
+  - uid: 900
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6440,13 +6487,13 @@ entities:
       parent: 2
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 788
+  - uid: 901
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-21.5
       parent: 2
-  - uid: 1982
+  - uid: 902
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6454,13 +6501,13 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 789
+  - uid: 903
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-11.5
       parent: 2
-  - uid: 790
+  - uid: 904
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6468,13 +6515,13 @@ entities:
       parent: 2
 - proto: ComputerId
   entities:
-  - uid: 791
+  - uid: 905
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-16.5
       parent: 2
-  - uid: 792
+  - uid: 906
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6482,20 +6529,20 @@ entities:
       parent: 2
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 793
+  - uid: 907
     components:
     - type: Transform
       pos: -23.5,5.5
       parent: 2
 - proto: ComputerRadar
   entities:
-  - uid: 794
+  - uid: 908
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-21.5
       parent: 2
-  - uid: 795
+  - uid: 909
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6503,14 +6550,14 @@ entities:
       parent: 2
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 796
+  - uid: 910
     components:
     - type: Transform
       pos: -27.5,-3.5
       parent: 2
 - proto: ComputerSalvageExpedition
   entities:
-  - uid: 797
+  - uid: 911
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6518,7 +6565,7 @@ entities:
       parent: 2
 - proto: ComputerShuttleCargo
   entities:
-  - uid: 798
+  - uid: 912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6526,7 +6573,7 @@ entities:
       parent: 2
 - proto: ComputerSolarControl
   entities:
-  - uid: 799
+  - uid: 913
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6534,7 +6581,7 @@ entities:
       parent: 2
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 800
+  - uid: 914
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6542,13 +6589,13 @@ entities:
       parent: 2
 - proto: ContainmentFieldGenerator
   entities:
-  - uid: 2491
+  - uid: 915
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-11.5
       parent: 2
-  - uid: 2509
+  - uid: 916
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6556,60 +6603,60 @@ entities:
       parent: 2
 - proto: ConveyorBelt
   entities:
-  - uid: 803
+  - uid: 917
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 2
-  - uid: 804
+  - uid: 918
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 2
-  - uid: 805
+  - uid: 919
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 2
-  - uid: 806
+  - uid: 920
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 2
-  - uid: 807
+  - uid: 921
     components:
     - type: Transform
       pos: -14.5,-8.5
       parent: 2
-  - uid: 808
+  - uid: 922
     components:
     - type: Transform
       pos: -14.5,-7.5
       parent: 2
-  - uid: 809
+  - uid: 923
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 2
 - proto: CrateEngineeringMiniJetpack
   entities:
-  - uid: 2364
+  - uid: 924
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 2
 - proto: CrateEngineeringShittle
   entities:
-  - uid: 810
+  - uid: 925
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
 - proto: CrateGenericSteel
   entities:
-  - uid: 1395
+  - uid: 926
     components:
     - type: MetaData
       name: basic materials crate
@@ -6640,36 +6687,36 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 2304
-          - 2205
-          - 2018
-          - 1950
-          - 1849
-          - 1840
-          - 1742
-          - 1733
-          - 1639
+          - 929
+          - 928
+          - 935
+          - 934
+          - 927
+          - 932
+          - 933
+          - 931
+          - 930
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CrateHydroponicsSeedsExotic
   entities:
-  - uid: 2465
+  - uid: 936
     components:
     - type: Transform
       pos: -10.5,8.5
       parent: 2
 - proto: CrateNPCHamlet
   entities:
-  - uid: 812
+  - uid: 937
     components:
     - type: Transform
       pos: -16.5,-18.5
       parent: 2
 - proto: CratePirate
   entities:
-  - uid: 813
+  - uid: 938
     components:
     - type: Transform
       anchored: True
@@ -6683,8 +6730,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 814
-          - 815
+          - 939
+          - 940
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6693,14 +6740,14 @@ entities:
       prevFixedRotation: True
 - proto: CrateServiceJanitorialHardsuit
   entities:
-  - uid: 134
+  - uid: 941
     components:
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
 - proto: CrateTrashCart
   entities:
-  - uid: 816
+  - uid: 942
     components:
     - type: Transform
       pos: -15.5,-7.5
@@ -6725,7 +6772,7 @@ entities:
         - 0
 - proto: Crematorium
   entities:
-  - uid: 817
+  - uid: 943
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6733,14 +6780,14 @@ entities:
       parent: 2
 - proto: CrewMonitoringServer
   entities:
-  - uid: 1790
+  - uid: 944
     components:
     - type: Transform
       pos: -26.5,-21.5
       parent: 2
 - proto: CryogenicSleepUnitSpawnerLateJoin
   entities:
-  - uid: 819
+  - uid: 945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6748,46 +6795,46 @@ entities:
       parent: 2
 - proto: CryoPod
   entities:
-  - uid: 1325
+  - uid: 946
     components:
     - type: Transform
       pos: -19.5,13.5
       parent: 2
 - proto: CryoxadoneBeakerSmall
   entities:
-  - uid: 2393
+  - uid: 947
     components:
     - type: Transform
       pos: -16.654175,11.564209
       parent: 2
 - proto: CurtainsBlue
   entities:
-  - uid: 820
+  - uid: 948
     components:
     - type: Transform
       pos: -28.5,-18.5
       parent: 2
 - proto: CurtainsGreenOpen
   entities:
-  - uid: 821
+  - uid: 949
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,9.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -60188.793
+      secondsUntilStateChange: -61127.7
       state: Closing
 - proto: DebugAPC
   entities:
-  - uid: 235
+  - uid: 950
     components:
     - type: Transform
-      pos: 5.5,4.5
+      pos: 6.5,4.5
       parent: 2
 - proto: DefaultStationBeacon
   entities:
-  - uid: 2259
+  - uid: 951
     components:
     - type: Transform
       pos: -9.5,-5.5
@@ -6796,146 +6843,146 @@ entities:
       text: Shuttle Bay
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 2249
+  - uid: 952
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 2
 - proto: DefaultStationBeaconBotany
   entities:
-  - uid: 2257
+  - uid: 953
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 2
 - proto: DefaultStationBeaconBridge
   entities:
-  - uid: 2260
+  - uid: 954
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
 - proto: DefaultStationBeaconCaptainsQuarters
   entities:
-  - uid: 2256
+  - uid: 955
     components:
     - type: Transform
       pos: -25.5,-18.5
       parent: 2
 - proto: DefaultStationBeaconCargoBay
   entities:
-  - uid: 2233
+  - uid: 956
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
 - proto: DefaultStationBeaconChemistry
   entities:
-  - uid: 2248
+  - uid: 957
     components:
     - type: Transform
       pos: -13.5,7.5
       parent: 2
 - proto: DefaultStationBeaconCryosleep
   entities:
-  - uid: 2261
+  - uid: 958
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
 - proto: DefaultStationBeaconEngineering
   entities:
-  - uid: 2258
+  - uid: 959
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
 - proto: DefaultStationBeaconEvac
   entities:
-  - uid: 2252
+  - uid: 960
     components:
     - type: Transform
       pos: -31.5,-15.5
       parent: 2
 - proto: DefaultStationBeaconEVAStorage
   entities:
-  - uid: 2255
+  - uid: 961
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
 - proto: DefaultStationBeaconHOPOffice
   entities:
-  - uid: 2250
+  - uid: 962
     components:
     - type: Transform
       pos: -17.5,-15.5
       parent: 2
 - proto: DefaultStationBeaconJanitorsCloset
   entities:
-  - uid: 2253
+  - uid: 963
     components:
     - type: Transform
       pos: -26.5,-12.5
       parent: 2
 - proto: DefaultStationBeaconKitchen
   entities:
-  - uid: 2232
+  - uid: 964
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
 - proto: DefaultStationBeaconMedbay
   entities:
-  - uid: 2254
+  - uid: 965
     components:
     - type: Transform
       pos: -18.5,8.5
       parent: 2
 - proto: DefaultStationBeaconMorgue
   entities:
-  - uid: 2263
+  - uid: 966
     components:
     - type: Transform
       pos: -23.5,7.5
       parent: 2
 - proto: DefaultStationBeaconSalvage
   entities:
-  - uid: 2247
+  - uid: 967
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
 - proto: DefaultStationBeaconScience
   entities:
-  - uid: 2251
+  - uid: 968
     components:
     - type: Transform
       pos: -27.5,-6.5
       parent: 2
 - proto: DefaultStationBeaconSecurity
   entities:
-  - uid: 2246
+  - uid: 969
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
 - proto: DefaultStationBeaconSolars
   entities:
-  - uid: 2262
+  - uid: 970
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 2
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 2392
+  - uid: 971
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,6.5
       parent: 2
-  - uid: 2439
+  - uid: 972
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6943,49 +6990,49 @@ entities:
       parent: 2
 - proto: DeskBell
   entities:
-  - uid: 2544
+  - uid: 973
     components:
     - type: Transform
       pos: 1.894989,3.5820312
       parent: 2
-  - uid: 2550
+  - uid: 974
     components:
     - type: Transform
       pos: -19.610687,-15.173004
       parent: 2
 - proto: DisposalBend
   entities:
-  - uid: 823
+  - uid: 975
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-2.5
       parent: 2
-  - uid: 824
+  - uid: 976
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 2
-  - uid: 825
+  - uid: 977
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-15.5
       parent: 2
-  - uid: 826
+  - uid: 978
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,-15.5
       parent: 2
-  - uid: 827
+  - uid: 979
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,0.5
       parent: 2
-  - uid: 828
+  - uid: 980
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6993,18 +7040,18 @@ entities:
       parent: 2
 - proto: DisposalJunction
   entities:
-  - uid: 829
+  - uid: 981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-12.5
       parent: 2
-  - uid: 830
+  - uid: 982
     components:
     - type: Transform
       pos: -13.5,0.5
       parent: 2
-  - uid: 831
+  - uid: 983
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7012,275 +7059,275 @@ entities:
       parent: 2
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 832
+  - uid: 984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-0.5
       parent: 2
-  - uid: 833
+  - uid: 985
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
 - proto: DisposalPipe
   entities:
-  - uid: 725
+  - uid: 986
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 2
-  - uid: 835
+  - uid: 987
     components:
     - type: Transform
       pos: -14.5,-4.5
       parent: 2
-  - uid: 836
+  - uid: 988
     components:
     - type: Transform
       pos: -14.5,-3.5
       parent: 2
-  - uid: 837
+  - uid: 989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-1.5
       parent: 2
-  - uid: 838
+  - uid: 990
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
-  - uid: 839
+  - uid: 991
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-15.5
       parent: 2
-  - uid: 840
+  - uid: 992
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-15.5
       parent: 2
-  - uid: 841
+  - uid: 993
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,-15.5
       parent: 2
-  - uid: 842
+  - uid: 994
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,-15.5
       parent: 2
-  - uid: 843
+  - uid: 995
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,-15.5
       parent: 2
-  - uid: 844
+  - uid: 996
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-15.5
       parent: 2
-  - uid: 845
+  - uid: 997
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-15.5
       parent: 2
-  - uid: 846
+  - uid: 998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-14.5
       parent: 2
-  - uid: 847
+  - uid: 999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-13.5
       parent: 2
-  - uid: 848
+  - uid: 1000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-11.5
       parent: 2
-  - uid: 849
+  - uid: 1001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-10.5
       parent: 2
-  - uid: 850
+  - uid: 1002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-9.5
       parent: 2
-  - uid: 851
+  - uid: 1003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-8.5
       parent: 2
-  - uid: 852
+  - uid: 1004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-7.5
       parent: 2
-  - uid: 853
+  - uid: 1005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-6.5
       parent: 2
-  - uid: 854
+  - uid: 1006
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-5.5
       parent: 2
-  - uid: 855
+  - uid: 1007
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-4.5
       parent: 2
-  - uid: 856
+  - uid: 1008
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-3.5
       parent: 2
-  - uid: 857
+  - uid: 1009
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-2.5
       parent: 2
-  - uid: 858
+  - uid: 1010
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-1.5
       parent: 2
-  - uid: 859
+  - uid: 1011
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-0.5
       parent: 2
-  - uid: 860
+  - uid: 1012
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,0.5
       parent: 2
-  - uid: 861
+  - uid: 1013
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,0.5
       parent: 2
-  - uid: 862
+  - uid: 1014
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,0.5
       parent: 2
-  - uid: 863
+  - uid: 1015
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,0.5
       parent: 2
-  - uid: 864
+  - uid: 1016
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,0.5
       parent: 2
-  - uid: 865
+  - uid: 1017
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,0.5
       parent: 2
-  - uid: 866
+  - uid: 1018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,0.5
       parent: 2
-  - uid: 867
+  - uid: 1019
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,1.5
       parent: 2
-  - uid: 868
+  - uid: 1020
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,2.5
       parent: 2
-  - uid: 869
+  - uid: 1021
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,3.5
       parent: 2
-  - uid: 870
+  - uid: 1022
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,1.5
       parent: 2
-  - uid: 871
+  - uid: 1023
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 2
-  - uid: 872
+  - uid: 1024
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,1.5
       parent: 2
-  - uid: 873
+  - uid: 1025
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 2
-  - uid: 874
+  - uid: 1026
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 2
-  - uid: 875
+  - uid: 1027
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 2
-  - uid: 879
+  - uid: 1028
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 2
-  - uid: 880
+  - uid: 1029
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7288,210 +7335,210 @@ entities:
       parent: 2
 - proto: DisposalTrunk
   entities:
-  - uid: 881
+  - uid: 1030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-0.5
       parent: 2
-  - uid: 882
+  - uid: 1031
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-16.5
       parent: 2
-  - uid: 883
+  - uid: 1032
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-12.5
       parent: 2
-  - uid: 884
+  - uid: 1033
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 2
-  - uid: 885
+  - uid: 1034
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 887
+  - uid: 1035
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
 - proto: DisposalUnit
   entities:
-  - uid: 888
+  - uid: 1036
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 890
+  - uid: 1037
     components:
     - type: Transform
       pos: -29.5,-16.5
       parent: 2
-  - uid: 891
+  - uid: 1038
     components:
     - type: Transform
       pos: -20.5,-12.5
       parent: 2
-  - uid: 892
+  - uid: 1039
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 893
+  - uid: 1040
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 2
-  - uid: 894
+  - uid: 1041
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 2
 - proto: DogBed
   entities:
-  - uid: 2460
+  - uid: 1042
     components:
     - type: Transform
       pos: -17.5,-14.5
       parent: 2
-  - uid: 2515
+  - uid: 1043
     components:
     - type: Transform
       pos: -13.5,9.5
       parent: 2
 - proto: DrinkCottonBoolGlass
   entities:
-  - uid: 2537
+  - uid: 1044
     components:
     - type: Transform
       pos: -11.6249695,5.4873047
       parent: 2
 - proto: DrinkGlass
   entities:
-  - uid: 897
+  - uid: 1046
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 898
+  - uid: 1047
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 899
+  - uid: 1048
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 900
+  - uid: 1049
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 901
+  - uid: 1050
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 902
+  - uid: 1051
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 903
+  - uid: 1052
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 904
+  - uid: 1053
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 905
+  - uid: 1054
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
-  - uid: 906
+  - uid: 1055
     components:
     - type: Transform
-      parent: 896
+      parent: 1045
     - type: Physics
       canCollide: False
 - proto: DrinkIrishCarBomb
   entities:
-  - uid: 907
+  - uid: 1056
     components:
     - type: Transform
       pos: 1.5483452,3.601201
       parent: 2
 - proto: DrinkOrangeJuice
   entities:
-  - uid: 908
+  - uid: 1057
     components:
     - type: Transform
       pos: 0.14050293,3.5414429
       parent: 2
 - proto: DrinkRaktaccinoGlass
   entities:
-  - uid: 886
+  - uid: 1058
     components:
     - type: Transform
       pos: -2.3842773,-2.246704
       parent: 2
-  - uid: 911
+  - uid: 1059
     components:
     - type: Transform
       pos: 2.25147,3.663701
       parent: 2
-  - uid: 2208
+  - uid: 1060
     components:
     - type: Transform
       pos: -2.5561523,-1.8248291
       parent: 2
-  - uid: 2375
+  - uid: 1061
     components:
     - type: Transform
       pos: -6.3760986,-1.6373291
       parent: 2
-  - uid: 2380
+  - uid: 1062
     components:
     - type: Transform
       pos: -6.5948486,-2.168579
       parent: 2
 - proto: DrinkShaker
   entities:
-  - uid: 912
+  - uid: 1063
     components:
     - type: Transform
       pos: 0.43737793,3.6039429
       parent: 2
 - proto: Emitter
   entities:
-  - uid: 1504
+  - uid: 1064
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
 - proto: FaxMachineBase
   entities:
-  - uid: 772
+  - uid: 1065
     components:
     - type: Transform
       pos: -17.5,2.5
@@ -7499,7 +7546,7 @@ entities:
     - type: FaxMachine
       name: Main Hall
       destinationAddress: north hallway
-  - uid: 914
+  - uid: 1066
     components:
     - type: Transform
       pos: 4.5,-4.5
@@ -7507,7 +7554,7 @@ entities:
     - type: FaxMachine
       name: Cargo
       destinationAddress: Cargo
-  - uid: 915
+  - uid: 1067
     components:
     - type: Transform
       pos: -16.5,-16.5
@@ -7517,7 +7564,7 @@ entities:
       destinationAddress: HoP
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 916
+  - uid: 1068
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7525,15 +7572,15 @@ entities:
       parent: 2
 - proto: Firelock
   entities:
-  - uid: 917
+  - uid: 1069
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-  - uid: 918
+      - 10
+  - uid: 1070
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7541,9 +7588,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 21
       - 23
-      - 25
-  - uid: 919
+  - uid: 1071
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7551,9 +7598,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
-      - 28
-  - uid: 920
+      - 21
+      - 27
+  - uid: 1072
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7562,7 +7609,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 5
-  - uid: 921
+  - uid: 1073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7571,19 +7618,19 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 5
-  - uid: 922
+  - uid: 1074
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,4.5
       parent: 2
-  - uid: 923
+  - uid: 1075
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,5.5
       parent: 2
-  - uid: 924
+  - uid: 1076
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7591,9 +7638,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-      - 7
-  - uid: 925
+      - 8
+      - 6
+  - uid: 1077
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7601,9 +7648,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 8
       - 9
-      - 10
-  - uid: 926
+  - uid: 1078
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7611,9 +7658,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-      - 10
-  - uid: 927
+      - 12
+      - 9
+  - uid: 1079
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7621,8 +7668,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-  - uid: 928
+      - 12
+  - uid: 1080
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7630,9 +7677,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
       - 12
-  - uid: 929
+      - 11
+  - uid: 1081
     components:
     - type: Transform
       pos: -24.5,0.5
@@ -7641,7 +7688,7 @@ entities:
       deviceLists:
       - 4
       - 5
-  - uid: 930
+  - uid: 1082
     components:
     - type: Transform
       pos: -24.5,1.5
@@ -7650,7 +7697,7 @@ entities:
       deviceLists:
       - 4
       - 5
-  - uid: 931
+  - uid: 1083
     components:
     - type: Transform
       pos: -22.5,3.5
@@ -7659,23 +7706,7 @@ entities:
       deviceLists:
       - 4
       - 5
-  - uid: 932
-    components:
-    - type: Transform
-      pos: -19.5,-7.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 16
-  - uid: 933
-    components:
-    - type: Transform
-      pos: -17.5,-5.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 16
-  - uid: 934
+  - uid: 1084
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7683,15 +7714,15 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 20
       - 22
-      - 24
-  - uid: 935
+  - uid: 1085
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-15.5
       parent: 2
-  - uid: 936
+  - uid: 1086
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7699,9 +7730,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
-      - 20
-  - uid: 937
+      - 17
+      - 18
+  - uid: 1087
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7709,9 +7740,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 20
       - 22
-      - 24
-  - uid: 941
+  - uid: 1088
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7719,9 +7750,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 18
-      - 19
-  - uid: 942
+      - 16
+      - 17
+  - uid: 1089
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7729,8 +7760,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-  - uid: 945
+      - 19
+  - uid: 1090
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7738,9 +7769,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-      - 24
-  - uid: 946
+      - 13
+      - 22
+  - uid: 1091
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7748,9 +7779,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-      - 24
-  - uid: 947
+      - 13
+      - 22
+  - uid: 1092
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7758,105 +7789,85 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-      - 24
-  - uid: 948
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-8.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 3
-      - 16
-  - uid: 949
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-8.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 3
-      - 16
-  - uid: 950
+      - 13
+      - 22
+  - uid: 1093
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
-      - 28
-  - uid: 951
+      - 21
+      - 27
+  - uid: 1094
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 21
       - 23
-      - 25
-  - uid: 952
+  - uid: 1095
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 21
       - 23
-      - 25
-  - uid: 953
+  - uid: 1096
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 21
       - 23
-      - 25
-  - uid: 954
+  - uid: 1097
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
-  - uid: 955
+      - 27
+  - uid: 1098
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
-  - uid: 956
+      - 27
+  - uid: 1099
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
-  - uid: 957
+      - 27
+  - uid: 1100
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
-  - uid: 958
+      - 27
+  - uid: 1101
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
-  - uid: 959
+      - 27
+  - uid: 1102
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7864,9 +7875,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 18
-      - 24
-  - uid: 961
+      - 16
+      - 22
+  - uid: 1103
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7875,7 +7886,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 963
+  - uid: 1104
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7883,9 +7894,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-      - 7
-  - uid: 964
+      - 8
+      - 6
+  - uid: 1105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7893,9 +7904,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-      - 7
-  - uid: 965
+      - 8
+      - 6
+  - uid: 1106
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7903,8 +7914,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-  - uid: 966
+      - 6
+  - uid: 1107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7912,8 +7923,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-  - uid: 967
+      - 6
+  - uid: 1108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7921,9 +7932,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 6
       - 7
-      - 8
-  - uid: 968
+  - uid: 1109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7931,8 +7942,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
-  - uid: 1326
+      - 9
+  - uid: 1110
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7940,23 +7951,23 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
-      - 1035
+      - 17
+      - 25
 - proto: FirelockEdge
   entities:
-  - uid: 970
+  - uid: 1111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -46345.184
+      secondsUntilStateChange: -47284.09
       state: Closing
     - type: DeviceNetwork
       deviceLists:
-      - 25
-  - uid: 971
+      - 23
+  - uid: 1112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7964,8 +7975,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 972
+      - 14
+  - uid: 1113
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7973,24 +7984,24 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-  - uid: 973
+      - 23
+  - uid: 1114
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
-  - uid: 974
+      - 21
+  - uid: 1115
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
-  - uid: 975
+      - 21
+  - uid: 1116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7998,8 +8009,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
-  - uid: 976
+      - 20
+  - uid: 1117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8007,28 +8018,28 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
-  - uid: 2383
+      - 20
+  - uid: 1118
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-      - 120
-  - uid: 2384
+      - 23
+      - 28
+  - uid: 1119
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-      - 2424
+      - 23
+      - 26
 - proto: FirelockGlass
   entities:
-  - uid: 545
+  - uid: 1120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8036,9 +8047,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
-      - 24
-  - uid: 610
+      - 17
+      - 22
+  - uid: 1121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8046,9 +8057,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
-      - 24
-  - uid: 611
+      - 17
+      - 22
+  - uid: 1122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8056,9 +8067,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
-      - 24
-  - uid: 612
+      - 17
+      - 22
+  - uid: 1123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8066,9 +8077,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 13
       - 14
-      - 15
-  - uid: 613
+  - uid: 1124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8076,14 +8087,53 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 13
       - 14
+  - uid: 1125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
       - 15
-  - uid: 977
+  - uid: 1126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+      - 15
+  - uid: 1127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 15
+  - uid: 1128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 15
+      - 13
+  - uid: 1129
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 2
-  - uid: 978
+  - uid: 1130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8091,9 +8141,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-      - 26
-  - uid: 979
+      - 23
+      - 24
+  - uid: 1131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8101,9 +8151,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-      - 26
-  - uid: 980
+      - 23
+      - 24
+  - uid: 1132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8111,9 +8161,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-      - 26
-  - uid: 981
+      - 23
+      - 24
+  - uid: 1133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8122,8 +8172,8 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 5
-      - 26
-  - uid: 982
+      - 24
+  - uid: 1134
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8132,8 +8182,8 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 5
-      - 26
-  - uid: 983
+      - 24
+  - uid: 1135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8142,8 +8192,8 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 5
-      - 26
-  - uid: 984
+      - 24
+  - uid: 1136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8151,9 +8201,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 25
-  - uid: 985
+      - 11
+      - 23
+  - uid: 1137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8161,9 +8211,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 25
-  - uid: 986
+      - 11
+      - 23
+  - uid: 1138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8171,9 +8221,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 25
-  - uid: 987
+      - 11
+      - 23
+  - uid: 1139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8181,9 +8231,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 25
-  - uid: 988
+      - 11
+      - 23
+  - uid: 1140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8191,8 +8241,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-  - uid: 989
+      - 13
+  - uid: 1141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8200,8 +8250,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-  - uid: 990
+      - 13
+  - uid: 1142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8209,8 +8259,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-  - uid: 991
+      - 13
+  - uid: 1143
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8218,9 +8268,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-      - 25
-  - uid: 992
+      - 12
+      - 23
+  - uid: 1144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8228,9 +8278,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 25
-  - uid: 993
+      - 11
+      - 23
+  - uid: 1145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8238,9 +8288,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-      - 25
-  - uid: 2297
+      - 12
+      - 23
+  - uid: 1146
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8248,35 +8298,55 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 13
       - 14
-      - 15
-  - uid: 2514
+  - uid: 1147
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
+      - 9
+      - 12
+  - uid: 1148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-10.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+      - 13
+  - uid: 1149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
       - 13
 - proto: Flash
   entities:
-  - uid: 1536
+  - uid: 157
     components:
     - type: Transform
-      parent: 1534
+      parent: 155
     - type: Physics
       canCollide: False
 - proto: FloorDrain
   entities:
-  - uid: 994
+  - uid: 1150
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 995
+  - uid: 1151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8284,21 +8354,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 996
+  - uid: 1152
     components:
     - type: Transform
       pos: -15.5,-6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 997
+  - uid: 1153
     components:
     - type: Transform
       pos: -24.5,-11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2467
+  - uid: 1154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8308,120 +8378,120 @@ entities:
       fixtures: {}
 - proto: FoodBakedBunHoney
   entities:
-  - uid: 2554
+  - uid: 1155
     components:
     - type: Transform
       pos: -5.0829163,4.475281
       parent: 2
 - proto: FoodBoxPizzaFilled
   entities:
-  - uid: 998
+  - uid: 1156
     components:
     - type: Transform
       pos: -3.3944511,3.726201
       parent: 2
 - proto: FoodCondimentBottleEnzyme
   entities:
-  - uid: 1000
+  - uid: 1158
     components:
     - type: Transform
-      parent: 999
+      parent: 1157
     - type: Physics
       canCollide: False
 - proto: FoodDonutPink
   entities:
-  - uid: 1580
+  - uid: 158
     components:
     - type: Transform
-      parent: 1534
+      parent: 155
     - type: Physics
       canCollide: False
 - proto: FoodPizzaUraniumSlice
   entities:
-  - uid: 2446
+  - uid: 162
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2447
+  - uid: 163
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2448
+  - uid: 164
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2449
+  - uid: 165
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2450
+  - uid: 166
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2451
+  - uid: 167
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2452
+  - uid: 168
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2453
+  - uid: 169
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
-  - uid: 2454
+  - uid: 170
     components:
     - type: Transform
-      parent: 2445
+      parent: 161
     - type: Physics
       canCollide: False
 - proto: ForensicScanner
   entities:
-  - uid: 2487
+  - uid: 159
     components:
     - type: Transform
-      parent: 1534
+      parent: 155
     - type: Physics
       canCollide: False
 - proto: FuelDispenser
   entities:
-  - uid: 1671
+  - uid: 1164
     components:
     - type: Transform
       pos: -13.5,10.5
       parent: 2
 - proto: GasFilter
   entities:
-  - uid: 969
+  - uid: 1165
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,11.5
       parent: 2
-  - uid: 1007
+  - uid: 1166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,5.5
       parent: 2
-  - uid: 1048
+  - uid: 1167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8429,21 +8499,21 @@ entities:
       parent: 2
 - proto: GasMinerNitrogenStation
   entities:
-  - uid: 1008
+  - uid: 1168
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
 - proto: GasMinerOxygenStation
   entities:
-  - uid: 1009
+  - uid: 1169
     components:
     - type: Transform
       pos: -27.5,8.5
       parent: 2
 - proto: GasMixerFlipped
   entities:
-  - uid: 1017
+  - uid: 1170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8454,38 +8524,38 @@ entities:
       inletOneConcentration: 0.78
 - proto: GasOutletInjector
   entities:
-  - uid: 1011
+  - uid: 1171
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 1012
+  - uid: 1172
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
 - proto: GasPassiveVent
   entities:
-  - uid: 1013
+  - uid: 1173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,9.5
       parent: 2
-  - uid: 1014
+  - uid: 1174
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,9.5
       parent: 2
-  - uid: 1015
+  - uid: 1175
     components:
     - type: Transform
       pos: -35.5,10.5
       parent: 2
 - proto: GasPipeBend
   entities:
-  - uid: 1010
+  - uid: 1176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8493,34 +8563,34 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1018
+  - uid: 1177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,5.5
       parent: 2
-  - uid: 1019
+  - uid: 1178
     components:
     - type: Transform
       pos: -28.5,9.5
       parent: 2
-  - uid: 1020
+  - uid: 1179
     components:
     - type: Transform
       pos: -26.5,9.5
       parent: 2
-  - uid: 1021
+  - uid: 1180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,6.5
       parent: 2
-  - uid: 1022
+  - uid: 1181
     components:
     - type: Transform
       pos: -25.5,6.5
       parent: 2
-  - uid: 1025
+  - uid: 1182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8528,7 +8598,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1034
+  - uid: 1183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8536,7 +8606,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1038
+  - uid: 1184
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8544,13 +8614,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1040
+  - uid: 1185
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,13.5
       parent: 2
-  - uid: 1066
+  - uid: 1186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8558,7 +8628,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1071
+  - uid: 1187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8566,7 +8636,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1085
+  - uid: 1188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8574,7 +8644,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1086
+  - uid: 1189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8582,7 +8652,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1087
+  - uid: 1190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8590,14 +8660,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1090
+  - uid: 1191
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1120
+  - uid: 1192
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8605,21 +8675,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1179
+  - uid: 1193
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1205
+  - uid: 1194
     components:
     - type: Transform
       pos: -21.5,-13.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1234
+  - uid: 1195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8627,7 +8697,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1259
+  - uid: 1196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8635,20 +8705,20 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1261
+  - uid: 1197
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1274
+  - uid: 1198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,11.5
       parent: 2
-  - uid: 1296
+  - uid: 1199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8656,7 +8726,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1299
+  - uid: 1200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8664,7 +8734,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1300
+  - uid: 1201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8672,7 +8742,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1304
+  - uid: 1202
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8680,7 +8750,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1329
+  - uid: 1203
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8688,14 +8758,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1333
+  - uid: 1204
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1386
+  - uid: 1205
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8703,14 +8773,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1390
+  - uid: 1206
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1400
+  - uid: 1207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8718,7 +8788,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1863
+  - uid: 1208
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8726,13 +8796,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2265
+  - uid: 1209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,11.5
       parent: 2
-  - uid: 2377
+  - uid: 1210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8740,7 +8810,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2399
+  - uid: 1211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8748,7 +8818,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2402
+  - uid: 1212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8756,7 +8826,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2405
+  - uid: 1213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8764,7 +8834,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2408
+  - uid: 1214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8772,7 +8842,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2410
+  - uid: 1215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8780,7 +8850,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2415
+  - uid: 1216
     components:
     - type: Transform
       pos: -3.5,0.5
@@ -8789,7 +8859,7 @@ entities:
       color: '#FFD500FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 1166
+  - uid: 1217
     components:
     - type: Transform
       pos: -5.5,-0.5
@@ -8798,7 +8868,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 17
+  - uid: 1218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8806,7 +8876,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 101
+  - uid: 1219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8814,7 +8884,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 910
+  - uid: 1220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8822,7 +8892,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1023
+  - uid: 1221
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8830,7 +8900,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1024
+  - uid: 1222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8838,7 +8908,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1026
+  - uid: 1223
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8846,14 +8916,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1028
+  - uid: 1224
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1029
+  - uid: 1225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8861,970 +8931,11 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1030
+  - uid: 1226
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1031
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1033
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1042
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1044
-    components:
-    - type: Transform
-      pos: -17.5,-17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1049
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,5.5
-      parent: 2
-  - uid: 1050
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,5.5
-      parent: 2
-  - uid: 1051
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -34.5,5.5
-      parent: 2
-  - uid: 1052
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,5.5
-      parent: 2
-  - uid: 1053
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,5.5
-      parent: 2
-  - uid: 1054
-    components:
-    - type: Transform
-      pos: -28.5,8.5
-      parent: 2
-  - uid: 1055
-    components:
-    - type: Transform
-      pos: -28.5,7.5
-      parent: 2
-  - uid: 1056
-    components:
-    - type: Transform
-      pos: -26.5,8.5
-      parent: 2
-  - uid: 1057
-    components:
-    - type: Transform
-      pos: -26.5,7.5
-      parent: 2
-  - uid: 1058
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.5,6.5
-      parent: 2
-  - uid: 1059
-    components:
-    - type: Transform
-      pos: -29.5,6.5
-      parent: 2
-  - uid: 1060
-    components:
-    - type: Transform
-      pos: -27.5,6.5
-      parent: 2
-  - uid: 1062
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,6.5
-      parent: 2
-  - uid: 1063
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,7.5
-      parent: 2
-  - uid: 1064
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,8.5
-      parent: 2
-  - uid: 1065
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,9.5
-      parent: 2
-  - uid: 1068
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1069
-    components:
-    - type: Transform
-      pos: -22.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1070
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1072
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1073
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1074
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1075
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1076
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1077
-    components:
-    - type: Transform
-      pos: -25.5,5.5
-      parent: 2
-  - uid: 1078
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1079
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1081
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1082
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1083
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1084
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1088
-    components:
-    - type: Transform
-      pos: -20.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1091
-    components:
-    - type: Transform
-      pos: -20.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1092
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1093
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1094
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1095
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1096
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1100
-    components:
-    - type: Transform
-      pos: -20.5,-6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1101
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1105
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1106
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1107
-    components:
-    - type: Transform
-      pos: -13.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1108
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1109
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1110
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1111
-    components:
-    - type: Transform
-      pos: -4.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1112
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1116
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1118
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1119
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1121
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1122
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1123
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1124
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1125
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1126
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1128
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1129
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1130
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1131
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1132
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1133
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1134
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1135
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1139
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1141
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1142
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1143
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1144
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1145
-    components:
-    - type: Transform
-      pos: -3.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1147
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1148
-    components:
-    - type: Transform
-      pos: -3.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1149
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1150
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1151
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1152
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1155
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1156
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1157
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1159
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1161
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1163
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1164
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1167
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1168
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1169
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1170
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1171
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1172
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1173
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1174
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1177
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1178
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1180
-    components:
-    - type: Transform
-      pos: -22.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1184
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1185
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1186
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1187
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1188
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1189
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1197
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1198
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1199
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1200
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1201
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1202
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1203
-    components:
-    - type: Transform
-      pos: -20.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1204
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1207
-    components:
-    - type: Transform
-      pos: -22.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1210
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1211
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1212
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1213
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1214
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1215
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1216
-    components:
-    - type: Transform
-      pos: -20.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1217
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1218
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1219
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1220
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-13.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1221
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1222
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1225
-    components:
-    - type: Transform
-      pos: -22.5,-9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -9832,240 +8943,297 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,-14.5
+      pos: -8.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
+  - uid: 1228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 1230
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-16.5
+      pos: -17.5,-17.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 1231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,5.5
+      parent: 2
+  - uid: 1232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -28.5,5.5
+      parent: 2
   - uid: 1233
     components:
     - type: Transform
-      pos: -20.5,-17.5
+      rot: -1.5707963267948966 rad
+      pos: -34.5,5.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
+  - uid: 1234
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,5.5
+      parent: 2
   - uid: 1235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -18.5,-18.5
+      pos: -33.5,5.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1236
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-14.5
+      pos: -28.5,8.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
+  - uid: 1237
+    components:
+    - type: Transform
+      pos: -28.5,7.5
+      parent: 2
   - uid: 1238
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-15.5
+      pos: -26.5,8.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1239
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.5,-20.5
+      pos: -26.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1240
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-20.5
+      rot: 1.5707963267948966 rad
+      pos: -27.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1241
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-15.5
+      pos: -29.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1242
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-20.5
+      pos: -27.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1243
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1244
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1245
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,8.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1246
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,9.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1247
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1248
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-14.5
+      pos: -22.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1249
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1250
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -27.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1251
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-15.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1252
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -19.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1253
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: -19.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1254
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1255
     components:
     - type: Transform
+      pos: -25.5,5.5
+      parent: 2
+  - uid: 1256
+    components:
+    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -30.5,-14.5
+      pos: -24.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1257
     components:
     - type: Transform
-      pos: -16.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -24.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1258
     components:
     - type: Transform
-      pos: -16.5,5.5
+      rot: 3.141592653589793 rad
+      pos: -26.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1259
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -26.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1260
     components:
     - type: Transform
-      pos: -17.5,9.5
+      rot: 3.141592653589793 rad
+      pos: -26.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
+  - uid: 1261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1262
+    components:
+    - type: Transform
+      pos: -20.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 1263
     components:
     - type: Transform
-      pos: -25.5,3.5
+      pos: -20.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1264
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-2.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1265
     components:
     - type: Transform
-      pos: -22.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: -17.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1266
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,1.5
+      rot: -1.5707963267948966 rad
+      pos: -15.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1267
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1269
     components:
     - type: Transform
-      pos: -25.5,0.5
+      pos: -20.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -10073,15 +9241,38 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,7.5
+      pos: -21.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1272
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1274
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -10089,7 +9280,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-5.5
+      pos: 0.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -10097,31 +9288,45 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -12.5,1.5
+      pos: -15.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1277
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,6.5
+      pos: -4.5,7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1279
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,1.5
+      pos: -4.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1280
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1281
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -10129,22 +9334,63 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1285
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-7.5
+      pos: -11.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 1283
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 1286
     components:
     - type: Transform
-      pos: -22.5,-7.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1287
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1288
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -10152,162 +9398,401 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -20.5,-12.5
+      pos: -9.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1292
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1293
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -9.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1294
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: -9.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1295
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1298
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1302
+  - uid: 1296
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,-0.5
+      pos: -5.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1297
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1299
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1300
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1301
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1303
     components:
     - type: Transform
-      pos: -25.5,2.5
+      pos: -3.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1305
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1306
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1307
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1308
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1309
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1310
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1311
+    components:
+    - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -10.5,-0.5
+      pos: -6.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1312
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1313
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1314
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1315
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-16.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1316
     components:
     - type: Transform
-      pos: -22.5,-5.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1317
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1318
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-10.5
+      pos: -0.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1319
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1320
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-0.5
+      pos: -1.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
+  - uid: 1321
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1322
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1324
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1327
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -21.5,8.5
+      pos: -0.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1328
+  - uid: 1323
     components:
     - type: Transform
-      pos: -17.5,6.5
+      pos: -0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1324
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 1325
+    components:
+    - type: Transform
+      pos: -22.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1326
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1327
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 1331
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-6.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1332
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1333
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1335
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1336
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1337
+    components:
+    - type: Transform
       rot: 3.141592653589793 rad
-      pos: -9.5,0.5
+      pos: -22.5,-14.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1338
     components:
     - type: Transform
+      pos: -20.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1339
+    components:
+    - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,0.5
+      pos: -22.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1340
+    components:
+    - type: Transform
+      pos: -22.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1341
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-12.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -10315,11 +9800,596 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -24.5,-7.5
+      pos: -20.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1343
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1344
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1345
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1346
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1347
+    components:
+    - type: Transform
+      pos: -20.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1349
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1350
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1351
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1352
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1354
+    components:
+    - type: Transform
+      pos: -22.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1355
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1356
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1357
+    components:
+    - type: Transform
+      pos: -20.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1358
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1360
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1361
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1362
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1363
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1365
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1366
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1368
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -27.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1373
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -28.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1374
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -28.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1377
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1378
+    components:
+    - type: Transform
+      pos: -16.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1379
+    components:
+    - type: Transform
+      pos: -16.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1380
+    components:
+    - type: Transform
+      pos: -17.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1381
+    components:
+    - type: Transform
+      pos: -25.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1382
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1383
+    components:
+    - type: Transform
+      pos: -22.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1384
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1385
+    components:
+    - type: Transform
+      pos: -25.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1386
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1387
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1388
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1389
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1390
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1391
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1392
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1393
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1394
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1395
+    components:
+    - type: Transform
+      pos: -22.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1396
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1397
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1398
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1399
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -27.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1400
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1401
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1402
+    components:
+    - type: Transform
+      pos: -25.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1403
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1404
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1405
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1406
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1407
+    components:
+    - type: Transform
+      pos: -22.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1409
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1410
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1411
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1412
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1413
+    components:
+    - type: Transform
+      pos: -17.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1414
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10327,14 +10397,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1385
+  - uid: 1419
     components:
     - type: Transform
       pos: -19.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1389
+  - uid: 1420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10342,7 +10412,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1812
+  - uid: 1421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10350,7 +10420,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2400
+  - uid: 1422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10358,7 +10428,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2401
+  - uid: 1423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10366,7 +10436,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2403
+  - uid: 1424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10374,7 +10444,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2404
+  - uid: 1425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10382,12 +10452,12 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2406
+  - uid: 1426
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 2
-  - uid: 2407
+  - uid: 1427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10395,7 +10465,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2409
+  - uid: 1428
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10403,7 +10473,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2411
+  - uid: 1429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10411,7 +10481,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2412
+  - uid: 1430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10419,7 +10489,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2413
+  - uid: 1431
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10427,7 +10497,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2414
+  - uid: 1432
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10435,14 +10505,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2416
+  - uid: 1433
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2427
+  - uid: 1434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10450,7 +10520,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2428
+  - uid: 1435
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10460,13 +10530,13 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 1027
+  - uid: 1436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,12.5
       parent: 2
-  - uid: 1032
+  - uid: 1437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10474,7 +10544,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1037
+  - uid: 1438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10482,14 +10552,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1041
+  - uid: 1439
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1043
+  - uid: 1440
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10497,7 +10567,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1045
+  - uid: 1441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10505,13 +10575,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1047
+  - uid: 1442
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,5.5
       parent: 2
-  - uid: 1067
+  - uid: 1443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10519,7 +10589,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1097
+  - uid: 1444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10527,7 +10597,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1098
+  - uid: 1445
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10535,21 +10605,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1099
+  - uid: 1446
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1115
+  - uid: 1447
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1117
+  - uid: 1448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10557,28 +10627,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1127
+  - uid: 1449
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1137
+  - uid: 1450
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1146
+  - uid: 1451
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1153
+  - uid: 1452
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10586,7 +10656,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1158
+  - uid: 1453
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10594,7 +10664,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1162
+  - uid: 1454
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10602,7 +10672,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1175
+  - uid: 1455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10610,7 +10680,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1181
+  - uid: 1456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10618,7 +10688,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1182
+  - uid: 1457
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10626,7 +10696,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1183
+  - uid: 1458
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10634,7 +10704,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1190
+  - uid: 1459
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10642,7 +10712,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1192
+  - uid: 1460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10650,7 +10720,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1194
+  - uid: 1461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10658,7 +10728,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1208
+  - uid: 1462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10666,14 +10736,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1224
+  - uid: 1463
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1226
+  - uid: 1464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10681,7 +10751,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1228
+  - uid: 1465
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10689,7 +10759,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1231
+  - uid: 1466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10697,7 +10767,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1237
+  - uid: 1467
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10705,7 +10775,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1268
+  - uid: 1468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10713,7 +10783,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1273
+  - uid: 1469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10721,7 +10791,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1278
+  - uid: 1470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10729,7 +10799,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1280
+  - uid: 1471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10737,7 +10807,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1283
+  - uid: 1472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10745,7 +10815,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1284
+  - uid: 1473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10753,7 +10823,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1287
+  - uid: 1474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10761,7 +10831,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1289
+  - uid: 1475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10769,7 +10839,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1291
+  - uid: 1476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10777,20 +10847,20 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1297
+  - uid: 1477
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,12.5
       parent: 2
-  - uid: 1305
+  - uid: 1478
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1330
+  - uid: 1479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10798,7 +10868,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1334
+  - uid: 1480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10806,7 +10876,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1335
+  - uid: 1481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10814,7 +10884,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1337
+  - uid: 1482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10822,7 +10892,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1344
+  - uid: 1483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10830,7 +10900,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1346
+  - uid: 1484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10838,7 +10908,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1399
+  - uid: 1485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10846,18 +10916,18 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2266
+  - uid: 1486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,12.5
       parent: 2
-  - uid: 2365
+  - uid: 1487
     components:
     - type: Transform
       pos: -26.5,5.5
       parent: 2
-  - uid: 2379
+  - uid: 1488
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10867,14 +10937,14 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 1766
+  - uid: 1489
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 2476
+  - uid: 1490
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10884,14 +10954,14 @@ entities:
       currentLabel: Waste port
 - proto: GasPressurePump
   entities:
-  - uid: 1046
+  - uid: 1491
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1392
+  - uid: 1492
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10901,14 +10971,14 @@ entities:
       color: '#0055CCFF'
 - proto: GasThermoMachineFreezer
   entities:
-  - uid: 1006
+  - uid: 1493
     components:
     - type: Transform
       pos: -20.5,13.5
       parent: 2
 - proto: GasVentPump
   entities:
-  - uid: 1016
+  - uid: 1494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10919,7 +10989,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1061
+  - uid: 1495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10930,7 +11000,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1102
+  - uid: 1496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10938,10 +11008,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
+      - 23
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1104
+  - uid: 1497
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10949,20 +11019,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
+      - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1140
+  - uid: 1498
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 11
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1195
+  - uid: 1499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10970,10 +11040,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 13
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1196
+  - uid: 1500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10981,10 +11051,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 14
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1229
+  - uid: 1501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10992,20 +11062,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24
+      - 22
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1232
+  - uid: 1502
     components:
     - type: Transform
       pos: -17.5,-16.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 18
+      - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1271
+  - uid: 1503
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11013,10 +11083,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 21
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1301
+  - uid: 1504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11024,10 +11094,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1306
+  - uid: 1505
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11035,20 +11105,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
+      - 9
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1307
+  - uid: 1506
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1311
+  - uid: 1507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11056,10 +11126,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
+      - 23
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1312
+  - uid: 1508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11067,10 +11137,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 16
+      - 15
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1313
+  - uid: 1509
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11078,10 +11148,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 8
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1314
+  - uid: 1510
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11092,7 +11162,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1317
+  - uid: 1511
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11100,10 +11170,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
+      - 17
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1319
+  - uid: 1512
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11111,10 +11181,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
+      - 20
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1336
+  - uid: 1513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11122,10 +11192,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
+      - 27
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2376
+  - uid: 1514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11133,12 +11203,12 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentPumpDecapoid
   entities:
-  - uid: 2426
+  - uid: 1515
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11146,10 +11216,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2424
+      - 26
 - proto: GasVentPumpVox
   entities:
-  - uid: 1739
+  - uid: 1516
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11157,12 +11227,12 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 120
+      - 28
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 6
+  - uid: 1517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11170,10 +11240,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
+      - 7
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1039
+  - uid: 1518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11181,10 +11251,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 12
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1080
+  - uid: 1519
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11195,7 +11265,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1089
+  - uid: 1520
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11203,30 +11273,30 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 6
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1103
+  - uid: 1521
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
+      - 23
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1113
+  - uid: 1522
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
+      - 24
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1114
+  - uid: 1523
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11234,20 +11304,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 21
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1136
+  - uid: 1524
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 11
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1154
+  - uid: 1525
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11255,15 +11325,15 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
+      - 23
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1160
+  - uid: 1526
     components:
     - type: Transform
       pos: -32.5,6.5
       parent: 2
-  - uid: 1176
+  - uid: 1527
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11271,10 +11341,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
+      - 27
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1191
+  - uid: 1528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11282,10 +11352,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 14
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1193
+  - uid: 1529
     components:
     - type: Transform
       pos: -21.5,0.5
@@ -11295,7 +11365,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1206
+  - uid: 1530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11303,10 +11373,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24
+      - 22
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1209
+  - uid: 1531
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11314,10 +11384,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
+      - 19
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1223
+  - uid: 1532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11325,10 +11395,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
+      - 17
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1256
+  - uid: 1533
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11336,10 +11406,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
+      - 18
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1267
+  - uid: 1534
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11347,10 +11417,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
+      - 10
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1288
+  - uid: 1535
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11358,10 +11428,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 13
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1321
+  - uid: 1536
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11369,20 +11439,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 1035
+      - 25
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1323
+  - uid: 1537
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
+      - 9
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1339
+  - uid: 1538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11390,10 +11460,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 16
+      - 15
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1340
+  - uid: 1539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11401,10 +11471,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 8
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1341
+  - uid: 1540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11415,7 +11485,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1343
+  - uid: 1541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11423,10 +11493,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 18
+      - 16
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1347
+  - uid: 1542
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11434,29 +11504,29 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
+      - 20
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2374
+  - uid: 1543
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2378
+  - uid: 1544
     components:
     - type: Transform
       pos: -17.5,12.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 6
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVentScrubberDecapoid
   entities:
-  - uid: 2425
+  - uid: 1545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11464,12 +11534,12 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2424
+      - 26
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVentScrubberVox
   entities:
-  - uid: 724
+  - uid: 1546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11477,12 +11547,12 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 120
+      - 28
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVolumePump
   entities:
-  - uid: 1262
+  - uid: 1547
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11492,14 +11562,14 @@ entities:
       color: '#990000FF'
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 1349
+  - uid: 1548
     components:
     - type: Transform
       pos: -28.5,-0.5
       parent: 2
     - type: PowerSupplier
       supplyRate: 25000
-  - uid: 1350
+  - uid: 1549
     components:
     - type: Transform
       pos: -29.5,-0.5
@@ -11508,917 +11578,917 @@ entities:
       supplyRate: 25000
 - proto: GravityGenerator
   entities:
-  - uid: 1351
+  - uid: 1550
     components:
     - type: Transform
       pos: -32.5,8.5
       parent: 2
 - proto: GreatWrench
   entities:
-  - uid: 1352
+  - uid: 1551
     components:
     - type: Transform
       pos: -24.482302,-5.3658857
       parent: 2
 - proto: Grille
   entities:
-  - uid: 27
+  - uid: 1552
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 2
-  - uid: 614
+  - uid: 1553
     components:
     - type: Transform
       pos: -14.5,-13.5
       parent: 2
-  - uid: 822
+  - uid: 1554
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,14.5
       parent: 2
-  - uid: 960
+  - uid: 1555
     components:
     - type: Transform
       pos: -32.5,-1.5
       parent: 2
-  - uid: 962
+  - uid: 1556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 1036
+  - uid: 1557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,14.5
       parent: 2
-  - uid: 1295
+  - uid: 1558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,14.5
       parent: 2
-  - uid: 1353
+  - uid: 1559
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,12.5
       parent: 2
-  - uid: 1354
+  - uid: 1560
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 2
-  - uid: 1355
+  - uid: 1561
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
-  - uid: 1356
+  - uid: 1562
     components:
     - type: Transform
       pos: -15.5,-15.5
       parent: 2
-  - uid: 1358
+  - uid: 1563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,2.5
       parent: 2
-  - uid: 1359
+  - uid: 1564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,2.5
       parent: 2
-  - uid: 1360
+  - uid: 1565
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-18.5
       parent: 2
-  - uid: 1361
+  - uid: 1566
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,10.5
       parent: 2
-  - uid: 1362
+  - uid: 1567
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,8.5
       parent: 2
-  - uid: 1363
+  - uid: 1568
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,6.5
       parent: 2
-  - uid: 1364
+  - uid: 1569
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,5.5
       parent: 2
-  - uid: 1365
+  - uid: 1570
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,3.5
       parent: 2
-  - uid: 1366
+  - uid: 1571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,4.5
       parent: 2
-  - uid: 1367
+  - uid: 1572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,9.5
       parent: 2
-  - uid: 1368
+  - uid: 1573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-12.5
       parent: 2
-  - uid: 1369
+  - uid: 1574
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,-9.5
       parent: 2
-  - uid: 1370
+  - uid: 1575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-5.5
       parent: 2
-  - uid: 1371
+  - uid: 1576
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-4.5
       parent: 2
-  - uid: 1372
+  - uid: 1577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-3.5
       parent: 2
-  - uid: 1374
+  - uid: 1578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-0.5
       parent: 2
-  - uid: 1377
+  - uid: 1579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,1.5
       parent: 2
-  - uid: 1378
+  - uid: 1580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,13.5
       parent: 2
-  - uid: 1379
+  - uid: 1581
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,13.5
       parent: 2
-  - uid: 1380
+  - uid: 1582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,11.5
       parent: 2
-  - uid: 1381
+  - uid: 1583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,14.5
       parent: 2
-  - uid: 1388
+  - uid: 1584
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,14.5
       parent: 2
-  - uid: 1398
+  - uid: 1585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,14.5
       parent: 2
-  - uid: 1401
+  - uid: 1586
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,13.5
       parent: 2
-  - uid: 1402
+  - uid: 1587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,14.5
       parent: 2
-  - uid: 1403
+  - uid: 1588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,14.5
       parent: 2
-  - uid: 1404
+  - uid: 1589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,14.5
       parent: 2
-  - uid: 1405
+  - uid: 1590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,12.5
       parent: 2
-  - uid: 1406
+  - uid: 1591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,14.5
       parent: 2
-  - uid: 1407
+  - uid: 1592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,13.5
       parent: 2
-  - uid: 1408
+  - uid: 1593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,13.5
       parent: 2
-  - uid: 1409
+  - uid: 1594
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,13.5
       parent: 2
-  - uid: 1412
+  - uid: 1595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-19.5
       parent: 2
-  - uid: 1413
+  - uid: 1596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-10.5
       parent: 2
-  - uid: 1414
+  - uid: 1597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-9.5
       parent: 2
-  - uid: 1415
+  - uid: 1598
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-23.5
       parent: 2
-  - uid: 1416
+  - uid: 1599
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-6.5
       parent: 2
-  - uid: 1417
+  - uid: 1600
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 2
-  - uid: 1418
+  - uid: 1601
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,8.5
       parent: 2
-  - uid: 1419
+  - uid: 1602
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-24.5
       parent: 2
-  - uid: 1420
+  - uid: 1603
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-24.5
       parent: 2
-  - uid: 1421
+  - uid: 1604
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-26.5
       parent: 2
-  - uid: 1422
+  - uid: 1605
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-25.5
       parent: 2
-  - uid: 1423
+  - uid: 1606
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-25.5
       parent: 2
-  - uid: 1424
+  - uid: 1607
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-23.5
       parent: 2
-  - uid: 1425
+  - uid: 1608
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-26.5
       parent: 2
-  - uid: 1426
+  - uid: 1609
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-25.5
       parent: 2
-  - uid: 1427
+  - uid: 1610
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-23.5
       parent: 2
-  - uid: 1428
+  - uid: 1611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-23.5
       parent: 2
-  - uid: 1429
+  - uid: 1612
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-24.5
       parent: 2
-  - uid: 1430
+  - uid: 1613
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-23.5
       parent: 2
-  - uid: 1431
+  - uid: 1614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-19.5
       parent: 2
-  - uid: 1432
+  - uid: 1615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-18.5
       parent: 2
-  - uid: 1433
+  - uid: 1616
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-15.5
       parent: 2
-  - uid: 1434
+  - uid: 1617
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-14.5
       parent: 2
-  - uid: 1435
+  - uid: 1618
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-13.5
       parent: 2
-  - uid: 1436
+  - uid: 1619
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-17.5
       parent: 2
-  - uid: 1437
+  - uid: 1620
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-21.5
       parent: 2
-  - uid: 1438
+  - uid: 1621
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,9.5
       parent: 2
-  - uid: 1439
+  - uid: 1622
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,6.5
       parent: 2
-  - uid: 1440
+  - uid: 1623
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
-  - uid: 1441
+  - uid: 1624
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,11.5
       parent: 2
-  - uid: 1442
+  - uid: 1625
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 2
-  - uid: 1443
+  - uid: 1626
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,12.5
       parent: 2
-  - uid: 1444
+  - uid: 1627
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-10.5
       parent: 2
-  - uid: 1445
+  - uid: 1628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,8.5
       parent: 2
-  - uid: 1446
+  - uid: 1629
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 1447
+  - uid: 1630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 2
-  - uid: 1448
+  - uid: 1631
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 2
-  - uid: 1449
+  - uid: 1632
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 2
-  - uid: 1450
+  - uid: 1633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 2
-  - uid: 1451
+  - uid: 1634
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 2
-  - uid: 1452
+  - uid: 1635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 2
-  - uid: 1453
+  - uid: 1636
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-2.5
       parent: 2
-  - uid: 1454
+  - uid: 1637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 2
-  - uid: 1456
+  - uid: 1638
     components:
     - type: Transform
       pos: -21.5,-22.5
       parent: 2
-  - uid: 1457
+  - uid: 1639
     components:
     - type: Transform
       pos: -20.5,-22.5
       parent: 2
-  - uid: 1458
+  - uid: 1640
     components:
     - type: Transform
       pos: -19.5,-22.5
       parent: 2
-  - uid: 1459
+  - uid: 1641
     components:
     - type: Transform
       pos: -18.5,-22.5
       parent: 2
-  - uid: 1460
+  - uid: 1642
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
-  - uid: 1461
+  - uid: 1643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-18.5
       parent: 2
-  - uid: 1462
+  - uid: 1644
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,10.5
       parent: 2
-  - uid: 1463
+  - uid: 1645
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,10.5
       parent: 2
-  - uid: 1464
+  - uid: 1646
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,10.5
       parent: 2
-  - uid: 1465
+  - uid: 1647
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,10.5
       parent: 2
-  - uid: 1466
+  - uid: 1648
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,10.5
       parent: 2
-  - uid: 1467
+  - uid: 1649
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 2
-  - uid: 1468
+  - uid: 1650
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 2
-  - uid: 1469
+  - uid: 1651
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 2
-  - uid: 1470
+  - uid: 1652
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 1471
+  - uid: 1653
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 1472
+  - uid: 1654
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 1473
+  - uid: 1655
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 1476
+  - uid: 1656
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,3.5
       parent: 2
-  - uid: 1477
+  - uid: 1657
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,3.5
       parent: 2
-  - uid: 1478
+  - uid: 1658
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,3.5
       parent: 2
-  - uid: 1479
+  - uid: 1659
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,3.5
       parent: 2
-  - uid: 1480
+  - uid: 1660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,3.5
       parent: 2
-  - uid: 1481
+  - uid: 1661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,3.5
       parent: 2
-  - uid: 1482
+  - uid: 1662
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,3.5
       parent: 2
-  - uid: 1483
+  - uid: 1663
     components:
     - type: Transform
       pos: -28.5,-24.5
       parent: 2
-  - uid: 1484
+  - uid: 1664
     components:
     - type: Transform
       pos: -31.5,-21.5
       parent: 2
-  - uid: 1485
+  - uid: 1665
     components:
     - type: Transform
       pos: -30.5,-23.5
       parent: 2
-  - uid: 1486
+  - uid: 1666
     components:
     - type: Transform
       pos: -29.5,-23.5
       parent: 2
-  - uid: 1487
+  - uid: 1667
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 2
-  - uid: 2267
+  - uid: 1668
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,14.5
       parent: 2
-  - uid: 2291
+  - uid: 1669
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
-  - uid: 2292
+  - uid: 1670
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 2
-  - uid: 2298
+  - uid: 1671
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-7.5
       parent: 2
-  - uid: 2300
+  - uid: 1672
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-4.5
       parent: 2
-  - uid: 2301
+  - uid: 1673
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-6.5
       parent: 2
-  - uid: 2302
+  - uid: 1674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-11.5
       parent: 2
-  - uid: 2343
+  - uid: 1675
     components:
     - type: Transform
       pos: -14.5,14.5
       parent: 2
-  - uid: 2345
+  - uid: 1676
     components:
     - type: Transform
       pos: -22.5,14.5
       parent: 2
-  - uid: 2347
+  - uid: 1677
     components:
     - type: Transform
       pos: -20.5,16.5
       parent: 2
-  - uid: 2348
+  - uid: 1678
     components:
     - type: Transform
       pos: -19.5,16.5
       parent: 2
-  - uid: 2349
+  - uid: 1679
     components:
     - type: Transform
       pos: -16.5,16.5
       parent: 2
-  - uid: 2350
+  - uid: 1680
     components:
     - type: Transform
       pos: -17.5,16.5
       parent: 2
-  - uid: 2351
+  - uid: 1681
     components:
     - type: Transform
       pos: -15.5,16.5
       parent: 2
-  - uid: 2352
+  - uid: 1682
     components:
     - type: Transform
       pos: -23.5,16.5
       parent: 2
-  - uid: 2353
+  - uid: 1683
     components:
     - type: Transform
       pos: -24.5,15.5
       parent: 2
-  - uid: 2354
+  - uid: 1684
     components:
     - type: Transform
       pos: -25.5,15.5
       parent: 2
-  - uid: 2355
+  - uid: 1685
     components:
     - type: Transform
       pos: -25.5,13.5
       parent: 2
-  - uid: 2356
+  - uid: 1686
     components:
     - type: Transform
       pos: -25.5,12.5
       parent: 2
-  - uid: 2359
+  - uid: 1687
     components:
     - type: Transform
       pos: -28.5,13.5
       parent: 2
-  - uid: 2360
+  - uid: 1688
     components:
     - type: Transform
       pos: -27.5,14.5
       parent: 2
-  - uid: 2361
+  - uid: 1689
     components:
     - type: Transform
       pos: -28.5,14.5
       parent: 2
-  - uid: 2362
+  - uid: 1690
     components:
     - type: Transform
       pos: -31.5,12.5
       parent: 2
-  - uid: 2367
+  - uid: 1691
     components:
     - type: Transform
       pos: -13.5,12.5
       parent: 2
-  - uid: 2368
+  - uid: 1692
     components:
     - type: Transform
       pos: -12.5,15.5
       parent: 2
-  - uid: 2369
+  - uid: 1693
     components:
     - type: Transform
       pos: -13.5,16.5
       parent: 2
-  - uid: 2371
+  - uid: 1694
     components:
     - type: Transform
       pos: -21.5,16.5
       parent: 2
-  - uid: 2372
+  - uid: 1695
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
-  - uid: 2373
+  - uid: 1696
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 2
-  - uid: 2437
+  - uid: 1697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,16.5
       parent: 2
-  - uid: 2485
+  - uid: 1698
     components:
     - type: Transform
       pos: -31.5,-12.5
       parent: 2
-  - uid: 2493
+  - uid: 1699
     components:
     - type: Transform
       pos: -21.5,17.5
       parent: 2
-  - uid: 2494
+  - uid: 1700
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 2
-  - uid: 2495
+  - uid: 1701
     components:
     - type: Transform
       pos: -20.5,17.5
       parent: 2
-  - uid: 2496
+  - uid: 1702
     components:
     - type: Transform
       pos: -17.5,17.5
       parent: 2
-  - uid: 2497
+  - uid: 1703
     components:
     - type: Transform
       pos: -19.5,17.5
       parent: 2
-  - uid: 2498
+  - uid: 1704
     components:
     - type: Transform
       pos: -18.5,17.5
       parent: 2
-  - uid: 2499
+  - uid: 1705
     components:
     - type: Transform
       pos: -16.5,17.5
       parent: 2
-  - uid: 2556
+  - uid: 1706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,5.5
       parent: 2
-  - uid: 2557
+  - uid: 1707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,6.5
       parent: 2
-  - uid: 2558
+  - uid: 1708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,7.5
       parent: 2
-  - uid: 2559
+  - uid: 1709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,8.5
       parent: 2
-  - uid: 2560
+  - uid: 1710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12426,80 +12496,80 @@ entities:
       parent: 2
 - proto: HandHeldMassScanner
   entities:
-  - uid: 1488
+  - uid: 1711
     components:
     - type: Transform
       pos: -4.351738,-4.137145
       parent: 2
-  - uid: 1489
+  - uid: 1712
     components:
     - type: Transform
       pos: -4.6998143,-4.27777
       parent: 2
-  - uid: 1490
+  - uid: 1713
     components:
     - type: Transform
       pos: -8.579288,-3.2672858
       parent: 2
 - proto: hydroponicsTray
   entities:
-  - uid: 1491
+  - uid: 1714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,9.5
       parent: 2
-  - uid: 1492
+  - uid: 1715
     components:
     - type: Transform
       pos: -8.5,7.5
       parent: 2
-  - uid: 1493
+  - uid: 1716
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 2
-  - uid: 1494
+  - uid: 1717
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 2
-  - uid: 1495
+  - uid: 1718
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 2
-  - uid: 1496
+  - uid: 1719
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 2
-  - uid: 1497
+  - uid: 1720
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 2
 - proto: IngotGold
   entities:
-  - uid: 814
+  - uid: 939
     components:
     - type: Transform
-      parent: 813
+      parent: 938
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: IngotSilver
   entities:
-  - uid: 815
+  - uid: 940
     components:
     - type: Transform
-      parent: 813
+      parent: 938
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: IngotSilver1
   entities:
-  - uid: 1651
+  - uid: 1721
     components:
     - type: Transform
       pos: -12.696228,-9.841797
@@ -12508,14 +12578,14 @@ entities:
       count: 3
 - proto: IrishBoolGlass
   entities:
-  - uid: 1498
+  - uid: 1722
     components:
     - type: Transform
       pos: 1.0952202,3.741826
       parent: 2
 - proto: JanitorialTrolley
   entities:
-  - uid: 1537
+  - uid: 1723
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12523,220 +12593,220 @@ entities:
       parent: 2
 - proto: JetpackMiniFilled
   entities:
-  - uid: 1499
+  - uid: 1724
     components:
     - type: Transform
       pos: -8.278852,-3.2150235
       parent: 2
-  - uid: 1500
+  - uid: 1725
     components:
     - type: Transform
       pos: -8.513227,-3.5743985
       parent: 2
 - proto: Jukebox
   entities:
-  - uid: 2272
+  - uid: 1726
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
 - proto: KitchenElectricGrill
   entities:
-  - uid: 1501
+  - uid: 1727
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 2
 - proto: KitchenKnife
   entities:
-  - uid: 1001
+  - uid: 1159
     components:
     - type: Transform
-      parent: 999
+      parent: 1157
     - type: Physics
       canCollide: False
-  - uid: 1502
+  - uid: 1728
     components:
     - type: Transform
       pos: -5.3560333,4.55838
       parent: 2
 - proto: KitchenMicrowave
   entities:
-  - uid: 1503
+  - uid: 1729
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 2218
+  - uid: 1730
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 2
-  - uid: 2512
+  - uid: 1731
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
 - proto: KitchenSpike
   entities:
-  - uid: 1505
+  - uid: 1732
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 1506
+  - uid: 1733
     components:
     - type: Transform
       pos: -14.664459,8.579437
       parent: 2
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 94
+  - uid: 1734
     components:
     - type: Transform
       pos: -27.5,1.5
       parent: 2
 - proto: LockerBoozeFilled
   entities:
-  - uid: 1507
+  - uid: 1735
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
 - proto: LockerBotanistFilled
   entities:
-  - uid: 1508
+  - uid: 1736
     components:
     - type: Transform
       pos: -9.5,9.5
       parent: 2
 - proto: LockerCaptainFilledHardsuit
   entities:
-  - uid: 1509
+  - uid: 1737
     components:
     - type: Transform
       pos: -27.5,-17.5
       parent: 2
 - proto: LockerChemistryFilled
   entities:
-  - uid: 1510
+  - uid: 1738
     components:
     - type: Transform
       pos: -14.5,9.5
       parent: 2
 - proto: LockerChiefEngineerFilledHardsuit
   entities:
-  - uid: 1511
+  - uid: 1739
     components:
     - type: Transform
       pos: -28.5,1.5
       parent: 2
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 65
+  - uid: 1740
     components:
     - type: Transform
       pos: -20.5,10.5
       parent: 2
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 1513
+  - uid: 1741
     components:
     - type: Transform
       pos: -29.5,1.5
       parent: 2
 - proto: LockerEvidence
   entities:
-  - uid: 1514
+  - uid: 1742
     components:
     - type: Transform
       pos: -18.5,-6.5
       parent: 2
 - proto: LockerFreezer
   entities:
-  - uid: 1515
+  - uid: 1743
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 2
 - proto: LockerHeadOfPersonnelFilled
   entities:
-  - uid: 1516
+  - uid: 1744
     components:
     - type: Transform
       pos: -18.5,-14.5
       parent: 2
 - proto: LockerHeadOfSecurityFilledHardsuit
   entities:
-  - uid: 1517
+  - uid: 1745
     components:
     - type: Transform
       pos: -16.5,-10.5
       parent: 2
 - proto: LockerQuarterMasterFilled
   entities:
-  - uid: 1518
+  - uid: 1746
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 2
 - proto: LockerResearchDirectorFilledHardsuit
   entities:
-  - uid: 1519
+  - uid: 1747
     components:
     - type: Transform
       pos: -26.5,-9.5
       parent: 2
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
-  - uid: 2236
+  - uid: 1748
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 2
 - proto: LockerScienceFilled
   entities:
-  - uid: 1521
+  - uid: 1749
     components:
     - type: Transform
       pos: -25.5,-9.5
       parent: 2
 - proto: LockerSecurityFilled
   entities:
-  - uid: 1522
+  - uid: 1750
     components:
     - type: Transform
       pos: -16.5,-9.5
       parent: 2
 - proto: LogProbeCartridge
   entities:
-  - uid: 2486
+  - uid: 160
     components:
     - type: Transform
-      parent: 1534
+      parent: 155
     - type: Physics
       canCollide: False
 - proto: MachineAnomalyGenerator
   entities:
-  - uid: 1523
+  - uid: 1751
     components:
     - type: Transform
       pos: -25.5,-4.5
       parent: 2
 - proto: MachineAnomalyVessel
   entities:
-  - uid: 1524
+  - uid: 1752
     components:
     - type: Transform
       pos: -29.5,-9.5
       parent: 2
 - proto: MachineAPE
   entities:
-  - uid: 2490
+  - uid: 1753
     components:
     - type: Transform
       anchored: False
@@ -12748,180 +12818,180 @@ entities:
       bodyType: Dynamic
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 1526
+  - uid: 1754
     components:
     - type: Transform
       pos: -29.5,-7.5
       parent: 2
 - proto: MachineCentrifuge
   entities:
-  - uid: 2211
+  - uid: 1755
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 2
 - proto: MaterialCloth
   entities:
-  - uid: 1527
+  - uid: 1756
     components:
     - type: Transform
       pos: -16.436615,-15.322025
       parent: 2
 - proto: MaterialDurathread
   entities:
-  - uid: 1528
+  - uid: 1757
     components:
     - type: Transform
       pos: -16.592865,-15.092859
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 1529
+  - uid: 1758
     components:
     - type: Transform
       pos: -20.5,7.5
       parent: 2
-  - uid: 1530
+  - uid: 1759
     components:
     - type: Transform
       pos: -18.5,7.5
       parent: 2
-  - uid: 1531
+  - uid: 1760
     components:
     - type: Transform
       pos: -26.5,-17.5
       parent: 2
-  - uid: 2327
+  - uid: 1761
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 2
 - proto: MedicalTechFab
   entities:
-  - uid: 1532
+  - uid: 1762
     components:
     - type: Transform
       pos: -15.5,6.5
       parent: 2
 - proto: MedicatedSuture
   entities:
-  - uid: 1792
+  - uid: 1763
     components:
     - type: Transform
       pos: -16.313232,10.487671
       parent: 2
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 1806
+  - uid: 1764
     components:
     - type: Transform
       pos: -16.281982,10.768921
       parent: 2
 - proto: MedkitFilled
   entities:
-  - uid: 1981
+  - uid: 1765
     components:
     - type: Transform
       pos: -16.297607,11.065796
       parent: 2
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 1813
+  - uid: 1766
     components:
     - type: Transform
       pos: -16.594482,10.925171
       parent: 2
 - proto: Morgue
   entities:
-  - uid: 1538
+  - uid: 1767
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 2
-  - uid: 1539
+  - uid: 1768
     components:
     - type: Transform
       pos: -23.5,9.5
       parent: 2
 - proto: Multitool
   entities:
-  - uid: 1540
+  - uid: 1769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.49931192,6.4915857
       parent: 2
-  - uid: 1541
+  - uid: 1770
     components:
     - type: Transform
       pos: -12.760731,-8.397345
       parent: 2
 - proto: NitrogenCanister
   entities:
-  - uid: 1543
+  - uid: 1771
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
-  - uid: 1544
+  - uid: 1772
     components:
     - type: Transform
       pos: -36.5,4.5
       parent: 2
 - proto: OreProcessor
   entities:
-  - uid: 1545
+  - uid: 1773
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
 - proto: OxygenCanister
   entities:
-  - uid: 1546
+  - uid: 1774
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 1547
+  - uid: 1775
     components:
     - type: Transform
       pos: -36.5,5.5
       parent: 2
 - proto: PairedChopsticks
   entities:
-  - uid: 1002
+  - uid: 1160
     components:
     - type: Transform
-      parent: 999
+      parent: 1157
     - type: Physics
       canCollide: False
 - proto: Paper
   entities:
-  - uid: 1548
+  - uid: 1776
     components:
     - type: Transform
       pos: 4.2468195,-5.4433904
       parent: 2
-  - uid: 1549
+  - uid: 1777
     components:
     - type: Transform
       pos: -16.609146,-15.752253
       parent: 2
-  - uid: 1550
+  - uid: 1778
     components:
     - type: Transform
       pos: -16.702896,-15.8564205
       parent: 2
 - proto: PaperCaptainsThoughts
   entities:
-  - uid: 2243
+  - uid: 1779
     components:
     - type: Transform
       pos: -16.24289,-21.431488
       parent: 2
 - proto: PaperOffice
   entities:
-  - uid: 1850
+  - uid: 1780
     components:
     - type: Transform
       pos: -26.945587,1.3583984
@@ -12967,71 +13037,71 @@ entities:
         ───────────────────────────────────────
 
         Sincerely, CENTCOMM Engineering.
-  - uid: 2244
+  - uid: 1781
     components:
     - type: Transform
       pos: -16.508514,-21.697113
       parent: 2
-  - uid: 2551
+  - uid: 1782
     components:
     - type: Transform
       pos: -19.376312,-15.360504
       parent: 2
 - proto: PartRodMetal
   entities:
-  - uid: 1814
+  - uid: 1783
     components:
     - type: Transform
       pos: -12.477478,-10.044922
       parent: 2
 - proto: Pen
   entities:
-  - uid: 1551
+  - uid: 1784
     components:
     - type: Transform
       pos: 4.4968195,-5.3027654
       parent: 2
-  - uid: 2552
+  - uid: 1785
     components:
     - type: Transform
       pos: -19.610687,-15.548004
       parent: 2
 - proto: PenCentcom
   entities:
-  - uid: 2553
+  - uid: 1786
     components:
     - type: Transform
       pos: -23.342499,-21.316711
       parent: 2
 - proto: PhoneInstrument
   entities:
-  - uid: 2245
+  - uid: 1787
     components:
     - type: Transform
       pos: -16.633514,-21.306488
       parent: 2
 - proto: PlasmaCanister
   entities:
-  - uid: 1552
+  - uid: 1788
     components:
     - type: Transform
       pos: -36.5,6.5
       parent: 2
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 940
+  - uid: 1789
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-12.5
       parent: 2
-  - uid: 943
+  - uid: 1790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 944
+  - uid: 1791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13039,13 +13109,13 @@ entities:
       parent: 2
 - proto: PlasmaWindoorSecureScienceLocked
   entities:
-  - uid: 1553
+  - uid: 1792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-3.5
       parent: 2
-  - uid: 1554
+  - uid: 1793
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13053,18 +13123,18 @@ entities:
       parent: 2
 - proto: PlasmaWindoorSecureSecurityLocked
   entities:
-  - uid: 771
+  - uid: 1794
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 939
+  - uid: 1795
     components:
     - type: Transform
       pos: -18.5,-11.5
       parent: 2
-  - uid: 1660
+  - uid: 1796
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13072,67 +13142,67 @@ entities:
       parent: 2
 - proto: PlasmaWindowDirectional
   entities:
-  - uid: 1555
+  - uid: 1797
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 2
-  - uid: 1556
+  - uid: 1798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-9.5
       parent: 2
-  - uid: 1557
+  - uid: 1799
     components:
     - type: Transform
       pos: -29.5,-6.5
       parent: 2
-  - uid: 1558
+  - uid: 1800
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
-  - uid: 1559
+  - uid: 1801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-9.5
       parent: 2
-  - uid: 1560
+  - uid: 1802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-7.5
       parent: 2
-  - uid: 1561
+  - uid: 1803
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
-  - uid: 1562
+  - uid: 1804
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 2463
+  - uid: 1805
     components:
     - type: Transform
       pos: -25.5,10.5
       parent: 2
-  - uid: 2477
+  - uid: 1806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,10.5
       parent: 2
-  - uid: 2480
+  - uid: 1807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,10.5
       parent: 2
-  - uid: 2481
+  - uid: 1808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13140,14 +13210,14 @@ entities:
       parent: 2
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 1563
+  - uid: 1809
     components:
     - type: Transform
       pos: -14.5,-8.5
       parent: 2
 - proto: PlasticFlapsAirtightOpaque
   entities:
-  - uid: 1564
+  - uid: 1810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13155,56 +13225,63 @@ entities:
       parent: 2
 - proto: PlushieArachind
   entities:
-  - uid: 2564
+  - uid: 1811
     components:
     - type: Transform
       pos: -12.538422,2.5822754
       parent: 2
 - proto: PlushieCosmicCult
   entities:
-  - uid: 2547
+  - uid: 1812
     components:
     - type: Transform
       pos: 6.1757812,-7.0670166
       parent: 2
+- proto: PlushieDecapoid
+  entities:
+  - uid: 1813
+    components:
+    - type: Transform
+      pos: -3.4657288,-2.3069458
+      parent: 2
 - proto: PlushieDiona
   entities:
-  - uid: 2538
+  - uid: 1814
     components:
     - type: Transform
       pos: -18.5401,-15.4539795
       parent: 2
 - proto: PlushieFinfin
   entities:
-  - uid: 2543
+  - uid: 1815
     components:
     - type: Transform
       pos: 2.6047668,3.8632812
       parent: 2
 - proto: PlushieGray
   entities:
-  - uid: 2548
+  - uid: 1816
     components:
     - type: Transform
       pos: -6.3056335,-9.643036
       parent: 2
 - proto: PlushieLamp
   entities:
-  - uid: 2242
+  - uid: 1817
     components:
     - type: Transform
       pos: -23.564392,-21.203064
       parent: 2
 - proto: PlushieLizard
   entities:
-  - uid: 2540
+  - uid: 1818
     components:
     - type: Transform
       pos: -18.48291,13.490936
       parent: 2
 - proto: PlushieRouny
   entities:
-  - uid: 2541
+  - uid: 1819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13212,47 +13289,42 @@ entities:
       parent: 2
 - proto: PlushieSlime
   entities:
-  - uid: 2539
+  - uid: 1820
     components:
     - type: Transform
       pos: -26.82434,-7.36322
       parent: 2
 - proto: PlushieVox
   entities:
-  - uid: 2542
+  - uid: 1821
     components:
     - type: Transform
       pos: -5.570587,-2.3172302
       parent: 2
 - proto: PortableGeneratorJrPacman
   entities:
-  - uid: 1565
-    components:
-    - type: Transform
-      pos: -12.5,-2.5
-      parent: 2
-  - uid: 1566
+  - uid: 1822
     components:
     - type: Transform
       pos: -16.5,-19.5
       parent: 2
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 782
+  - uid: 1823
     components:
     - type: Transform
       pos: -25.5,7.5
       parent: 2
 - proto: PortableScrubber
   entities:
-  - uid: 1567
+  - uid: 1824
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 2
 - proto: PosterContrabandMissingGloves
   entities:
-  - uid: 2531
+  - uid: 1825
     components:
     - type: MetaData
       desc: "Across the bottom of the poster, its normal writing has been graffiti'd over, instead reading: \"yellows of hand, of glove. electricity\"."
@@ -13262,14 +13334,14 @@ entities:
       parent: 2
 - proto: PosterContrabandSunkist
   entities:
-  - uid: 2566
+  - uid: 1826
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 2
 - proto: PosterLegitEnlist
   entities:
-  - uid: 2436
+  - uid: 1827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13277,7 +13349,7 @@ entities:
       parent: 2
 - proto: PosterLegitJustAWeekAway
   entities:
-  - uid: 2513
+  - uid: 1828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13285,7 +13357,7 @@ entities:
       parent: 2
 - proto: PosterLegitSafetyMothEpi
   entities:
-  - uid: 2535
+  - uid: 1829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13293,7 +13365,7 @@ entities:
       parent: 2
 - proto: PosterLegitSafetyMothMeth
   entities:
-  - uid: 2565
+  - uid: 1830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13301,467 +13373,490 @@ entities:
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 1700
+  - uid: 1831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 1957
+  - uid: 1832
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-  - uid: 2318
+  - uid: 1833
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 2
-  - uid: 2484
+  - uid: 1834
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 778
+  - uid: 1835
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,6.5
       parent: 2
-  - uid: 1568
+  - uid: 1836
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
-  - uid: 1569
+  - uid: 1837
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-4.5
       parent: 2
-  - uid: 1570
+  - uid: 1838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-4.5
       parent: 2
-  - uid: 1571
+  - uid: 1839
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 2
-  - uid: 1572
+  - uid: 1840
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-2.5
       parent: 2
-  - uid: 1573
+  - uid: 1841
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-6.5
       parent: 2
-  - uid: 1574
+  - uid: 1842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-11.5
       parent: 2
-  - uid: 1575
+  - uid: 1843
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-15.5
       parent: 2
-  - uid: 1576
+  - uid: 1844
     components:
     - type: Transform
       pos: -23.5,-18.5
       parent: 2
-  - uid: 1577
+  - uid: 1845
     components:
     - type: Transform
       pos: -16.5,-18.5
       parent: 2
-  - uid: 1578
+  - uid: 1846
     components:
     - type: Transform
       pos: -28.5,-14.5
       parent: 2
-  - uid: 1579
+  - uid: 1847
     components:
     - type: Transform
       pos: -24.5,-14.5
       parent: 2
-  - uid: 1581
+  - uid: 1848
     components:
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
-  - uid: 1582
+  - uid: 1849
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-9.5
       parent: 2
-  - uid: 1583
+  - uid: 1850
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-9.5
       parent: 2
-  - uid: 1584
+  - uid: 1851
     components:
     - type: Transform
       pos: -26.5,-3.5
       parent: 2
-  - uid: 1585
+  - uid: 1852
     components:
     - type: Transform
       pos: -22.5,5.5
       parent: 2
-  - uid: 1586
+  - uid: 1853
     components:
     - type: Transform
       pos: -28.5,6.5
       parent: 2
-  - uid: 1587
+  - uid: 1854
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-0.5
       parent: 2
-  - uid: 1588
+  - uid: 1855
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,0.5
       parent: 2
-  - uid: 1591
+  - uid: 1856
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,4.5
       parent: 2
-  - uid: 1592
+  - uid: 1857
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,9.5
       parent: 2
-  - uid: 1593
+  - uid: 1858
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 2
-  - uid: 1594
+  - uid: 1859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,9.5
       parent: 2
-  - uid: 1595
+  - uid: 1860
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,9.5
       parent: 2
-  - uid: 1596
+  - uid: 1861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 2
-  - uid: 1597
+  - uid: 1862
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
-  - uid: 1598
+  - uid: 1863
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 2
-  - uid: 1599
+  - uid: 1864
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 1600
+  - uid: 1865
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
-  - uid: 1601
+  - uid: 1866
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 2
-  - uid: 1602
+  - uid: 1867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 2
-  - uid: 1603
+  - uid: 1868
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 2
-  - uid: 1604
+  - uid: 1869
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 1605
+  - uid: 1870
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
-  - uid: 1606
+  - uid: 1871
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
-  - uid: 1607
+  - uid: 1872
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
-  - uid: 1608
+  - uid: 1873
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
-  - uid: 1609
+  - uid: 1874
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 1610
+  - uid: 1875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-10.5
       parent: 2
-  - uid: 1611
+  - uid: 1876
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
       parent: 2
-  - uid: 1612
+  - uid: 1877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 2
-  - uid: 1613
+  - uid: 1878
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 2
-  - uid: 1614
+  - uid: 1879
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 2
-  - uid: 1615
+  - uid: 1880
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-2.5
       parent: 2
-  - uid: 1616
+  - uid: 1881
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-5.5
       parent: 2
-  - uid: 1617
+  - uid: 1882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-9.5
       parent: 2
-  - uid: 1618
+  - uid: 1883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-13.5
       parent: 2
-  - uid: 1619
+  - uid: 1884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-16.5
       parent: 2
-  - uid: 1620
+  - uid: 1885
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-20.5
       parent: 2
-  - uid: 1621
+  - uid: 1886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-10.5
       parent: 2
-  - uid: 1622
+  - uid: 1887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-9.5
       parent: 2
-  - uid: 1623
+  - uid: 1888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,6.5
       parent: 2
-  - uid: 1624
+  - uid: 1889
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,6.5
       parent: 2
-  - uid: 1625
+  - uid: 1890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,7.5
       parent: 2
-  - uid: 1626
+  - uid: 1891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,4.5
       parent: 2
-  - uid: 1627
+  - uid: 1892
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,2.5
       parent: 2
-  - uid: 1628
+  - uid: 1893
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 2
-  - uid: 1629
+  - uid: 1894
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,8.5
       parent: 2
-  - uid: 1630
+  - uid: 1895
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,8.5
       parent: 2
-  - uid: 1631
+  - uid: 1896
     components:
     - type: Transform
       pos: -32.5,-14.5
       parent: 2
-  - uid: 1632
+  - uid: 1897
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-16.5
       parent: 2
-  - uid: 1634
+  - uid: 1898
     components:
     - type: Transform
       pos: -27.5,9.5
       parent: 2
-  - uid: 1635
+  - uid: 1899
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 2
-  - uid: 1636
+  - uid: 1900
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-0.5
       parent: 2
-  - uid: 1637
+  - uid: 1901
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-0.5
       parent: 2
-  - uid: 1638
+  - uid: 1902
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 1858
+  - uid: 1903
     components:
     - type: Transform
       pos: -25.5,-11.5
       parent: 2
-  - uid: 1879
+  - uid: 1904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,10.5
       parent: 2
-  - uid: 2135
+  - uid: 1905
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,10.5
       parent: 2
-  - uid: 2435
+  - uid: 1906
     components:
     - type: Transform
       pos: -25.5,7.5
       parent: 2
-  - uid: 2455
+  - uid: 1907
     components:
     - type: Transform
       pos: -28.5,-20.5
       parent: 2
-  - uid: 2468
+  - uid: 1908
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,8.5
       parent: 2
-  - uid: 2529
+  - uid: 1909
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,7.5
       parent: 2
+  - uid: 2577
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,2.5
+      parent: 2
+  - uid: 2578
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-0.5
+      parent: 2
+  - uid: 2579
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 2580
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-0.5
+      parent: 2
 - proto: PoweredlightUV
   entities:
-  - uid: 72
+  - uid: 1910
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,7.5
       parent: 2
-  - uid: 73
+  - uid: 1911
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
-  - uid: 1640
+  - uid: 1912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13769,48 +13864,48 @@ entities:
       parent: 2
 - proto: Protolathe
   entities:
-  - uid: 1641
+  - uid: 1913
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 1642
+  - uid: 1914
     components:
     - type: Transform
       pos: -29.5,-5.5
       parent: 2
 - proto: Rack
   entities:
-  - uid: 1643
+  - uid: 1915
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 2
-  - uid: 1645
+  - uid: 1916
     components:
     - type: Transform
       pos: -24.5,-5.5
       parent: 2
-  - uid: 1646
+  - uid: 1917
     components:
     - type: Transform
       pos: -22.5,5.5
       parent: 2
 - proto: RadiationCollectorFullTank
   entities:
-  - uid: 1851
+  - uid: 1918
     components:
     - type: Transform
       pos: -28.5,3.5
       parent: 2
-  - uid: 1852
+  - uid: 1919
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 2
 - proto: RandomArtifactSpawner
   entities:
-  - uid: 2429
+  - uid: 1920
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13818,34 +13913,34 @@ entities:
       parent: 2
 - proto: RandomSpawner
   entities:
-  - uid: 2270
+  - uid: 1921
     components:
     - type: Transform
       pos: -11.5,-0.5
       parent: 2
 - proto: ReagentContainerFlour
   entities:
-  - uid: 1003
+  - uid: 1161
     components:
     - type: Transform
-      parent: 999
+      parent: 1157
     - type: Physics
       canCollide: False
-  - uid: 1004
+  - uid: 1162
     components:
     - type: Transform
-      parent: 999
+      parent: 1157
     - type: Physics
       canCollide: False
 - proto: Recycler
   entities:
-  - uid: 1649
+  - uid: 1922
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 2
-  - uid: 1650
+  - uid: 1923
     components:
     - type: Transform
       rot: -3.141592653589793 rad
@@ -13853,14 +13948,14 @@ entities:
       parent: 2
 - proto: RegenerativeMesh
   entities:
-  - uid: 1880
+  - uid: 1924
     components:
     - type: Transform
       pos: -16.656982,10.612671
       parent: 2
 - proto: RemoteSignallerAdvanced
   entities:
-  - uid: 1980
+  - uid: 1925
     components:
     - type: MetaData
       name: shuttle bay field remote
@@ -13869,269 +13964,269 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1504:
+        1064:
         - Pressed: Toggle
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 1652
+  - uid: 1926
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 2
 - proto: RollerBed
   entities:
-  - uid: 1978
+  - uid: 1927
     components:
     - type: Transform
       pos: -16.533813,4.4702454
       parent: 2
 - proto: RollingPin
   entities:
-  - uid: 1005
+  - uid: 1163
     components:
     - type: Transform
-      parent: 999
+      parent: 1157
     - type: Physics
       canCollide: False
-  - uid: 1653
+  - uid: 1928
     components:
     - type: Transform
       pos: -5.5435333,4.62088
       parent: 2
 - proto: RubberStampApproved
   entities:
-  - uid: 1654
+  - uid: 1929
     components:
     - type: Transform
       pos: 4.7468195,-5.5215154
       parent: 2
-  - uid: 1655
+  - uid: 1930
     components:
     - type: Transform
       pos: -16.22373,-15.710587
       parent: 2
 - proto: RubberStampDenied
   entities:
-  - uid: 1656
+  - uid: 1931
     components:
     - type: Transform
       pos: 4.5124445,-5.5996404
       parent: 2
-  - uid: 1657
+  - uid: 1932
     components:
     - type: Transform
       pos: -16.390396,-15.877253
       parent: 2
 - proto: SalvageMagnet
   entities:
-  - uid: 1658
+  - uid: 1933
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 2
 - proto: Screen
   entities:
-  - uid: 1659
+  - uid: 1934
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
 - proto: SecurityTechFab
   entities:
-  - uid: 1661
+  - uid: 1935
     components:
     - type: Transform
       pos: -18.5,-12.5
       parent: 2
 - proto: SeedExtractor
   entities:
-  - uid: 1373
+  - uid: 1936
     components:
     - type: Transform
       pos: -10.5,9.5
       parent: 2
 - proto: ShardCrystalGreen
   entities:
-  - uid: 1662
+  - uid: 1937
     components:
     - type: Transform
       rot: 0.6984487791196443 rad
       pos: -27.57602,3.4105835
       parent: 2
-  - uid: 1663
+  - uid: 1938
     components:
     - type: Transform
       pos: -29.691925,2.629486
       parent: 2
 - proto: SheetGlass
   entities:
-  - uid: 1665
+  - uid: 927
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 928
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 929
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1939
     components:
     - type: Transform
       pos: -22.49598,5.4455404
       parent: 2
-  - uid: 1849
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 2205
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 2304
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 2530
+  - uid: 1940
     components:
     - type: Transform
       pos: -24.43573,-5.293335
       parent: 2
 - proto: SheetPlasma
   entities:
-  - uid: 802
+  - uid: 890
     components:
     - type: Transform
-      parent: 801
+      parent: 889
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1666
+  - uid: 1941
     components:
     - type: Transform
       pos: -24.541372,-5.4864893
       parent: 2
 - proto: SheetPlasma1
   entities:
-  - uid: 2325
+  - uid: 1942
     components:
     - type: Transform
       pos: -15.433319,7.4024963
       parent: 2
 - proto: SheetPlasteel
   entities:
-  - uid: 1667
+  - uid: 1943
     components:
     - type: Transform
       pos: -22.413675,5.5141277
       parent: 2
-  - uid: 1668
+  - uid: 1944
     components:
     - type: Transform
       pos: -22.427393,5.527845
       parent: 2
 - proto: SheetPlastic
   entities:
-  - uid: 1639
+  - uid: 930
     components:
     - type: Transform
-      parent: 1395
+      parent: 926
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1669
+  - uid: 931
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 932
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1945
     components:
     - type: Transform
       pos: -22.482264,5.4866924
       parent: 2
-  - uid: 1733
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 1840
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 2483
+  - uid: 1946
     components:
     - type: Transform
       pos: -24.465942,-5.2782288
       parent: 2
 - proto: SheetSteel
   entities:
-  - uid: 1670
+  - uid: 933
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 934
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 935
+    components:
+    - type: Transform
+      parent: 926
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1947
     components:
     - type: Transform
       pos: -22.427393,5.4729753
       parent: 2
-  - uid: 1742
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 1950
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 2018
-    components:
-    - type: Transform
-      parent: 1395
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 2366
+  - uid: 1948
     components:
     - type: Transform
       pos: -24.262817,-5.3251038
       parent: 2
 - proto: ShelfBar
   entities:
-  - uid: 896
+  - uid: 1045
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
     - type: Storage
       storedItems:
-        897:
+        1046:
           position: 0,0
           _rotation: South
-        898:
+        1047:
           position: 1,0
           _rotation: South
-        899:
+        1048:
           position: 2,0
           _rotation: South
-        900:
+        1049:
           position: 3,0
           _rotation: South
-        901:
+        1050:
           position: 4,0
           _rotation: South
-        902:
+        1051:
           position: 5,0
           _rotation: South
-        903:
+        1052:
           position: 0,3
           _rotation: South
-        904:
+        1053:
           position: 1,3
           _rotation: South
-        905:
+        1054:
           position: 2,3
           _rotation: South
-        906:
+        1055:
           position: 3,3
           _rotation: South
     - type: ContainerContainer
@@ -14140,41 +14235,41 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 897
-          - 898
-          - 899
-          - 900
-          - 901
-          - 902
-          - 903
-          - 904
-          - 905
-          - 906
+          - 1046
+          - 1047
+          - 1048
+          - 1049
+          - 1050
+          - 1051
+          - 1052
+          - 1053
+          - 1054
+          - 1055
 - proto: ShelfKitchen
   entities:
-  - uid: 999
+  - uid: 1157
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
     - type: Storage
       storedItems:
-        1003:
+        1161:
           position: 0,0
           _rotation: South
-        1004:
+        1162:
           position: 1,0
           _rotation: South
-        1000:
+        1158:
           position: 2,0
           _rotation: South
-        1005:
+        1163:
           position: 3,0
           _rotation: South
-        1001:
+        1159:
           position: 4,0
           _rotation: South
-        1002:
+        1160:
           position: 5,0
           _rotation: South
     - type: ContainerContainer
@@ -14183,253 +14278,253 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1003
-          - 1004
-          - 1000
-          - 1005
-          - 1001
-          - 1002
+          - 1161
+          - 1162
+          - 1158
+          - 1163
+          - 1159
+          - 1160
 - proto: ShuttleWindow
   entities:
-  - uid: 895
+  - uid: 1949
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 1672
+  - uid: 1950
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,8.5
       parent: 2
-  - uid: 1673
+  - uid: 1951
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,3.5
       parent: 2
-  - uid: 1674
+  - uid: 1952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,10.5
       parent: 2
-  - uid: 1675
+  - uid: 1953
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,10.5
       parent: 2
-  - uid: 1676
+  - uid: 1954
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,10.5
       parent: 2
-  - uid: 1677
+  - uid: 1955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,10.5
       parent: 2
-  - uid: 1678
+  - uid: 1956
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,10.5
       parent: 2
-  - uid: 1679
+  - uid: 1957
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,3.5
       parent: 2
-  - uid: 1680
+  - uid: 1958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,3.5
       parent: 2
-  - uid: 1681
+  - uid: 1959
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,3.5
       parent: 2
-  - uid: 1682
+  - uid: 1960
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,3.5
       parent: 2
-  - uid: 1683
+  - uid: 1961
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,3.5
       parent: 2
-  - uid: 1684
+  - uid: 1962
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,3.5
       parent: 2
-  - uid: 1688
+  - uid: 1963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 2
-  - uid: 1689
+  - uid: 1964
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 1690
+  - uid: 1965
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 1691
+  - uid: 1966
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-2.5
       parent: 2
-  - uid: 1692
+  - uid: 1967
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
-  - uid: 1693
+  - uid: 1968
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 1694
+  - uid: 1969
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 1695
+  - uid: 1970
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
-  - uid: 1696
+  - uid: 1971
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 1697
+  - uid: 1972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 2
-  - uid: 1698
+  - uid: 1973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 2
-  - uid: 1699
+  - uid: 1974
     components:
     - type: Transform
       pos: -28.5,-18.5
       parent: 2
-  - uid: 1702
+  - uid: 1975
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-22.5
       parent: 2
-  - uid: 1703
+  - uid: 1976
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-22.5
       parent: 2
-  - uid: 1704
+  - uid: 1977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-22.5
       parent: 2
-  - uid: 1705
+  - uid: 1978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-22.5
       parent: 2
-  - uid: 1706
+  - uid: 1979
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-5.5
       parent: 2
-  - uid: 1707
+  - uid: 1980
     components:
     - type: Transform
       pos: -15.5,-15.5
       parent: 2
-  - uid: 1708
+  - uid: 1981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 2
-  - uid: 1709
+  - uid: 1982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 2
-  - uid: 1710
+  - uid: 1983
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 2
-  - uid: 1711
+  - uid: 1984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 2
-  - uid: 2172
+  - uid: 1985
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 2
-  - uid: 2299
+  - uid: 1986
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,14.5
       parent: 2
-  - uid: 2326
+  - uid: 1987
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,14.5
       parent: 2
-  - uid: 2344
+  - uid: 1988
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,14.5
       parent: 2
-  - uid: 2346
+  - uid: 1989
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,14.5
       parent: 2
-  - uid: 2370
+  - uid: 1990
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14437,7 +14532,7 @@ entities:
       parent: 2
 - proto: SignalButtonDirectional
   entities:
-  - uid: 149
+  - uid: 1991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14445,9 +14540,9 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        137:
+        150:
         - Pressed: Toggle
-  - uid: 1713
+  - uid: 1992
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14455,29 +14550,29 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        61:
+        60:
         - Pressed: Open
-        62:
+        61:
         - Pressed: Open
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 1714
+  - uid: 1993
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1649:
+        1922:
         - On: Reverse
         - Off: Off
-        804:
+        918:
         - On: Reverse
         - Off: Off
-        803:
+        917:
         - On: Reverse
         - Off: Off
-  - uid: 1715
+  - uid: 1994
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14485,27 +14580,27 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        809:
+        923:
         - On: Forward
         - Off: Off
-        806:
+        920:
         - On: Forward
         - Off: Off
-        808:
+        922:
         - On: Forward
         - Off: Off
-        807:
+        921:
         - On: Forward
         - Off: Off
-        805:
+        919:
         - On: Forward
         - Off: Off
-        1650:
+        1923:
         - On: Reverse
         - Off: Off
 - proto: SignAtmos
   entities:
-  - uid: 1717
+  - uid: 1995
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14513,21 +14608,21 @@ entities:
       parent: 2
 - proto: SignBar
   entities:
-  - uid: 1718
+  - uid: 1996
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
 - proto: SignBridge
   entities:
-  - uid: 1719
+  - uid: 1997
     components:
     - type: Transform
       pos: -23.5,-16.5
       parent: 2
 - proto: SignCans
   entities:
-  - uid: 1720
+  - uid: 1998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14535,7 +14630,7 @@ entities:
       parent: 2
 - proto: SignCargo
   entities:
-  - uid: 1721
+  - uid: 1999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14543,7 +14638,7 @@ entities:
       parent: 2
 - proto: SignCargoDock
   entities:
-  - uid: 1722
+  - uid: 2000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14551,7 +14646,7 @@ entities:
       parent: 2
 - proto: SignChem
   entities:
-  - uid: 1723
+  - uid: 2001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14559,12 +14654,12 @@ entities:
       parent: 2
 - proto: SignDirectionalEvac
   entities:
-  - uid: 1724
+  - uid: 2002
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 2
-  - uid: 1725
+  - uid: 2003
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14572,19 +14667,19 @@ entities:
       parent: 2
 - proto: SignDisposalSpace
   entities:
-  - uid: 1727
+  - uid: 2004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-4.5
       parent: 2
-  - uid: 1728
+  - uid: 2005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-4.5
       parent: 2
-  - uid: 1729
+  - uid: 2006
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14592,7 +14687,7 @@ entities:
       parent: 2
 - proto: SignDoors
   entities:
-  - uid: 1730
+  - uid: 2007
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14600,7 +14695,7 @@ entities:
       parent: 2
 - proto: SignEngineering
   entities:
-  - uid: 1731
+  - uid: 2008
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14608,7 +14703,7 @@ entities:
       parent: 2
 - proto: SignEVA
   entities:
-  - uid: 1732
+  - uid: 2009
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14616,7 +14711,7 @@ entities:
       parent: 2
 - proto: SignFire
   entities:
-  - uid: 2457
+  - uid: 2010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14624,7 +14719,7 @@ entities:
       parent: 2
 - proto: SignGravity
   entities:
-  - uid: 1734
+  - uid: 2011
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14632,21 +14727,21 @@ entities:
       parent: 2
 - proto: SignHead
   entities:
-  - uid: 1735
+  - uid: 2012
     components:
     - type: Transform
       pos: -19.5,-16.5
       parent: 2
 - proto: SignKitchen
   entities:
-  - uid: 1736
+  - uid: 2013
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
 - proto: SignMorgue
   entities:
-  - uid: 1737
+  - uid: 2014
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14654,14 +14749,14 @@ entities:
       parent: 2
 - proto: SignShipDock
   entities:
-  - uid: 1738
+  - uid: 2015
     components:
     - type: Transform
       pos: -23.5,-13.5
       parent: 2
 - proto: SignVox
   entities:
-  - uid: 2430
+  - uid: 2016
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14669,13 +14764,13 @@ entities:
       parent: 2
 - proto: Sink
   entities:
-  - uid: 1740
+  - uid: 2017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 2
-  - uid: 1741
+  - uid: 2018
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14683,18 +14778,18 @@ entities:
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 1743
+  - uid: 2019
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,4.5
       parent: 2
-  - uid: 2320
+  - uid: 2020
     components:
     - type: Transform
       pos: -24.5,-11.5
       parent: 2
-  - uid: 2466
+  - uid: 2021
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14702,371 +14797,371 @@ entities:
       parent: 2
 - proto: SmartFridge
   entities:
-  - uid: 1744
+  - uid: 2022
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 2
 - proto: SMESBasic
   entities:
-  - uid: 1745
+  - uid: 2023
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
-  - uid: 1746
+  - uid: 2024
     components:
     - type: Transform
       pos: -29.5,-1.5
       parent: 2
-  - uid: 1747
+  - uid: 2025
     components:
     - type: Transform
       pos: -28.5,-1.5
       parent: 2
 - proto: SodaDispenser
   entities:
-  - uid: 1748
+  - uid: 2026
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
 - proto: SolarPanel
   entities:
-  - uid: 1749
+  - uid: 2027
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 2
-  - uid: 1750
+  - uid: 2028
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 2
-  - uid: 1751
+  - uid: 2029
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 1752
+  - uid: 2030
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 2
-  - uid: 1753
+  - uid: 2031
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 2
-  - uid: 1754
+  - uid: 2032
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 2
-  - uid: 1755
+  - uid: 2033
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 2
-  - uid: 1756
+  - uid: 2034
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 1757
+  - uid: 2035
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
-  - uid: 1758
+  - uid: 2036
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
 - proto: SolarTracker
   entities:
-  - uid: 1759
+  - uid: 2037
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
 - proto: SpawnMobCatRuntime
   entities:
-  - uid: 2532
+  - uid: 2038
     components:
     - type: Transform
       pos: -19.5,12.5
       parent: 2
 - proto: SpawnMobCorgi
   entities:
-  - uid: 1138
+  - uid: 2039
     components:
     - type: Transform
       pos: -17.5,-14.5
       parent: 2
 - proto: SpawnMobMonkeyPunpun
   entities:
-  - uid: 2567
+  - uid: 2040
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
 - proto: SpawnMobShiva
   entities:
-  - uid: 2545
+  - uid: 2041
     components:
     - type: Transform
       pos: -17.5,-9.5
       parent: 2
 - proto: SpawnMobWalter
   entities:
-  - uid: 140
+  - uid: 2042
     components:
     - type: Transform
       pos: -13.5,9.5
       parent: 2
 - proto: SpawnPointAtmos
   entities:
-  - uid: 2418
+  - uid: 2043
     components:
     - type: Transform
       pos: -26.5,0.5
       parent: 2
 - proto: SpawnPointBartender
   entities:
-  - uid: 2221
+  - uid: 2044
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
 - proto: SpawnPointBotanist
   entities:
-  - uid: 2213
+  - uid: 2045
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 2230
+  - uid: 2046
     components:
     - type: Transform
       pos: -26.5,-18.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 2223
+  - uid: 2047
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
 - proto: SpawnPointChef
   entities:
-  - uid: 2216
+  - uid: 2048
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 2
 - proto: SpawnPointChemist
   entities:
-  - uid: 2212
+  - uid: 2049
     components:
     - type: Transform
       pos: -13.5,6.5
       parent: 2
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 2264
+  - uid: 2050
     components:
     - type: Transform
       pos: -18.5,-19.5
       parent: 2
 - proto: SpawnPointClown
   entities:
-  - uid: 2546
+  - uid: 2051
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 2
 - proto: SpawnPointHeadOfPersonnel
   entities:
-  - uid: 2226
+  - uid: 2052
     components:
     - type: Transform
       pos: -17.5,-15.5
       parent: 2
 - proto: SpawnPointHeadOfSecurity
   entities:
-  - uid: 2229
+  - uid: 2053
     components:
     - type: Transform
       pos: -19.5,-19.5
       parent: 2
 - proto: SpawnPointJanitor
   entities:
-  - uid: 2231
+  - uid: 2054
     components:
     - type: Transform
       pos: -27.5,-12.5
       parent: 2
 - proto: SpawnPointMedicalDoctor
   entities:
-  - uid: 2214
+  - uid: 2055
     components:
     - type: Transform
       pos: -17.5,8.5
       parent: 2
 - proto: SpawnPointMedicalIntern
   entities:
-  - uid: 2215
+  - uid: 2056
     components:
     - type: Transform
       pos: -18.5,8.5
       parent: 2
 - proto: SpawnPointMime
   entities:
-  - uid: 2549
+  - uid: 2057
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 2
 - proto: SpawnPointMusician
   entities:
-  - uid: 2536
+  - uid: 2058
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
-  - uid: 2419
+  - uid: 2059
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 2
 - proto: SpawnPointPassenger
   entities:
-  - uid: 2225
+  - uid: 2060
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 2227
+  - uid: 2061
     components:
     - type: Transform
       pos: -21.5,-19.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
-  - uid: 2220
+  - uid: 2062
     components:
     - type: Transform
       pos: -25.5,-6.5
       parent: 2
 - proto: SpawnPointResearchDirector
   entities:
-  - uid: 2228
+  - uid: 2063
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 2224
+  - uid: 2064
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 2
 - proto: SpawnPointScientist
   entities:
-  - uid: 2222
+  - uid: 2065
     components:
     - type: Transform
       pos: -26.5,-6.5
       parent: 2
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 393
+  - uid: 2066
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 2237
+  - uid: 2067
     components:
     - type: Transform
       pos: -17.5,-11.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 2217
+  - uid: 2068
     components:
     - type: Transform
       pos: -28.5,0.5
       parent: 2
 - proto: SpawnPointTechnicalAssistant
   entities:
-  - uid: 1835
+  - uid: 2069
     components:
     - type: Transform
       pos: -27.5,0.5
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 1525
+  - uid: 2070
     components:
     - type: Transform
       pos: -20.5,9.5
       parent: 2
 - proto: StationAnchor
   entities:
-  - uid: 1761
+  - uid: 2071
     components:
     - type: Transform
       pos: -32.5,3.5
       parent: 2
 - proto: StationMap
   entities:
-  - uid: 1726
+  - uid: 2072
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
-  - uid: 2234
+  - uid: 2073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 2
-  - uid: 2235
+  - uid: 2074
     components:
     - type: Transform
       pos: -26.5,-13.5
       parent: 2
 - proto: StoolBar
   entities:
-  - uid: 1762
+  - uid: 2075
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
       parent: 2
-  - uid: 1763
+  - uid: 2076
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 2
-  - uid: 1764
+  - uid: 2077
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 2
-  - uid: 1765
+  - uid: 2078
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15074,45 +15169,45 @@ entities:
       parent: 2
 - proto: SubstationWallBasic
   entities:
-  - uid: 1767
+  - uid: 2079
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 2
-  - uid: 1768
+  - uid: 2080
     components:
     - type: Transform
       pos: -22.5,6.5
       parent: 2
-  - uid: 1769
+  - uid: 2081
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-10.5
       parent: 2
-  - uid: 1770
+  - uid: 2082
     components:
     - type: Transform
       pos: -18.5,-17.5
       parent: 2
-  - uid: 1771
+  - uid: 2083
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 2
-  - uid: 1772
+  - uid: 2084
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-3.5
       parent: 2
-  - uid: 1773
+  - uid: 2085
     components:
     - type: Transform
       pos: -25.5,-19.5
       parent: 2
-  - uid: 1774
+  - uid: 2086
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15120,19 +15215,19 @@ entities:
       parent: 2
 - proto: SuitStorageEVA
   entities:
-  - uid: 1775
+  - uid: 2087
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 2
-  - uid: 1776
+  - uid: 2088
     components:
     - type: Transform
       pos: -10.5,-4.5
       parent: 2
 - proto: SurveillanceCameraEngineering
   entities:
-  - uid: 1780
+  - uid: 2089
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15140,7 +15235,7 @@ entities:
       parent: 2
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 1782
+  - uid: 2090
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15151,7 +15246,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Walkway south
-  - uid: 1783
+  - uid: 2091
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15162,7 +15257,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Shuttle Bay
-  - uid: 1787
+  - uid: 2092
     components:
     - type: Transform
       pos: -18.5,-0.5
@@ -15172,7 +15267,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Walkway north
-  - uid: 1791
+  - uid: 2093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15183,7 +15278,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Evac
-  - uid: 1793
+  - uid: 2094
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15194,7 +15289,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Science
-  - uid: 1796
+  - uid: 2095
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15205,7 +15300,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Hydroponics
-  - uid: 1798
+  - uid: 2096
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15216,7 +15311,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Bar
-  - uid: 1979
+  - uid: 2097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15227,7 +15322,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Medbay
-  - uid: 2219
+  - uid: 2098
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15238,7 +15333,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Engineering
-  - uid: 2273
+  - uid: 2099
     components:
     - type: Transform
       pos: -28.5,12.5
@@ -15248,7 +15343,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Engineering exterior
-  - uid: 2293
+  - uid: 2100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15259,7 +15354,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Cargo bay
-  - uid: 2338
+  - uid: 2101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15272,7 +15367,7 @@ entities:
       id: Kitchen
 - proto: SurveillanceCameraMedical
   entities:
-  - uid: 1785
+  - uid: 2102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15285,21 +15380,21 @@ entities:
       id: Medical
 - proto: SurveillanceCameraRouterGeneral
   entities:
-  - uid: 1788
+  - uid: 2103
     components:
     - type: Transform
       pos: -28.5,-21.5
       parent: 2
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 1789
+  - uid: 2104
     components:
     - type: Transform
       pos: -27.5,-21.5
       parent: 2
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 1781
+  - uid: 2105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15310,7 +15405,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Bridge external
-  - uid: 1784
+  - uid: 2106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15321,7 +15416,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Bridge
-  - uid: 1794
+  - uid: 2107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15332,7 +15427,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security
-  - uid: 1795
+  - uid: 2108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15345,7 +15440,7 @@ entities:
       id: Brig
 - proto: SurveillanceCameraService
   entities:
-  - uid: 1797
+  - uid: 2109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15358,217 +15453,217 @@ entities:
       id: Bar
 - proto: Table
   entities:
-  - uid: 1391
+  - uid: 2110
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-  - uid: 1393
+  - uid: 2111
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-10.5
       parent: 2
-  - uid: 1801
+  - uid: 2112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-9.5
       parent: 2
-  - uid: 1802
+  - uid: 2113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-8.5
       parent: 2
-  - uid: 1803
+  - uid: 2114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-4.5
       parent: 2
-  - uid: 1804
+  - uid: 2115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-5.5
       parent: 2
-  - uid: 1805
+  - uid: 2116
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
-  - uid: 1807
+  - uid: 2117
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
-  - uid: 1808
+  - uid: 2118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 1809
+  - uid: 2119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 2
-  - uid: 1810
+  - uid: 2120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,7.5
       parent: 2
-  - uid: 1811
+  - uid: 2121
     components:
     - type: Transform
       pos: -15.5,7.5
       parent: 2
-  - uid: 1815
+  - uid: 2122
     components:
     - type: Transform
       pos: -23.5,7.5
       parent: 2
-  - uid: 1816
+  - uid: 2123
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 2
-  - uid: 1817
+  - uid: 2124
     components:
     - type: Transform
       pos: -19.5,-15.5
       parent: 2
-  - uid: 1818
+  - uid: 2125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-15.5
       parent: 2
-  - uid: 1819
+  - uid: 2126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-16.5
       parent: 2
-  - uid: 1820
+  - uid: 2127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 2
-  - uid: 1821
+  - uid: 2128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 2
-  - uid: 1822
+  - uid: 2129
     components:
     - type: Transform
       pos: -19.5,-10.5
       parent: 2
-  - uid: 1823
+  - uid: 2130
     components:
     - type: Transform
       pos: -19.5,-9.5
       parent: 2
-  - uid: 1824
+  - uid: 2131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 2
-  - uid: 2209
+  - uid: 2132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,8.5
       parent: 2
-  - uid: 2328
+  - uid: 2133
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 2
-  - uid: 2386
+  - uid: 2134
     components:
     - type: Transform
       pos: -16.5,11.5
       parent: 2
-  - uid: 2506
+  - uid: 2135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
-  - uid: 2508
+  - uid: 2136
     components:
     - type: Transform
       pos: -16.5,10.5
       parent: 2
 - proto: TableCounterMetal
   entities:
-  - uid: 1825
+  - uid: 2137
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 2
-  - uid: 1826
+  - uid: 2138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
       parent: 2
-  - uid: 1827
+  - uid: 2139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,3.5
       parent: 2
-  - uid: 2240
+  - uid: 2140
     components:
     - type: Transform
       pos: -16.5,-21.5
       parent: 2
-  - uid: 2241
+  - uid: 2141
     components:
     - type: Transform
       pos: -23.5,-21.5
       parent: 2
 - proto: TableCounterWood
   entities:
-  - uid: 1828
+  - uid: 2142
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
-  - uid: 1829
+  - uid: 2143
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 1830
+  - uid: 2144
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 1831
+  - uid: 2145
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
 - proto: TableFancyRed
   entities:
-  - uid: 1475
+  - uid: 2146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-1.5
       parent: 2
-  - uid: 1685
+  - uid: 2147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15576,13 +15671,13 @@ entities:
       parent: 2
 - proto: TableFancyWhite
   entities:
-  - uid: 909
+  - uid: 2148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
       parent: 2
-  - uid: 1687
+  - uid: 2149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15590,55 +15685,46 @@ entities:
       parent: 2
 - proto: TelecomServerFilled
   entities:
-  - uid: 2363
+  - uid: 2150
     components:
     - type: Transform
       pos: -25.5,-21.5
       parent: 2
 - proto: ThrusterFlatpack
   entities:
-  - uid: 1836
+  - uid: 2151
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.648619,-9.497838
+      pos: -12.681641,-9.030365
       parent: 2
-  - uid: 1837
+  - uid: 2152
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.336119,-9.185338
+      pos: -12.384766,-8.70224
       parent: 2
-  - uid: 1838
+  - uid: 2153
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.711119,-8.919713
-      parent: 2
-  - uid: 1839
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.336119,-8.560338
+      pos: -12.416016,-9.38974
       parent: 2
 - proto: TwoWayLever
   entities:
-  - uid: 938
+  - uid: 2154
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        135:
+        148:
         - Left: Open
         - Right: Close
-        136:
+        149:
         - Left: Open
         - Right: Close
 - proto: UniformPrinter
   entities:
-  - uid: 1841
+  - uid: 2155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15646,50 +15732,50 @@ entities:
       parent: 2
 - proto: UnstableMutagenChemistryBottle
   entities:
-  - uid: 1842
+  - uid: 2156
     components:
     - type: Transform
       pos: -11.408546,5.8188944
       parent: 2
 - proto: UraniumCrabSpawnerFrank
   entities:
-  - uid: 1854
+  - uid: 2157
     components:
     - type: Transform
       pos: -28.5,2.5
       parent: 2
 - proto: UraniumOre1
   entities:
-  - uid: 1843
+  - uid: 2158
     components:
     - type: Transform
       pos: -29.2388,2.863861
       parent: 2
-  - uid: 1844
+  - uid: 2159
     components:
     - type: Transform
       pos: -27.8638,2.520111
       parent: 2
 - proto: UraniumReinforcedWindowDirectional
   entities:
-  - uid: 1648
+  - uid: 2160
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
-  - uid: 1716
+  - uid: 2161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,1.5
       parent: 2
-  - uid: 1845
+  - uid: 2162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,1.5
       parent: 2
-  - uid: 1846
+  - uid: 2163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15697,7 +15783,7 @@ entities:
       parent: 2
     - type: RadiationBlocker
       resistance: 5
-  - uid: 1847
+  - uid: 2164
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15705,7 +15791,7 @@ entities:
       parent: 2
     - type: RadiationBlocker
       resistance: 5
-  - uid: 1848
+  - uid: 2165
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15713,308 +15799,308 @@ entities:
       parent: 2
 - proto: UraniumWindoorSecureEngineeringLocked
   entities:
-  - uid: 1647
+  - uid: 2166
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 2
-  - uid: 1664
+  - uid: 2167
     components:
     - type: Transform
       pos: -28.5,4.5
       parent: 2
 - proto: VendingMachineBooze
   entities:
-  - uid: 1855
+  - uid: 2168
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
 - proto: VendingMachineCargoDrobe
   entities:
-  - uid: 1520
+  - uid: 2169
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 2
 - proto: VendingMachineChefvend
   entities:
-  - uid: 1856
+  - uid: 2170
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 2
 - proto: VendingMachineChemDrobe
   entities:
-  - uid: 117
+  - uid: 2171
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 2
 - proto: VendingMachineChemicals
   entities:
-  - uid: 1857
+  - uid: 2172
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 2
 - proto: VendingMachineClothing
   entities:
-  - uid: 2269
+  - uid: 2173
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 2
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 2136
+  - uid: 2174
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
 - proto: VendingMachineDonut
   entities:
-  - uid: 2517
+  - uid: 2175
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 2
 - proto: VendingMachineEngiDrobe
   entities:
-  - uid: 2478
+  - uid: 2176
     components:
     - type: Transform
       pos: -29.5,6.5
       parent: 2
 - proto: VendingMachineEngivend
   entities:
-  - uid: 1860
+  - uid: 2177
     components:
     - type: Transform
       pos: -26.5,-1.5
       parent: 2
 - proto: VendingMachineMedical
   entities:
-  - uid: 1861
+  - uid: 2178
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 2459
+  - uid: 2179
     components:
     - type: Transform
       pos: -16.5,12.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
-  - uid: 1862
+  - uid: 2180
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 2
 - proto: VendingMachineRestockChemVend
   entities:
-  - uid: 2390
+  - uid: 2181
     components:
     - type: Transform
       pos: -16.26355,11.626709
       parent: 2
 - proto: VendingMachineRestockMedical
   entities:
-  - uid: 2391
+  - uid: 2182
     components:
     - type: Transform
       pos: -16.685425,11.829834
       parent: 2
 - proto: VendingMachineSalvage
   entities:
-  - uid: 1864
+  - uid: 2183
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 2
 - proto: VendingMachineSec
   entities:
-  - uid: 1865
+  - uid: 2184
     components:
     - type: Transform
       pos: -16.5,-12.5
       parent: 2
 - proto: VendingMachineSeeds
   entities:
-  - uid: 1866
+  - uid: 2185
     components:
     - type: Transform
       pos: -7.5,9.5
       parent: 2
 - proto: VendingMachineSnack
   entities:
-  - uid: 1867
+  - uid: 2186
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
 - proto: VendingMachineSoda
   entities:
-  - uid: 1868
+  - uid: 2187
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:
-  - uid: 501
+  - uid: 2188
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
 - proto: VendingMachineTankDispenserEngineering
   entities:
-  - uid: 1869
+  - uid: 2189
     components:
     - type: Transform
       pos: -35.5,4.5
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 1870
+  - uid: 2190
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 2
 - proto: VendingMachineWinter
   entities:
-  - uid: 779
+  - uid: 2191
     components:
     - type: Transform
       pos: -30.5,-16.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 777
+  - uid: 2192
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 2
-  - uid: 1871
+  - uid: 2193
     components:
     - type: Transform
       pos: -25.5,-1.5
       parent: 2
 - proto: ViolinInstrument
   entities:
-  - uid: 2319
+  - uid: 2194
     components:
     - type: Transform
       pos: -0.12158203,6.3308105
       parent: 2
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 913
+  - uid: 2195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-12.5
       parent: 2
-  - uid: 1644
+  - uid: 2196
     components:
     - type: Transform
       pos: -22.5,12.5
       parent: 2
-  - uid: 1760
+  - uid: 2197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-12.5
       parent: 2
-  - uid: 1872
+  - uid: 2198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,2.5
       parent: 2
-  - uid: 1873
+  - uid: 2199
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 2
-  - uid: 1874
+  - uid: 2200
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
-  - uid: 1875
+  - uid: 2201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 2
-  - uid: 1876
+  - uid: 2202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,11.5
       parent: 2
-  - uid: 1877
+  - uid: 2203
     components:
     - type: Transform
       pos: -31.5,2.5
       parent: 2
-  - uid: 1878
+  - uid: 2204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,1.5
       parent: 2
-  - uid: 1881
+  - uid: 2205
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-22.5
       parent: 2
-  - uid: 1884
+  - uid: 2206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,2.5
       parent: 2
-  - uid: 2385
+  - uid: 2207
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,11.5
       parent: 2
-  - uid: 2394
+  - uid: 2208
     components:
     - type: Transform
       pos: -32.5,10.5
       parent: 2
-  - uid: 2395
+  - uid: 2209
     components:
     - type: Transform
       pos: -31.5,11.5
       parent: 2
-  - uid: 2438
+  - uid: 2210
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,12.5
       parent: 2
-  - uid: 2442
+  - uid: 2211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,0.5
       parent: 2
-  - uid: 2443
+  - uid: 2212
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-0.5
       parent: 2
-  - uid: 2444
+  - uid: 2213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16022,1618 +16108,1618 @@ entities:
       parent: 2
 - proto: WallShuttleInterior
   entities:
-  - uid: 32
+  - uid: 2214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,11.5
       parent: 2
-  - uid: 615
+  - uid: 2215
     components:
     - type: Transform
       pos: -30.5,4.5
       parent: 2
-  - uid: 756
+  - uid: 2216
     components:
     - type: Transform
       pos: -30.5,3.5
       parent: 2
-  - uid: 811
+  - uid: 2217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,11.5
       parent: 2
-  - uid: 818
+  - uid: 2218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,9.5
       parent: 2
-  - uid: 1165
+  - uid: 2219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,11.5
       parent: 2
-  - uid: 1375
+  - uid: 2220
     components:
     - type: Transform
       pos: -31.5,-0.5
       parent: 2
-  - uid: 1376
+  - uid: 2221
     components:
     - type: Transform
       pos: -31.5,-1.5
       parent: 2
-  - uid: 1382
+  - uid: 2222
     components:
     - type: Transform
       pos: -21.5,12.5
       parent: 2
-  - uid: 1383
+  - uid: 2223
     components:
     - type: Transform
       pos: -21.5,13.5
       parent: 2
-  - uid: 1384
+  - uid: 2224
     components:
     - type: Transform
       pos: -15.5,13.5
       parent: 2
-  - uid: 1387
+  - uid: 2225
     components:
     - type: Transform
       pos: -21.5,11.5
       parent: 2
-  - uid: 1394
+  - uid: 2226
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,11.5
       parent: 2
-  - uid: 1396
+  - uid: 2227
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,14.5
       parent: 2
-  - uid: 1397
+  - uid: 2228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,14.5
       parent: 2
-  - uid: 1410
+  - uid: 2229
     components:
     - type: Transform
       pos: -15.5,12.5
       parent: 2
-  - uid: 1411
+  - uid: 2230
     components:
     - type: Transform
       pos: -15.5,11.5
       parent: 2
-  - uid: 1633
+  - uid: 2231
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,11.5
       parent: 2
-  - uid: 1859
+  - uid: 2232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-12.5
       parent: 2
-  - uid: 1882
+  - uid: 2233
     components:
     - type: Transform
       pos: -31.5,0.5
       parent: 2
-  - uid: 1883
+  - uid: 2234
     components:
     - type: Transform
       pos: -30.5,11.5
       parent: 2
-  - uid: 1885
+  - uid: 2235
     components:
     - type: Transform
       pos: -29.5,-20.5
       parent: 2
-  - uid: 1886
+  - uid: 2236
     components:
     - type: Transform
       pos: -29.5,-19.5
       parent: 2
-  - uid: 1887
+  - uid: 2237
     components:
     - type: Transform
       pos: -29.5,-22.5
       parent: 2
-  - uid: 1888
+  - uid: 2238
     components:
     - type: Transform
       pos: -29.5,-21.5
       parent: 2
-  - uid: 1889
+  - uid: 2239
     components:
     - type: Transform
       pos: -24.5,-21.5
       parent: 2
-  - uid: 1890
+  - uid: 2240
     components:
     - type: Transform
       pos: -23.5,-22.5
       parent: 2
-  - uid: 1891
+  - uid: 2241
     components:
     - type: Transform
       pos: -16.5,-22.5
       parent: 2
-  - uid: 1892
+  - uid: 2242
     components:
     - type: Transform
       pos: -15.5,-21.5
       parent: 2
-  - uid: 1893
+  - uid: 2243
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 2
-  - uid: 1894
+  - uid: 2244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,6.5
       parent: 2
-  - uid: 1895
+  - uid: 2245
     components:
     - type: Transform
       pos: -30.5,-12.5
       parent: 2
-  - uid: 1896
+  - uid: 2246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,6.5
       parent: 2
-  - uid: 1897
+  - uid: 2247
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 2
-  - uid: 1898
+  - uid: 2248
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 2
-  - uid: 1899
+  - uid: 2249
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
-  - uid: 1900
+  - uid: 2250
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
-  - uid: 1901
+  - uid: 2251
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 2
-  - uid: 1902
+  - uid: 2252
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 2
-  - uid: 1903
+  - uid: 2253
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 2
-  - uid: 1904
+  - uid: 2254
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 2
-  - uid: 1905
+  - uid: 2255
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 2
-  - uid: 1906
+  - uid: 2256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-4.5
       parent: 2
-  - uid: 1907
+  - uid: 2257
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 2
-  - uid: 1908
+  - uid: 2258
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
-  - uid: 1909
+  - uid: 2259
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 2
-  - uid: 1910
+  - uid: 2260
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 2
-  - uid: 1911
+  - uid: 2261
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 2
-  - uid: 1912
+  - uid: 2262
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 2
-  - uid: 1913
+  - uid: 2263
     components:
     - type: Transform
       pos: -13.5,-8.5
       parent: 2
-  - uid: 1914
+  - uid: 2264
     components:
     - type: Transform
       pos: -13.5,-9.5
       parent: 2
-  - uid: 1915
+  - uid: 2265
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 1916
+  - uid: 2266
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 1917
+  - uid: 2267
     components:
     - type: Transform
       pos: -13.5,-10.5
       parent: 2
-  - uid: 1918
+  - uid: 2268
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 2
-  - uid: 1919
+  - uid: 2269
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 1920
+  - uid: 2270
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 2
-  - uid: 1921
+  - uid: 2271
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 1922
+  - uid: 2272
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 2
-  - uid: 1923
+  - uid: 2273
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 2
-  - uid: 1924
+  - uid: 2274
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 2
-  - uid: 1925
+  - uid: 2275
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-2.5
       parent: 2
-  - uid: 1926
+  - uid: 2276
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 2
-  - uid: 1927
+  - uid: 2277
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 2
-  - uid: 1928
+  - uid: 2278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 2
-  - uid: 1929
+  - uid: 2279
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-3.5
       parent: 2
-  - uid: 1930
+  - uid: 2280
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-3.5
       parent: 2
-  - uid: 1931
+  - uid: 2281
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-4.5
       parent: 2
-  - uid: 1932
+  - uid: 2282
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 2
-  - uid: 1933
+  - uid: 2283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 2
-  - uid: 1934
+  - uid: 2284
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 1935
+  - uid: 2285
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
-  - uid: 1936
+  - uid: 2286
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 1937
+  - uid: 2287
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 1938
+  - uid: 2288
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 2
-  - uid: 1939
+  - uid: 2289
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 2
-  - uid: 1940
+  - uid: 2290
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 1941
+  - uid: 2291
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
-  - uid: 1942
+  - uid: 2292
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 1943
+  - uid: 2293
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 1944
+  - uid: 2294
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 2
-  - uid: 1945
+  - uid: 2295
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 2
-  - uid: 1946
+  - uid: 2296
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 2
-  - uid: 1947
+  - uid: 2297
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-  - uid: 1948
+  - uid: 2298
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 2
-  - uid: 1949
+  - uid: 2299
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 2
-  - uid: 1951
+  - uid: 2300
     components:
     - type: Transform
       pos: -15.5,-8.5
       parent: 2
-  - uid: 1952
+  - uid: 2301
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 1953
+  - uid: 2302
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-  - uid: 1954
+  - uid: 2303
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
-  - uid: 1955
+  - uid: 2304
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
-  - uid: 1956
+  - uid: 2305
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 1958
+  - uid: 2306
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 2
-  - uid: 1959
+  - uid: 2307
     components:
     - type: Transform
       pos: -11.5,10.5
       parent: 2
-  - uid: 1960
+  - uid: 2308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,3.5
       parent: 2
-  - uid: 1961
+  - uid: 2309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,4.5
       parent: 2
-  - uid: 1962
+  - uid: 2310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,6.5
       parent: 2
-  - uid: 1963
+  - uid: 2311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,7.5
       parent: 2
-  - uid: 1964
+  - uid: 2312
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,8.5
       parent: 2
-  - uid: 1965
+  - uid: 2313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,9.5
       parent: 2
-  - uid: 1966
+  - uid: 2314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,3.5
       parent: 2
-  - uid: 1967
+  - uid: 2315
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 2
-  - uid: 1968
+  - uid: 2316
     components:
     - type: Transform
       pos: -15.5,4.5
       parent: 2
-  - uid: 1969
+  - uid: 2317
     components:
     - type: Transform
       pos: -15.5,8.5
       parent: 2
-  - uid: 1970
+  - uid: 2318
     components:
     - type: Transform
       pos: -15.5,9.5
       parent: 2
-  - uid: 1971
+  - uid: 2319
     components:
     - type: Transform
       pos: -15.5,10.5
       parent: 2
-  - uid: 1972
+  - uid: 2320
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
-  - uid: 1973
+  - uid: 2321
     components:
     - type: Transform
       pos: -13.5,10.5
       parent: 2
-  - uid: 1974
+  - uid: 2322
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 2
-  - uid: 1975
+  - uid: 2323
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 2
-  - uid: 1976
+  - uid: 2324
     components:
     - type: Transform
       pos: -29.5,-13.5
       parent: 2
-  - uid: 1977
+  - uid: 2325
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-6.5
       parent: 2
-  - uid: 1983
+  - uid: 2326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,6.5
       parent: 2
-  - uid: 1984
+  - uid: 2327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,6.5
       parent: 2
-  - uid: 1985
+  - uid: 2328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,6.5
       parent: 2
-  - uid: 1986
+  - uid: 2329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,6.5
       parent: 2
-  - uid: 1987
+  - uid: 2330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,5.5
       parent: 2
-  - uid: 1988
+  - uid: 2331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,4.5
       parent: 2
-  - uid: 1989
+  - uid: 2332
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,3.5
       parent: 2
-  - uid: 1990
+  - uid: 2333
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,10.5
       parent: 2
-  - uid: 1991
+  - uid: 2334
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,9.5
       parent: 2
-  - uid: 1992
+  - uid: 2335
     components:
     - type: Transform
       pos: -22.5,10.5
       parent: 2
-  - uid: 1993
+  - uid: 2336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,7.5
       parent: 2
-  - uid: 1994
+  - uid: 2337
     components:
     - type: Transform
       pos: -23.5,10.5
       parent: 2
-  - uid: 1995
+  - uid: 2338
     components:
     - type: Transform
       pos: -24.5,10.5
       parent: 2
-  - uid: 1996
+  - uid: 2339
     components:
     - type: Transform
       pos: -24.5,9.5
       parent: 2
-  - uid: 1997
+  - uid: 2340
     components:
     - type: Transform
       pos: -24.5,8.5
       parent: 2
-  - uid: 1998
+  - uid: 2341
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 2
-  - uid: 1999
+  - uid: 2342
     components:
     - type: Transform
       pos: -24.5,6.5
       parent: 2
-  - uid: 2000
+  - uid: 2343
     components:
     - type: Transform
       pos: -22.5,6.5
       parent: 2
-  - uid: 2001
+  - uid: 2344
     components:
     - type: Transform
       pos: -23.5,6.5
       parent: 2
-  - uid: 2002
+  - uid: 2345
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,10.5
       parent: 2
-  - uid: 2003
+  - uid: 2346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-1.5
       parent: 2
-  - uid: 2004
+  - uid: 2347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 2
-  - uid: 2005
+  - uid: 2348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-1.5
       parent: 2
-  - uid: 2006
+  - uid: 2349
     components:
     - type: Transform
       pos: -16.5,-3.5
       parent: 2
-  - uid: 2007
+  - uid: 2350
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
-  - uid: 2008
+  - uid: 2351
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 2
-  - uid: 2009
+  - uid: 2352
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 2
-  - uid: 2010
+  - uid: 2353
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 2
-  - uid: 2011
+  - uid: 2354
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-9.5
       parent: 2
-  - uid: 2012
+  - uid: 2355
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
-  - uid: 2013
+  - uid: 2356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-2.5
       parent: 2
-  - uid: 2014
+  - uid: 2357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,10.5
       parent: 2
-  - uid: 2015
+  - uid: 2358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,10.5
       parent: 2
-  - uid: 2016
+  - uid: 2359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,10.5
       parent: 2
-  - uid: 2017
+  - uid: 2360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,9.5
       parent: 2
-  - uid: 2019
+  - uid: 2361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,10.5
       parent: 2
-  - uid: 2020
+  - uid: 2362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,9.5
       parent: 2
-  - uid: 2021
+  - uid: 2363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,8.5
       parent: 2
-  - uid: 2022
+  - uid: 2364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-1.5
       parent: 2
-  - uid: 2023
+  - uid: 2365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-1.5
       parent: 2
-  - uid: 2024
+  - uid: 2366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,-1.5
       parent: 2
-  - uid: 2025
+  - uid: 2367
     components:
     - type: Transform
       pos: -19.5,-8.5
       parent: 2
-  - uid: 2026
+  - uid: 2368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-1.5
       parent: 2
-  - uid: 2027
+  - uid: 2369
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-1.5
       parent: 2
-  - uid: 2028
+  - uid: 2370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,2.5
       parent: 2
-  - uid: 2029
+  - uid: 2371
     components:
     - type: Transform
       pos: -30.5,-11.5
       parent: 2
-  - uid: 2030
+  - uid: 2372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,3.5
       parent: 2
-  - uid: 2031
+  - uid: 2373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,3.5
       parent: 2
-  - uid: 2032
+  - uid: 2374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,8.5
       parent: 2
-  - uid: 2033
+  - uid: 2375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,9.5
       parent: 2
-  - uid: 2034
+  - uid: 2376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,8.5
       parent: 2
-  - uid: 2035
+  - uid: 2377
     components:
     - type: Transform
       pos: -30.5,7.5
       parent: 2
-  - uid: 2036
+  - uid: 2378
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 2
-  - uid: 2037
+  - uid: 2379
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 2
-  - uid: 2038
+  - uid: 2380
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 2
-  - uid: 2039
+  - uid: 2381
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 2
-  - uid: 2040
+  - uid: 2382
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
-  - uid: 2041
+  - uid: 2383
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
-  - uid: 2042
+  - uid: 2384
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 2
-  - uid: 2043
+  - uid: 2385
     components:
     - type: Transform
       pos: -24.5,3.5
       parent: 2
-  - uid: 2044
+  - uid: 2386
     components:
     - type: Transform
       pos: -23.5,3.5
       parent: 2
-  - uid: 2045
+  - uid: 2387
     components:
     - type: Transform
       pos: -19.5,-1.5
       parent: 2
-  - uid: 2046
+  - uid: 2388
     components:
     - type: Transform
       pos: -30.5,0.5
       parent: 2
-  - uid: 2047
+  - uid: 2389
     components:
     - type: Transform
       pos: -30.5,-0.5
       parent: 2
-  - uid: 2048
+  - uid: 2390
     components:
     - type: Transform
       pos: -30.5,-1.5
       parent: 2
-  - uid: 2049
+  - uid: 2391
     components:
     - type: Transform
       pos: -30.5,-2.5
       parent: 2
-  - uid: 2050
+  - uid: 2392
     components:
     - type: Transform
       pos: -29.5,-2.5
       parent: 2
-  - uid: 2051
+  - uid: 2393
     components:
     - type: Transform
       pos: -28.5,-2.5
       parent: 2
-  - uid: 2052
+  - uid: 2394
     components:
     - type: Transform
       pos: -27.5,-2.5
       parent: 2
-  - uid: 2053
+  - uid: 2395
     components:
     - type: Transform
       pos: -26.5,-2.5
       parent: 2
-  - uid: 2054
+  - uid: 2396
     components:
     - type: Transform
       pos: -25.5,-2.5
       parent: 2
-  - uid: 2055
-    components:
-    - type: Transform
-      pos: -24.5,-2.5
-      parent: 2
-  - uid: 2056
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,3.5
-      parent: 2
-  - uid: 2057
-    components:
-    - type: Transform
-      pos: -31.5,9.5
-      parent: 2
-  - uid: 2058
-    components:
-    - type: Transform
-      pos: -32.5,9.5
-      parent: 2
-  - uid: 2059
-    components:
-    - type: Transform
-      pos: -33.5,9.5
-      parent: 2
-  - uid: 2060
-    components:
-    - type: Transform
-      pos: -34.5,9.5
-      parent: 2
-  - uid: 2061
-    components:
-    - type: Transform
-      pos: -34.5,8.5
-      parent: 2
-  - uid: 2062
-    components:
-    - type: Transform
-      pos: -34.5,7.5
-      parent: 2
-  - uid: 2063
-    components:
-    - type: Transform
-      pos: -34.5,4.5
-      parent: 2
-  - uid: 2064
-    components:
-    - type: Transform
-      pos: -34.5,3.5
-      parent: 2
-  - uid: 2065
-    components:
-    - type: Transform
-      pos: -34.5,2.5
-      parent: 2
-  - uid: 2066
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -37.5,8.5
-      parent: 2
-  - uid: 2067
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -37.5,7.5
-      parent: 2
-  - uid: 2068
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -37.5,6.5
-      parent: 2
-  - uid: 2069
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -37.5,5.5
-      parent: 2
-  - uid: 2070
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -37.5,4.5
-      parent: 2
-  - uid: 2071
-    components:
-    - type: Transform
-      pos: -23.5,-5.5
-      parent: 2
-  - uid: 2072
-    components:
-    - type: Transform
-      pos: -19.5,-2.5
-      parent: 2
-  - uid: 2073
-    components:
-    - type: Transform
-      pos: -19.5,-5.5
-      parent: 2
-  - uid: 2074
-    components:
-    - type: Transform
-      pos: -23.5,-3.5
-      parent: 2
-  - uid: 2075
-    components:
-    - type: Transform
-      pos: -23.5,-2.5
-      parent: 2
-  - uid: 2076
-    components:
-    - type: Transform
-      pos: -23.5,-4.5
-      parent: 2
-  - uid: 2077
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-6.5
-      parent: 2
-  - uid: 2078
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-11.5
-      parent: 2
-  - uid: 2079
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -16.5,-13.5
-      parent: 2
-  - uid: 2080
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-12.5
-      parent: 2
-  - uid: 2081
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-13.5
-      parent: 2
-  - uid: 2082
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,-13.5
-      parent: 2
-  - uid: 2083
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,-13.5
-      parent: 2
-  - uid: 2084
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-4.5
-      parent: 2
-  - uid: 2085
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,4.5
-      parent: 2
-  - uid: 2086
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,4.5
-      parent: 2
-  - uid: 2087
-    components:
-    - type: Transform
-      pos: -30.5,-3.5
-      parent: 2
-  - uid: 2088
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,-2.5
-      parent: 2
-  - uid: 2089
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,4.5
-      parent: 2
-  - uid: 2090
-    components:
-    - type: Transform
-      pos: -23.5,-11.5
-      parent: 2
-  - uid: 2091
-    components:
-    - type: Transform
-      pos: -30.5,-10.5
-      parent: 2
-  - uid: 2092
-    components:
-    - type: Transform
-      pos: -29.5,-10.5
-      parent: 2
-  - uid: 2093
-    components:
-    - type: Transform
-      pos: -28.5,-10.5
-      parent: 2
-  - uid: 2094
-    components:
-    - type: Transform
-      pos: -27.5,-10.5
-      parent: 2
-  - uid: 2095
-    components:
-    - type: Transform
-      pos: -26.5,-10.5
-      parent: 2
-  - uid: 2096
-    components:
-    - type: Transform
-      pos: -25.5,-10.5
-      parent: 2
-  - uid: 2097
-    components:
-    - type: Transform
-      pos: -24.5,-10.5
-      parent: 2
-  - uid: 2098
-    components:
-    - type: Transform
-      pos: -23.5,-10.5
-      parent: 2
-  - uid: 2099
-    components:
-    - type: Transform
-      pos: -23.5,-9.5
-      parent: 2
-  - uid: 2100
-    components:
-    - type: Transform
-      pos: -28.5,-16.5
-      parent: 2
-  - uid: 2101
-    components:
-    - type: Transform
-      pos: 4.5,3.5
-      parent: 2
-  - uid: 2102
-    components:
-    - type: Transform
-      pos: -30.5,-13.5
-      parent: 2
-  - uid: 2103
-    components:
-    - type: Transform
-      pos: -23.5,-13.5
-      parent: 2
-  - uid: 2104
-    components:
-    - type: Transform
-      pos: -30.5,-17.5
-      parent: 2
-  - uid: 2105
-    components:
-    - type: Transform
-      pos: -24.5,-13.5
-      parent: 2
-  - uid: 2106
-    components:
-    - type: Transform
-      pos: -29.5,-17.5
-      parent: 2
-  - uid: 2107
-    components:
-    - type: Transform
-      pos: -28.5,-17.5
-      parent: 2
-  - uid: 2108
-    components:
-    - type: Transform
-      pos: -25.5,-13.5
-      parent: 2
-  - uid: 2109
-    components:
-    - type: Transform
-      pos: -26.5,-13.5
-      parent: 2
-  - uid: 2110
-    components:
-    - type: Transform
-      pos: -27.5,-16.5
-      parent: 2
-  - uid: 2111
-    components:
-    - type: Transform
-      pos: -26.5,-16.5
-      parent: 2
-  - uid: 2112
-    components:
-    - type: Transform
-      pos: -27.5,-13.5
-      parent: 2
-  - uid: 2113
-    components:
-    - type: Transform
-      pos: -25.5,-16.5
-      parent: 2
-  - uid: 2114
-    components:
-    - type: Transform
-      pos: -24.5,-16.5
-      parent: 2
-  - uid: 2115
-    components:
-    - type: Transform
-      pos: -28.5,-13.5
-      parent: 2
-  - uid: 2116
-    components:
-    - type: Transform
-      pos: -23.5,-16.5
-      parent: 2
-  - uid: 2117
-    components:
-    - type: Transform
-      pos: -4.5,11.5
-      parent: 2
-  - uid: 2118
-    components:
-    - type: Transform
-      pos: -25.5,-19.5
-      parent: 2
-  - uid: 2119
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,-19.5
-      parent: 2
-  - uid: 2120
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,-17.5
-      parent: 2
-  - uid: 2121
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-16.5
-      parent: 2
-  - uid: 2122
-    components:
-    - type: Transform
-      pos: -16.5,-8.5
-      parent: 2
-  - uid: 2123
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-17.5
-      parent: 2
-  - uid: 2124
-    components:
-    - type: Transform
-      pos: -26.5,-19.5
-      parent: 2
-  - uid: 2125
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-17.5
-      parent: 2
-  - uid: 2126
-    components:
-    - type: Transform
-      pos: -27.5,-19.5
-      parent: 2
-  - uid: 2127
-    components:
-    - type: Transform
-      pos: -28.5,-19.5
-      parent: 2
-  - uid: 2128
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-14.5
-      parent: 2
-  - uid: 2129
-    components:
-    - type: Transform
-      pos: -16.5,-17.5
-      parent: 2
-  - uid: 2130
-    components:
-    - type: Transform
-      pos: -18.5,-17.5
-      parent: 2
-  - uid: 2131
-    components:
-    - type: Transform
-      pos: -15.5,-13.5
-      parent: 2
-  - uid: 2132
-    components:
-    - type: Transform
-      pos: -15.5,-14.5
-      parent: 2
-  - uid: 2133
-    components:
-    - type: Transform
-      pos: -15.5,-16.5
-      parent: 2
-  - uid: 2134
-    components:
-    - type: Transform
-      pos: -15.5,-17.5
-      parent: 2
-  - uid: 2137
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,-22.5
-      parent: 2
-  - uid: 2138
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-22.5
-      parent: 2
-  - uid: 2139
-    components:
-    - type: Transform
-      pos: -15.5,-20.5
-      parent: 2
-  - uid: 2140
-    components:
-    - type: Transform
-      pos: -15.5,-19.5
-      parent: 2
-  - uid: 2141
-    components:
-    - type: Transform
-      pos: -15.5,-18.5
-      parent: 2
-  - uid: 2142
-    components:
-    - type: Transform
-      pos: -31.5,-17.5
-      parent: 2
-  - uid: 2143
-    components:
-    - type: Transform
-      pos: -33.5,-17.5
-      parent: 2
-  - uid: 2144
-    components:
-    - type: Transform
-      pos: -33.5,-13.5
-      parent: 2
-  - uid: 2145
-    components:
-    - type: Transform
-      pos: -32.5,-13.5
-      parent: 2
-  - uid: 2146
-    components:
-    - type: Transform
-      pos: -31.5,-13.5
-      parent: 2
-  - uid: 2147
-    components:
-    - type: Transform
-      pos: -31.5,1.5
-      parent: 2
-  - uid: 2148
-    components:
-    - type: Transform
-      pos: -32.5,1.5
-      parent: 2
-  - uid: 2149
-    components:
-    - type: Transform
-      pos: -33.5,1.5
-      parent: 2
-  - uid: 2150
-    components:
-    - type: Transform
-      pos: -32.5,-17.5
-      parent: 2
-  - uid: 2151
-    components:
-    - type: Transform
-      pos: -15.5,-12.5
-      parent: 2
-  - uid: 2152
-    components:
-    - type: Transform
-      pos: -15.5,-11.5
-      parent: 2
-  - uid: 2153
-    components:
-    - type: Transform
-      pos: -15.5,-10.5
-      parent: 2
-  - uid: 2154
-    components:
-    - type: Transform
-      pos: -15.5,-9.5
-      parent: 2
-  - uid: 2155
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,4.5
-      parent: 2
-  - uid: 2156
-    components:
-    - type: Transform
-      pos: -26.5,7.5
-      parent: 2
-  - uid: 2157
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-2.5
-      parent: 2
-  - uid: 2158
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 2
-  - uid: 2159
-    components:
-    - type: Transform
-      pos: -24.5,-22.5
-      parent: 2
-  - uid: 2160
-    components:
-    - type: Transform
-      pos: -28.5,-22.5
-      parent: 2
-  - uid: 2161
-    components:
-    - type: Transform
-      pos: -27.5,-22.5
-      parent: 2
-  - uid: 2162
-    components:
-    - type: Transform
-      pos: -26.5,-22.5
-      parent: 2
-  - uid: 2163
-    components:
-    - type: Transform
-      pos: -25.5,-22.5
-      parent: 2
-  - uid: 2268
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -26.5,11.5
-      parent: 2
-  - uid: 2339
-    components:
-    - type: Transform
-      pos: -31.5,10.5
-      parent: 2
-  - uid: 2357
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,11.5
-      parent: 2
-  - uid: 2358
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,11.5
-      parent: 2
-  - uid: 2389
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-11.5
-      parent: 2
-  - uid: 2396
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,11.5
-      parent: 2
   - uid: 2397
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,8.5
+      pos: -24.5,-2.5
       parent: 2
   - uid: 2398
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,11.5
+      pos: -35.5,3.5
+      parent: 2
+  - uid: 2399
+    components:
+    - type: Transform
+      pos: -31.5,9.5
+      parent: 2
+  - uid: 2400
+    components:
+    - type: Transform
+      pos: -32.5,9.5
+      parent: 2
+  - uid: 2401
+    components:
+    - type: Transform
+      pos: -33.5,9.5
+      parent: 2
+  - uid: 2402
+    components:
+    - type: Transform
+      pos: -34.5,9.5
+      parent: 2
+  - uid: 2403
+    components:
+    - type: Transform
+      pos: -34.5,8.5
+      parent: 2
+  - uid: 2404
+    components:
+    - type: Transform
+      pos: -34.5,7.5
+      parent: 2
+  - uid: 2405
+    components:
+    - type: Transform
+      pos: -34.5,4.5
+      parent: 2
+  - uid: 2406
+    components:
+    - type: Transform
+      pos: -34.5,3.5
+      parent: 2
+  - uid: 2407
+    components:
+    - type: Transform
+      pos: -34.5,2.5
+      parent: 2
+  - uid: 2408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -37.5,8.5
+      parent: 2
+  - uid: 2409
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -37.5,7.5
+      parent: 2
+  - uid: 2410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -37.5,6.5
+      parent: 2
+  - uid: 2411
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -37.5,5.5
+      parent: 2
+  - uid: 2412
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -37.5,4.5
+      parent: 2
+  - uid: 2413
+    components:
+    - type: Transform
+      pos: -23.5,-5.5
+      parent: 2
+  - uid: 2414
+    components:
+    - type: Transform
+      pos: -19.5,-2.5
+      parent: 2
+  - uid: 2415
+    components:
+    - type: Transform
+      pos: -19.5,-5.5
+      parent: 2
+  - uid: 2416
+    components:
+    - type: Transform
+      pos: -23.5,-3.5
+      parent: 2
+  - uid: 2417
+    components:
+    - type: Transform
+      pos: -23.5,-2.5
+      parent: 2
+  - uid: 2418
+    components:
+    - type: Transform
+      pos: -23.5,-4.5
+      parent: 2
+  - uid: 2419
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-6.5
+      parent: 2
+  - uid: 2420
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-11.5
+      parent: 2
+  - uid: 2421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,-13.5
+      parent: 2
+  - uid: 2422
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-12.5
+      parent: 2
+  - uid: 2423
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-13.5
+      parent: 2
+  - uid: 2424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,-13.5
+      parent: 2
+  - uid: 2425
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,-13.5
+      parent: 2
+  - uid: 2426
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 2427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 2
+  - uid: 2428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 2429
+    components:
+    - type: Transform
+      pos: -30.5,-3.5
+      parent: 2
+  - uid: 2430
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 2431
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 2432
+    components:
+    - type: Transform
+      pos: -23.5,-11.5
+      parent: 2
+  - uid: 2433
+    components:
+    - type: Transform
+      pos: -30.5,-10.5
+      parent: 2
+  - uid: 2434
+    components:
+    - type: Transform
+      pos: -29.5,-10.5
+      parent: 2
+  - uid: 2435
+    components:
+    - type: Transform
+      pos: -28.5,-10.5
+      parent: 2
+  - uid: 2436
+    components:
+    - type: Transform
+      pos: -27.5,-10.5
+      parent: 2
+  - uid: 2437
+    components:
+    - type: Transform
+      pos: -26.5,-10.5
+      parent: 2
+  - uid: 2438
+    components:
+    - type: Transform
+      pos: -25.5,-10.5
+      parent: 2
+  - uid: 2439
+    components:
+    - type: Transform
+      pos: -24.5,-10.5
       parent: 2
   - uid: 2440
     components:
     - type: Transform
-      pos: -31.5,-2.5
+      pos: -23.5,-10.5
       parent: 2
   - uid: 2441
     components:
     - type: Transform
-      pos: -32.5,0.5
+      pos: -23.5,-9.5
+      parent: 2
+  - uid: 2442
+    components:
+    - type: Transform
+      pos: -28.5,-16.5
+      parent: 2
+  - uid: 2443
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 2444
+    components:
+    - type: Transform
+      pos: -30.5,-13.5
+      parent: 2
+  - uid: 2445
+    components:
+    - type: Transform
+      pos: -23.5,-13.5
+      parent: 2
+  - uid: 2446
+    components:
+    - type: Transform
+      pos: -30.5,-17.5
+      parent: 2
+  - uid: 2447
+    components:
+    - type: Transform
+      pos: -24.5,-13.5
+      parent: 2
+  - uid: 2448
+    components:
+    - type: Transform
+      pos: -29.5,-17.5
+      parent: 2
+  - uid: 2449
+    components:
+    - type: Transform
+      pos: -28.5,-17.5
+      parent: 2
+  - uid: 2450
+    components:
+    - type: Transform
+      pos: -25.5,-13.5
+      parent: 2
+  - uid: 2451
+    components:
+    - type: Transform
+      pos: -26.5,-13.5
+      parent: 2
+  - uid: 2452
+    components:
+    - type: Transform
+      pos: -27.5,-16.5
+      parent: 2
+  - uid: 2453
+    components:
+    - type: Transform
+      pos: -26.5,-16.5
+      parent: 2
+  - uid: 2454
+    components:
+    - type: Transform
+      pos: -27.5,-13.5
+      parent: 2
+  - uid: 2455
+    components:
+    - type: Transform
+      pos: -25.5,-16.5
+      parent: 2
+  - uid: 2456
+    components:
+    - type: Transform
+      pos: -24.5,-16.5
+      parent: 2
+  - uid: 2457
+    components:
+    - type: Transform
+      pos: -28.5,-13.5
+      parent: 2
+  - uid: 2458
+    components:
+    - type: Transform
+      pos: -23.5,-16.5
+      parent: 2
+  - uid: 2459
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 2
+  - uid: 2460
+    components:
+    - type: Transform
+      pos: -25.5,-19.5
       parent: 2
   - uid: 2461
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-19.5
+      parent: 2
+  - uid: 2462
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-17.5
+      parent: 2
+  - uid: 2463
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-16.5
+      parent: 2
+  - uid: 2464
+    components:
+    - type: Transform
+      pos: -16.5,-8.5
+      parent: 2
+  - uid: 2465
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-17.5
+      parent: 2
+  - uid: 2466
+    components:
+    - type: Transform
+      pos: -26.5,-19.5
+      parent: 2
+  - uid: 2467
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-17.5
+      parent: 2
+  - uid: 2468
+    components:
+    - type: Transform
+      pos: -27.5,-19.5
+      parent: 2
+  - uid: 2469
+    components:
+    - type: Transform
+      pos: -28.5,-19.5
+      parent: 2
+  - uid: 2470
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-14.5
+      parent: 2
+  - uid: 2471
+    components:
+    - type: Transform
+      pos: -16.5,-17.5
+      parent: 2
+  - uid: 2472
+    components:
+    - type: Transform
+      pos: -18.5,-17.5
+      parent: 2
+  - uid: 2473
+    components:
+    - type: Transform
+      pos: -15.5,-13.5
+      parent: 2
+  - uid: 2474
+    components:
+    - type: Transform
+      pos: -15.5,-14.5
+      parent: 2
+  - uid: 2475
+    components:
+    - type: Transform
+      pos: -15.5,-16.5
+      parent: 2
+  - uid: 2476
+    components:
+    - type: Transform
+      pos: -15.5,-17.5
+      parent: 2
+  - uid: 2477
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,-22.5
+      parent: 2
+  - uid: 2478
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,-22.5
+      parent: 2
+  - uid: 2479
+    components:
+    - type: Transform
+      pos: -15.5,-20.5
+      parent: 2
+  - uid: 2480
+    components:
+    - type: Transform
+      pos: -15.5,-19.5
+      parent: 2
+  - uid: 2481
+    components:
+    - type: Transform
+      pos: -15.5,-18.5
+      parent: 2
+  - uid: 2482
+    components:
+    - type: Transform
+      pos: -31.5,-17.5
+      parent: 2
+  - uid: 2483
+    components:
+    - type: Transform
+      pos: -33.5,-17.5
+      parent: 2
+  - uid: 2484
+    components:
+    - type: Transform
+      pos: -33.5,-13.5
+      parent: 2
+  - uid: 2485
+    components:
+    - type: Transform
+      pos: -32.5,-13.5
+      parent: 2
+  - uid: 2486
+    components:
+    - type: Transform
+      pos: -31.5,-13.5
+      parent: 2
+  - uid: 2487
+    components:
+    - type: Transform
+      pos: -31.5,1.5
+      parent: 2
+  - uid: 2488
+    components:
+    - type: Transform
+      pos: -32.5,1.5
+      parent: 2
+  - uid: 2489
+    components:
+    - type: Transform
+      pos: -33.5,1.5
+      parent: 2
+  - uid: 2490
+    components:
+    - type: Transform
+      pos: -32.5,-17.5
+      parent: 2
+  - uid: 2491
+    components:
+    - type: Transform
+      pos: -15.5,-12.5
+      parent: 2
+  - uid: 2492
+    components:
+    - type: Transform
+      pos: -15.5,-11.5
+      parent: 2
+  - uid: 2493
+    components:
+    - type: Transform
+      pos: -15.5,-10.5
+      parent: 2
+  - uid: 2494
+    components:
+    - type: Transform
+      pos: -15.5,-9.5
+      parent: 2
+  - uid: 2495
+    components:
+    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,11.5
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 2496
+    components:
+    - type: Transform
+      pos: -26.5,7.5
+      parent: 2
+  - uid: 2497
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 2498
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 2499
+    components:
+    - type: Transform
+      pos: -24.5,-22.5
+      parent: 2
+  - uid: 2500
+    components:
+    - type: Transform
+      pos: -28.5,-22.5
+      parent: 2
+  - uid: 2501
+    components:
+    - type: Transform
+      pos: -27.5,-22.5
+      parent: 2
+  - uid: 2502
+    components:
+    - type: Transform
+      pos: -26.5,-22.5
+      parent: 2
+  - uid: 2503
+    components:
+    - type: Transform
+      pos: -25.5,-22.5
+      parent: 2
+  - uid: 2504
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,11.5
+      parent: 2
+  - uid: 2505
+    components:
+    - type: Transform
+      pos: -31.5,10.5
+      parent: 2
+  - uid: 2506
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,11.5
+      parent: 2
+  - uid: 2507
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,11.5
+      parent: 2
+  - uid: 2508
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-11.5
+      parent: 2
+  - uid: 2509
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,11.5
       parent: 2
   - uid: 2510
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,-11.5
+      pos: -25.5,8.5
       parent: 2
   - uid: 2511
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,11.5
+      parent: 2
+  - uid: 2512
+    components:
+    - type: Transform
+      pos: -31.5,-2.5
+      parent: 2
+  - uid: 2513
+    components:
+    - type: Transform
+      pos: -32.5,0.5
+      parent: 2
+  - uid: 2514
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,11.5
+      parent: 2
+  - uid: 2515
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-11.5
+      parent: 2
+  - uid: 2516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17641,7 +17727,7 @@ entities:
       parent: 2
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 1712
+  - uid: 2517
     components:
     - type: Transform
       pos: -17.5,-12.5
@@ -17666,35 +17752,35 @@ entities:
         - 0
 - proto: WarningN2
   entities:
-  - uid: 2164
+  - uid: 2518
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 2
 - proto: WarningO2
   entities:
-  - uid: 2165
+  - uid: 2519
     components:
     - type: Transform
       pos: -26.5,7.5
       parent: 2
 - proto: WarningWaste
   entities:
-  - uid: 2166
+  - uid: 2520
     components:
     - type: Transform
       pos: -30.5,6.5
       parent: 2
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 2167
+  - uid: 2521
     components:
     - type: Transform
       pos: -27.5,-11.5
       parent: 2
 - proto: WaterVaporCanister
   entities:
-  - uid: 1800
+  - uid: 2522
     components:
     - type: Transform
       anchored: True
@@ -17704,14 +17790,14 @@ entities:
       releaseValve: True
     - type: Physics
       bodyType: Static
-  - uid: 1833
+  - uid: 2523
     components:
     - type: Transform
       pos: -36.5,7.5
       parent: 2
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 1701
+  - uid: 2524
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17719,27 +17805,33 @@ entities:
       parent: 2
 - proto: WeaponQuadDisabler
   entities:
-  - uid: 2479
+  - uid: 2525
     components:
     - type: Transform
       pos: -25.477905,10.463043
       parent: 2
 - proto: WeldingFuelTankHighCapacity
   entities:
-  - uid: 2271
+  - uid: 2526
     components:
     - type: Transform
       pos: -27.5,-1.5
       parent: 2
 - proto: Windoor
   entities:
-  - uid: 1686
+  - uid: 2527
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-2.5
+      parent: 2
+  - uid: 2528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 2
-  - uid: 2168
+  - uid: 2529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17749,37 +17841,37 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        43:
+        40:
         - DoorStatus: DoorBolt
-  - uid: 2169
+  - uid: 2530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 2
-  - uid: 2170
+  - uid: 2531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 2
-  - uid: 2171
+  - uid: 2532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 2
-  - uid: 2173
+  - uid: 2533
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 2
-  - uid: 2174
+  - uid: 2534
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 2206
+  - uid: 2535
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17787,19 +17879,19 @@ entities:
       parent: 2
 - proto: WindoorHydroponicsLocked
   entities:
-  - uid: 2175
+  - uid: 2536
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 2387
+  - uid: 2537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
-  - uid: 2456
+  - uid: 2538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17807,7 +17899,7 @@ entities:
       parent: 2
 - proto: WindoorKitchenHydroponicsLocked
   entities:
-  - uid: 2176
+  - uid: 2539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17815,25 +17907,25 @@ entities:
       parent: 2
 - proto: WindoorKitchenLocked
   entities:
-  - uid: 1590
+  - uid: 2540
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
-  - uid: 2177
+  - uid: 2541
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
       parent: 2
-  - uid: 2178
+  - uid: 2542
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,3.5
       parent: 2
-  - uid: 2464
+  - uid: 2543
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17841,43 +17933,43 @@ entities:
       parent: 2
 - proto: WindoorSecure
   entities:
-  - uid: 1512
+  - uid: 2544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-5.5
       parent: 2
-  - uid: 2179
+  - uid: 2545
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 2180
+  - uid: 2546
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 2181
+  - uid: 2547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 2
-  - uid: 2182
+  - uid: 2548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-15.5
       parent: 2
-  - uid: 2183
+  - uid: 2549
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-6.5
       parent: 2
-  - uid: 2417
+  - uid: 2550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17885,36 +17977,36 @@ entities:
       parent: 2
 - proto: WindoorSecureBarLocked
   entities:
-  - uid: 2184
+  - uid: 2551
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
 - proto: WindoorSecureBrigLocked
   entities:
-  - uid: 2185
+  - uid: 2552
     components:
     - type: Transform
       pos: -17.5,-5.5
       parent: 2
 - proto: WindoorSecureCargoLocked
   entities:
-  - uid: 2186
+  - uid: 2553
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 2187
+  - uid: 2554
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
-  - uid: 2188
+  - uid: 2555
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 2189
+  - uid: 2556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17922,19 +18014,19 @@ entities:
       parent: 2
 - proto: WindoorSecureChemistryLocked
   entities:
-  - uid: 2190
+  - uid: 2557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 2191
+  - uid: 2558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,6.5
       parent: 2
-  - uid: 2192
+  - uid: 2559
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17942,7 +18034,7 @@ entities:
       parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
-  - uid: 2193
+  - uid: 2560
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17950,13 +18042,13 @@ entities:
       parent: 2
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 2194
+  - uid: 2561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,6.5
       parent: 2
-  - uid: 2195
+  - uid: 2562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17964,25 +18056,25 @@ entities:
       parent: 2
 - proto: WindoorSecureSalvageLocked
   entities:
-  - uid: 2196
+  - uid: 2563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 2197
+  - uid: 2564
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 2198
+  - uid: 2565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 2
-  - uid: 2199
+  - uid: 2566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17990,7 +18082,7 @@ entities:
       parent: 2
 - proto: WindoorSecureScienceLocked
   entities:
-  - uid: 2200
+  - uid: 2567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17998,49 +18090,49 @@ entities:
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 889
+  - uid: 2568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 2
-  - uid: 1474
+  - uid: 2569
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 2
-  - uid: 1832
+  - uid: 2570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 2
-  - uid: 2201
+  - uid: 2571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-5.5
       parent: 2
-  - uid: 2202
+  - uid: 2572
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-5.5
       parent: 2
-  - uid: 2203
+  - uid: 2573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-5.5
       parent: 2
-  - uid: 2204
+  - uid: 2574
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-5.5
       parent: 2
-  - uid: 2207
+  - uid: 2575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18048,7 +18140,7 @@ entities:
       parent: 2
 - proto: YarnNoodles
   entities:
-  - uid: 2210
+  - uid: 2576
     components:
     - type: Transform
       pos: -2.4257011,3.601201

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -4,6 +4,7 @@
   - Amber
   - Atlas
   - Bagel
+  - Banana
   - Barratry
   - Boat
   - Box

--- a/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
@@ -301,3 +301,15 @@
       prototypes:
         - MobFrank
 
+- type: entity
+  name: tck'tck spawner
+  suffix: Borg
+  id: BorgSpawnerTckTck
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+    - type: ConditionalSpawner
+      prototypes:
+        - MobTckTck


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Holy shit

![Banana-0](https://github.com/user-attachments/assets/c821433e-d748-4d4d-80fc-7a9311b5f072)

- Moved the arrivals APC to make it more accessible
- Replaced multiple solid firelocks with glass ones
- Fixed the radiation closet in engineering being empty
- Mapped the new decapoid plushie
- Replaced the Jr.Pac in disposals with a Tck'tck
- Added MV and HV coils to engineering
- Removed a thruster from the shuttle bay
- Moved the disposals APC to be easier to reach
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:kipdotnet, Darkmajia, Starlighthowls
- add: Added and rotated Banana, a new lowpop map!
