### PR TITLE
Add support for custom kill strings to Immovable Rods

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -1,9 +1,11 @@
 using Content.Shared.Damage;
 using Robust.Shared.Audio;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
 
 namespace Content.Server.ImmovableRod;
 
 [RegisterComponent]
+[AutoGenerateComponentPause]
 public sealed partial class ImmovableRodComponent : Component
 {
     public int MobCount = 0;
@@ -55,4 +57,12 @@ public sealed partial class ImmovableRodComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public LocId EviscerationPopup = "immovable-rod-penetrated-mob";
+
+    /// <summary>
+    ///     The time between gib popups
+    /// </summary>
+    public TimeSpan EviscerationPopupDelay = TimeSpan.FromMilliseconds(200);
+
+    [AutoPausedField]
+    public TimeSpan NextEviscerationPopup = new();
 }

--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -49,4 +49,10 @@ public sealed partial class ImmovableRodComponent : Component
     /// </summary>
     [DataField]
     public DamageSpecifier? Damage;
+
+    /// <summary>
+    ///     The string used when the rod gibs a mob.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId EviscerationPopup = "immovable-rod-penetrated-mob";
 }

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.ImmovableRod;
 
@@ -26,6 +27,7 @@ public sealed class ImmovableRodSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
 
     public override void Update(float frameTime)
     {
@@ -112,7 +114,11 @@ public sealed class ImmovableRodSystem : EntitySystem
         if (TryComp<BodyComponent>(ent, out var body))
         {
             component.MobCount++;
-            _popup.PopupEntity(Loc.GetString(component.EviscerationPopup, ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
+            if (_gameTiming.CurTime >= component.NextEviscerationPopup)
+            {
+                _popup.PopupEntity(Loc.GetString(component.EviscerationPopup, ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
+                component.NextEviscerationPopup = _gameTiming.CurTime + component.EviscerationPopupDelay;
+            }
 
             if (!component.ShouldGib)
             {

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -112,7 +112,7 @@ public sealed class ImmovableRodSystem : EntitySystem
         if (TryComp<BodyComponent>(ent, out var body))
         {
             component.MobCount++;
-            _popup.PopupEntity(Loc.GetString("immovable-rod-penetrated-mob", ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
+            _popup.PopupEntity(Loc.GetString(component.EviscerationPopup, ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
 
             if (!component.ShouldGib)
             {

--- a/Resources/Locale/en-US/_Impstation/immovable-rod/immovable-rod.ftl
+++ b/Resources/Locale/en-US/_Impstation/immovable-rod/immovable-rod.ftl
@@ -1,0 +1,1 @@
+immovable-rod-penetrated-mob-finfin = {CAPITALIZE(THE($mob))} came and saw him.

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/immovable_rod.yml
@@ -32,6 +32,10 @@
   name: immovable Fin Fin
   description: Your best friend! Don't touch him though.
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-finfin
   - type: Sprite
     sprite: _Impstation/Mobs/Pets/finfin.rsi
     state: finfin


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

this can be done by defining eviscerationPopup in the entity's immovablerod component. must be a LocId at the moment

also i made this PR from my phone so I have not tested it. probably dont merge it until someone does

edit: i have now tested it. it works we good


https://github.com/user-attachments/assets/e7a61bbf-73e0-4219-a6b2-135c1dca9ac3



**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Immovable Fin-Fin now has a custom kill message. Added support for custom kill messages to ImmovableRodComponent.
