### PR TITLE
remove greencomms

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -8,10 +8,10 @@
   - type: ContainerContainer
     containers:
       key_slots: !type:Container
-  - type: ContainerFill
-    containers:
-      key_slots:
-      - EncryptionKeyCommon
+  #- type: ContainerFill
+  #  containers:
+  #    key_slots:
+  #    - EncryptionKeyCommon
   - type: Headset
   - type: EncryptionKeyHolder
     keySlots: 4
@@ -45,7 +45,7 @@
     containers:
       key_slots:
       - EncryptionKeyCargo
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/cargo.rsi
   - type: Clothing
@@ -73,7 +73,7 @@
       key_slots:
       - EncryptionKeyCargo
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
 
 - type: entity
   parent: [ ClothingHeadset, BaseCentcommContraband ]
@@ -118,7 +118,7 @@
     containers:
       key_slots:
       - EncryptionKeyEngineering
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/engineering.rsi
   - type: Clothing
@@ -135,7 +135,7 @@
       key_slots:
       - EncryptionKeyEngineering
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: StealTarget #imp
     stealGroup: CommandHeadset
 
@@ -149,7 +149,7 @@
     containers:
       key_slots:
       - EncryptionKeyMedical
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/medical.rsi
   - type: Clothing
@@ -166,7 +166,7 @@
       key_slots:
       - EncryptionKeyMedical
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: StealTarget #imp
     stealGroup: CommandHeadset
 
@@ -180,7 +180,7 @@
     containers:
       key_slots:
       - EncryptionKeyScience
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/science.rsi
   - type: Clothing
@@ -196,7 +196,7 @@
     containers:
       key_slots:
       - EncryptionKeyMedicalScience
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/medicalscience.rsi
   - type: Clothing
@@ -212,7 +212,7 @@
     containers:
       key_slots:
       - EncryptionKeyRobo
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/robotics.rsi
   - type: Clothing
@@ -229,7 +229,7 @@
       key_slots:
       - EncryptionKeyScience
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: StealTarget #imp
     stealGroup: CommandHeadset
 
@@ -243,7 +243,7 @@
     containers:
       key_slots:
       - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/security.rsi
   - type: Clothing
@@ -259,7 +259,7 @@
     containers:
       key_slots:
       - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
       - EncryptionKeyCommand
   - type: Sprite
     sprite: Clothing/Ears/Headsets/security.rsi
@@ -279,7 +279,7 @@
       key_slots:
       - EncryptionKeyMedical
       - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/brigmedic.rsi
   - type: Clothing
@@ -295,7 +295,7 @@
     containers:
       key_slots:
       - EncryptionKeyService
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/service.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -22,7 +22,7 @@
       key_slots:
       - EncryptionKeyCargo
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/cargo.rsi
   - type: Clothing
@@ -67,7 +67,7 @@
       key_slots:
       - EncryptionKeyEngineering
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/engineering.rsi
   - type: Clothing
@@ -83,7 +83,7 @@
       key_slots:
       - EncryptionKeyMedical
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/medical.rsi
   - type: Clothing
@@ -99,7 +99,7 @@
       key_slots:
       - EncryptionKeySecurity
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/security.rsi
   - type: Clothing
@@ -115,7 +115,7 @@
       key_slots:
       - EncryptionKeyScience
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/science.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -94,12 +94,12 @@
   - type: IntrinsicRadioTransmitter
     channels:
     - Binary
-    - Common
+    # - Common
     - Science
   - type: ActiveRadio
     channels:
     - Binary
-    - Common
+    # - Common
     - Science
   - type: ZombieImmune
   - type: Repairable

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -29,7 +29,7 @@
     interactFailureString: petting-failure-generic-cyborg
   - type: BorgSwitchableType
     inherentRadioChannels:
-    - Common
+    # - Common
     - Binary
 
 - type: entity
@@ -124,13 +124,13 @@
     channels:
     - Supply
     - Binary
-    - Common
+    # - Common
     - Science
   - type: ActiveRadio
     channels:
     - Supply
     - Binary
-    - Common
+    # - Common
     - Science
   - type: AccessReader
     access: [["Cargo"], ["Salvage"], ["Command"], ["Research"]]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -32,12 +32,12 @@
     factions:
     - SimpleNeutral
   - type: IntrinsicRadioReceiver
-  - type: IntrinsicRadioTransmitter
-    channels:
-    - Common
-  - type: ActiveRadio
-    channels:
-    - Common
+  #- type: IntrinsicRadioTransmitter
+  #  channels:
+  #   - Common
+  #- type: ActiveRadio
+  #  channels:
+  #   - Common
   - type: HealthExaminable
     examinableTypes:
     - Blunt
@@ -467,11 +467,11 @@
     - FootstepSound
     - Bot
   - type: IntrinsicRadioReceiver
