### PR TITLE
Raise Amber Station's minimum player count to 15

### DIFF
--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -3,7 +3,7 @@
   mapName: 'Amber'
   mapPath: /Maps/_Impstation/amber.yml
   minPlayers: 15
-  maxPlayers: 45
+  maxPlayers: 50
   stations:
     Amber:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -2,8 +2,8 @@
   id: Amber
   mapName: 'Amber'
   mapPath: /Maps/_Impstation/amber.yml
-  minPlayers: 7
-  maxPlayers: 50
+  minPlayers: 15
+  maxPlayers: 45
   stations:
     Amber:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
Amber Station was introduced as a low to mid-pop map upstream, but it's just too big for only 7 people to support it. Raises the the minimum population from 7 to 15.
