### PR TITLE
Add blacklist to Vent Clog (backpressure surge) event

### DIFF
--- a/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
@@ -19,6 +19,15 @@ public sealed partial class VentClogRuleComponent : Component
     };
 
     /// <summary>
+    /// Blacklist for chemicals that should never be available from vent clog.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<ReagentPrototype>))]
+    public IReadOnlyList<string> BlacklistedVentChemicals = new[]
+    {
+        "Holium", "PhilosophersJuice"
+    };
+
+    /// <summary>
     /// Sound played when foam is being created.
     /// </summary>
     [DataField]

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -42,10 +42,12 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
         if (!TryGetRandomStation(out var chosenStation))
             return;
 
-        // TODO: "safe random" for chems. Right now this includes admin chemicals.
         var allReagents = PrototypeManager.EnumeratePrototypes<ReagentPrototype>()
             .Where(x => !x.Abstract)
             .Select(x => x.ID).ToList();
+
+        // 'Safe random' for chems, excludes chems in the blacklist defined in the component
+        allReagents.RemoveAll(r => component.BlacklistedVentChemicals.Any(a => a == r));
 
         foreach (var (_, transform) in EntityManager.EntityQuery<GasVentPumpComponent, TransformComponent>())
         {


### PR DESCRIPTION
One line fix (+ a field in the component that defines the blacklist).

Previously there was no blacklist for what chems could spawn from a vent clog event. #1038 

Added that blacklist. 
Blacklist currently has Holium and Philosopher's juice. Can include others in future if needed/upon suggestion.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: Holium can no longer spew out of the vents