### PR TITLE
Machines and Computers become contraband

### DIFF
--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -5,5 +5,5 @@ contraband-examine-text-Major = [color=red]This item is considered major contrab
 contraband-examine-text-GrandTheft = [color=red]This item is a highly valuable target for Syndicate agents![/color]
 contraband-examine-text-Syndicate = [color=crimson]This item is highly illegal Syndicate contraband![/color]
 
-contraband-examine-text-avoid-carrying-around = [color=red][italic]You probably want to avoid visibly carrying this around without a good reason.[/italic][/color]
-contraband-examine-text-in-the-clear = [color=green][italic]You should be in the clear to visibly carry this around.[/italic][/color]
+contraband-examine-text-avoid-carrying-around = [color=red][italic]You probably want to avoid having this in your possession without a good reason.[/italic][/color]
+contraband-examine-text-in-the-clear = [color=green][italic]You should be in the clear to have possession of this.[/italic][/color]

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/particle_accelerator.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/particle_accelerator.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: MachineParticleAcceleratorEndCapCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseEngineeringContraband ]
   name: PA end cap board
   description: A machine board for a particle accelerator end cap.
   components:
@@ -14,7 +14,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorFuelChamberCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseEngineeringContraband ]
   name: PA fuel chamber board
   description: A machine board for a particle accelerator fuel chamber.
   components:
@@ -32,7 +32,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorPowerBoxCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseEngineeringContraband ]
   name: PA power box board
   description: A machine board for a particle accelerator power box.
   components:
@@ -48,7 +48,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorEmitterStarboardCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseEngineeringContraband ]
   name: PA starboard emitter board
   description: A machine board for a particle accelerator left emitter.
   components:
@@ -62,7 +62,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorEmitterForeCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseEngineeringContraband ]
   name: PA fore emitter board
   description: A machine board for a particle accelerator center emitter.
   components:
@@ -76,7 +76,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorEmitterPortCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseEngineeringContraband ]
   name: PA port emitter board
   description: A machine board for a particle accelerator right emitter.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -33,7 +33,7 @@
   name: protolathe machine board
   description: A machine printed circuit board for a protolathe.
   components:
-    - type: Sprite
+    - type: Sprite #imp
       state: science
     - type: MachineBoard
       prototype: Protolathe
@@ -51,7 +51,7 @@
   name: hyper convection protolathe machine board
   description: A machine printed circuit board for a hyper convection protolathe.
   components:
-    - type: Sprite
+    - type: Sprite #imp
       state: science
     - type: MachineBoard
       prototype: ProtolatheHyperConvection

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1049,7 +1049,7 @@
 
 - type: entity
   id: SyndicateMicrowaveMachineCircuitboard
-  parent: [ BaseMachineCircuitboard, BaseSyndicateContraband ]
+  parent: [ BaseMachineCircuitboard, Tier1Contraband ]
   name: donk co. microwave machine board
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -29,10 +29,12 @@
 
 - type: entity
   id: ProtolatheMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   name: protolathe machine board
   description: A machine printed circuit board for a protolathe.
   components:
+    - type: Sprite
+      state: science
     - type: MachineBoard
       prototype: Protolathe
       stackRequirements:
@@ -44,22 +46,24 @@
           defaultPrototype: Beaker
 
 - type: entity
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   id: ProtolatheHyperConvectionMachineCircuitboard
   name: hyper convection protolathe machine board
   description: A machine printed circuit board for a hyper convection protolathe.
   components:
-  - type: MachineBoard
-    prototype: ProtolatheHyperConvection
-    stackRequirements:
-      MatterBin: 2
-    tagRequirements:
-      GlassBeaker:
-        amount: 2
-        defaultPrototype: Beaker
-      Igniter:
-        amount: 1
-        defaultPrototype: Igniter
+    - type: Sprite
+      state: science
+    - type: MachineBoard
+      prototype: ProtolatheHyperConvection
+      stackRequirements:
+        MatterBin: 2
+      tagRequirements:
+        GlassBeaker:
+          amount: 2
+          defaultPrototype: Beaker
+        Igniter:
+          amount: 1
+          defaultPrototype: Igniter
 
 - type: entity
   id: BiofabricatorMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -79,7 +79,7 @@
 
 - type: entity
   id: SecurityTechFabCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseSecurityContraband ]
   name: security techfab machine board
   description: A machine printed circuit board for a security techfab.
   components:
@@ -97,7 +97,7 @@
 
 - type: entity
   id: AmmoTechFabCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseSecurityContraband ]
   name: ammo techfab circuit board
   description: A machine printed circuit board for an ammo techfab.
   components:
