### PR TITLE
New DNA scrambling artifact effect

### DIFF
--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Components/ScrambleDNAArtifactComponent.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Components/ScrambleDNAArtifactComponent.cs
@@ -1,0 +1,34 @@
+﻿namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Scrambles DNA of some number of people within some range, possibly outside of their species
+/// </summary>
+[RegisterComponent]
+public sealed partial class ScrambleDNAArtifactComponent : Component
+{
+    /// <summary>
+    /// Distance from the artifact find people to scramble DNA
+    /// </summary>
+    [DataField("range"), ViewVariables(VVAccess.ReadWrite)]
+    public float Range = 6f;
+
+    /// <summary>
+    /// Number of people to DNA scramble
+    /// </summary>
+    [DataField("count"), ViewVariables(VVAccess.ReadWrite)]
+    public int Count = 1;
+
+    /// <summary>
+    /// Force scrambling to respect initial species
+    /// </summary>
+    [DataField("withinSpecies"), ViewVariables(VVAccess.ReadWrite)]
+    public bool WithinSpecies = true;
+
+    /// <summary>
+    /// if WithinSpecies is false, what species cannot be rolled
+    /// </summary>
+    [DataField("excludedSpecies"), ViewVariables(VVAccess.ReadWrite)]
+    public HashSet<string>? ExcludedSpecies = null;
+
+
+}

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Components/ScrambleDNAArtifactComponent.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Components/ScrambleDNAArtifactComponent.cs
@@ -17,18 +17,4 @@ public sealed partial class ScrambleDNAArtifactComponent : Component
     /// </summary>
     [DataField("count"), ViewVariables(VVAccess.ReadWrite)]
     public int Count = 1;
-
-    /// <summary>
-    /// Force scrambling to respect initial species
-    /// </summary>
-    [DataField("withinSpecies"), ViewVariables(VVAccess.ReadWrite)]
-    public bool WithinSpecies = true;
-
-    /// <summary>
-    /// if WithinSpecies is false, what species cannot be rolled
-    /// </summary>
-    [DataField("excludedSpecies"), ViewVariables(VVAccess.ReadWrite)]
-    public HashSet<string>? ExcludedSpecies = null;
-
-
 }

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/KnockdownArtifactSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/KnockdownArtifactSystem.cs
@@ -44,8 +44,6 @@ public sealed class KnockdownArtifactSystem : EntitySystem
                 _stuns.TryParalyze(child, TimeSpan.FromSeconds(component.KnockdownTime), true, status);
             }
 
-
-
         }
         else // knock over only people in range
         {

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/ScrambleDNAArtifactSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/ScrambleDNAArtifactSystem.cs
@@ -59,7 +59,7 @@ public sealed class ScrambleDNAArtifactSystem : EntitySystem
     {
         if (TryComp<HumanoidAppearanceComponent>(target, out var humanoid))
         {
-            var newProfile = (component.WithinSpecies ? HumanoidCharacterProfile.RandomWithSpecies(humanoid.Species) : HumanoidCharacterProfile.Random(component.ExcludedSpecies));
+            var newProfile = (HumanoidCharacterProfile.RandomWithSpecies(humanoid.Species));
             _humanoidAppearance.LoadProfile(target, newProfile, humanoid);
             _metaData.SetEntityName(target, newProfile.Name);
             if (TryComp<DnaComponent>(target, out var dna))

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/ScrambleDNAArtifactSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/ScrambleDNAArtifactSystem.cs
@@ -1,0 +1,79 @@
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Preferences;
+using Content.Server.Humanoid;
+using System.Linq;
+using Robust.Shared.Random;
+using Content.Shared.Humanoid;
+using Content.Shared.Forensics;
+using Content.Server.Forensics;
+
+
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class ScrambleDNAArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearance = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly ForensicsSystem _forensicsSystem = default!;
+
+
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ScrambleDNAArtifactComponent, ArtifactActivatedEvent>(OnActivated);
+    }
+
+    private void OnActivated(EntityUid uid, ScrambleDNAArtifactComponent component, ArtifactActivatedEvent args)
+    {
+        // Get all entities in range, and the person who activated the artifact even if they are not within range
+        var ents = _lookup.GetEntitiesInRange(uid, component.Range);
+        if (args.Activator != null)
+            ents.Add(args.Activator.Value);
+
+        //Extract the people who can be scrambled
+        var possibleVictims = new List<EntityUid>();
+        foreach (var ent in ents)
+        {
+            if (HasComp<HumanoidAppearanceComponent>(ent))
+                possibleVictims.Add(ent);
+        }
+
+        //Select random targets to scramble DNA
+        var numScrambled = 0;
+        while (numScrambled < component.Count){
+            var targetIndex = _random.Next(0, possibleVictims.Count);
+            var target = possibleVictims.ElementAt(targetIndex);
+            possibleVictims.Remove(target);
+
+            ScrambleTargetDNA(target, component);
+            numScrambled ++;
+        }
+    }
+
+    private void ScrambleTargetDNA(EntityUid target, ScrambleDNAArtifactComponent component)
+    {
+        if (TryComp<HumanoidAppearanceComponent>(target, out var humanoid))
+        {
+            var newProfile = (component.WithinSpecies ? HumanoidCharacterProfile.RandomWithSpecies(humanoid.Species) : HumanoidCharacterProfile.Random(component.ExcludedSpecies));
+            _humanoidAppearance.LoadProfile(target, newProfile, humanoid);
+            _metaData.SetEntityName(target, newProfile.Name);
+            if (TryComp<DnaComponent>(target, out var dna))
+            {
+                dna.DNA = _forensicsSystem.GenerateDNA();
+
+                var ev = new GenerateDnaEvent { Owner = target, DNA = dna.DNA };
+                RaiseLocalEvent(target, ref ev);
+            }
+            if (TryComp<FingerprintComponent>(target, out var fingerprint))
+            {
+                fingerprint.Fingerprint = _forensicsSystem.GenerateFingerprint();
+            }
+        }
+    }
+
+}

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -1089,7 +1089,6 @@
   components:
   - type: ScrambleDNAArtifact
     range: 4
-    withinSpecies: true
     count: 1
 
 - type: artifactEffect

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -1082,6 +1082,17 @@
     count: 1
 
 - type: artifactEffect
+  id: EffectScrambleSingleRare
+  targetDepth: 4
+  effectHint: artifact-effect-hint-polymorph
+  effectProb: 0.01
+  components:
+  - type: ScrambleDNAArtifact
+    range: 4
+    withinSpecies: true
+    count: 1
+
+- type: artifactEffect
   id: EffectSingulo
   targetDepth: 10
   effectHint: artifact-effect-hint-destruction


### PR DESCRIPTION
New DNA scrambling artifact effect based off of DNA scrambler implant.
Options:
 Range (how far from artifact)
 Count (how many people within range to scramble)


https://github.com/user-attachments/assets/52d82afb-898c-42fd-bf2e-dbe7565f5e26


currently have it put as very rare depth 4, because depth 5s are not yet ready.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- add: new absurdly rare artifact effect that will have you saying "that's not my doll!"
