### PR TITLE
entropic armor is no longer a chameleon option

### DIFF
--- a/Resources/Prototypes/_Impstation/CosmicCult/Clothing/cosmiccult_armor.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Clothing/cosmiccult_armor.yml
@@ -37,7 +37,6 @@
   - type: Tag
     tags:
     - Hardsuit
-    - WhitelistChameleon
 #Shoulder mounted flashlight
   - type: ToggleableLightVisuals
     spriteLayer: light


### PR DESCRIPTION
aftrlite asked me to pr this really quick. its going to be chameleon-able when cosmic cult is out but right now its meant to be admeme only. no cl
