### PR TITLE
Artifacts can now make items attack you

### DIFF
--- a/Content.Server/_Impstation/Revenant/EntitySystems/RevenantAnimatedSystem.cs
+++ b/Content.Server/_Impstation/Revenant/EntitySystems/RevenantAnimatedSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Mobs;
 using Robust.Shared.Timing;
+using Content.Shared.Construction.Components;
 
 namespace Content.Server.Revenant.EntitySystems;
 
@@ -176,7 +177,8 @@ public sealed partial class RevenantAnimatedSystem : EntitySystem
 
     public bool CanAnimateObject(EntityUid target)
     {
-        return !(HasComp<MindContainerComponent>(target) || HasComp<HTNComponent>(target) || HasComp<RevenantAnimatedComponent>(target));
+        return !(HasComp<AnchorableComponent>(target) || HasComp<MindContainerComponent>(target)
+            || HasComp<HTNComponent>(target) || HasComp<RevenantAnimatedComponent>(target));
     }
 
     public bool TryAnimateObject(EntityUid target, TimeSpan? duration = null, Entity<RevenantComponent>? revenant = null)

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Components/AnimateArtifactComponent.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Components/AnimateArtifactComponent.cs
@@ -1,0 +1,26 @@
+﻿namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Animates a number of entities within a range for a duration. Animated objects attack nearby beings.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AnimateArtifactComponent : Component
+{
+    /// <summary>
+    /// Distance from the artifact to animate objects
+    /// </summary>
+    [DataField("range"), ViewVariables(VVAccess.ReadWrite)]
+    public float Range = 6f;
+
+    /// <summary>
+    /// Duration of the animation.
+    /// </summary>
+    [DataField("duration"), ViewVariables(VVAccess.ReadWrite)]
+    public float Duration = 15f;
+
+    /// <summary>
+    /// Number of objects to animate
+    /// </summary>
+    [DataField("count"), ViewVariables(VVAccess.ReadWrite)]
+    public int Count = 1;
+}

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/AnimateArtifactSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/AnimateArtifactSystem.cs
@@ -1,0 +1,51 @@
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Server.Revenant.EntitySystems;
+using Content.Shared.Item;
+using System.Linq;
+using Robust.Shared.Random;
+using Robust.Shared.Containers;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class AnimateArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly RevenantAnimatedSystem _revenantAnimated = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<AnimateArtifactComponent, ArtifactActivatedEvent>(OnActivated);
+    }
+
+    private void OnActivated(EntityUid uid, AnimateArtifactComponent component, ArtifactActivatedEvent args)
+    {
+        // Get a list of all nearby objects in range
+
+        HashSet<EntityUid> entsHash = _lookup.GetEntitiesInRange(uid, component.Range);
+        var numSuccessfulAnimates = 0;
+
+        var unshuffledEnts = entsHash.ToList();
+        var ents = unshuffledEnts.OrderBy(_ => _random.Next()).ToList();
+
+        foreach (var ent in ents)
+        {
+            if (numSuccessfulAnimates >= component.Count)
+            {
+                break;
+            }
+            // need to only get items not in a container
+            if (HasComp<ItemComponent>(ent) && _revenantAnimated.CanAnimateObject(ent) && !_container.IsEntityInContainer(ent))
+            {
+                if (_revenantAnimated.TryAnimateObject(ent, TimeSpan.FromSeconds(component.Duration)))
+                {
+                    numSuccessfulAnimates += 1;
+                }
+            }
+        }
+    }
+}

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/AnimateArtifactSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/AnimateArtifactSystem.cs
@@ -26,7 +26,8 @@ public sealed class AnimateArtifactSystem : EntitySystem
     {
         // Get a list of all nearby objects in range
 
-        HashSet<EntityUid> entsHash = _lookup.GetEntitiesInRange(uid, component.Range);
+        var entsHash = _lookup.GetEntitiesInRange(uid, component.Range);
+        entsHash.Add(uid);
         var numSuccessfulAnimates = 0;
 
         var unshuffledEnts = entsHash.ToList();

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/KnockdownArtifactSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/KnockdownArtifactSystem.cs
@@ -1,10 +1,6 @@
 using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
 using Content.Shared.Buckle.Components;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
-using Content.Shared.Maps;
-using Content.Shared.Throwing;
-using Robust.Server.GameObjects;
-using Robust.Shared.Random;
 using Content.Shared.StatusEffect;
 using Content.Server.Stunnable;
 

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -1074,7 +1074,7 @@
   id: EffectAnimateSingle
   targetDepth: 4
   effectHint: artifact-effect-hint-sentience
-  effectProb: 10000
+  effectProb: 0.5
   components:
   - type: AnimateArtifact
     range: 6

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -1071,6 +1071,17 @@
     range: 15
 
 - type: artifactEffect
+  id: EffectAnimateSingle
+  targetDepth: 4
+  effectHint: artifact-effect-hint-sentience
+  effectProb: 10000
+  components:
+  - type: AnimateArtifact
+    range: 6
+    duration: 10
+    count: 1
+
+- type: artifactEffect
   id: EffectSingulo
   targetDepth: 10
   effectHint: artifact-effect-hint-destruction


### PR DESCRIPTION
Artifacts have learned from the Revenants, and will animate nearby items to attack people, occasionally. 
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: new artifact effect, learned from spooky ghosties