### PR TITLE
greytide virus made significantly more rare

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -472,7 +472,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 5
+    weight: 2 #imp. tf you mean this was weight 5
     minimumPlayers: 25
     reoccurrenceDelay: 20
   - type: GreytideVirusRule


### PR DESCRIPTION
previously it was as common as vent critters which is absurd for how disruptive this event is

**Changelog**
:cl:
- tweak: The greytide virus will infect much less often.
