### PR TITLE
remove subgamemodes from lowpop thief

### DIFF
--- a/Resources/Prototypes/_Impstation/game_presets.yml
+++ b/Resources/Prototypes/_Impstation/game_presets.yml
@@ -45,7 +45,6 @@
   showInVote: false
   rules:
     - Thief
-    - SubGamemodesRule
     - LowpopStationEventScheduler
     - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler


### PR DESCRIPTION
this was an experimental change and hasnt really worked out in my opinion. mostly because one person can get targetted by both thief roles, giving them double the objectives and gear

ideally this would, instead, be a change to AntagSelectionSystem to prevent rolling the same role twice (there's a todo on line 425) but i'm having a real brain moment (negative) trying to figure it out. if somebody else would like to look into it, feel free

**Changelog**
:cl:
- remove: Double thief is no longer possible during lowpop.