### PR TITLE
supermatter air alarm

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Wallmounts/air_alarm.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: AirAlarmSupermatter
+  parent: AirAlarm
+  suffix: Supermatter
+  components:
+  - type: AccessReader
+    access: [["Atmospherics"], ["Engineering"]]


### PR DESCRIPTION
purely for mapping. atmos + engineering access because station engineers are supposed to be able to roundstart set up the sm

**Changelog**
no cl