### PR TITLE
Alternate bananium smelting

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
@@ -53,3 +53,11 @@
      TearGasGrenade: 1
      FoodBowlBig: 1
      Cigarette: 8 # YUMMY!!!!!!!!!
+
+- type: microwaveMealRecipe
+  id: RecipeBananium
+  name: bananium recipe
+  result: MaterialBananium1
+  time: 30
+  solids:
+    BananiumOre1: 1


### PR DESCRIPTION
Just a weird thing for bananium to do. 30 seconds to process one ore.

:cl: aada
- add: Bananium can now be smelted in a microwave.