@@ -111,7 +111,7 @@
 
 - type: entity
   id: MedicalTechFabCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseMedicalContraband ]
   name: medical techfab machine board
   description: A machine printed circuit board for a medical techfab.
   components:
@@ -131,7 +131,7 @@
 
 - type: entity
   id: CircuitImprinterMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   name: circuit imprinter machine board
   components:
   - type: Sprite
@@ -147,7 +147,7 @@
         defaultPrototype: Beaker
 
 - type: entity
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   id: CircuitImprinterHyperConvectionMachineCircuitboard
   name: hyper convection circuit imprinter machine board
   description: A machine printed circuit board for a hyper convection circuit imprinter.
@@ -168,7 +168,7 @@
 
 - type: entity
   id: ExosuitFabricatorMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   name: exosuit fabricator machine board
   components:
   - type: Sprite
@@ -186,7 +186,7 @@
 # yes i know this prototype name is long i'm just following conventions
 - type: entity
   id: ResearchAndDevelopmentServerMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   name: R&D server machine board
   description: A machine printed circuit board for the R&D server.
   components:
@@ -280,7 +280,7 @@
 
 - type: entity
   id: ArtifactCrusherMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   name: artifact crusher machine board
   description: A machine printed circuit board for an artifact crusher.
   components:
@@ -309,7 +309,7 @@
         PlasmaGlass: 10
 
 - type: entity
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   id: AnomalyVesselExperimentalCircuitboard
   name: experimental anomaly vessel machine board
   description: A machine printed circuit board for an experimental anomaly vessel.
@@ -341,7 +341,7 @@
         Cable: 5
 
 - type: entity
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
   id: APECircuitboard
   name: A.P.E. machine board
   description: A machine printed circuit board for an A.P.E.
@@ -1049,7 +1049,7 @@
 
 - type: entity
   id: SyndicateMicrowaveMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseSyndicateContraband ]
   name: donk co. microwave machine board
   components:
     - type: Sprite
@@ -1184,7 +1184,7 @@
 
 - type: entity
   id: CargoTelepadMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseCargoContraband ]
   name: cargo telepad machine board
   description: A machine printed circuit board for a cargo telepad.
   components:
@@ -1226,7 +1226,7 @@
         Cable: 2
 
 - type: entity
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseCargoContraband ]
   id: SalvageMagnetMachineCircuitboard
   name: salvage magnet machine board
   description: A machine printed circuit board for a salvage magnet.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -186,7 +186,7 @@
 # yes i know this prototype name is long i'm just following conventions
 - type: entity
   id: ResearchAndDevelopmentServerMachineCircuitboard
-  parent: [ BaseMachineCircuitboard, BaseScienceContraband ]
+  parent: [ BaseMachineCircuitboard, BaseCommandContraband ]
   name: R&D server machine board
   description: A machine printed circuit board for the R&D server.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -22,7 +22,7 @@
         Silicon: 20
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseEngineeringContraband ]
   id: AlertsComputerCircuitboard
   name: atmospheric alerts computer board
   description: A computer printed circuit board for an atmospheric alerts computer.
@@ -31,7 +31,7 @@
       prototype: ComputerAlert
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseEngineeringContraband ]
   id: AtmosMonitoringComputerCircuitboard
   name: atmospheric network monitor board
   description: A computer printed circuit board for an atmospheric network monitor.
@@ -40,7 +40,7 @@
       prototype: ComputerAtmosMonitoring
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseEngineeringContraband ]
   id: PowerComputerCircuitboard
   name: power monitoring computer board
   description: A computer printed circuit board for a power monitoring computer.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -196,7 +196,7 @@
         - DroneUsable
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseCommandContraband ]
+  parent: [ BaseComputerCircuitboard, BaseScienceContraband ]
   id: ResearchComputerCircuitboard
   name: R&D computer board
   description: A computer printed circuit board for a R&D console.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -51,7 +51,7 @@
       prototype: ComputerPowerMonitoring
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseMedicalContraband ]
   id: MedicalRecordsComputerCircuitboard
   name: medical records computer board
   description: A computer printed circuit board for a medical records computer.
@@ -62,7 +62,7 @@
       prototype: ComputerMedicalRecords
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseSecurityContraband ]
   id: CriminalRecordsComputerCircuitboard
   name: criminal records computer board
   description: A computer printed circuit board for a criminal records computer.
@@ -73,7 +73,7 @@
       prototype: ComputerCriminalRecords
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseSecurityCommandContraband ]
   id: StationRecordsComputerCircuitboard
   name: station records computer board
   description: A computer printed circuit board for a station records computer.
