### PR TITLE
drones can now play music and always access a map

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -748,6 +748,12 @@
       - HighRiskItem
       components:
       - Contraband
+  - type: PAI # imp; this is added specifically for the internal station map feature but the other aspects are not especially against the identity of drones. and i dont want to put the work into ECS-ifying PAIComponent
+  - type: Instrument # imp
+    allowPercussion: false
+    handheld: false
+    bank: 1
+    program: 2
   - type: Loadout # imp special. this replaces the InnateTool component.
     prototypes:
       - StartingGearDroneTools
@@ -763,6 +769,13 @@
         type: StrippableBoundUserInterface
       enum.SiliconLawsUiKey.Key:
         type: SiliconLawBoundUserInterface
+      enum.InstrumentUiKey.Key: #imp
+        type: InstrumentBoundUserInterface
+        requireInputValidation: false
+      enum.StationMapUiKey.Key: #imp
+        type: StationMapBoundUserInterface
+        requireInputValidation: false
+  - type: StationMap #imp
   - type: GhostRole
     makeSentient: true
     name: Maintenance Drone


### PR DESCRIPTION
![SS14 Loader_MGCbx0nJJ1](https://github.com/user-attachments/assets/277eb4c0-d11d-45bc-a2d8-f2b1e59aaf1a)

okay so the Original intent of this PR was to make it so drones have a map button. which i have implemented by giving them PAI component. but because i guess ECS is just a suggestion that comes with several other traits of PAIs, namely being able to play midis and also having a chance to die if microwaved. i'm fine with drones being able to play music and because they can't be picked up by players without admin intervention they cant be microwaved. so this is messy but fine, and doing this Right would involve splitting PAIComponent into three different components which may cause issues with upstream merging later

known issues

- if a drone somehow gets microwaved it will display a locale string intended for PAIs. i didnt change this because its unlikely to come up in actual gameplay

**Changelog**
:cl:
- add: Drones can now sing a jaunty little tune and also check a map whenever they want.