### PR TITLE
Changeling Last Resort Updates

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -45,7 +45,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         base.Initialize();
 
         Log.Level = LogLevel.Debug;
-        
+
         SubscribeLocalEvent<TraitorRuleComponent, AntagPrereqSetupEvent>(AdditionalSetup);
         SubscribeLocalEvent<TraitorRuleComponent, AfterAntagEntitySelectedEvent>(AfterEntitySelected);
         SubscribeLocalEvent<TraitorRuleComponent, ObjectivesTextPrependEvent>(OnObjectivesTextPrepend);

--- a/Content.Server/_Goobstation/Changeling/ChangelingEggSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingEggSystem.cs
@@ -42,15 +42,15 @@ public sealed partial class ChangelingEggSystem : EntitySystem
         }
 
         var newUid = Spawn("MobMonkey", Transform(uid).Coordinates);
-        
+
         var mind = EnsureComp<MindComponent>(newUid);
         _mind.TransferTo(comp.lingMind, newUid);
 
         var ling = EnsureComp<ChangelingComponent>(newUid);
         ling = comp.lingComp;
-        
+
         EntityManager.AddComponent(newUid, comp.lingStore);
 
-        _bodySystem.GibBody((EntityUid) uid);
+        _bodySystem.GibBody((EntityUid)uid);
     }
 }

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -19,8 +19,6 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Damage.Components;
-using Content.Server.Radio.Components;
-using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -657,15 +655,15 @@ public sealed partial class ChangelingSystem : EntitySystem
         }
 
         _explosionSystem.QueueExplosion(
-            (EntityUid) newUid,
+            (EntityUid)newUid,
             typeId: "Default",
             totalIntensity: 1,
             slope: 4,
             maxTileIntensity: 2);
 
-        _actions.AddAction((EntityUid) newUid, "ActionLayEgg");
+        _actions.AddAction((EntityUid)newUid, "ActionLayEgg");
 
-        PlayMeatySound((EntityUid) newUid, comp);
+        PlayMeatySound((EntityUid)newUid, comp);
     }
     public void OnLesserForm(EntityUid uid, ChangelingComponent comp, ref ActionLesserFormEvent args)
     {

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -178,6 +178,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         Dirty(uid, comp);
         _alerts.ShowAlert(uid, "ChangelingChemicals");
     }
+
     private void UpdateBiomass(EntityUid uid, ChangelingComponent comp, float? amount = null)
     {
         comp.Biomass += amount ?? -1;
@@ -525,7 +526,7 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         var config = new PolymorphConfiguration()
         {
-            Entity = (EntProtoId) pid,
+            Entity = (EntProtoId)pid,
             TransferDamage = transferDamage,
             Forced = true,
             Inventory = (dropInventory) ? PolymorphInventoryChange.Drop : PolymorphInventoryChange.Transfer,
@@ -555,15 +556,18 @@ public sealed partial class ChangelingSystem : EntitySystem
         {
             // copy our stuff
             var newLingComp = CopyChangelingComponent(newEnt, comp);
-            if (!persistentDna && data != null)
-                newLingComp?.AbsorbedDNA.Remove(data);
-            RemCompDeferred<ChangelingComponent>(uid);
-
-            if (TryComp<StoreComponent>(uid, out var storeComp))
+            if (newLingComp != null)
             {
-                var storeCompCopy = _serialization.CreateCopy(storeComp, notNullableOverride: true);
-                RemComp<StoreComponent>(newUid.Value);
-                EntityManager.AddComponent(newUid.Value, storeCompCopy);
+                if (!persistentDna && data != null)
+                    newLingComp.AbsorbedDNA.Remove(data);
+                RemCompDeferred<ChangelingComponent>(uid);
+
+                if (TryComp<StoreComponent>(uid, out var storeComp))
+                {
+                    var storeCompCopy = _serialization.CreateCopy(storeComp, notNullableOverride: true);
+                    RemComp<StoreComponent>(newUid.Value);
+                    EntityManager.AddComponent(newUid.Value, storeCompCopy);
+                }
             }
         }
 

--- a/Content.Shared/_Goobstation/Changeling/ChangelingEggComponent.cs
+++ b/Content.Shared/_Goobstation/Changeling/ChangelingEggComponent.cs
@@ -16,6 +16,6 @@ public sealed partial class ChangelingEggComponent : Component
     ///     Countdown before spawning monkey.
     /// </summary>
     public TimeSpan UpdateTimer = TimeSpan.Zero;
-    public float UpdateCooldown = 120f;
+    public float UpdateCooldown = 60f;
     public bool active = false;
 }

--- a/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
@@ -512,6 +512,7 @@
 - type: entity
   id: ActionLastResort
   name: Last Resort
+  parent: BaseSuicideAction
   description: We abandon our vessel, escaping in our vulnerable true self, to find a new body to occupy. Costs a small amount of chemicals.
   categories: [ HideSpawnMenu ]
   components:
@@ -525,6 +526,7 @@
     event: !type:ActionLastResortEvent {}
   - type: ChangelingAction
     chemicalCost: 20
+    biomassCost: -30 # absorbing the rest of the current body on use
     useInLesserForm: true
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -5,6 +5,7 @@
   description: You don't want to touch it.
   components:
   - type: VentCrawler
+  - type: NoSlip
   - type: Sprite
     drawdepth: SmallMobs
     layers:


### PR DESCRIPTION
A few last resort changes. 

:cl:
- tweak: Changelings now absorb the rest of their current body on use of Last Resort, regaining biomass.
- tweak: Halved the incubation time of the changeling egg so you come back as a monkey sooner.
- fix: There is now a confirmation popup for Last Resort so you don't accidentally explode into a slug.
- fix: Headslugs can no longer slip. They're slugs. Have you ever seen a slug slip?

