### PR TITLE
Add suffix to CMO's cats, migrate Pipi spawner

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
@@ -157,6 +157,7 @@
 - type: entity
   name: Runtime Spawner
   id: SpawnMobCatRuntime
+  suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
   - type: Sprite
@@ -170,6 +171,7 @@
 - type: entity
   name: Exception Spawner
   id: SpawnMobCatException
+  suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
   - type: Sprite
@@ -196,6 +198,7 @@
 - type: entity
   name: Floppa Spawner
   id: SpawnMobCatFloppa
+  suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
   - type: Sprite
@@ -209,6 +212,7 @@
 - type: entity
   name: Bingus Spawner
   id: SpawnMobCatBingus
+  suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
   - type: Sprite
@@ -218,19 +222,6 @@
   - type: ConditionalSpawner
     prototypes:
       - MobBingus
-
-- type: entity
-  name: Pipi Spawner
-  id: SpawnMobCatKittenPipi
-  parent: MarkerBase
-  components:
-  - type: Sprite
-    layers:
-      - state: green
-      - state: ai
-  - type: ConditionalSpawner
-    prototypes:
-      - MobPipi
 
 - type: entity
   name: Space Cat Spawner
@@ -261,6 +252,7 @@
 - type: entity
   name: Cat Spawner
   id: SpawnMobCat
+  suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
@@ -313,3 +313,17 @@
     - type: ConditionalSpawner
       prototypes:
         - MobTckTck
+
+- type: entity
+  name: Pipi Spawner
+  id: SpawnMobCatKittenPipi
+  suffix: CMO's pet, steal target
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+      - MobPipi


### PR DESCRIPTION
Adds the suffix "CMO's pet, steal target" to the named cat spawner and their respective specific spawners, which are all part of the CMO's pet thief objective group. This is to help indicate to mappers that you should (probably) only map one of these and it should (probably) be in the CMO's office or elsewhere in medbay. Additionally migrates the Pipi spawner entity to the _Impstation file structure.
