### PR TITLE
riot-crates-have-stun-again

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -24,7 +24,7 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
     state: icon
   product: CrateSecurityRiot
-  cost: 7500
+  cost: 6000 # Imp
   category: cargoproduct-category-name-armory
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -82,7 +82,7 @@
       amount: 2
     - id: ClothingHeadHelmetRiot
       amount: 2
-    - id: WeaponShotgunEnforcerRubber
+    - id: WeaponShotgunEnforcerBeanbag # Imp
       amount: 2
     - id: BoxBeanbag
       amount: 2


### PR DESCRIPTION
an upstream merge changed the riot crates to have two real enforcers in them again, when it's about the same price as the crate that ONLY contains two real enforcers

this patches the stun enforcers back into it and also reduces its price to 6000 again

:cl:
- tweak: Riot crates now correctly have stun enforcers in them again