### PR TITLE
Fix sending webhook updates to github

### DIFF
--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-#
-# Sends updates to a Discord webhook for new changelog entries since the last GitHub Actions publish run.
-# Automatically figures out the last run and changelog contents with the GitHub API.
-#
+"""
+Sends updates to a Discord webhook for new changelog entries since the last GitHub Actions publish run.
+
+Automatically figures out the last run and changelog contents with the GitHub API.
+"""
 
 import io
 import itertools
@@ -172,4 +173,5 @@ def send_to_discord(entries: Iterable[ChangelogEntry]) -> None:
         send_discord(message_text)
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -145,7 +145,7 @@ def send_discord_webhook(content: str):
 
 def send_entries(entries: Iterable[ChangelogEntry]) -> None:
     if not DISCORD_WEBHOOK_URL:
-        print(f"No discord webhook URL found, skipping discord send")
+        print("No discord webhook URL found, skipping discord send")
         return
 
     message_content = io.StringIO()

--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -8,15 +8,16 @@
 import io
 import itertools
 import os
+from pathlib import Path
 from typing import Any, Iterable
 
 import requests
 import yaml
 
-GITHUB_API_URL = os.environ.get("GITHUB_API_URL", "https://api.github.com")
-GITHUB_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
-GITHUB_RUN = os.environ["GITHUB_RUN_ID"]
-GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+# GITHUB_API_URL = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+# GITHUB_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
+# GITHUB_RUN = os.environ["GITHUB_RUN_ID"]
+# GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 
 # https://discord.com/developers/docs/resources/webhook
 DISCORD_SPLIT_LIMIT = 2000
@@ -33,15 +34,15 @@ def main():
     if not DISCORD_WEBHOOK_URL:
         return
 
-    session = requests.Session()
-    session.headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
-    session.headers["Accept"] = "Accept: application/vnd.github+json"
-    session.headers["X-GitHub-Api-Version"] = "2022-11-28"
+    # session = requests.Session()
+    # session.headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
+    # session.headers["Accept"] = "Accept: application/vnd.github+json"
+    # session.headers["X-GitHub-Api-Version"] = "2022-11-28"
 
-    most_recent = get_most_recent_workflow(session)
-    last_sha = most_recent["head_commit"]["id"]
-    print(f"Last successful publish job was {most_recent['id']}: {last_sha}")
-    last_changelog = yaml.safe_load(get_last_changelog(session, last_sha))
+    # most_recent = get_most_recent_workflow(session)
+    # last_sha = most_recent["head_commit"]["id"]
+    # print(f"Last successful publish job was {most_recent['id']}: {last_sha}")
+    last_changelog = yaml.safe_load(Path("../Changelog-Impstation-old.yml").read_text())
     with open(CHANGELOG_FILE, "r") as f:
         cur_changelog = yaml.safe_load(f)
 

--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -35,8 +35,12 @@ def main():
         return
 
     if DEBUG:
+        # to debug this script locally, you can use
+        # a separate local file as the old changelog
         last_changelog_stream = DEBUG_CHANGELOG_FILE_OLD.read_text()
     else:
+        # when running this normally in a GitHub actions workflow,
+        # it will get the old changelog from the GitHub API
         last_changelog_stream = get_last_changelog()
 
     last_changelog = yaml.safe_load(last_changelog_stream)
@@ -150,6 +154,7 @@ def send_discord_webhook(lines: list[str]):
 
 
 def changelog_entries_to_message_lines(entries: Iterable[ChangelogEntry]) -> list[str]:
+    """Process structured changelog entries into a list of lines making up a formatted message."""
     message_lines = []
 
     for contributor_name, group in itertools.groupby(entries, lambda x: x["author"]):
@@ -179,6 +184,7 @@ def changelog_entries_to_message_lines(entries: Iterable[ChangelogEntry]) -> lis
 
 
 def send_message_lines(message_lines: list[str]):
+    """Join a list of message lines into chunks that are each below Discord's message length limit, and send them."""
     chunk_lines = []
     chunk_length = 0
 


### PR DESCRIPTION
The upstream script had a bug where if a single entry was too long it would fail to send to discord

I'll upstream this fix once we've tested it on our prod