-  - type: IntrinsicRadioTransmitter
+  #- type: IntrinsicRadioTransmitter
     channels:
-    - Common
+    # - Common
     - Supply
   - type: ActiveRadio
     channels:
-    - Common
+    # - Common
     - Supply

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -467,7 +467,7 @@
     - FootstepSound
     - Bot
   - type: IntrinsicRadioReceiver
-  #- type: IntrinsicRadioTransmitter
+  - type: IntrinsicRadioTransmitter
     channels:
     # - Common
     - Supply

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -723,7 +723,7 @@
   - type: ActiveRadio
     channels:
     - Binary
-    - Common
+    # - Common
   - type: DoAfter
   - type: Pullable
   - type: Examiner

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -44,12 +44,12 @@
     stopSearchVerbPopup: pai-system-stopped-searching
   - type: Examiner
   - type: IntrinsicRadioReceiver
-  - type: IntrinsicRadioTransmitter
-    channels:
-    - Common
-  - type: ActiveRadio
-    channels:
-    - Common
+  #- type: IntrinsicRadioTransmitter
+  #  channels:
+  #  - Common
+  #- type: ActiveRadio
+  #  channels:
+  #  - Common
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator
@@ -134,12 +134,12 @@
     roleName: pai-system-role-name-gilded
     roleDescription: pai-system-role-description-gilded
     roleRules: ghost-role-information-familiar-rules
-  - type: IntrinsicRadioTransmitter
-    channels:
-    - Common
-  - type: ActiveRadio
-    channels:
-    - Common
+  #- type: IntrinsicRadioTransmitter
+  #  channels:
+  #  - Common
+  #- type: ActiveRadio
+  #  channels:
+  #  - Common
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -25,7 +25,7 @@
   - type: ActiveRadio
     channels:
     - Binary
-    - Common
+  #  - Common
   - type: NameIdentifier
     group: MMI
   - type: DoAfter
@@ -104,7 +104,7 @@
     - type: ActiveRadio
       channels:
       - Binary
-      - Common
+    #  - Common
     - type: NameIdentifier
       group: PositronicBrain
     - type: DoAfter

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -79,12 +79,12 @@
     speechVerb: Robotic
     speechSounds: Vending
   - type: IntrinsicRadioReceiver
-  - type: IntrinsicRadioTransmitter
-    channels:
-    - Common
-  - type: ActiveRadio
-    channels:
-    - Common
+  #- type: IntrinsicRadioTransmitter
+  #  channels:
+  #  - Common
+  #- type: ActiveRadio
+  #  channels:
+  #  - Common
   - type: DoAfter
   - type: Electrified
     enabled: false

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Ears/headsets.yml
@@ -9,7 +9,7 @@
       key_slots:
       - EncryptionKeyCargo
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: _Impstation/Clothing/Ears/Headsets/commandveteranqm.rsi
   - type: Clothing
@@ -45,7 +45,7 @@
       key_slots:
       - EncryptionKeyEngineering
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: _Impstation/Clothing/Ears/Headsets/commandveterance.rsi
   - type: Clothing
@@ -64,7 +64,7 @@
       key_slots:
       - EncryptionKeyMedical
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: _Impstation/Clothing/Ears/Headsets/commandveterancmo.rsi
   - type: Clothing
@@ -83,7 +83,7 @@
       key_slots:
       - EncryptionKeyScience
       - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
   - type: Sprite
     sprite: _Impstation/Clothing/Ears/Headsets/commandveteranrd.rsi
   - type: Clothing
@@ -101,7 +101,7 @@
     containers:
       key_slots:
       - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
       - EncryptionKeyCommand
   - type: Sprite
     sprite: _Impstation/Clothing/Ears/Headsets/commandveteranhos.rsi
@@ -120,7 +120,7 @@
     containers:
       key_slots:
       - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      #- EncryptionKeyCommon
       - EncryptionKeyCommand
   - type: Sprite
     sprite: _Impstation/Clothing/Ears/Headsets/securitywarden.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
@@ -95,11 +95,11 @@
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:
-    - Common
+    # - Common
     - Binary
   - type: ActiveRadio
     channels:
-    - Common
+    # - Common
     - Binary
   - type: ZombieImmune
   - type: Repairable


### PR DESCRIPTION
i solely commented out nearly every roundstart access to common channel. this would be extremely easy to revert if we choose to do so

creative decisions i made

- master key still has common. this means captain, hop and enterprising salvagers keep it in their headset.
- all mapped common encryption keys remain. we should probably be pushing map changes to accommodate for this PR and i didn't want to cause conflicts
- HoP still has a box of common encryption keys which can be handed out during a round
- AI keeps common, even when in an intellicard. all other borgs and silicon life do not
- intercoms all have common

**Changelog**

:cl:
- tweak: Access to the Common radio channel ('greencomms') has been severely restricted.