### PR TITLE
Add blood-red phone to lone ops shuttle

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
@@ -13,7 +13,7 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 325
+  - uid: 1
     components:
     - type: MetaData
     - type: Transform
@@ -193,38 +193,38 @@ entities:
     - type: GridPathfinding
 - proto: AirCanister
   entities:
-  - uid: 91
+  - uid: 2
     components:
     - type: Transform
       pos: -0.5,-8.5
-      parent: 325
+      parent: 1
 - proto: AirlockExternalShuttleSyndicateLocked
   entities:
-  - uid: 142
+  - uid: 3
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-1.5
-      parent: 325
+      parent: 1
 - proto: AirlockSyndicateLocked
   entities:
-  - uid: 20
+  - uid: 4
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 88
+      parent: 1
+  - uid: 5
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
+      parent: 1
 - proto: APCBasic
   entities:
-  - uid: 107
+  - uid: 6
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
+      parent: 1
     - type: PowerNetworkBattery
       loadingNetworkDemand: 15107
       currentReceiving: 15106.935
@@ -232,1454 +232,1421 @@ entities:
       supplyRampPosition: 0.064453125
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 6
+  - uid: 7
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
-      parent: 325
+      parent: 1
 - proto: Bed
   entities:
-  - uid: 76
+  - uid: 8
     components:
     - type: Transform
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: BedsheetSyndie
   entities:
-  - uid: 164
+  - uid: 9
     components:
     - type: Transform
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: BlastDoorOpen
   entities:
-  - uid: 190
+  - uid: 10
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 331
-  - uid: 191
+          - 11
+  - uid: 12
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 332
-  - uid: 192
+          - 13
+  - uid: 14
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 333
-  - uid: 193
+          - 15
+  - uid: 16
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 334
-  - uid: 196
+          - 17
+  - uid: 18
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 337
-  - uid: 198
+          - 19
+  - uid: 20
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 339
-  - uid: 199
+          - 21
+  - uid: 22
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 340
-  - uid: 200
+          - 23
+  - uid: 24
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 341
-  - uid: 201
+          - 25
+  - uid: 26
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 342
-  - uid: 202
+          - 27
+  - uid: 28
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 343
+          - 29
 - proto: BoxMRE
   entities:
-  - uid: 320
+  - uid: 30
     components:
     - type: Transform
       pos: 0.70504504,-7.29326
-      parent: 325
+      parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 120
+  - uid: 31
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
-  - uid: 121
+      parent: 1
+  - uid: 32
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 122
+      parent: 1
+  - uid: 33
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 123
+      parent: 1
+  - uid: 34
     components:
     - type: Transform
       pos: -0.5,-8.5
-      parent: 325
-  - uid: 124
+      parent: 1
+  - uid: 35
     components:
     - type: Transform
       pos: -1.5,-8.5
-      parent: 325
-  - uid: 125
+      parent: 1
+  - uid: 36
     components:
     - type: Transform
       pos: 0.5,-8.5
-      parent: 325
-  - uid: 126
+      parent: 1
+  - uid: 37
     components:
     - type: Transform
       pos: 1.5,-8.5
-      parent: 325
-  - uid: 127
+      parent: 1
+  - uid: 38
     components:
     - type: Transform
       pos: -2.5,-8.5
-      parent: 325
-  - uid: 128
+      parent: 1
+  - uid: 39
     components:
     - type: Transform
       pos: -3.5,-8.5
-      parent: 325
-  - uid: 129
+      parent: 1
+  - uid: 40
     components:
     - type: Transform
       pos: -3.5,-7.5
-      parent: 325
-  - uid: 130
+      parent: 1
+  - uid: 41
     components:
     - type: Transform
       pos: 2.5,-8.5
-      parent: 325
-  - uid: 131
+      parent: 1
+  - uid: 42
     components:
     - type: Transform
       pos: 2.5,-7.5
-      parent: 325
-  - uid: 132
+      parent: 1
+  - uid: 43
     components:
     - type: Transform
       pos: -0.5,-5.5
-      parent: 325
-  - uid: 133
+      parent: 1
+  - uid: 44
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 134
+      parent: 1
+  - uid: 45
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 135
+      parent: 1
+  - uid: 46
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 325
-  - uid: 136
+      parent: 1
+  - uid: 47
     components:
     - type: Transform
       pos: -0.5,-1.5
-      parent: 325
-  - uid: 137
+      parent: 1
+  - uid: 48
     components:
     - type: Transform
       pos: -0.5,-0.5
-      parent: 325
-  - uid: 138
+      parent: 1
+  - uid: 49
     components:
     - type: Transform
       pos: -0.5,0.5
-      parent: 325
-  - uid: 139
+      parent: 1
+  - uid: 50
     components:
     - type: Transform
       pos: -0.5,1.5
-      parent: 325
-  - uid: 140
+      parent: 1
+  - uid: 51
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 141
+      parent: 1
+  - uid: 52
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 143
+      parent: 1
+  - uid: 53
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 145
+      parent: 1
+  - uid: 54
     components:
     - type: Transform
       pos: -1.5,-1.5
-      parent: 325
-  - uid: 146
+      parent: 1
+  - uid: 55
     components:
     - type: Transform
       pos: -2.5,-1.5
-      parent: 325
-  - uid: 147
+      parent: 1
+  - uid: 56
     components:
     - type: Transform
       pos: -3.5,-1.5
-      parent: 325
-  - uid: 148
+      parent: 1
+  - uid: 57
     components:
     - type: Transform
       pos: -4.5,-1.5
-      parent: 325
-  - uid: 149
+      parent: 1
+  - uid: 58
     components:
     - type: Transform
       pos: 0.5,-1.5
-      parent: 325
-  - uid: 150
+      parent: 1
+  - uid: 59
     components:
     - type: Transform
       pos: 1.5,-1.5
-      parent: 325
-  - uid: 151
+      parent: 1
+  - uid: 60
     components:
     - type: Transform
       pos: 2.5,-1.5
-      parent: 325
-  - uid: 152
+      parent: 1
+  - uid: 61
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 153
+      parent: 1
+  - uid: 62
     components:
     - type: Transform
       pos: 0.5,-4.5
-      parent: 325
-  - uid: 154
+      parent: 1
+  - uid: 63
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
-  - uid: 155
+      parent: 1
+  - uid: 64
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 156
+      parent: 1
+  - uid: 65
     components:
     - type: Transform
       pos: -1.5,-4.5
-      parent: 325
-  - uid: 157
+      parent: 1
+  - uid: 66
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 158
+      parent: 1
+  - uid: 67
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
 - proto: CableHV
   entities:
-  - uid: 111
+  - uid: 68
     components:
     - type: Transform
       pos: 1.5,-7.5
-      parent: 325
-  - uid: 112
+      parent: 1
+  - uid: 69
     components:
     - type: Transform
       pos: 0.5,-7.5
-      parent: 325
-  - uid: 113
+      parent: 1
+  - uid: 70
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 114
+      parent: 1
+  - uid: 71
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
-  - uid: 115
+      parent: 1
+  - uid: 72
     components:
     - type: Transform
       pos: -2.5,-7.5
-      parent: 325
-  - uid: 116
+      parent: 1
+  - uid: 73
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
+      parent: 1
 - proto: CableHVStack1
   entities:
-  - uid: 235
+  - uid: 75
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Stack
       count: 10
     - type: Physics
       canCollide: False
-  - uid: 239
+  - uid: 80
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Stack
       count: 10
     - type: Physics
       canCollide: False
 - proto: CableMV
   entities:
-  - uid: 117
+  - uid: 84
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
-  - uid: 118
+      parent: 1
+  - uid: 85
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 119
+      parent: 1
+  - uid: 86
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
+      parent: 1
 - proto: CapacitorStockPart
   entities:
-  - uid: 233
+  - uid: 76
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Physics
       canCollide: False
-  - uid: 234
+  - uid: 77
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Physics
       canCollide: False
-  - uid: 237
+  - uid: 81
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Physics
       canCollide: False
-  - uid: 238
+  - uid: 82
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Physics
       canCollide: False
-  - uid: 241
+  - uid: 88
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
-  - uid: 242
+  - uid: 89
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
-  - uid: 243
+  - uid: 90
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
-  - uid: 254
+  - uid: 94
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 261
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 268
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 275
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 282
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 289
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 296
+  - uid: 102
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 303
+  - uid: 110
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Physics
+      canCollide: False
+  - uid: 118
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 126
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 134
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 142
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 150
+    components:
+    - type: Transform
+      parent: 149
     - type: Physics
       canCollide: False
 - proto: Carpet
   entities:
-  - uid: 74
+  - uid: 157
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 89
+      parent: 1
+  - uid: 158
     components:
     - type: Transform
       pos: -0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: Catwalk
   entities:
   - uid: 159
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
   - uid: 160
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
+      parent: 1
   - uid: 161
     components:
     - type: Transform
       pos: 0.5,-7.5
