### PR TITLE
changed up ling sting chemicals

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -420,8 +420,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     {
         var reagents = new List<(string, FixedPoint2)>()
         {
-            ("Fresium", 20f),
-            ("ChloralHydrate", 10f)
+            ("Fresium", 20f)
         };
 
         if (!TryReagentSting(uid, comp, args, reagents))
@@ -431,8 +430,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     {
         var reagents = new List<(string, FixedPoint2)>()
         {
-            ("Impedrezene", 10f),
-            ("MuteToxin", 5f)
+            ("ChloralHydrate", 15f)
         };
 
         if (!TryReagentSting(uid, comp, args, reagents))
@@ -442,7 +440,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     {
         var reagents = new List<(string, FixedPoint2)>()
         {
-            ("MuteToxin", 15f)
+            ("MuteToxin", 9f)
         };
 
         if (!TryReagentSting(uid, comp, args, reagents))

--- a/Resources/Locale/en-US/_Goobstation/changeling/store/changeling-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/changeling/store/changeling-catalog.ftl
@@ -53,12 +53,12 @@ evolutionmenu-sting-cryo-desc =
 
 evolutionmenu-sting-lethargic-name = Lethargic Sting
 evolutionmenu-sting-lethargic-desc =
-    We stealithly inject our victim with a cocktail of anesthetics, inhibiting their movement.
+    We stealithly inject our victim with a cocktail of anesthetics, causing them to become slow and drowsy.
     Costs a medium amount of chemicals.
 
 evolutionmenu-sting-mute-name = Mute Sting
 evolutionmenu-sting-mute-desc =
-    We stealthily sting our victim, silencing them for a short time.
+    We stealthily sting our victim, silencing them for a few minutes.
     Costs a medium amount of chemicals.
 
 evolutionmenu-sting-transform-name = Transformation Sting

--- a/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
@@ -299,7 +299,7 @@
 - type: entity
   id: ActionStingLethargic
   name: Lethargic Sting
-  description: We inject a target with a cocktail of anesthetics, inhibiting their movement. Costs a medium amount of chemicals.
+  description: We inject a target with a cocktail of anesthetics, causing them to become slow and drowsy. Costs a medium amount of chemicals.
   categories: [ HideSpawnMenu ]
   components:
   - type: EntityTargetAction
@@ -320,7 +320,7 @@
 - type: entity
   id: ActionStingMute
   name: Mute Sting
-  description: We sting a target, silencing them for a short time. Costs a medium amount of chemicals.
+  description: We sting a target, silencing them for a few minutes. Costs a medium amount of chemicals.
   categories: [ HideSpawnMenu ]
   components:
   - type: EntityTargetAction


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

quick stopgap fix to some of the changeling stings while dark works on a more permanent solution. changes are as follows:

- removed chloral hydrate from cryogenic sting
- removed mute toxin from lethargic sting
- lethargic sting now uses Chloral Hydrate instead of impedrezene, which adds a small chance to cause sleep
- mute sting injection amount lowered to only last for 3 minutes

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: changed up the cryogenic sting to no longer have a chance to cause sleep.
- tweak: changed up the lethargic sting so it has a chance to cause sleep, and no longer mutes victims.
- tweak: changed up the mute sting so it mutes the victim for 3 minutes instead of 5.