### PR TITLE
remove flagship derelict and increase max count a little

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -57,7 +57,7 @@
           hide: true
           nameGrid: true
           minCount: 2
-          maxCount: 2
+          maxCount: 3 #changed on imp
           stationGrid: false
           paths:
           - /Maps/Ruins/abandoned_outpost.yml
@@ -65,7 +65,7 @@
           - /Maps/Ruins/biodome_satellite.yml
           - /Maps/Ruins/derelict.yml
           - /Maps/Ruins/djstation.yml
-          - /Maps/Ruins/empty_flagship.yml
+          #- /Maps/Ruins/empty_flagship.yml #imp. fuck this one
           - /Maps/Ruins/old_ai_sat.yml
           - /Maps/Ruins/syndicate_dropship.yml
           - /Maps/Ruins/whiteship_ancient.yml


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
This PR allows random mapgen derelicts to roll 2-3 spawns, up from the vanilla 2 max. Also I commented out the flagship. fuck that thing
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: There can now sometimes be more derelicts on mapgen.
- tweak: Removed the flagship derelict.
