### PR TITLE
goblin event weight changes

### DIFF
--- a/Resources/Prototypes/_Impstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/events.yml
@@ -10,7 +10,6 @@
     - id: NinjaSpawn
     - id: RevenantSpawn
     - id: GoblinStowawaysEvent # imp
-    - id: GoblinCastawaysEvent # imp
 
 - type: entity
   id: ChangelingAwakening

--- a/Resources/Prototypes/_Impstation/GameRules/goblins.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/goblins.yml
@@ -3,10 +3,10 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 1 # theoretically as rare as zombies. this can be increased to 1.3 if they become too uncommon, i'm just making sure that they're actually using the correct weight.
+    weight: 1.8 # more common than zombies, but should theoretically not happen every shift. maybe once every two shifts. if it's too often, bump it down to 1.5
     duration: 1
     minimumPlayers: 15
-    maxOccurrences: 1
+    maxOccurrences: 1 # six goblins is a lot
   - type: VentCrittersRule
     specialEntries:
     - id: GoblinStowawaysVentSpawner
@@ -17,7 +17,7 @@
   id: GoblinKnightEvent
   components:
   - type: StationEvent
-    weight: 1 # gollylad is a calm event, and the station is rolling calm events 90% of the time, so he should be less common if we want him to not roll on every shift
+    weight: 1.5 # gollylad is a calm event, and the station is rolling calm events 90% of the time, so he should be less common if we want him to not roll on every shift
     duration: 1
     maxOccurrences: 1 # he's a named character. there's only one of him
   - type: RandomEntityStorageSpawnRule


### PR DESCRIPTION


<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
:cl:
- tweak: Goblin event weights adjusted to make them more common.