-      parent: 325
+      parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 93
+  - uid: 162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
-      parent: 325
+      parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 78
+  - uid: 163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
-      parent: 325
+      parent: 1
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 40
+  - uid: 164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 325
+      parent: 1
 - proto: ComputerShuttleSyndie
   entities:
-  - uid: 64
+  - uid: 165
     components:
     - type: Transform
       pos: -0.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 245
+          - 166
         disk_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CyberPen
   entities:
-  - uid: 77
+  - uid: 167
     components:
     - type: Transform
       pos: -1.1813428,-5.15565
-      parent: 325
+      parent: 1
 - proto: DoorElectronics
   entities:
-  - uid: 331
+  - uid: 11
     components:
     - type: Transform
-      parent: 190
+      parent: 10
     - type: Physics
       canCollide: False
-  - uid: 332
+  - uid: 13
     components:
     - type: Transform
-      parent: 191
+      parent: 12
     - type: Physics
       canCollide: False
-  - uid: 333
+  - uid: 15
     components:
     - type: Transform
-      parent: 192
+      parent: 14
     - type: Physics
       canCollide: False
-  - uid: 334
+  - uid: 17
     components:
     - type: Transform
-      parent: 193
+      parent: 16
     - type: Physics
       canCollide: False
-  - uid: 337
+  - uid: 19
     components:
     - type: Transform
-      parent: 196
+      parent: 18
     - type: Physics
       canCollide: False
-  - uid: 339
+  - uid: 21
     components:
     - type: Transform
-      parent: 198
+      parent: 20
     - type: Physics
       canCollide: False
-  - uid: 340
+  - uid: 23
     components:
     - type: Transform
-      parent: 199
+      parent: 22
     - type: Physics
       canCollide: False
-  - uid: 341
+  - uid: 25
     components:
     - type: Transform
-      parent: 200
+      parent: 24
     - type: Physics
       canCollide: False
-  - uid: 342
+  - uid: 27
     components:
     - type: Transform
-      parent: 201
+      parent: 26
     - type: Physics
       canCollide: False
-  - uid: 343
+  - uid: 29
     components:
     - type: Transform
-      parent: 202
+      parent: 28
     - type: Physics
       canCollide: False
-  - uid: 346
+  - uid: 169
     components:
     - type: Transform
-      parent: 206
+      parent: 168
     - type: Physics
       canCollide: False
 - proto: DresserFilled
   entities:
-  - uid: 85
+  - uid: 170
     components:
     - type: Transform
       pos: 0.5,-4.5
-      parent: 325
+      parent: 1
 - proto: DrinkNukieCan
   entities:
-  - uid: 144
+  - uid: 171
     components:
     - type: Transform
       pos: -2.6964839,-2.109029
-      parent: 325
+      parent: 1
 - proto: FaxMachineSyndie
   entities:
-  - uid: 46
+  - uid: 172
     components:
     - type: Transform
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
     - type: FaxMachine
       name: Striker
 - proto: filingCabinetRandom
   entities:
-  - uid: 75
+  - uid: 173
     components:
     - type: Transform
       pos: -1.5,-4.5
-      parent: 325
+      parent: 1
 - proto: Firelock
   entities:
-  - uid: 224
+  - uid: 174
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 350
+          - 175
     - type: DeviceNetwork
       address: 44a24659
       receiveFrequency: 1621
-  - uid: 225
+  - uid: 176
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 351
+          - 177
     - type: DeviceNetwork
       address: 6fdb75cf
       receiveFrequency: 1621
 - proto: FirelockElectronics
   entities:
-  - uid: 350
+  - uid: 175
     components:
     - type: Transform
-      parent: 224
+      parent: 174
     - type: Physics
       canCollide: False
-  - uid: 351
+  - uid: 177
     components:
     - type: Transform
-      parent: 225
+      parent: 176
     - type: Physics
       canCollide: False
 - proto: FoodBoxDonut
   entities:
-  - uid: 87
+  - uid: 178
     components:
     - type: Transform
       pos: -2.470145,-2.3953476
-      parent: 325
+      parent: 1
 - proto: GasPipeFourway
   entities:
-  - uid: 216
+  - uid: 179
     components:
     - type: Transform
       pos: -0.5,-1.5
-      parent: 325
+      parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 211
+  - uid: 180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 213
+      parent: 1
+  - uid: 181
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 214
+      parent: 1
+  - uid: 182
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 215
+      parent: 1
+  - uid: 183
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 325
-  - uid: 217
+      parent: 1
+  - uid: 184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
-      parent: 325
+      parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 210
+  - uid: 185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 212
+      parent: 1
+  - uid: 186
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: GasPort
   entities:
-  - uid: 59
+  - uid: 187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
-      parent: 325
+      parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 218
+  - uid: 188
     components:
     - type: Transform
       pos: -0.5,0.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-5f41a0ae
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 219
+  - uid: 189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-129c27d2
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 220
+  - uid: 190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-1.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-11c4609d
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 221
+  - uid: 191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-6859729f
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 222
+  - uid: 192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-19d24c7f
       transmitFrequency: 1621
       receiveFrequency: 1621
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 41
+  - uid: 74
     components:
     - type: Transform
       pos: -2.5,-7.5
-      parent: 325
+      parent: 1
     - type: PowerSupplier
       supplyRampPosition: 7552.5303
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           ents:
-          - 232
+          - 78
         machine_parts: !type:Container
           ents:
-          - 233
-          - 234
-          - 235
-  - uid: 56
+          - 76
+          - 77
+          - 75
+  - uid: 79
     components:
     - type: Transform
       pos: 1.5,-7.5
-      parent: 325
+      parent: 1
     - type: PowerSupplier
       supplyRampPosition: 7552.5303
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           ents:
-          - 236
+          - 83
         machine_parts: !type:Container
           ents:
-          - 237
-          - 238
-          - 239
+          - 81
+          - 82
+          - 80
 - proto: GravityGeneratorMini
   entities:
-  - uid: 57
+  - uid: 193
     components:
     - type: Transform
       pos: -1.5,-8.5
-      parent: 325
+      parent: 1
 - proto: Grille
   entities:
-  - uid: 1
+  - uid: 194
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 2
+      parent: 1
+  - uid: 195
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
-  - uid: 3
+      parent: 1
+  - uid: 196
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 4
+      parent: 1
+  - uid: 197
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
-  - uid: 5
+      parent: 1
+  - uid: 198
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 21
+      parent: 1
+  - uid: 199
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 50
+      parent: 1
+  - uid: 200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-5.5
-      parent: 325
-  - uid: 51
+      parent: 1
+  - uid: 201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 52
+      parent: 1
+  - uid: 202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 53
+      parent: 1
+  - uid: 203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
-      parent: 325
+      parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 58
+  - uid: 87
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-8.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 240
+          - 91
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 241
-          - 242
-          - 243
-          - 244
+          - 88
+          - 89
+          - 90
+          - 92
 - proto: GyroscopeMachineCircuitboard
   entities:
-  - uid: 240
+  - uid: 91
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
 - proto: MedkitCombatFilled
   entities:
-  - uid: 19
+  - uid: 204
     components:
     - type: Transform
       pos: 1.48298,-0.3211529
-      parent: 325
+      parent: 1
 - proto: MicroManipulatorStockPart
   entities:
-  - uid: 250
+  - uid: 95
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 251
+  - uid: 96
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 252
+  - uid: 97
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 253
+  - uid: 98
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 257
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 258
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 259
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 260
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 264
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 265
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 266
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 267
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 271
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 272
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 273
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 274
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 278
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 279
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 280
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 281
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 285
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 286
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 287
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 288
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 292
+  - uid: 103
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 293
+  - uid: 104
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 294
+  - uid: 105
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 295
+  - uid: 106
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 299
+  - uid: 111
     components:
     - type: Transform
-      parent: 102
+      parent: 109
     - type: Physics
       canCollide: False
-  - uid: 300
+  - uid: 112
     components:
     - type: Transform
-      parent: 102
+      parent: 109
     - type: Physics
       canCollide: False
-  - uid: 301
+  - uid: 113
     components:
     - type: Transform
-      parent: 102
+      parent: 109
     - type: Physics
       canCollide: False
-  - uid: 302
+  - uid: 114
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Physics
+      canCollide: False
+  - uid: 119
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 120
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 121
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 122
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 127
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 128
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 129
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 130
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 135
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 136
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 137
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 138
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 143
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 144
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 145
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 146
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 151
+    components:
+    - type: Transform
+      parent: 149
+    - type: Physics
+      canCollide: False
+  - uid: 152
+    components:
+    - type: Transform
+      parent: 149
+    - type: Physics
+      canCollide: False
+  - uid: 153
+    components:
+    - type: Transform
+      parent: 149
+    - type: Physics
+      canCollide: False
+  - uid: 154
+    components:
+    - type: Transform
+      parent: 149
     - type: Physics
       canCollide: False
 - proto: Mirror
   entities:
