### PR TITLE
Add Handcuffs tag back to Cablecuffs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -72,6 +72,7 @@
     color: forestgreen
   - type: Tag # Imp start
     tags:
+    - Handcuffs
     - Cablecuffs # Imp end
 
 - type: entity


### PR DESCRIPTION
This is in addition to the Cablecuffs tag. Honestly doesn't need a changelog I think. Just a quick bugfix turnaround.
