### PR TITLE
unembed projectiles on parent destruction/consumption

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
+using Content.Shared.Projectiles;
 
 namespace Content.Server.Destructible
 {
@@ -40,6 +41,7 @@ namespace Content.Server.Destructible
         [Dependency] public readonly SharedSolutionContainerSystem SolutionContainerSystem = default!;
         [Dependency] public readonly PuddleSystem PuddleSystem = default!;
         [Dependency] public readonly SharedContainerSystem ContainerSystem = default!;
+        [Dependency] public readonly SharedProjectileSystem ProjectileSystem = default!;
         [Dependency] public readonly IPrototypeManager PrototypeManager = default!;
         [Dependency] public readonly IComponentFactory ComponentFactory = default!;
         [Dependency] public readonly IAdminLogManager _adminLogger = default!;
@@ -80,6 +82,14 @@ namespace Content.Server.Destructible
                     {
                         _adminLogger.Add(LogType.Damaged, LogImpact.Medium,
                             $"Unknown damage source caused {ToPrettyString(uid):subject} to trigger [{triggeredBehaviors}]");
+                    }
+
+                    // Unembed any embedded projectiles
+                    var childEnumerator = Transform(uid).ChildEnumerator;
+                    while (childEnumerator.MoveNext(out var child))
+                    {
+                        if (TryComp<EmbeddableProjectileComponent>(child, out var embeddable))
+                            ProjectileSystem.RemoveEmbed(child, embeddable);
                     }
 
                     threshold.Execute(uid, this, EntityManager, args.Origin);

--- a/Content.Shared/Destructible/SharedDestructibleSystem.cs
+++ b/Content.Shared/Destructible/SharedDestructibleSystem.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Shared.Destructible;
+namespace Content.Shared.Destructible;
 
 public abstract class SharedDestructibleSystem : EntitySystem
 {


### PR DESCRIPTION
as title. pretty much just copying homework from #1171

**Changelog**
:cl:
- fix: Embedded projectiles no longer disappear along with the destroyed or eaten objects they're attached to.