-  - uid: 321
+  - uid: 205
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
-      parent: 325
+      parent: 1
 - proto: NitrogenTankFilled
   entities:
-  - uid: 105
+  - uid: 206
     components:
     - type: Transform
       pos: 1.373605,-0.2749618
-      parent: 325
+      parent: 1
 - proto: NukeCodePaper
   entities:
-  - uid: 323
+  - uid: 207
     components:
     - type: Transform
       pos: 1.561105,-2.5567772
-      parent: 325
+      parent: 1
 - proto: OxygenTankFilled
   entities:
-  - uid: 167
+  - uid: 208
     components:
     - type: Transform
       pos: 1.60798,-0.3062118
-      parent: 325
+      parent: 1
+- proto: PhoneInstrumentSyndicate
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 0.48305517,-4.170118
+      parent: 1
 - proto: PinpointerNuclear
   entities:
-  - uid: 162
+  - uid: 209
     components:
     - type: Transform
       pos: 1.3790641,-2.3161128
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 104
+  - uid: 210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
-      parent: 325
-  - uid: 109
+      parent: 1
+  - uid: 211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-0.5
-      parent: 325
+      parent: 1
 - proto: PlushieNuke
   entities:
-  - uid: 47
+  - uid: 212
     components:
     - type: Transform
       pos: 0.5061571,-5.233775
-      parent: 325
+      parent: 1
 - proto: PortableGeneratorSuperPacmanMachineCircuitboard
   entities:
-  - uid: 232
+  - uid: 78
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Physics
       canCollide: False
-  - uid: 236
+  - uid: 83
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Physics
       canCollide: False
 - proto: PosterContrabandC20r
   entities:
-  - uid: 24
+  - uid: 213
     components:
     - type: Transform
       pos: 2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: PosterContrabandEnergySwords
   entities:
-  - uid: 227
+  - uid: 214
     components:
     - type: Transform
       pos: -2.5,-6.5
-      parent: 325
+      parent: 1
 - proto: PosterContrabandNuclearDeviceInformational
   entities:
-  - uid: 228
+  - uid: 215
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 325
+      parent: 1
 - proto: PosterContrabandSyndicateRecruitment
   entities:
-  - uid: 229
+  - uid: 216
     components:
     - type: Transform
       pos: 0.5,-3.5
-      parent: 325
+      parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 94
+  - uid: 217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 325
-  - uid: 110
+      parent: 1
+  - uid: 218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 182
+  - uid: 219
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 183
+  - uid: 220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 184
+  - uid: 221
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: PoweredSmallLight
   entities:
-  - uid: 204
+  - uid: 222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: Rack
   entities:
-  - uid: 83
+  - uid: 223
     components:
     - type: Transform
       pos: 1.5,-0.5
-      parent: 325
-  - uid: 84
+      parent: 1
+  - uid: 224
     components:
     - type: Transform
       pos: 1.5,-2.5
-      parent: 325
+      parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 14
+  - uid: 225
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 15
+      parent: 1
+  - uid: 226
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
-  - uid: 16
+      parent: 1
+  - uid: 227
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 17
+      parent: 1
+  - uid: 228
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
-  - uid: 18
+      parent: 1
+  - uid: 229
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 26
+      parent: 1
+  - uid: 230
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 42
+      parent: 1
+  - uid: 231
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
-  - uid: 70
+      parent: 1
+  - uid: 232
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 71
+      parent: 1
+  - uid: 233
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 72
+      parent: 1
+  - uid: 234
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
 - proto: RemoteSignaller
   entities:
-  - uid: 176
+  - uid: 235
     components:
     - type: Transform
       pos: 1.3427892,-2.379079
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: SheetGlass1
   entities:
-  - uid: 244
+  - uid: 92
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Stack
       count: 2
     - type: Physics
       canCollide: False
 - proto: SheetSteel1
   entities:
-  - uid: 255
+  - uid: 99
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 262
-    components:
-    - type: Transform
-      parent: 96
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 269
-    components:
-    - type: Transform
-      parent: 97
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 276
-    components:
-    - type: Transform
-      parent: 98
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 283
-    components:
-    - type: Transform
-      parent: 99
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 290
-    components:
-    - type: Transform
-      parent: 100
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 297
+  - uid: 107
     components:
     - type: Transform
       parent: 101
@@ -1687,83 +1654,123 @@ entities:
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 304
+  - uid: 115
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 123
+    components:
+    - type: Transform
+      parent: 117
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 131
+    components:
+    - type: Transform
+      parent: 125
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 139
+    components:
+    - type: Transform
+      parent: 133
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 147
+    components:
+    - type: Transform
+      parent: 141
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 155
+    components:
+    - type: Transform
+      parent: 149
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
 - proto: SignalButton
   entities:
-  - uid: 205
+  - uid: 236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
-      parent: 325
+      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        193:
+        16:
         - Pressed: Toggle
-        192:
+        14:
         - Pressed: Toggle
-        190:
+        10:
         - Pressed: Toggle
-        191:
+        12:
         - Pressed: Toggle
-        196:
+        18:
         - Pressed: Toggle
-        202:
+        28:
         - Pressed: Toggle
-        201:
+        26:
         - Pressed: Toggle
-        200:
+        24:
         - Pressed: Toggle
-        199:
+        22:
         - Pressed: Toggle
-        198:
+        20:
         - Pressed: Toggle
 - proto: SignSpace
   entities:
-  - uid: 230
+  - uid: 237
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 325
+      parent: 1
 - proto: SoapSyndie
   entities:
-  - uid: 90
+  - uid: 238
     components:
     - type: Transform
       pos: 0.5436061,-7.5129323
-      parent: 325
+      parent: 1
 - proto: SpawnPointNukies
   entities:
-  - uid: 322
+  - uid: 239
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
+      parent: 1
 - proto: StealthBox
   entities:
-  - uid: 106
+  - uid: 240
     components:
     - type: Transform
       pos: 0.49860507,-2.4513345
-      parent: 325
+      parent: 1
     - type: Stealth
       enabled: False
     - type: EntityStorage
       open: True
 - proto: SubstationWallBasic
   entities:
-  - uid: 103
+  - uid: 241
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
+      parent: 1
     - type: PowerNetworkBattery
       loadingNetworkDemand: 15106.935
       currentReceiving: 15105.06
@@ -1771,580 +1778,580 @@ entities:
       supplyRampPosition: 1.875
 - proto: SuitStorageSyndie
   entities:
-  - uid: 67
+  - uid: 242
     components:
     - type: Transform
       pos: 2.5,-1.5
-      parent: 325
+      parent: 1
 - proto: SyndicateCommsComputerCircuitboard
   entities:
-  - uid: 246
+  - uid: 244
     components:
     - type: Transform
-      parent: 65
+      parent: 243
     - type: Physics
       canCollide: False
 - proto: SyndicateComputerComms
   entities:
-  - uid: 65
+  - uid: 243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 246
+          - 244
 - proto: SyndicateIDCard
-  entities:
-  - uid: 324
-    components:
-    - type: Transform
-      pos: 1.57673,-2.3849022
-      parent: 325
-- proto: SyndicateShuttleConsoleCircuitboard
   entities:
   - uid: 245
     components:
     - type: Transform
-      parent: 64
+      pos: 1.57673,-2.3849022
+      parent: 1
+- proto: SyndicateShuttleConsoleCircuitboard
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      parent: 165
     - type: Physics
       canCollide: False
 - proto: Table
   entities:
-  - uid: 165
+  - uid: 246
     components:
     - type: Transform
       pos: -2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: TableWood
   entities:
-  - uid: 45
+  - uid: 247
     components:
     - type: Transform
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
 - proto: Thruster
   entities:
-  - uid: 95
+  - uid: 93
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 249
+          - 100
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 250
-          - 251
-          - 252
-          - 253
-          - 254
-          - 255
-  - uid: 96
+          - 95
+          - 96
+          - 97
+          - 98
+          - 94
+          - 99
+  - uid: 101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-9.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 256
+          - 108
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 257
-          - 258
-          - 259
-          - 260
-          - 261
-          - 262
-  - uid: 97
+          - 103
+          - 104
+          - 105
+          - 106
+          - 102
+          - 107
+  - uid: 109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 263
+          - 116
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 264
-          - 265
-          - 266
-          - 267
-          - 268
-          - 269
-  - uid: 98
+          - 111
+          - 112
+          - 113
+          - 114
+          - 110
+          - 115
+  - uid: 117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 270
+          - 124
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 271
-          - 272
-          - 273
-          - 274
-          - 275
-          - 276
-  - uid: 99
+          - 119
+          - 120
+          - 121
+          - 122
+          - 118
+          - 123
+  - uid: 125
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 277
+          - 132
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 278
-          - 279
-          - 280
-          - 281
-          - 282
-          - 283
-  - uid: 100
+          - 127
+          - 128
+          - 129
+          - 130
+          - 126
+          - 131
+  - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 284
+          - 140
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 285
-          - 286
-          - 287
-          - 288
-          - 289
-          - 290
-  - uid: 101
+          - 135
+          - 136
+          - 137
+          - 138
+          - 134
+          - 139
+  - uid: 141
     components:
     - type: Transform
       pos: -3.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 291
