### PR TITLE
Add custom kill text for all immovable rod types.

### DIFF
--- a/Resources/Locale/en-US/_Impstation/immovable-rod/immovable-rod.ftl
+++ b/Resources/Locale/en-US/_Impstation/immovable-rod/immovable-rod.ftl
@@ -1,1 +1,11 @@
+immovable-rod-penetrated-mob-mop = {CAPITALIZE(THE($mob))} has been scrubbed clean of this existence!
+immovable-rod-penetrated-mob-shark = {CAPITALIZE(THE($rod))} chomped {CAPITALIZE(THE($mob))}!
+immovable-rod-penetrated-mob-clown = {CAPITALIZE(THE($rod))} has claimed {CAPITALIZE(THE($mob))}'s soul for the Honkmother.
+immovable-rod-penetrated-mob-banana = {CAPITALIZE(THE($mob))} slipped and fell. Badly.
+immovable-rod-penetrated-mob-hammer = {CAPITALIZE(THE($mob))} got bwoinked!
+immovable-rod-penetrated-mob-throngler = {CAPITALIZE(THE($mob))} did not win the lottery.
+immovable-rod-penetrated-mob-gibstick = {CAPITALIZE(THE($rod))} did about what you would expect to {CAPITALIZE(THE($mob))}.
+immovable-rod-penetrated-mob-weh = WEH!
 immovable-rod-penetrated-mob-finfin = {CAPITALIZE(THE($mob))} came and saw him.
+immovable-rod-penetrated-mob-gondal = {CAPITALIZE(THE($mob))}'s eardrums exploded. Badly.
+immovable-rod-penetrated-mob-hollowbarrel = {CAPITALIZE(THE($mob))} died with no honor!

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -134,6 +134,10 @@
   name: immovable mop
   description: Hurled like a javelin, with the power of a thousand furious janitors.
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-mop
   - type: Sprite
     sprite: Objects/Specific/Janitorial/mop.rsi
     state: mop
@@ -146,6 +150,10 @@
   name: immovable shark
   description: SHARK TORNADO!
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-shark
   - type: Sprite
     sprite: Objects/Fun/sharkplush.rsi
     state: blue
@@ -158,6 +166,10 @@
   name: immovable clown
   description: Ejected from the neighbouring station one solar system over. HONK!
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-clown
   - type: Sprite
     sprite: Markers/jobs.rsi
     state: clown
@@ -170,6 +182,10 @@
   name: immovable banana
   description: At least you won't slip on it.
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-banana
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/banana.rsi
     state: produce
@@ -181,6 +197,10 @@
   name: immovable hammer
   description: Bwoink.
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-hammer
   - type: Sprite
     sprite: Objects/Weapons/Melee/sledgehammer.rsi
     state: icon
@@ -193,6 +213,10 @@
   name: immovable throngler
   description: If you catch it, you can keep it.
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-throngler
   - type: Sprite
     sprite: Objects/Weapons/Melee/Throngler2.rsi
     state: icon
@@ -205,6 +229,10 @@
   name: immovable gibstick
   description: What did you expect?
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-gibstick
   - type: Sprite
     sprite: Objects/Weapons/Melee/debug.rsi
     state: icon
@@ -217,6 +245,10 @@
   name: immovable weh
   description: WEH!
   components:
+  - type: ImmovableRod
+    randomizeVelocity: false
+    maxSpeed: 0
+    eviscerationPopup: immovable-rod-penetrated-mob-weh
   - type: Sprite
     sprite: Objects/Fun/toys.rsi
     state: plushie_lizard

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/immovable_rod.yml
@@ -58,6 +58,7 @@
   - type: ImmovableRod
     minSpeed: 0.25
     maxSpeed: 0.25
+    eviscerationPopup: immovable-rod-penetrated-mob-gondal
   - type: TimedDespawn
     lifetime: 141.0
   - type: EmitSoundOnSpawn
@@ -90,6 +91,7 @@
       params:
         volume: 20
         variation: 0.125
+    eviscerationPopup: immovable-rod-penetrated-mob-hollowbarrel
   - type: PointLight
     radius: 3
     color: red


### PR DESCRIPTION
Does what it says on the tin.

**Changelog**

:cl:
- add: All immovable rod types now have a custom kill message.
