### PR TITLE
Adjust Xeno Playercount

### DIFF
--- a/Resources/Prototypes/Maps/xeno.yml
+++ b/Resources/Prototypes/Maps/xeno.yml
@@ -2,7 +2,7 @@
   id: Xeno
   mapName: 'Xeno'
   mapPath: /Maps/_Impstation/xeno.yml
-  minPlayers: 40
+  minPlayers: 35
   maxPlayers: 80
   stations:
     Xeno:


### PR DESCRIPTION
Doesn't need a changelog, i don't think, but lowers xenos minimum playercount in order to match train and bagel, two similar pop maps.