### PR TITLE
derotate heretic

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -22,8 +22,6 @@
     rules:
     - id: Thief
       prob: 0.5
-    - id: Heretic # goob edit
-      prob: 0.2
 
 - type: entity
   id: DeathMatch31


### PR DESCRIPTION
i was originally going to straight up rip heretic out from the files entirely but there is a level of interest in maintenance. i still have a pr ready to go in case this antagonist doesn't go anywhere: even as an admin option, it's still full of issues.

why is heretic being removed?
- primarily, nobody is maintaining it. i ported it but i have other things i'd rather work on, so i can't reasonably say i will ever do anything to update heretic
- shitty, buggy code: codex cicatrix does not work as a focus despite having the component, organ removal fucks you over for the entire round and can't be fixed, ghouls have no limit, god knows what else
- it's pretty overtuned. how many rounds have we had heretics freely teleport everywhere, steal guns from the armory, etc
- it doesn't fit into being a minor antagonist at all, and can flop quite often. i don't think the current iteration would fit well as a main antagonist: this kind of design thrives more in dynamic, which we don't have yet

**Changelog**
:cl:
- remove: Heretic can no longer be rolled.