### PR TITLE
nerfing goliath tentacles slightly

### DIFF
--- a/Content.Shared/Stunnable/StunOnContactComponent.cs
+++ b/Content.Shared/Stunnable/StunOnContactComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class StunOnContactComponent : Component
     /// The duration of the stun.
     /// </summary>
     [DataField]
-    public TimeSpan Duration = TimeSpan.FromSeconds(5);
+    public TimeSpan Duration = TimeSpan.FromSeconds(3.5);
 
     [DataField]
     public EntityWhitelist Blacklist = new();

--- a/Content.Shared/Stunnable/StunOnContactComponent.cs
+++ b/Content.Shared/Stunnable/StunOnContactComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class StunOnContactComponent : Component
     /// The duration of the stun.
     /// </summary>
     [DataField]
-    public TimeSpan Duration = TimeSpan.FromSeconds(3.5);
+    public TimeSpan Duration = TimeSpan.FromSeconds(3.5); # imp
 
     [DataField]
     public EntityWhitelist Blacklist = new();

--- a/Content.Shared/Stunnable/StunOnContactComponent.cs
+++ b/Content.Shared/Stunnable/StunOnContactComponent.cs
@@ -13,10 +13,10 @@ public sealed partial class StunOnContactComponent : Component
     public string FixtureId = "fix";
 
     /// <summary>
-    /// The duration of the stun.
+    /// The duration of the stun. Edited 5 -> 3.5 for impstation
     /// </summary>
     [DataField]
-    public TimeSpan Duration = TimeSpan.FromSeconds(3.5); # imp
+    public TimeSpan Duration = TimeSpan.FromSeconds(3.5); 
 
     [DataField]
     public EntityWhitelist Blacklist = new();


### PR DESCRIPTION
it's not the most elegant solution to goliaths stunlocking you to crit but with the getup doafter for crawling their stun was effectively a total of 6 seconds. this will even it out a little. and, to be honest, what you get out of going to the asteroid isn't really proportionate to the danger there but i don't want to nerf goliaths into the ground either.


:cl: suyo
- tweak: shaved 1.5 seconds off of the goliath's tentacle grapple stun to accommodate for crawling's extremely interruptible doafter (1 second)
