### PR TITLE
subgamemodes for lowpop thief

### DIFF
--- a/Resources/Prototypes/_Impstation/game_presets.yml
+++ b/Resources/Prototypes/_Impstation/game_presets.yml
@@ -45,6 +45,7 @@
   showInVote: false
   rules:
     - Thief
+    - SubGamemodesRule
     - LowpopStationEventScheduler
     - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler


### PR DESCRIPTION
adds the potential for thief to roll twice during lowpop thief rounds, and for heretic to roll if the player count is at least 15. thief is the second most common lowpop gamemode, and the most common below 5 players, so this should help make things a little more interesting more often

this _might_ be too many pacified people for the population count, so if it's a problem i'll walk this one back and figure something else out

**Changelog**
:cl:
- add: Lowpop rounds with thief as a main antagonist can roll additional thieves and a potential heretic with enough population.