### PR TITLE
Remove chemmaster flatpack from bartender prestige gear

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -57,7 +57,6 @@ loadout-group-bartender-neck = Bartender neck
 loadout-group-bartender-outerclothing = Bartender outer clothing
 loadout-group-bartender-shoes = Bartender shoes
 loadout-group-bartender-id = Bartender ID
-loadout-group-bartender-mixologist = Mixologist Qualification
 
 loadout-group-chef-head = Chef head
 loadout-group-chef-mask = Chef mask

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -1,17 +1,3 @@
-# "Mixologist" Time req
-- type: loadoutEffectGroup
-  id: Mixologist
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobBartender
-      time: 36000 #10 hrs
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Medical
-      time: 36000 # 10 hrs
 # Senior times
 - type: loadoutEffectGroup
   id: SeniorBartender
@@ -21,6 +7,7 @@
       !type:RoleTimeRequirement
       role: JobBartender
       time: 187200 #52 hrs (1 hour per week for 1 year)
+
 # Head
 - type: loadout
   id: BartenderHead
@@ -83,13 +70,3 @@
     proto: SeniorBartender
   equipment:
     id: SeniorBartenderPDA
-
- # Trinket
-- type: loadout
-  id: ChemMasterFlatpack
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: Mixologist
-  storage:
-    back:
-    - ChemMasterFlatpack

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -344,13 +344,6 @@
   - SeniorBartenderPDA
 
 - type: loadoutGroup
-  id: Mixologist
-  name: loadout-group-bartender-mixologist
-  minLimit: 0
-  loadouts:
-  - ChemMasterFlatpack
-
-- type: loadoutGroup
   id: ChefHead
   name: loadout-group-chef-head
   minLimit: 0

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -75,7 +75,6 @@
   - BartenderPDA
   - Survival
   - Trinkets
-  - Mixologist
   - GroupSpeciesBreathTool
   - GroupTankHarnessWithOuterwear
   - GroupBreathToolDecapoid # imp special

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/flatpack.yml
@@ -12,3 +12,12 @@
     - state: overlay
       color: "#cec8ac"
     - state: icon-default
+
+- type: entity
+  parent: BaseFlatpack
+  id: ChemMasterFlatpack
+  name: ChemMaster 4000 flatpack
+  description: A flatpack used for constructing a ChemMaster 4000.
+  components:
+  - type: Flatpack
+    entity: ChemMaster

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/flatpack.yml
@@ -12,12 +12,3 @@
     - state: overlay
       color: "#cec8ac"
     - state: icon-default
-
-- type: entity
-  parent: BaseFlatpack
-  id: ChemMasterFlatpack
-  name: ChemMaster 4000 flatpack
-  description: A flatpack used for constructing a ChemMaster 4000.
-  components:
-  - type: Flatpack
-    entity: ChemMaster


### PR DESCRIPTION
Removes the mixologist qualification, which granted bartenders a loadout option to spawn with a chemmaster flatpack with enough bartender and chemistry playtime. While there's nothing crazy about letting bartenders have access to a chemmaster round start, it sets a bad precedent for what is okay to add to prestige gear. Prestige gear should be limited to cosmetics and not have gameplay implications.

To go along with this change, chemmasters and chemmaster machine boards will be mapped to be available round start to bartenders across a number of stations. This PR retains the chemmaster flatpack prototype in the event that mappers want to utilize these. If/when a bartender specific type of chemmaster is added, those will be mapped instead.

:cl:
- remove: Removed the chemmaster flatpack prestige item from the bartender's loadout.
- add: Chemmasters and chemmaster machine boards have been added to the bar across a number of stations.