+          - 148
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 292
-          - 293
-          - 294
-          - 295
-          - 296
-          - 297
-  - uid: 102
+          - 143
+          - 144
+          - 145
+          - 146
+          - 142
+          - 147
+  - uid: 149
     components:
     - type: Transform
       pos: 2.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 298
+          - 156
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 299
-          - 300
-          - 301
-          - 302
-          - 303
-          - 304
+          - 151
+          - 152
+          - 153
+          - 154
+          - 150
+          - 155
 - proto: ThrusterMachineCircuitboard
   entities:
-  - uid: 249
+  - uid: 100
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 256
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 263
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 270
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 277
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 284
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 291
+  - uid: 108
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 298
+  - uid: 116
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Physics
+      canCollide: False
+  - uid: 124
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 132
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 140
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 148
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 156
+    components:
+    - type: Transform
+      parent: 149
     - type: Physics
       canCollide: False
 - proto: ToolboxSyndicateFilled
   entities:
-  - uid: 177
+  - uid: 248
     components:
     - type: Transform
       pos: 1.5699697,-0.44908836
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: ToyFigurineNukie
   entities:
-  - uid: 10
+  - uid: 249
     components:
     - type: Transform
       pos: -2.3371089,-2.140279
-      parent: 325
+      parent: 1
 - proto: VendingMachineSyndieDrobe
   entities:
-  - uid: 163
+  - uid: 250
     components:
     - type: Transform
       pos: -2.5,-0.5
-      parent: 325
+      parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 7
+  - uid: 251
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 325
-  - uid: 8
+      parent: 1
+  - uid: 252
     components:
     - type: Transform
       pos: -3.5,0.5
-      parent: 325
-  - uid: 9
+      parent: 1
+  - uid: 253
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 325
-  - uid: 11
+      parent: 1
+  - uid: 254
     components:
     - type: Transform
       pos: 1.5,0.5
-      parent: 325
-  - uid: 12
+      parent: 1
+  - uid: 255
     components:
     - type: Transform
       pos: 2.5,0.5
-      parent: 325
-  - uid: 13
+      parent: 1
+  - uid: 256
     components:
     - type: Transform
       pos: -4.5,-0.5
-      parent: 325
-  - uid: 22
+      parent: 1
+  - uid: 257
     components:
     - type: Transform
       pos: 3.5,-0.5
-      parent: 325
-  - uid: 25
+      parent: 1
+  - uid: 258
     components:
     - type: Transform
       pos: 3.5,-2.5
-      parent: 325
-  - uid: 27
+      parent: 1
+  - uid: 259
     components:
     - type: Transform
       pos: -3.5,-2.5
-      parent: 325
-  - uid: 28
+      parent: 1
+  - uid: 260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
-      parent: 325
-  - uid: 29
+      parent: 1
+  - uid: 261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
-      parent: 325
-  - uid: 30
+      parent: 1
+  - uid: 262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-6.5
-      parent: 325
-  - uid: 31
+      parent: 1
+  - uid: 263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-8.5
-      parent: 325
-  - uid: 32
+      parent: 1
+  - uid: 264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-8.5
-      parent: 325
-  - uid: 33
+      parent: 1
+  - uid: 265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
-      parent: 325
-  - uid: 34
+      parent: 1
+  - uid: 266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
-      parent: 325
-  - uid: 35
+      parent: 1
+  - uid: 267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-9.5
-      parent: 325
-  - uid: 36
+      parent: 1
+  - uid: 268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-8.5
-      parent: 325
-  - uid: 37
+      parent: 1
+  - uid: 269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-9.5
-      parent: 325
-  - uid: 38
+      parent: 1
+  - uid: 270
     components:
     - type: Transform
       pos: -4.5,-2.5
-      parent: 325
-  - uid: 39
+      parent: 1
+  - uid: 271
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
-      parent: 325
-  - uid: 44
+      parent: 1
+  - uid: 272
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
-      parent: 325
-  - uid: 48
+      parent: 1
+  - uid: 273
     components:
     - type: Transform
       pos: 2.5,-7.5
-      parent: 325
-  - uid: 49
+      parent: 1
+  - uid: 274
     components:
     - type: Transform
       pos: -3.5,-7.5
-      parent: 325
-  - uid: 54
+      parent: 1
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
-      parent: 325
-  - uid: 55
+      parent: 1
+  - uid: 276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
-      parent: 325
-  - uid: 60
+      parent: 1
+  - uid: 277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-6.5
-      parent: 325
-  - uid: 61
+      parent: 1
+  - uid: 278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
-      parent: 325
-  - uid: 62
+      parent: 1
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
-      parent: 325
-  - uid: 63
+      parent: 1
+  - uid: 280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
-      parent: 325
-  - uid: 66
+      parent: 1
+  - uid: 281
     components:
     - type: Transform
       pos: 0.5,-9.5
-      parent: 325
-  - uid: 69
+      parent: 1
+  - uid: 282
     components:
     - type: Transform
       pos: -2.5,1.5
-      parent: 325
-  - uid: 73
+      parent: 1
+  - uid: 283
     components:
     - type: Transform
       pos: 1.5,1.5
-      parent: 325
-  - uid: 80
+      parent: 1
+  - uid: 284
     components:
     - type: Transform
       pos: 2.5,-2.5
-      parent: 325
-  - uid: 81
+      parent: 1
+  - uid: 285
     components:
     - type: Transform
       pos: 2.5,-0.5
-      parent: 325
-  - uid: 92
+      parent: 1
+  - uid: 286
     components:
     - type: Transform
       pos: -1.5,-9.5
-      parent: 325
-  - uid: 108
+      parent: 1
+  - uid: 287
     components:
     - type: Transform
       pos: -0.5,-9.5
-      parent: 325
+      parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 23
+  - uid: 288
     components:
     - type: Transform
       pos: -4.5,0.5
-      parent: 325
-  - uid: 43
+      parent: 1
+  - uid: 289
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
-      parent: 325
-  - uid: 68
+      parent: 1
+  - uid: 290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 325
-  - uid: 79
+      parent: 1
+  - uid: 291
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
-      parent: 325
-  - uid: 82
+      parent: 1
+  - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
-      parent: 325
-  - uid: 86
+      parent: 1
+  - uid: 293
     components:
     - type: Transform
       pos: -2.5,2.5
-      parent: 325
+      parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 325
-  - uid: 206
+  - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 346
+          - 169
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
 ...

--- a/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
@@ -374,6 +374,13 @@ entities:
           occludes: True
           ents:
           - 29
+- proto: BoxFolderRed
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -1.595145,-4.7171545
+      parent: 1
 - proto: BoxMRE
   entities:
   - uid: 30
@@ -803,7 +810,7 @@ entities:
   - uid: 167
     components:
     - type: Transform
-      pos: -1.1813428,-5.15565
+      pos: -1.23577,-5.0140295
       parent: 1
 - proto: DoorElectronics
   entities:
@@ -896,13 +903,6 @@ entities:
       parent: 1
     - type: FaxMachine
       name: Striker
-- proto: filingCabinetRandom
-  entities:
-  - uid: 173
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
 - proto: Firelock
   entities:
   - uid: 174
@@ -1425,12 +1425,24 @@ entities:
     - type: Transform
       pos: 1.60798,-0.3062118
       parent: 1
-- proto: PhoneInstrumentSyndicate
+- proto: Paper
   entities:
-  - uid: 295
+  - uid: 296
     components:
     - type: Transform
-      pos: 0.48305517,-4.170118
+      pos: -1.438895,-4.8890295
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -1.313895,-4.8421545
+      parent: 1
+- proto: PhoneInstrumentSyndicate
+  entities:
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -1.501395,-4.3577795
       parent: 1
 - proto: PinpointerNuclear
   entities:
@@ -1830,6 +1842,11 @@ entities:
       parent: 1
 - proto: TableWood
   entities:
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
   - uid: 247
     components:
     - type: Transform

--- a/Resources/Maps/_Impstation/Shuttles/ShuttleEvent/striker.yml
+++ b/Resources/Maps/_Impstation/Shuttles/ShuttleEvent/striker.yml
@@ -13,7 +13,7 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 325
+  - uid: 1
     components:
     - type: MetaData
     - type: Transform