@@ -84,7 +84,7 @@
       prototype: ComputerStationRecords
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCargoContraband ]
   id: CargoRequestComputerCircuitboard
   name: cargo request computer board
   description: A computer printed circuit board for a cargo request computer.
@@ -100,7 +100,7 @@
         - DroneUsable
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCargoContraband ]
   id: CargoSaleComputerCircuitboard
   name: cargo sale computer board
   description: A computer printed circuit board for a cargo sale computer.
@@ -112,7 +112,7 @@
 
 - type: entity
   id: CargoBountyComputerCircuitboard
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCargoContraband ]
   name: cargo bounty computer board
   description: A computer printed circuit board for a cargo bounty computer.
   components:
@@ -126,7 +126,7 @@
     - DroneUsable
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCargoContraband ]
   id: CargoShuttleComputerCircuitboard
   name: cargo shuttle computer board
   description: A computer printed circuit board for a cargo shuttle computer.
@@ -137,7 +137,7 @@
       prototype: ComputerCargoShuttle
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCargoContraband ]
   id: SalvageExpeditionsComputerCircuitboard
   name: salvage expeditions computer board
   description: A computer printed circuit board for a salvage expeditions computer.
@@ -150,7 +150,7 @@
       stealGroup: SalvageExpeditionsComputerCircuitboard
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCargoContraband ]
   id: CargoShuttleConsoleCircuitboard
   name: cargo shuttle console board
   description: A computer printed circuit board for a cargo shuttle console.
@@ -196,7 +196,7 @@
         - DroneUsable
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCommandContraband ]
   id: ResearchComputerCircuitboard
   name: R&D computer board
   description: A computer printed circuit board for a R&D console.
@@ -218,7 +218,7 @@
       prototype: ComputerAnalysisConsole
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseScienceContraband ]
   id: TechDiskComputerCircuitboard
   name: tech disk terminal board
   description: A computer printed circuit board for a technology disk terminal.
@@ -294,7 +294,7 @@
     prototype: ComputerRadar
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseEngineeringContraband ]
   id: SolarControlComputerCircuitboard
   name: solar control computer board
   description: A computer printed circuit board for a solar control console.
@@ -323,7 +323,7 @@
       prototype: BlockGameArcade
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseEngineeringContraband ]
   id: ParticleAcceleratorComputerCircuitboard
   name: PA control box computer board
   description: A computer printed circuit board for a particle accelerator control box.
@@ -343,7 +343,7 @@
       prototype: ComputerShuttle
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, Tier2Contraband ]
   id: SyndicateShuttleConsoleCircuitboard
   name: syndicate shuttle console board
   description: A computer printed circuit board for a syndicate shuttle console.
@@ -374,7 +374,7 @@
       prototype: ComputerIFF
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, Tier2Contraband ]
   id: ComputerIFFSyndicateCircuitboard
   name: syndicate IFF console board
   description: Allows you to control the IFF and stealth characteristics of this vessel.
@@ -407,7 +407,7 @@
       prototype: ComputerSensorMonitoring
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCommandContraband ]
   id: RoboticsConsoleCircuitboard
   name: robotics control console board
   description: A computer printed circuit board for a robotics control console.
@@ -418,7 +418,7 @@
       prototype: ComputerRoboticsControl
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCommandContraband ]
   id: StationAiUploadCircuitboard
   name: AI upload console board
   description: A computer printed circuit board for a AI upload console.

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -458,7 +458,7 @@
     range: 1200
 
 - type: entity
-  parent: [ BaseComputerAiAccess, BaseCommandContraband ]
+  parent: [ BaseComputerAiAccess, BaseScienceContraband ]
   id: ComputerResearchAndDevelopment
   name: R&D computer
   description: A computer used to interface with R&D tools.

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -171,7 +171,7 @@
     board: ShuttleConsoleCircuitboard
 
 - type: entity
-  parent: BaseComputerShuttle
+  parent: [ BaseComputerShuttle, Tier2Contraband ]
   id: ComputerShuttleSyndie
   name: syndicate shuttle console
   description: Used to pilot a syndicate shuttle.
@@ -203,7 +203,7 @@
     board: SyndicateShuttleConsoleCircuitboard
 
 - type: entity
-  parent: BaseComputerShuttle
+  parent: [ BaseComputerShuttle, BaseCargoContraband ]
   id: ComputerShuttleCargo
   name: cargo shuttle console
   description: Used to pilot the cargo shuttle.
