### PR TITLE
Senior Bartender Suit Actually Will Be On Your Bod

### DIFF
--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/bartender.yml
@@ -22,7 +22,7 @@
   - !type:GroupLoadoutEffect
     proto: SeniorBartender
   equipment:
-    id: ClothingUniformSeniorBartender #imp
+    jumpsuit: ClothingUniformSeniorBartender #imp
 
 - type: loadout
   id: ClothingUniformSeniorBartenderSkirt
@@ -30,5 +30,5 @@
   - !type:GroupLoadoutEffect
     proto: SeniorBartender
   equipment:
-    id: ClothingUniformSeniorBartenderSkirt #imp
+    jumpsuit: ClothingUniformSeniorBartenderSkirt #imp
     


### PR DESCRIPTION
Ported over the new senior bartender suit I made and forgot to change the equipment section for em to be jumpsuit instead of ID after I copied over the senior bartender PDA info to use as a template. Just a two line edit to make it call the the right stuff into the right place. 