@@ -193,38 +193,38 @@ entities:
     - type: GridPathfinding
 - proto: AirCanister
   entities:
-  - uid: 91
+  - uid: 2
     components:
     - type: Transform
       pos: -0.5,-8.5
-      parent: 325
+      parent: 1
 - proto: AirlockExternalShuttleSyndicateLocked
   entities:
-  - uid: 142
+  - uid: 3
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-1.5
-      parent: 325
+      parent: 1
 - proto: AirlockSyndicateLocked
   entities:
-  - uid: 20
+  - uid: 4
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 88
+      parent: 1
+  - uid: 5
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
+      parent: 1
 - proto: APCBasic
   entities:
-  - uid: 107
+  - uid: 6
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
+      parent: 1
     - type: PowerNetworkBattery
       loadingNetworkDemand: 15107
       currentReceiving: 15106.935
@@ -232,1454 +232,1433 @@ entities:
       supplyRampPosition: 0.064453125
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 6
+  - uid: 7
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
-      parent: 325
+      parent: 1
 - proto: Bed
   entities:
-  - uid: 76
+  - uid: 8
     components:
     - type: Transform
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: BedsheetSyndie
   entities:
-  - uid: 164
+  - uid: 9
     components:
     - type: Transform
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: BlastDoorOpen
   entities:
-  - uid: 190
+  - uid: 10
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 331
-  - uid: 191
+          - 11
+  - uid: 12
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 332
-  - uid: 192
+          - 13
+  - uid: 14
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 333
-  - uid: 193
+          - 15
+  - uid: 16
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 334
-  - uid: 196
+          - 17
+  - uid: 18
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 337
-  - uid: 198
+          - 19
+  - uid: 20
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 339
-  - uid: 199
+          - 21
+  - uid: 22
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 340
-  - uid: 200
+          - 23
+  - uid: 24
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 341
-  - uid: 201
+          - 25
+  - uid: 26
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 342
-  - uid: 202
+          - 27
+  - uid: 28
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 343
+          - 29
+- proto: BoxFolderRed
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -1.595145,-4.7171545
+      parent: 1
 - proto: BoxMRE
   entities:
-  - uid: 320
+  - uid: 30
     components:
     - type: Transform
       pos: 0.70504504,-7.29326
-      parent: 325
+      parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 120
+  - uid: 31
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
-  - uid: 121
+      parent: 1
+  - uid: 32
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 122
+      parent: 1
+  - uid: 33
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 123
+      parent: 1
+  - uid: 34
     components:
     - type: Transform
       pos: -0.5,-8.5
-      parent: 325
-  - uid: 124
+      parent: 1
+  - uid: 35
     components:
     - type: Transform
       pos: -1.5,-8.5
-      parent: 325
-  - uid: 125
+      parent: 1
+  - uid: 36
     components:
     - type: Transform
       pos: 0.5,-8.5
-      parent: 325
-  - uid: 126
+      parent: 1
+  - uid: 37
     components:
     - type: Transform
       pos: 1.5,-8.5
-      parent: 325
-  - uid: 127
+      parent: 1
+  - uid: 38
     components:
     - type: Transform
       pos: -2.5,-8.5
-      parent: 325
-  - uid: 128
+      parent: 1
+  - uid: 39
     components:
     - type: Transform
       pos: -3.5,-8.5
-      parent: 325
-  - uid: 129
+      parent: 1
+  - uid: 40
     components:
     - type: Transform
       pos: -3.5,-7.5
-      parent: 325
-  - uid: 130
+      parent: 1
+  - uid: 41
     components:
     - type: Transform
       pos: 2.5,-8.5
-      parent: 325
-  - uid: 131
+      parent: 1
+  - uid: 42
     components:
     - type: Transform
       pos: 2.5,-7.5
-      parent: 325
-  - uid: 132
+      parent: 1
+  - uid: 43
     components:
     - type: Transform
       pos: -0.5,-5.5
-      parent: 325
-  - uid: 133
+      parent: 1
+  - uid: 44
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 134
+      parent: 1
+  - uid: 45
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 135
+      parent: 1
+  - uid: 46
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 325
-  - uid: 136
+      parent: 1
+  - uid: 47
     components:
     - type: Transform
       pos: -0.5,-1.5
-      parent: 325
-  - uid: 137
+      parent: 1
+  - uid: 48
     components:
     - type: Transform
       pos: -0.5,-0.5
-      parent: 325
-  - uid: 138
+      parent: 1
+  - uid: 49
     components:
     - type: Transform
       pos: -0.5,0.5
-      parent: 325
-  - uid: 139
+      parent: 1
+  - uid: 50
     components:
     - type: Transform
       pos: -0.5,1.5
-      parent: 325
-  - uid: 140
+      parent: 1
+  - uid: 51
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 141
+      parent: 1
+  - uid: 52
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 143
+      parent: 1
+  - uid: 53
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 145
+      parent: 1
+  - uid: 54
     components:
     - type: Transform
       pos: -1.5,-1.5
-      parent: 325
-  - uid: 146
+      parent: 1
+  - uid: 55
     components:
     - type: Transform
       pos: -2.5,-1.5
-      parent: 325
-  - uid: 147
+      parent: 1
+  - uid: 56
     components:
     - type: Transform
       pos: -3.5,-1.5
-      parent: 325
-  - uid: 148
+      parent: 1
+  - uid: 57
     components:
     - type: Transform
       pos: -4.5,-1.5
-      parent: 325
-  - uid: 149
+      parent: 1
+  - uid: 58
     components:
     - type: Transform
       pos: 0.5,-1.5
-      parent: 325
-  - uid: 150
+      parent: 1
+  - uid: 59
     components:
     - type: Transform
       pos: 1.5,-1.5
-      parent: 325
-  - uid: 151
+      parent: 1
+  - uid: 60
     components:
     - type: Transform
       pos: 2.5,-1.5
-      parent: 325
-  - uid: 152
+      parent: 1
+  - uid: 61
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 153
+      parent: 1
+  - uid: 62
     components:
     - type: Transform
       pos: 0.5,-4.5
-      parent: 325
-  - uid: 154
+      parent: 1
+  - uid: 63
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
-  - uid: 155
+      parent: 1
+  - uid: 64
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 156
+      parent: 1
+  - uid: 65
     components:
     - type: Transform
       pos: -1.5,-4.5
-      parent: 325
-  - uid: 157
+      parent: 1
+  - uid: 66
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 158
+      parent: 1
+  - uid: 67
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
 - proto: CableHV
   entities:
-  - uid: 111
+  - uid: 68
     components:
     - type: Transform
       pos: 1.5,-7.5
-      parent: 325
-  - uid: 112
+      parent: 1
+  - uid: 69
     components:
     - type: Transform
       pos: 0.5,-7.5
-      parent: 325
-  - uid: 113
+      parent: 1
+  - uid: 70
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 114
+      parent: 1
+  - uid: 71
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
-  - uid: 115
+      parent: 1
+  - uid: 72
     components:
     - type: Transform
       pos: -2.5,-7.5
-      parent: 325
-  - uid: 116
+      parent: 1
+  - uid: 73
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
+      parent: 1
 - proto: CableHVStack1
   entities:
-  - uid: 235
+  - uid: 75
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Stack
       count: 10
     - type: Physics
       canCollide: False
-  - uid: 239
+  - uid: 80
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Stack
       count: 10
     - type: Physics
       canCollide: False
 - proto: CableMV
   entities:
-  - uid: 117
+  - uid: 84
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
-  - uid: 118
+      parent: 1
+  - uid: 85
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 119
+      parent: 1
+  - uid: 86
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
+      parent: 1
 - proto: CapacitorStockPart
   entities:
-  - uid: 233
+  - uid: 76
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Physics
       canCollide: False
-  - uid: 234
+  - uid: 77
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Physics
       canCollide: False
-  - uid: 237
+  - uid: 81
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Physics
       canCollide: False
-  - uid: 238
+  - uid: 82
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Physics
       canCollide: False
-  - uid: 241
+  - uid: 88
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
-  - uid: 242
+  - uid: 89
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
-  - uid: 243
+  - uid: 90
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
-  - uid: 254
+  - uid: 94
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 261
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 268
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 275
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 282
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 289
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 296
+  - uid: 102
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 303
+  - uid: 110
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Physics
+      canCollide: False
+  - uid: 118
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 126
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 134
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 142
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 150
+    components:
+    - type: Transform
+      parent: 149
     - type: Physics
       canCollide: False
 - proto: Carpet
   entities:
-  - uid: 74
+  - uid: 157
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 89
+      parent: 1
+  - uid: 158
     components:
     - type: Transform
       pos: -0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: Catwalk
   entities:
   - uid: 159
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
   - uid: 160
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
+      parent: 1
   - uid: 161
     components:
     - type: Transform
       pos: 0.5,-7.5