@@ -266,7 +266,7 @@
     board: ComputerIFFCircuitboard
 
 - type: entity
-  parent: ComputerIFF
+  parent: [ ComputerIFF, Tier2Contraband ]
   id: ComputerIFFSyndicate
   name: IFF computer
   suffix: Syndicate
@@ -330,7 +330,7 @@
         type: WiresBoundUserInterface
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseMedicalContraband ]
   id: ComputerMedicalRecords
   name: medical records computer
   description: This can be used to check medical records.
@@ -355,7 +355,7 @@
     board: MedicalRecordsComputerCircuitboard
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseSecurityContraband ]
   id: ComputerCriminalRecords
   name: criminal records computer
   description: This can be used to check criminal records. Only security can modify them.
@@ -394,7 +394,7 @@
     - CriminalRecords
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseSecurityCommandContraband ]
   id: ComputerStationRecords
   name: station records computer
   description: This can be used to check station records.
@@ -458,7 +458,7 @@
     range: 1200
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseCommandContraband ]
   id: ComputerResearchAndDevelopment
   name: R&D computer
   description: A computer used to interface with R&D tools.
@@ -556,7 +556,7 @@
     - Xenoarchaeology
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseGrandTheftContraband ]
   id: ComputerId
   name: ID card computer
   description: Terminal for programming Nanotrasen employee ID cards to access parts of the station.
@@ -709,7 +709,7 @@
     color: "#f71713"
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseEngineeringContraband ]
   id: ComputerSolarControl
   name: solar control computer
   description: A controller for solar panel arrays.
@@ -781,7 +781,7 @@
 
 - type: entity
   id: ComputerCargoShuttle
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseCargoContraband ]
   name: cargo shuttle computer
   description: Used to order the shuttle.
   components:
@@ -820,7 +820,7 @@
 
 - type: entity
   id: ComputerCargoOrders
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseCargoContraband ]
   name: cargo request computer
   description: Used to order supplies and approve requests.
   components:
@@ -872,7 +872,7 @@
 
 - type: entity
   id: ComputerCargoBounty
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseCargoContraband ]
   name: cargo bounty computer
   description: Used to manage currently active bounties.
   components:
@@ -965,7 +965,7 @@
 
 - type: entity
   id: ComputerSalvageExpedition
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseCargoContraband ]
   name: salvage expeditions computer
   description: Used to accept salvage missions, if you're tough enough.
   components:
@@ -1098,7 +1098,7 @@
 
 - type: entity
   id: ComputerPalletConsole
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseCargoContraband ]
   name: cargo sale computer
   description: Used to sell goods loaded onto cargo pallets.
   components:
@@ -1220,7 +1220,7 @@
     - type: AtmosDevice
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseCommandContraband ]
   id: ComputerRoboticsControl
   name: robotics control console
   description: Used to remotely monitor, disable and destroy the station's cyborgs.
@@ -1264,7 +1264,7 @@
 
 - type: entity
   id: StationAiUploadComputer
-  parent: BaseComputer
+  parent: [ BaseComputer, BaseCommandContraband ]
   name: AI upload console
   description: Used to update the laws of the station AI.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseEngineeringContraband ]
   id: ComputerAlert
   name: atmospheric alerts computer
   description: Used to access the station's atmospheric automated alert system.
@@ -50,7 +50,7 @@
           type: WiresBoundUserInterface
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseEngineeringContraband ]
   id: ComputerAtmosMonitoring
   name: atmospheric network monitor
   description: Used to monitor the station's atmospheric networks.
@@ -288,7 +288,7 @@
     board: ComputerIFFSyndicateCircuitboard
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseEngineeringContraband ]
   id: ComputerPowerMonitoring
   name: power monitoring computer
   description: It monitors power levels across the station.
@@ -634,7 +634,7 @@
     color: "#1f8c28"
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [ BaseComputerAiAccess, BaseGrandTheftContraband ]
   id: ComputerComms
   name: communications computer
   description: A computer used to make station wide announcements via keyboard, set the appropriate alert level, and call the emergency shuttle.

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseComputer
+  parent: [ BaseComputer, BaseScienceContraband ]
   id: ComputerTechnologyDiskTerminal
   name: tech disk terminal
   description: A terminal used to print out technology disks.

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -90,7 +90,7 @@
 
 - type: entity
   id: MachineAnomalyVesselExperimental
-  parent: MachineAnomalyVessel
+  parent: [ MachineAnomalyVessel, BaseScienceContraband ]
   name: experimental anomaly vessel
   description: An advanced anomaly vessel capable of greater research potential at the cost of increased volatility and low-level radioactive decay into the environment.
   components:
