### PR TITLE
Ported cvar config to a config preset

### DIFF
--- a/Resources/ConfigPresets/Impstation/impstation.toml
+++ b/Resources/ConfigPresets/Impstation/impstation.toml
@@ -1,0 +1,39 @@
+[game]
+hostname = "[EN][MRP] Impstation"
+soft_max_players = 80
+desc = "Unofficial server for fans of RTVS featuring custom content. Come and see him."
+# seconds
+# default 150
+lobbyduration = 300
+
+[server]
+# rules_file = "ImpstationRuleset" # TODO
+uptime_restart_minutes = 240
+
+[chat]
+# Message Of The Day
+motd = "Be sure to fill out the Impstation rules survey, found in the impstation #status channel in the Discord server! Your feedback is appreciated!!"
+
+[ic]
+flavor_text = true
+restricted_names = false # allows for use of nonalphanumeric characters in names. immediately going off if people get stupid with it.
+
+[interaction]
+# defaults
+# rate_limit_count = 5
+# rate_limit_period = 0.5
+# rate_limit_announce_admins_delay = 120
+rate_limit_count = 20
+
+[infolinks]
+discord = "https://discord.gg/mirakurutaimu"
+github = "https://github.com/impstation/imp-station-14"
+website = "https://impstation.gay"
+# wiki = ""
+bug_report = "https://github.com/impstation/imp-station-14/issues"
+
+[shuttle]
+emergency_early_launch_allowed = true # allows for early shuttle launch with approval of 3 heads
+
+[ghost]
+role_time = 10 # sets time before ghost role buttons enable, so people hopefully Actually Read


### PR DESCRIPTION
This moves the server's current [CVar config](https://github.com/impstation/hosting-config-example/blob/7662daf/ss14/impstation/config.toml) into the repo as a config preset, which can be selected by setting the cvar `config.presets` to `Impstation/impstation`. Resolves #851.

Categories moved to preset: `[game]`, `[server]`, `[chat]`, `[ic]`, `[interaction]`, `[infolinks]`, `[shuttle]`, `[ghost]`
Categories excluded (these categories should remain in the `server_config.toml`): `[log]`, `[net]`, `[status]`, `[console]`, `[hub]`, `[build]`, `[auth]`, `[database]`, `[discord]`, `[metrics]`, `[loki]`, `[replay]`

These categories were chosen based on what I felt was relevant to contributors/maintainers, but is admittedly a bit arbitrary. We can include/exclude more as is appropriate.

When this is published, the server also needs to be configured to run with the config preset. This can be achieved with an additional section in the `server_config.toml`:
```toml
[config]
presets = "Impstation/impstation"
```

The server should then be restarted to apply the preset CVars.