-      parent: 325
+      parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 93
+  - uid: 162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
-      parent: 325
+      parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 78
+  - uid: 163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
-      parent: 325
+      parent: 1
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 40
+  - uid: 164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 325
+      parent: 1
 - proto: ComputerShuttleSyndie
   entities:
-  - uid: 64
+  - uid: 165
     components:
     - type: Transform
       pos: -0.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 245
+          - 166
         disk_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CyberPen
   entities:
-  - uid: 77
+  - uid: 167
     components:
     - type: Transform
-      pos: -1.1813428,-5.15565
-      parent: 325
+      pos: -1.23577,-5.0140295
+      parent: 1
 - proto: DoorElectronics
   entities:
-  - uid: 331
+  - uid: 11
     components:
     - type: Transform
-      parent: 190
+      parent: 10
     - type: Physics
       canCollide: False
-  - uid: 332
+  - uid: 13
     components:
     - type: Transform
-      parent: 191
+      parent: 12
     - type: Physics
       canCollide: False
-  - uid: 333
+  - uid: 15
     components:
     - type: Transform
-      parent: 192
+      parent: 14
     - type: Physics
       canCollide: False
-  - uid: 334
+  - uid: 17
     components:
     - type: Transform
-      parent: 193
+      parent: 16
     - type: Physics
       canCollide: False
-  - uid: 337
+  - uid: 19
     components:
     - type: Transform
-      parent: 196
+      parent: 18
     - type: Physics
       canCollide: False
-  - uid: 339
+  - uid: 21
     components:
     - type: Transform
-      parent: 198
+      parent: 20
     - type: Physics
       canCollide: False
-  - uid: 340
+  - uid: 23
     components:
     - type: Transform
-      parent: 199
+      parent: 22
     - type: Physics
       canCollide: False
-  - uid: 341
+  - uid: 25
     components:
     - type: Transform
-      parent: 200
+      parent: 24
     - type: Physics
       canCollide: False
-  - uid: 342
+  - uid: 27
     components:
     - type: Transform
-      parent: 201
+      parent: 26
     - type: Physics
       canCollide: False
-  - uid: 343
+  - uid: 29
     components:
     - type: Transform
-      parent: 202
+      parent: 28
     - type: Physics
       canCollide: False
-  - uid: 346
+  - uid: 169
     components:
     - type: Transform
-      parent: 206
+      parent: 168
     - type: Physics
       canCollide: False
 - proto: DresserFilled
   entities:
-  - uid: 85
+  - uid: 170
     components:
     - type: Transform
       pos: 0.5,-4.5
-      parent: 325
+      parent: 1
 - proto: DrinkNukieCan
   entities:
-  - uid: 144
+  - uid: 171
     components:
     - type: Transform
       pos: -2.6964839,-2.109029
-      parent: 325
+      parent: 1
 - proto: FaxMachineSyndie
   entities:
-  - uid: 46
+  - uid: 172
     components:
     - type: Transform
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
     - type: FaxMachine
       name: Striker
-- proto: filingCabinetRandom
-  entities:
-  - uid: 75
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 325
 - proto: Firelock
   entities:
-  - uid: 224
+  - uid: 174
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 350
+          - 175
     - type: DeviceNetwork
       address: 44a24659
       receiveFrequency: 1621
-  - uid: 225
+  - uid: 176
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 351
+          - 177
     - type: DeviceNetwork
       address: 6fdb75cf
       receiveFrequency: 1621
 - proto: FirelockElectronics
   entities:
-  - uid: 350
+  - uid: 175
     components:
     - type: Transform
-      parent: 224
+      parent: 174
     - type: Physics
       canCollide: False
-  - uid: 351
+  - uid: 177
     components:
     - type: Transform
-      parent: 225
+      parent: 176
     - type: Physics
       canCollide: False
 - proto: FoodBoxDonut
   entities:
-  - uid: 87
+  - uid: 178
     components:
     - type: Transform
       pos: -2.470145,-2.3953476
-      parent: 325
+      parent: 1
 - proto: GasPipeFourway
   entities:
-  - uid: 216
+  - uid: 179
     components:
     - type: Transform
       pos: -0.5,-1.5
-      parent: 325
+      parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 211
+  - uid: 180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 213
+      parent: 1
+  - uid: 181
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 214
+      parent: 1
+  - uid: 182
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 215
+      parent: 1
+  - uid: 183
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 325
-  - uid: 217
+      parent: 1
+  - uid: 184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
-      parent: 325
+      parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 210
+  - uid: 185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 212
+      parent: 1
+  - uid: 186
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: GasPort
   entities:
-  - uid: 59
+  - uid: 187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
-      parent: 325
+      parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 218
+  - uid: 188
     components:
     - type: Transform
       pos: -0.5,0.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-5f41a0ae
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 219
+  - uid: 189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-129c27d2
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 220
+  - uid: 190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-1.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-11c4609d
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 221
+  - uid: 191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-6859729f
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 222
+  - uid: 192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-19d24c7f
       transmitFrequency: 1621
       receiveFrequency: 1621
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 41
+  - uid: 74
     components:
     - type: Transform
       pos: -2.5,-7.5
-      parent: 325
+      parent: 1
     - type: PowerSupplier
       supplyRampPosition: 7552.5303
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           ents:
-          - 232
+          - 78
         machine_parts: !type:Container
           ents:
-          - 233
-          - 234
-          - 235
-  - uid: 56
+          - 76
+          - 77
+          - 75
+  - uid: 79
     components:
     - type: Transform
       pos: 1.5,-7.5
-      parent: 325
+      parent: 1
     - type: PowerSupplier
       supplyRampPosition: 7552.5303
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           ents:
-          - 236
+          - 83
         machine_parts: !type:Container
           ents:
-          - 237
-          - 238
-          - 239
+          - 81
+          - 82
+          - 80
 - proto: GravityGeneratorMini
   entities:
-  - uid: 57
+  - uid: 193
     components:
     - type: Transform
       pos: -1.5,-8.5
-      parent: 325
+      parent: 1
 - proto: Grille
   entities:
-  - uid: 1
+  - uid: 194
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 2
+      parent: 1
+  - uid: 195
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
-  - uid: 3
+      parent: 1
+  - uid: 196
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 4
+      parent: 1
+  - uid: 197
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
-  - uid: 5
+      parent: 1
+  - uid: 198
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 21
+      parent: 1
+  - uid: 199
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 50
+      parent: 1
+  - uid: 200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-5.5
-      parent: 325
-  - uid: 51
+      parent: 1
+  - uid: 201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 52
+      parent: 1
+  - uid: 202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 53
+      parent: 1
+  - uid: 203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
-      parent: 325
+      parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 58
+  - uid: 87
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-8.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 240
+          - 91
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 241
-          - 242
-          - 243
-          - 244
+          - 88
+          - 89
+          - 90
+          - 92
 - proto: GyroscopeMachineCircuitboard
   entities:
-  - uid: 240
+  - uid: 91
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Physics
       canCollide: False
 - proto: MedkitCombatFilled
   entities:
-  - uid: 19
+  - uid: 204
     components:
     - type: Transform
       pos: 1.48298,-0.3211529
-      parent: 325
+      parent: 1
 - proto: MicroManipulatorStockPart
   entities:
-  - uid: 250
+  - uid: 95
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 251
+  - uid: 96
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 252
+  - uid: 97
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 253
+  - uid: 98
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 257
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 258
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 259
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 260
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 264
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 265
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 266
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 267
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 271
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 272
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 273
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 274
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 278
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 279
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 280
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 281
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 285
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 286
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 287
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 288
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 292
+  - uid: 103
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 293
+  - uid: 104
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 294
+  - uid: 105
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 295
+  - uid: 106
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 299
+  - uid: 111
     components:
     - type: Transform
-      parent: 102
+      parent: 109
     - type: Physics
       canCollide: False
-  - uid: 300
+  - uid: 112
     components:
     - type: Transform
-      parent: 102
+      parent: 109
     - type: Physics
       canCollide: False
-  - uid: 301
+  - uid: 113
     components:
     - type: Transform
-      parent: 102
+      parent: 109
     - type: Physics
       canCollide: False
-  - uid: 302
+  - uid: 114
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Physics
+      canCollide: False
+  - uid: 119
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 120
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 121
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 122
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 127
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 128
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 129
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 130
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 135
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 136
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 137
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 138
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 143
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 144
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 145
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 146
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 151
+    components:
+    - type: Transform
+      parent: 149
+    - type: Physics
+      canCollide: False
+  - uid: 152
+    components:
+    - type: Transform
+      parent: 149
+    - type: Physics
+      canCollide: False
+  - uid: 153
+    components:
+    - type: Transform
+      parent: 149
+    - type: Physics
+      canCollide: False
+  - uid: 154
+    components:
+    - type: Transform
+      parent: 149
     - type: Physics
       canCollide: False
 - proto: Mirror
   entities:
