### PR TITLE
brigmedic hardsuit buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -237,10 +237,13 @@
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.7
+        Piercing: 0.75
+        Heat: 0.9
+        Radiation: 0.3
+        Caustic: 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.8
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic


### PR DESCRIPTION
the people desire it. i'm just ripping values from before the brigmedic hardsuit got nerfed

| stat | old | new |
|---|---|---|
| movement speed | 35% slower | 20% slower |
| blunt resistance | 20% | 20% |
| slash resistance | 20% | 20% |
| pierce resistance | 30% | 25% |
| heat resistance | 0% | 10% |
| radiation resistance | 0% | 70% |
| caustic resistance | 0% | 80% |

notably, this does make the brigmedic hardsuit the only security hardsuit with heat and radiation resistance, but.. why the fuck dont the other security hardsuits have these? hello? am i stupid? i saw an upstream pull request somewhere or other to adjust values for these but i feel like i should really fast-track some changes to the other hardsuits

**Changelog**
:cl:
- tweak: The brigmedic's hardsuit slows its user down less, and its resistances have received adjustment.