### PR TITLE
Reduce event weight of Mass Hallucinations

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -432,7 +432,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
-    weight: 7
+    weight: 2
     duration: 150
     maxDuration: 300
     reoccurrenceDelay: 30


### PR DESCRIPTION
this is resultant of a conversation between myself and hive on discord
i believe reducing the frequency of mass hallucinations will give both mass hallucinations and paracusia more impact, because at the moment mass hallucinations happen almost every round, so the effect is that *everyone* has paracusia and the trait just gives you more of it. 

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reduced the event weight of mass hallucinations.