-  - uid: 321
+  - uid: 205
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
-      parent: 325
+      parent: 1
 - proto: NitrogenTankFilled
   entities:
-  - uid: 105
+  - uid: 206
     components:
     - type: Transform
       pos: 1.373605,-0.2749618
-      parent: 325
+      parent: 1
 - proto: NukeCodePaper
   entities:
-  - uid: 323
+  - uid: 207
     components:
     - type: Transform
       pos: 1.561105,-2.5567772
-      parent: 325
+      parent: 1
 - proto: OxygenTankFilled
   entities:
-  - uid: 167
+  - uid: 208
     components:
     - type: Transform
       pos: 1.60798,-0.3062118
-      parent: 325
+      parent: 1
+- proto: Paper
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -1.438895,-4.8890295
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -1.313895,-4.8421545
+      parent: 1
+- proto: PhoneInstrumentSyndicate
+  entities:
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -1.501395,-4.3577795
+      parent: 1
 - proto: PinpointerNuclear
   entities:
-  - uid: 162
+  - uid: 209
     components:
     - type: Transform
       pos: 1.3790641,-2.3161128
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 104
+  - uid: 210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
-      parent: 325
-  - uid: 109
+      parent: 1
+  - uid: 211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-0.5
-      parent: 325
+      parent: 1
 - proto: PlushieNuke
   entities:
-  - uid: 47
+  - uid: 212
     components:
     - type: Transform
       pos: 0.5061571,-5.233775
-      parent: 325
+      parent: 1
 - proto: PortableGeneratorSuperPacmanMachineCircuitboard
   entities:
-  - uid: 232
+  - uid: 78
     components:
     - type: Transform
-      parent: 41
+      parent: 74
     - type: Physics
       canCollide: False
-  - uid: 236
+  - uid: 83
     components:
     - type: Transform
-      parent: 56
+      parent: 79
     - type: Physics
       canCollide: False
 - proto: PosterContrabandC20r
   entities:
-  - uid: 24
+  - uid: 213
     components:
     - type: Transform
       pos: 2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: PosterContrabandEnergySwords
   entities:
-  - uid: 227
+  - uid: 214
     components:
     - type: Transform
       pos: -2.5,-6.5
-      parent: 325
+      parent: 1
 - proto: PosterContrabandNuclearDeviceInformational
   entities:
-  - uid: 228
+  - uid: 215
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 325
+      parent: 1
 - proto: PosterContrabandSyndicateRecruitment
   entities:
-  - uid: 229
+  - uid: 216
     components:
     - type: Transform
       pos: 0.5,-3.5
-      parent: 325
+      parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 94
+  - uid: 217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 325
-  - uid: 110
+      parent: 1
+  - uid: 218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 182
+  - uid: 219
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 183
+  - uid: 220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 184
+  - uid: 221
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: PoweredSmallLight
   entities:
-  - uid: 204
+  - uid: 222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: Rack
   entities:
-  - uid: 83
+  - uid: 223
     components:
     - type: Transform
       pos: 1.5,-0.5
-      parent: 325
-  - uid: 84
+      parent: 1
+  - uid: 224
     components:
     - type: Transform
       pos: 1.5,-2.5
-      parent: 325
+      parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 14
+  - uid: 225
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 15
+      parent: 1
+  - uid: 226
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
-  - uid: 16
+      parent: 1
+  - uid: 227
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 17
+      parent: 1
+  - uid: 228
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
-  - uid: 18
+      parent: 1
+  - uid: 229
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 26
+      parent: 1
+  - uid: 230
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 42
+      parent: 1
+  - uid: 231
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
-  - uid: 70
+      parent: 1
+  - uid: 232
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 71
+      parent: 1
+  - uid: 233
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 72
+      parent: 1
+  - uid: 234
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
 - proto: RemoteSignaller
   entities:
-  - uid: 176
+  - uid: 235
     components:
     - type: Transform
       pos: 1.3427892,-2.379079
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: SheetGlass1
   entities:
-  - uid: 244
+  - uid: 92
     components:
     - type: Transform
-      parent: 58
+      parent: 87
     - type: Stack
       count: 2
     - type: Physics
       canCollide: False
 - proto: SheetSteel1
   entities:
-  - uid: 255
+  - uid: 99
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 262
-    components:
-    - type: Transform
-      parent: 96
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 269
-    components:
-    - type: Transform
-      parent: 97
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 276
-    components:
-    - type: Transform
-      parent: 98
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 283
-    components:
-    - type: Transform
-      parent: 99
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 290
-    components:
-    - type: Transform
-      parent: 100
-    - type: Stack
-      count: 5
-    - type: Physics
-      canCollide: False
-  - uid: 297
+  - uid: 107
     components:
     - type: Transform
       parent: 101
@@ -1687,83 +1666,123 @@ entities:
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 304
+  - uid: 115
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 123
+    components:
+    - type: Transform
+      parent: 117
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 131
+    components:
+    - type: Transform
+      parent: 125
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 139
+    components:
+    - type: Transform
+      parent: 133
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 147
+    components:
+    - type: Transform
+      parent: 141
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 155
+    components:
+    - type: Transform
+      parent: 149
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
 - proto: SignalButton
   entities:
-  - uid: 205
+  - uid: 236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
-      parent: 325
+      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        193:
+        16:
         - Pressed: Toggle
-        192:
+        14:
         - Pressed: Toggle
-        190:
+        10:
         - Pressed: Toggle
-        191:
+        12:
         - Pressed: Toggle
-        196:
+        18:
         - Pressed: Toggle
-        202:
+        28:
         - Pressed: Toggle
-        201:
+        26:
         - Pressed: Toggle
-        200:
+        24:
         - Pressed: Toggle
-        199:
+        22:
         - Pressed: Toggle
-        198:
+        20:
         - Pressed: Toggle
 - proto: SignSpace
   entities:
-  - uid: 230
+  - uid: 237
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 325
+      parent: 1
 - proto: SoapSyndie
   entities:
-  - uid: 90
+  - uid: 238
     components:
     - type: Transform
       pos: 0.5436061,-7.5129323
-      parent: 325
+      parent: 1
 - proto: SpawnPointNukies
   entities:
-  - uid: 322
+  - uid: 239
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
+      parent: 1
 - proto: StealthBox
   entities:
-  - uid: 106
+  - uid: 240
     components:
     - type: Transform
       pos: 0.49860507,-2.4513345
-      parent: 325
+      parent: 1
     - type: Stealth
       enabled: False
     - type: EntityStorage
       open: True
 - proto: SubstationWallBasic
   entities:
-  - uid: 103
+  - uid: 241
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
+      parent: 1
     - type: PowerNetworkBattery
       loadingNetworkDemand: 15106.935
       currentReceiving: 15105.06
@@ -1771,580 +1790,585 @@ entities:
       supplyRampPosition: 1.875
 - proto: SuitStorageSyndie
   entities:
-  - uid: 67
+  - uid: 242
     components:
     - type: Transform
       pos: 2.5,-1.5
-      parent: 325
+      parent: 1
 - proto: SyndicateCommsComputerCircuitboard
   entities:
-  - uid: 246
+  - uid: 244
     components:
     - type: Transform
-      parent: 65
+      parent: 243
     - type: Physics
       canCollide: False
 - proto: SyndicateComputerComms
   entities:
-  - uid: 65
+  - uid: 243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 246
+          - 244
 - proto: SyndicateIDCard
-  entities:
-  - uid: 324
-    components:
-    - type: Transform
-      pos: 1.57673,-2.3849022
-      parent: 325
-- proto: SyndicateShuttleConsoleCircuitboard
   entities:
   - uid: 245
     components:
     - type: Transform
-      parent: 64
+      pos: 1.57673,-2.3849022
+      parent: 1
+- proto: SyndicateShuttleConsoleCircuitboard
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      parent: 165
     - type: Physics
       canCollide: False
 - proto: Table
   entities:
-  - uid: 165
+  - uid: 246
     components:
     - type: Transform
       pos: -2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: TableWood
   entities:
-  - uid: 45
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 247
     components:
     - type: Transform
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
 - proto: Thruster
   entities:
