### PR TITLE
Add body hair markings to unisex characters

### DIFF
--- a/Resources/Locale/en-US/_Impstation/markings/bodyhair.ftl
+++ b/Resources/Locale/en-US/_Impstation/markings/bodyhair.ftl
@@ -6,3 +6,6 @@ marking-BodyhairHumanFemale = Body Hair
 
 marking-BodyhairSpelf-spelf_bodyhair = Body Hair
 marking-BodyhairSpelf = Body Hair
+
+marking-BodyhairHumanUnsexed-human_bodyhair_unsexed = Body Hair
+marking-BodyhairHumanUnsexed = Body Hair

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/bodyhair.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/bodyhair.yml
@@ -26,3 +26,13 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/bodyhair.rsi
     state: spelf_bodyhair
+
+- type: marking
+  id: BodyhairHumanUnsexed
+  bodyPart: Chest
+  markingCategory: Chest
+  speciesRestriction: [ Dwarf, Human ]
+  sexRestriction: [ Unsexed ]
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/bodyhair.rsi
+    state: human_bodyhair_male


### PR DESCRIPTION
Allows body hair added from #1096 to be used on unisex dwarves and humans.

**Changelog**

:cl:
- tweak: The body hair marking for dwarves and humans may now be used by unisex characters.