### PR TITLE
gastropoid tag fix

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/snail.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/snail.yml
@@ -115,7 +115,10 @@
   - type: Tag
     tags:
       - Gastropod
+      - CanPilot
+      - FootstepSound
       - DoorBumpOpener
+      - AnomalyHost
   - type: Inventory
     templateId: snail
     displacements:


### PR DESCRIPTION
puts a few missing tags back on gastropoids

this tag only ever seems used for mucin, so it'd probably be better to change that reagent to look for something else at some point in case the base species gets more tags added on top later. but this should be fiiiiiiine for now

**Changelog**
:cl:
- fix: Gastropoids can fly shuttles again.