### PR TITLE
lowering hos prestige requirements per feedback

### DIFF
--- a/Resources/Locale/en-US/_Impstation/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Impstation/preferences/loadout-groups.ftl
@@ -6,7 +6,6 @@ loadout-group-tank-harness-with-outerwear-aquatic = Tank harness for water-breat
 loadout-group-tank-harness-command-with-outerwear-aquatic = Command tank harness for water-breathers (in inventory)
 loadout-group-breath-tool-decapoid = Vaporizer for decapoids
 loadout-group-breath-tool-inventory-decapoid = Vaporizer for decapoids (in inventory)
-loadout-group-head-of-security-mask = Head of Security mask
 loadout-group-hop-shoes = Head of Personnel shoes
 loadout-group-clown-mask = Clown mask
 loadout-group-clown-neck = Clown neck

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfSecurity
-      time: 72000 #20 hrs
+      time: 36000 # Imp, 10 hrs
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -431,7 +431,6 @@
   groups:
   - HeadofSecurityHead
   - HeadofSecurityNeck
-  - HeadofSecurityMask
   - HeadofSecurityJumpsuit
   - HeadofSecurityOuterClothing
   - UpperSecurityShoes

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/head_of_security.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfSecurity
-      time: 180000 #50 hrs
+      time: 90000 #50 hrs
 
 - type: loadout
   id: HeadofSecurityVeteranHeadset
@@ -15,12 +15,6 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: VeteranHOS
-
-# A mask so the HoS can choose to spawn with the standard security gas mask that their new survival box removes
-- type: loadout
-  id: HeadofSecurityMask
-  equipment:
-    mask: ClothingMaskGasSecurity
 
 - type: loadout
   id: HeadofSecurityGreatcoat

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/head_of_security.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfSecurity
-      time: 90000 #50 hrs
+      time: 90000 #25 hrs
 
 - type: loadout
   id: HeadofSecurityVeteranHeadset

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -242,13 +242,6 @@
   - CommandVeteranDuffel
 
 - type: loadoutGroup
-  id: HeadofSecurityMask
-  name: loadout-group-head-of-security-mask
-  minLimit: 0
-  loadouts:
-  - HeadofSecurityMask
-
-- type: loadoutGroup
   id: HoPShoes
   name: loadout-group-hop-shoes
   loadouts:


### PR DESCRIPTION
when we increased hos unlock requirement we never changed the mantle down from 20 hours, and people say they'd appreciate the coat and the armor sooner too

i don't disagree that 140 hours in security for a cosmetic is extreme lol

bumpin mantle down to 10 hours (so it lines up with the security star) and the coat/armor down to 25 (so it's 10 more full shifts as hos past the mantle) seems appropriate

also removing the loadout selector that lets the hos spawn with the regular security mask, since it was added to the hos's locker in a previous pr.  they got their own personal mask in their command box, their locker already contains the regular security mask, AND their hardsuit locker contains the swat mask.  this way it's all readily accessible based on what they want, and vox of course already spawn with the security mask too

:cl:
- remove: Removed security breath mask from HoS loadout options since it's already in the locker lol
- tweak: HoS Mantle is now 10 hours to account for the 90 hour unlock requirement of the job
- tweak: HoS prestige coat, armor, and headset are now 25 hours