-  - uid: 95
+  - uid: 93
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 249
+          - 100
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 250
-          - 251
-          - 252
-          - 253
-          - 254
-          - 255
-  - uid: 96
+          - 95
+          - 96
+          - 97
+          - 98
+          - 94
+          - 99
+  - uid: 101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-9.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 256
+          - 108
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 257
-          - 258
-          - 259
-          - 260
-          - 261
-          - 262
-  - uid: 97
+          - 103
+          - 104
+          - 105
+          - 106
+          - 102
+          - 107
+  - uid: 109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 263
+          - 116
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 264
-          - 265
-          - 266
-          - 267
-          - 268
-          - 269
-  - uid: 98
+          - 111
+          - 112
+          - 113
+          - 114
+          - 110
+          - 115
+  - uid: 117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 270
+          - 124
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 271
-          - 272
-          - 273
-          - 274
-          - 275
-          - 276
-  - uid: 99
+          - 119
+          - 120
+          - 121
+          - 122
+          - 118
+          - 123
+  - uid: 125
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 277
+          - 132
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 278
-          - 279
-          - 280
-          - 281
-          - 282
-          - 283
-  - uid: 100
+          - 127
+          - 128
+          - 129
+          - 130
+          - 126
+          - 131
+  - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 284
+          - 140
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 285
-          - 286
-          - 287
-          - 288
-          - 289
-          - 290
-  - uid: 101
+          - 135
+          - 136
+          - 137
+          - 138
+          - 134
+          - 139
+  - uid: 141
     components:
     - type: Transform
       pos: -3.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 291
+          - 148
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 292
-          - 293
-          - 294
-          - 295
-          - 296
-          - 297
-  - uid: 102
+          - 143
+          - 144
+          - 145
+          - 146
+          - 142
+          - 147
+  - uid: 149
     components:
     - type: Transform
       pos: 2.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 298
+          - 156
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 299
-          - 300
-          - 301
-          - 302
-          - 303
-          - 304
+          - 151
+          - 152
+          - 153
+          - 154
+          - 150
+          - 155
 - proto: ThrusterMachineCircuitboard
   entities:
-  - uid: 249
+  - uid: 100
     components:
     - type: Transform
-      parent: 95
+      parent: 93
     - type: Physics
       canCollide: False
-  - uid: 256
-    components:
-    - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 263
-    components:
-    - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 270
-    components:
-    - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 277
-    components:
-    - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 284
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 291
+  - uid: 108
     components:
     - type: Transform
       parent: 101
     - type: Physics
       canCollide: False
-  - uid: 298
+  - uid: 116
     components:
     - type: Transform
-      parent: 102
+      parent: 109
+    - type: Physics
+      canCollide: False
+  - uid: 124
+    components:
+    - type: Transform
+      parent: 117
+    - type: Physics
+      canCollide: False
+  - uid: 132
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+  - uid: 140
+    components:
+    - type: Transform
+      parent: 133
+    - type: Physics
+      canCollide: False
+  - uid: 148
+    components:
+    - type: Transform
+      parent: 141
+    - type: Physics
+      canCollide: False
+  - uid: 156
+    components:
+    - type: Transform
+      parent: 149
     - type: Physics
       canCollide: False
 - proto: ToolboxSyndicateFilled
   entities:
-  - uid: 177
+  - uid: 248
     components:
     - type: Transform
       pos: 1.5699697,-0.44908836
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: ToyFigurineNukie
   entities:
-  - uid: 10
+  - uid: 249
     components:
     - type: Transform
       pos: -2.3371089,-2.140279
-      parent: 325
+      parent: 1
 - proto: VendingMachineSyndieDrobe
   entities:
-  - uid: 163
+  - uid: 250
     components:
     - type: Transform
       pos: -2.5,-0.5
-      parent: 325
+      parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 7
+  - uid: 251
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 325
-  - uid: 8
+      parent: 1
+  - uid: 252
     components:
     - type: Transform
       pos: -3.5,0.5
-      parent: 325
-  - uid: 9
+      parent: 1
+  - uid: 253
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 325
-  - uid: 11
+      parent: 1
+  - uid: 254
     components:
     - type: Transform
       pos: 1.5,0.5
-      parent: 325
-  - uid: 12
+      parent: 1
+  - uid: 255
     components:
     - type: Transform
       pos: 2.5,0.5
-      parent: 325
-  - uid: 13
+      parent: 1
+  - uid: 256
     components:
     - type: Transform
       pos: -4.5,-0.5
-      parent: 325
-  - uid: 22
+      parent: 1
+  - uid: 257
     components:
     - type: Transform
       pos: 3.5,-0.5
-      parent: 325
-  - uid: 25
+      parent: 1
+  - uid: 258
     components:
     - type: Transform
       pos: 3.5,-2.5
-      parent: 325
-  - uid: 27
+      parent: 1
+  - uid: 259
     components:
     - type: Transform
       pos: -3.5,-2.5
-      parent: 325
-  - uid: 28
+      parent: 1
+  - uid: 260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
-      parent: 325
-  - uid: 29
+      parent: 1
+  - uid: 261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
-      parent: 325
-  - uid: 30
+      parent: 1
+  - uid: 262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-6.5
-      parent: 325
-  - uid: 31
+      parent: 1
+  - uid: 263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-8.5
-      parent: 325
-  - uid: 32
+      parent: 1
+  - uid: 264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-8.5
-      parent: 325
-  - uid: 33
+      parent: 1
+  - uid: 265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
-      parent: 325
-  - uid: 34
+      parent: 1
+  - uid: 266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
-      parent: 325
-  - uid: 35
+      parent: 1
+  - uid: 267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-9.5
-      parent: 325
-  - uid: 36
+      parent: 1
+  - uid: 268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-8.5
-      parent: 325
-  - uid: 37
+      parent: 1
+  - uid: 269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-9.5
-      parent: 325
-  - uid: 38
+      parent: 1
+  - uid: 270
     components:
     - type: Transform
       pos: -4.5,-2.5
-      parent: 325
-  - uid: 39
+      parent: 1
+  - uid: 271
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
-      parent: 325
-  - uid: 44
+      parent: 1
+  - uid: 272
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
-      parent: 325
-  - uid: 48
+      parent: 1
+  - uid: 273
     components:
     - type: Transform
       pos: 2.5,-7.5
-      parent: 325
-  - uid: 49
+      parent: 1
+  - uid: 274
     components:
     - type: Transform
       pos: -3.5,-7.5
-      parent: 325
-  - uid: 54
+      parent: 1
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
-      parent: 325
-  - uid: 55
+      parent: 1
+  - uid: 276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
-      parent: 325
-  - uid: 60
+      parent: 1
+  - uid: 277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-6.5
-      parent: 325
-  - uid: 61
+      parent: 1
+  - uid: 278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
-      parent: 325
-  - uid: 62
+      parent: 1
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
-      parent: 325
-  - uid: 63
+      parent: 1
+  - uid: 280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
-      parent: 325
-  - uid: 66
+      parent: 1
+  - uid: 281
     components:
     - type: Transform
       pos: 0.5,-9.5
-      parent: 325
-  - uid: 69
+      parent: 1
+  - uid: 282
     components:
     - type: Transform
       pos: -2.5,1.5
-      parent: 325
-  - uid: 73
+      parent: 1
+  - uid: 283
     components:
     - type: Transform
       pos: 1.5,1.5
-      parent: 325
-  - uid: 80
+      parent: 1
+  - uid: 284
     components:
     - type: Transform
       pos: 2.5,-2.5
-      parent: 325
-  - uid: 81
+      parent: 1
+  - uid: 285
     components:
     - type: Transform
       pos: 2.5,-0.5
-      parent: 325
-  - uid: 92
+      parent: 1
+  - uid: 286
     components:
     - type: Transform
       pos: -1.5,-9.5
-      parent: 325
-  - uid: 108
+      parent: 1
+  - uid: 287
     components:
     - type: Transform
       pos: -0.5,-9.5
-      parent: 325
+      parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 23
+  - uid: 288
     components:
     - type: Transform
       pos: -4.5,0.5
-      parent: 325
-  - uid: 43
+      parent: 1
+  - uid: 289
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
-      parent: 325
-  - uid: 68
+      parent: 1
+  - uid: 290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 325
-  - uid: 79
+      parent: 1
+  - uid: 291
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
-      parent: 325
-  - uid: 82
+      parent: 1
+  - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
-      parent: 325
-  - uid: 86
+      parent: 1
+  - uid: 293
     components:
     - type: Transform
       pos: -2.5,2.5
-      parent: 325
+      parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 325
-  - uid: 206
+  - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 346
+          - 169
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
 ...

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -380,7 +380,7 @@
     duration: 1
   - type: RuleGrids
   - type: LoadMapRule
-    mapPath: /Maps/Shuttles/ShuttleEvent/striker.yml
+    mapPath: /Maps/_Impstation/Shuttles/ShuttleEvent/striker.yml
   - type: NukeopsRule
     roundEndBehavior: Nothing
   - type: AntagSelection


### PR DESCRIPTION
By request.

![l6jJLMO](https://github.com/user-attachments/assets/f530379e-55af-4eb4-86e3-4ad4f8148a34)

**Changelog**

:cl:
- add: Added a blood-red phone to the lone ops shuttle.