### PR TITLE
Adjustment to rolling pin lathe recipe, add sterile swabs to service techfab.

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -46,6 +46,7 @@
       - WetFloorSign
       - SoapNT #imp recipe
       #botany
+      - DiseaseSwab
       - HydroponicsToolMiniHoe
       - HydroponicsToolScythe
       - HydroponicsToolHatchet

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/cooking.yml
@@ -100,4 +100,5 @@
   id: RollingPin
   result: RollingPin
   materials:
-    Wood: 400
+    Wood: 200
+    Steel: 50


### PR DESCRIPTION
Adjusts the rolling pin's lathe recipe to 2 wood and .5 steel to match its crafting menu cost of 2 wood and 1 metal rod (I had no idea this was craftable through the crafting menu when I made the recipe.) Additionally added the sterile swab recipe to the service techfab.

**Changelog**

:cl:
- add: Sterile swabs are now able to crafted from the service techfab.
- tweak: The rolling pin's service techfab recipe now better reflects its crafting menu recipe.
