### PR TITLE
Adjust Gas Prices

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 2.5
+  pricePerMole: 2
 
 - type: gas
   id: 5
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 1.5
+  pricePerMole: 3


### PR DESCRIPTION
Trit is now 2 per mol Frezon up to 3 from 1.5. If I murder the economy so be it.

:cl:
- tweak: Gas prices are both higher and lower. Frezon up to 3 spesos per mol, Tritium down to 2 per mol.

