### PR TITLE
disables greytide virus event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -9,7 +9,7 @@
     - id: BureaucraticError
     - id: ClericalError
     - id: GasLeak
-    - id: GreytideVirus
+    # - id: GreytideVirus
     - id: IonStorm # its calm like 90% of the time smh
     - id: KudzuGrowth
     - id: MassHallucinations


### PR DESCRIPTION
i was originally intending to look into the event to whitelist it to airlocks only. however, even if i do that, the event still has major problems:
- although it's more of a mapping issue, some departments with external airlocks to space will just space themselves. box's atmos is one in particular i noticed
- there is no way of defining a department, so airlocks and lockable objects across the _entire station_ that match the access will be unlocked. this includes every single substation airlock if it hits engineering, every single security checkpoint and the lockers within if it hits security, etc

without proper support for defining departments, this event is far too much. i wanted to let people get used to the event but it simply does not function as it should

**Changelog**
:cl:
- remove: The greytide virus event has been disabled.