@@ -116,7 +116,7 @@
 
 - type: entity
   id: MachineAPE
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseScienceContraband ]
   name: A.P.E.
   description: An Anomalous Particle Emitter, capable of shooting out unstable particles which can interface with anomalies.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -83,7 +83,7 @@
 
 - type: entity
   id: MachineArtifactCrusher
-  parent: [ ConstructibleMachine, BaseMachinePowered ]
+  parent: [ ConstructibleMachine, BaseMachinePowered, BaseScienceContraband ]
   name: artifact crusher
   description: Best not to let your fingers get stuck...
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -423,7 +423,7 @@
 
 - type: entity
   id: CircuitImprinter
-  parent: BaseLatheLube
+  parent: [ BaseLatheLube, BaseScienceContraband ]
   name: circuit imprinter
   description: Prints circuit boards for machines.
   components:
@@ -568,7 +568,7 @@
 
 - type: entity
   id: ExosuitFabricator
-  parent: BaseLatheLube
+  parent: [ BaseLatheLube, BaseScienceContraband ]
   name: exosuit fabricator
   description: Creates parts for robotics and other mechanical needs.
   components:
@@ -693,7 +693,7 @@
 
 - type: entity
   id: SecurityTechFab
-  parent: BaseLatheLube
+  parent: [ BaseLatheLube, BaseSecurityContraband ]
   name: security techfab
   description: Prints equipment for use by security crew.
   components:
@@ -835,7 +835,7 @@
 
 - type: entity
   id: AmmoTechFab
-  parent: BaseLatheLube
+  parent: [ BaseLatheLube, BaseSecurityContraband ]
   name: ammo techfab
   description: Prints the bare minimum of bullets that any budget military or armory could need. Nothing fancy.
   components:
@@ -891,7 +891,7 @@
 
 - type: entity
   id: MedicalTechFab
-  parent: BaseLatheLube
+  parent: [ BaseLatheLube, BaseMedicalContraband ]
   name: medical techfab
   description: Prints equipment for use by the medbay.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -258,7 +258,7 @@
 
 - type: entity
   id: Protolathe
-  parent: BaseLatheLube
+  parent: [ BaseLatheLube, BaseScienceContraband ]
   name: protolathe
   description: Converts raw materials into advanced items.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -109,7 +109,7 @@
 
 - type: entity
   id: SyndicateMicrowave
-  parent: KitchenMicrowave
+  parent: [ KitchenMicrowave, BaseSyndicateContraband ]
   name: donk co. microwave
   description: So advanced, it can cook donk-pockets in a mere 2.5 seconds!
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: ResearchAndDevelopmentServer
-  parent: [ BaseMachinePowered, ConstructibleMachine, BaseScienceContraband ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseCommandContraband ]
   name: R&D server
   description: Contains the collective knowledge of the station's scientists. Destroying it would send them back to the stone age. You don't want that do you?
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: ResearchAndDevelopmentServer
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseScienceContraband ]
   name: R&D server
   description: Contains the collective knowledge of the station's scientists. Destroying it would send them back to the stone age. You don't want that do you?
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseCargoContraband ]
   id: SalvageMagnet
   name: salvage magnet
   description: Pulls in salvage.

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/base_particleaccelerator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/base_particleaccelerator.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: ParticleAcceleratorBase
+  parent: BaseEngineeringContraband #imp
   abstract: true
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
+++ b/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: CargoTelepad
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseCargoContraband ]
   name: cargo telepad
   description: Beam in the pizzas and dig in.
   components:

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/CircuitBoards/computer.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/CircuitBoards/computer.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCargoContraband ]
   id: ShipyardComputerCircuitboard
   name: shipyard computer board
   description: A computer printed circuit board for a shipyard computer.

--- a/Resources/Prototypes/_DeltaV/Entities/Structures/Machines/computer.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Structures/Machines/computer.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseComputer
+  parent: [ BaseComputer, BaseCargoContraband ]
   id: ComputerShipyard
   name: shipyard console
   description: Used to purchase and sell shuttles


### PR DESCRIPTION
This PR was originally about making the protolathe science contraband (see edit history), but has been expanded to mark many different machines and computers as department contraband. This has very little balance consideration besides the odd thief steal target (which was treated as theft when caught anyway).

Adding contraband tags is about reinforcing in-game what belongs where and who should have what. It doesn't actually stop anyone for giving people these items, but adds a sliver of conflict to the act. Bureaucracy and gentleman's agreements can resolve the conflict IC.


:cl: aada
- tweak: Several machines and computers are now contraband.
