### PR TITLE
Apid bugfixes

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/apid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/apid.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: apid
   id: MobApid
-  parent: [BaseSimpleMob, StripableInventoryBase, FlyingMobBase, MobRespirator, MobFlammable, MobBloodstream]
+  parent: [BaseSimpleMob, StripableInventoryBase, MobRespirator, MobFlammable, MobBloodstream]
   description: Enthusiastic workers, these cute little balls of fuzz are distant relatives to moth people.
   suffix: Ghost role
   components:
@@ -245,6 +245,10 @@
     attributes:
       proper: true
   - type: MothAccent
+  - type: Physics
+    bodyStatus: InAir
+  - type: NoSlip
+  - type: CanMoveInAir
 
 - type: entity
   name: apid botanist

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Specific/apid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Specific/apid.yml
@@ -9,6 +9,17 @@
     noRot: true
     sprite: _Impstation/Structures/apidcryopod.rsi
     state: icon
+  - type: Fixtures #this is copied from crates so they should hopefully handle the same
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.25
+        density: 50
+        mask:
+        - CrateMask #this is so they can go under plastic flaps
+        layer:
+        - MachineLayer
   - type: GhostRole
     name: ghost-role-information-apid-botanist-name
     description: ghost-role-information-apid-botanist-description

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -260,7 +260,7 @@
     belt: ClothingBeltPlantFilled
     outerClothing: ClothingOuterApronBotanist
     head: ClothingHeadBandBotany
-    pocket1: EmergencyOxygenTank
+    pocket1: EmergencyOxygenTankFilled
     pocket2: ClothingMaskBreath
     ears: ClothingHeadsetService
 
@@ -272,7 +272,7 @@
     belt: ClothingBeltMedicalFilled
     outerClothing: ClothingOuterWinterMed
     #head: 
-    pocket1: EmergencyOxygenTank
+    pocket1: EmergencyOxygenTankFilled
     pocket2: ClothingMaskBreath
     ears: ClothingHeadsetMedical
     eyes: ClothingEyesGlassesHudMedical
@@ -285,7 +285,7 @@
     belt: ClothingBeltUtilityEngineering
     outerClothing: ClothingOuterHardsuitEngineering
     head: ClothingHeadHatHardhatYellow
-    pocket1: DoubleEmergencyOxygenTank
+    pocket1: DoubleEmergencyOxygenTankFilled
     pocket2: ClothingMaskBreath
     ears: ClothingHeadsetEngineering
     eyes: ClothingEyesGlassesMeson


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Apid cryopods have a huge hitbox that cant fit through doorways or under plastic flaps, this fixes that. This also removes their ability to fly off grid and fixes their oxygen tanks spawning empty.
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Apid cryopod's hitbox has been fixed so they can be moved through 1 wide gaps and under plastic flaps.
- fix: Apid's oxygen tanks no longer spawn empty.
- fix: Apids can no longer fly in space.