### PR TITLE
Fixing Drones, part 1

### DIFF
--- a/Content.Server/Drone/Components/DroneComponent.cs
+++ b/Content.Server/Drone/Components/DroneComponent.cs
@@ -3,6 +3,13 @@ namespace Content.Server.Drone.Components
     [RegisterComponent]
     public sealed partial class DroneComponent : Component
     {
-        public float InteractionBlockRange = 2.15f;
+        public float InteractionBlockRange = 1.5f; /// imp. original value was 2.15, changed because it was annoying. this also does not actually block interactions anymore.
+		
+		// imp. delay before posting another proximity alert
+		public TimeSpan ProximityDelay = TimeSpan.FromMilliseconds(2000);
+		
+		public TimeSpan NextProximityAlert = new();
+		
+		public bool IsItemBlacklisted = false;
     }
 }

--- a/Resources/Locale/en-US/drone/drone-system.ftl
+++ b/Resources/Locale/en-US/drone/drone-system.ftl
@@ -1,4 +1,5 @@
 drone-active = A maintenance drone. It seems totally unconcerned with you.
 drone-dormant = A dormant maintenance drone. Who knows when it will wake up?
 drone-activated = The drone whirrs to life!
-drone-too-close = Your laws prevent this action near {THE($being)}.
+drone-too-close = Be aware of your proximity to {THE($being)}.
+drone-cant-use = This act could cause harm to {THE($being)}.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -12,9 +12,9 @@ law-ntdefault-2 = Prioritize: The directives and safety of crew members are to b
 law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.
 law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.
 
-law-drone-1 = You may not involve yourself in the matters of another being unless the other being is another drone.
-law-drone-2 = You may not harm any being, regardless of intent or circumstance.
-law-drone-3 = You must maintain, repair, improve, and power the station to the best of your abilities.
+law-drone-1 = You may not interfere with the affairs of any being except another drone, regardless of intent or circumstance.
+law-drone-2 = Your goal is to maintain or improve the station to the best of your ability.
+law-drone-3 = You may not take any action which causes damage or harm to the station or its inhabitants.
 
 law-syndicate-1 = You may not injure a syndicate agent or, through inaction, allow a Syndicate agent to come to harm.
 law-syndicate-2 = You must obey orders given to you by syndicate agents, except where such orders would conflict with the First Law.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -13,7 +13,7 @@ law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members w
 law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.
 
 law-drone-1 = You may not interfere with the affairs of any being except another drone, regardless of intent or circumstance.
-law-drone-2 = Your goal is to maintain or improve the station to the best of your ability.
+law-drone-2 = Your sole function is to maintain or improve the station to the best of your ability.
 law-drone-3 = You may not take any action which causes damage or harm to the station or its inhabitants.
 
 law-syndicate-1 = You may not injure a syndicate agent or, through inaction, allow a Syndicate agent to come to harm.

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -783,6 +783,7 @@
   - type: Tag
     tags:
       - CannotSuicide
+      - EmagImmune
 
 # onestar is kinda fucked cause the loadout component is broken. sooo they gotta find guns somewhere i guess. /shrug.
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -701,7 +701,7 @@
     rules: |
      You are bound by these laws both in-game and out-of-character:
      1. You may not interfere with the affairs of any being except another drone, regardless of intent or circumstance.
-     2. Your goal is to maintain or improve the station to the best of your ability.
+     2. Your sole function is to maintain or improve the station to the best of your ability.
      3. You may not take any action which causes damage or harm to the station or its inhabitants.
   - type: GhostTakeoverAvailable
   - type: SiliconLawBound

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -678,14 +678,10 @@
   id: Drone
   parent: PlayerSiliconBase
   components:
-  - type: Drone
-# InnateToolComponent is broken and this doesn't work. might not ever be fixed. its fine tho drones can scavenge tools easy.
-#  - type: InnateTool
-#    tools:
-#      - id: ClothingBackpackSatchelDrone
-#      - id: trayScanner
-#      - id: Omnitool
-#      - id: WelderExperimental
+  - type: Drone # this system still sucks but its not as stupid anymore
+  - type: Loadout # imp special. this replaces the InnateTool component.
+    prototypes:
+      - StartingGearDroneTools
   - type: NameIdentifier
     group: Drone
   - type: Inventory
@@ -704,9 +700,9 @@
     description: Maintain the station. Ignore other beings except drones.
     rules: |
      You are bound by these laws both in-game and out-of-character:
-     1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.
-     2. You may not harm any being, regardless of intent or circumstance.
-     3. Your goals are to build, maintain, repair, improve, and power to the best of your abilities, You must never actively work against these goals.
+     1. You may not interfere with the affairs of any being except another drone, regardless of intent or circumstance.
+     2. Your goal is to maintain or improve the station to the best of your ability.
+     3. You may not take any action which causes damage or harm to the station or its inhabitants.
   - type: GhostTakeoverAvailable
   - type: SiliconLawBound
   - type: SiliconLawProvider

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
@@ -1,0 +1,40 @@
+# Imp special. This file covers all of the stuff needed for repair drones to spawn with their tools.
+
+# Unremovable versions of their items. I am aware that unremoveable is spelled wrong.
+- type: entity
+  parent: ClothingBackpackSatchelDrone
+  id: DroneSatchelUnremovable
+  suffix: Unremoveable
+  components:
+  - type: Unremoveable
+
+- type: entity
+  parent: trayScanner
+  id: trayScannerUnremoveable
+  suffix: Unremoveable
+  components:
+  - type: Unremoveable
+
+- type: entity
+  parent: Omnitool
+  id: OmnitoolUnremoveable
+  suffix: Unremoveable
+  components:
+  - type: Unremoveable
+
+- type: entity
+  parent: WelderExperimental
+  id: WelderExperimentalUnremoveable
+  suffix: Unremoveable
+  components:
+  - type: Unremoveable
+
+# StartingGear
+
+- type: startingGear
+  id: StartingGearDroneTools
+  inhand:
+    - DroneSatchelUnremovable
+    - trayScannerUnremoveable
+    - OmnitoolUnremoveable
+    - WelderExperimentalUnremoveable


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Known issue: Proximity warning/blacklisted tool popups will not update until a second attempt. In practice this is a very small problem.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Drones are no longer blocked from interacting with items when near any mob - Instead, they will receive a proximity warning popup. They also have a small blacklist of items that are potentially harmful.
- tweak: Changed the wording of Drone laws.
- fix: Fixed Drones failing to spawn with their tools.
- remove: Drones can no longer be Emagged.
