### PR TITLE
remove the cyrillic text conversion from the russian accent

### DIFF
--- a/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
@@ -13,32 +13,7 @@ public sealed class RussianAccentSystem : EntitySystem
 
     public string Accentuate(string message)
     {
-        var accentedMessage = new StringBuilder(_replacement.ApplyReplacements(message, "russian"));
-
-        for (var i = 0; i < accentedMessage.Length; i++)
-        {
-            var c = accentedMessage[i];
-
-            accentedMessage[i] = c switch
-            {
-            //    'A' => 'Д', //im not sure how to cleanly excise this from the code so im ripping it out at the roots like a caveman
-            //    'b' => 'в',
-            //    'N' => 'И',
-            //    'n' => 'и',
-            //    'K' => 'К',
-            //    'k' => 'к',
-            //    'm' => 'м',
-            //    'h' => 'н',
-            //    't' => 'т',
-            //    'R' => 'Я',
-            //    'r' => 'я',
-            //    'Y' => 'У',
-            //    'W' => 'Ш',
-            //    'w' => 'ш',
-                _ => accentedMessage[i]
-            };
-        }
-
+        var accentedMessage = _replacement.ApplyReplacements(message, "russian"); //imp change. die
         return accentedMessage.ToString();
     }
 

--- a/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
@@ -21,20 +21,20 @@ public sealed class RussianAccentSystem : EntitySystem
 
             accentedMessage[i] = c switch
             {
-                'A' => 'Д',
-                'b' => 'в',
-                'N' => 'И',
-                'n' => 'и',
-                'K' => 'К',
-                'k' => 'к',
-                'm' => 'м',
-                'h' => 'н',
-                't' => 'т',
-                'R' => 'Я',
-                'r' => 'я',
-                'Y' => 'У',
-                'W' => 'Ш',
-                'w' => 'ш',
+            //    'A' => 'Д', //im not sure how to cleanly excise this from the code so im ripping it out at the roots like a caveman
+            //    'b' => 'в',
+            //    'N' => 'И',
+            //    'n' => 'и',
+            //    'K' => 'К',
+            //    'k' => 'к',
+            //    'm' => 'м',
+            //    'h' => 'н',
+            //    't' => 'т',
+            //    'R' => 'Я',
+            //    'r' => 'я',
+            //    'Y' => 'У',
+            //    'W' => 'Ш',
+            //    'w' => 'ш',
                 _ => accentedMessage[i]
             };
         }
@@ -44,6 +44,6 @@ public sealed class RussianAccentSystem : EntitySystem
 
     private void OnAccent(EntityUid uid, RussianAccentComponent component, AccentGetEvent args)
     {
-        args.Message = Accentuate(args.Message);
+        args.Message = Accentuate(args.Message); 
     }
 }

--- a/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
@@ -19,6 +19,6 @@ public sealed class RussianAccentSystem : EntitySystem
 
     private void OnAccent(EntityUid uid, RussianAccentComponent component, AccentGetEvent args)
     {
-        args.Message = Accentuate(args.Message); 
+        args.Message = Accentuate(args.Message);
     }
 }


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
this isnt a great way to do this but it is arguably the most violent so its what I did. the russian accent is an accessibility nightmare and its insane it was ever put into the game like this at all

![image](https://github.com/user-attachments/assets/55d5ec2b-ab5c-43a9-9f01-acec97a3b621)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed the cyrillic text conversion from the russian accent.
