### PR TITLE
unknown shuttle announcement fixes

### DIFF
--- a/Resources/Locale/en-US/_Impstation/station-events/events/unknown_shuttles.ftl
+++ b/Resources/Locale/en-US/_Impstation/station-events/events/unknown_shuttles.ftl
@@ -1,0 +1,15 @@
+station-event-unknown-shuttle-cargo-lost-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-traveling-cuisine-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-disaster-evac-pod-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-honki-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-cruiser-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-cryptid-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-eternal-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-flatline-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-gym-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-n-t-incorporation-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-joe-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-lambordeere-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-meat-zone-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-microshuttle-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.
+station-event-unknown-shuttle-spacebus-announcement = Attention! An unidentified space shuttle has been spotted approaching your sector.

--- a/Resources/Prototypes/_DeltaV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DeltaV/GameRules/unknown_shuttles.yml
@@ -9,6 +9,7 @@
   id: SyndicateRecruiter
   components:
   - type: StationEvent
+    startAnnouncement: false
     weight: 4
     minimumPlayers: 20
     maxOccurrences: 1


### PR DESCRIPTION
unknown shuttle announcements were just broke for a while? now they're back and have no locales. theres definitely a better way to do this but im really tired and it works

**Changelog**
:cl:
- fix: Unknown shuttles will now announce properly.