### PR TITLE
Hummingbird update, evil skull thief objective, make Fin-Fin steal objective check if he exists

### DIFF
--- a/Resources/Locale/en-US/_Impstation/objectives/conditions/steal-target-groups.ftl
+++ b/Resources/Locale/en-US/_Impstation/objectives/conditions/steal-target-groups.ftl
@@ -15,6 +15,7 @@ steal-target-groups-shipyardcomputercircuitboard = shipyard computer board
 steal-target-groups-commscomputercircuitboard = communications computer board
 
 steal-target-groups-secpillcanister = head of security's pill canister
+steal-target-groups-evil-skull = evil skull
 
 # Thief Animal
 

--- a/Resources/Locale/en-US/_Impstation/objectives/conditions/steal.ftl
+++ b/Resources/Locale/en-US/_Impstation/objectives/conditions/steal.ftl
@@ -1,6 +1,6 @@
 # this is so scuffed im so fucking sorry
 objective-condition-thief-generator-description = If the station needed this generator, they should have used it! Now it'll be mine...!
 objective-condition-thief-cigarettes = THUI TEK NEW PORTS
-objective-condition-thief-evil-skull-description = From what I hear, the chaplain keeps it in chapel morgue... It's as good as mine!
+objective-condition-thief-evil-skull-description = From what I hear, the chaplain keeps it the in chapel morgue... It's as good as mine!
 
 objective-condition-thief-multiply-structure-description = I need to get {$count} parts of the {$itemName} and take them with me.

--- a/Resources/Locale/en-US/_Impstation/objectives/conditions/steal.ftl
+++ b/Resources/Locale/en-US/_Impstation/objectives/conditions/steal.ftl
@@ -1,6 +1,6 @@
 # this is so scuffed im so fucking sorry
 objective-condition-thief-generator-description = If the station needed this generator, they should have used it! Now it'll be mine...!
 objective-condition-thief-cigarettes = THUI TEK NEW PORTS
-objective-condition-thief-evil-skull-description = From what I hear, the chaplain keeps it the in chapel morgue... It's as good as mine!
+objective-condition-thief-evil-skull-description = From what I hear, the chaplain keeps it in the chapel morgue... It's as good as mine!
 
 objective-condition-thief-multiply-structure-description = I need to get {$count} parts of the {$itemName} and take them with me.

--- a/Resources/Locale/en-US/_Impstation/objectives/conditions/steal.ftl
+++ b/Resources/Locale/en-US/_Impstation/objectives/conditions/steal.ftl
@@ -1,5 +1,6 @@
 # this is so scuffed im so fucking sorry
 objective-condition-thief-generator-description = If the station needed this generator, they should have used it! Now it'll be mine...!
 objective-condition-thief-cigarettes = THUI TEK NEW PORTS
+objective-condition-thief-evil-skull-description = From what I hear, the chaplain keeps it in chapel morgue... It's as good as mine!
 
 objective-condition-thief-multiply-structure-description = I need to get {$count} parts of the {$itemName} and take them with me.

--- a/Resources/Maps/_Impstation/hummingbird.yml
+++ b/Resources/Maps/_Impstation/hummingbird.yml
@@ -3258,6 +3258,9 @@ entities:
             3718: 67,0
             4259: 67,1
             4789: 111,-16
+            5203: 85,-47
+            5204: 85,-48
+            5205: 85,-49
         - node:
             color: '#F00000FF'
             id: WarnLineW
@@ -60377,7 +60380,6 @@ entities:
   - uid: 9854
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 86.5,-31.5
       parent: 2
   - uid: 9855
@@ -130961,15 +130963,45 @@ entities:
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
+  - uid: 16641
+    components:
+    - type: Transform
+      pos: 44.5,-57.5
+      parent: 2
   - uid: 19912
     components:
     - type: Transform
-      pos: 87.5,-31.5
+      pos: 44.5,-59.5
       parent: 2
-  - uid: 19913
+  - uid: 24117
     components:
     - type: Transform
-      pos: 86.5,-31.5
+      pos: 44.5,-53.5
+      parent: 2
+  - uid: 24309
+    components:
+    - type: Transform
+      pos: 60.5,-56.5
+      parent: 2
+  - uid: 24310
+    components:
+    - type: Transform
+      pos: 60.5,-54.5
+      parent: 2
+  - uid: 24311
+    components:
+    - type: Transform
+      pos: 60.5,-51.5
+      parent: 2
+  - uid: 24312
+    components:
+    - type: Transform
+      pos: 60.5,-59.5
+      parent: 2
+  - uid: 24313
+    components:
+    - type: Transform
+      pos: 44.5,-51.5
       parent: 2
 - proto: SpawnPointLawyer
   entities:
@@ -155124,6 +155156,12 @@ entities:
       parent: 2
 - proto: WindoorSecureCommandLocked
   entities:
+  - uid: 19913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 85.5,-46.5
+      parent: 2
   - uid: 24107
     components:
     - type: Transform
@@ -155192,12 +155230,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 25.5,-6.5
       parent: 2
-  - uid: 24117
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 85.5,-46.5
-      parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
   - uid: 24118
@@ -155222,7 +155254,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -159504.58
+      secondsUntilStateChange: -159708.83
       state: Opening
     - type: Airlock
       autoClose: False

--- a/Resources/Maps/_Impstation/hummingbird.yml
+++ b/Resources/Maps/_Impstation/hummingbird.yml
@@ -5331,7 +5331,8 @@ entities:
           22,11:
             1: 62207
           22,12:
-            1: 61695
+            1: 61693
+            9: 2
           23,9:
             1: 4368
             8: 52416
@@ -6304,6 +6305,21 @@ entities:
           moles:
           - 0
           - 103.92799
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.823984
+          - 82.09976
           - 0
           - 0
           - 0
@@ -58985,43 +59001,67 @@ entities:
   - uid: 9639
     components:
     - type: Transform
+      anchored: False
       pos: 11.5,8.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
   - uid: 9640
     components:
     - type: Transform
+      anchored: False
       pos: 13.5,8.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
   - uid: 9641
     components:
     - type: Transform
+      anchored: False
       pos: 14.5,8.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
   - uid: 9642
     components:
     - type: Transform
+      anchored: False
       pos: 9.5,9.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
   - uid: 9643
     components:
     - type: Transform
+      anchored: False
       pos: 8.5,9.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
   - uid: 9644
     components:
     - type: Transform
+      anchored: False
       pos: 8.5,8.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
   - uid: 9645
     components:
     - type: Transform
+      anchored: False
       pos: 9.5,8.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
   - uid: 9646
     components:
     - type: Transform
+      anchored: False
       pos: 12.5,8.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
 - proto: ContrabassInstrument
   entities:
   - uid: 9647
@@ -67817,6 +67857,15 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: EvilSkullArtifactItem
+  entities:
+  - uid: 16489
+    components:
+    - type: Transform
+      parent: 16488
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: ExosuitFabricator
   entities:
   - uid: 11066
@@ -75469,23 +75518,6 @@ entities:
     components:
     - type: Transform
       pos: 104.528625,49.596867
-      parent: 2
-- proto: FlippoEngravedLighter
-  entities:
-  - uid: 11775
-    components:
-    - type: Transform
-      pos: 108.304375,-19.19907
-      parent: 2
-  - uid: 11776
-    components:
-    - type: Transform
-      pos: 128.58989,-18.799398
-      parent: 2
-  - uid: 11777
-    components:
-    - type: Transform
-      pos: 143.19699,3.705914
       parent: 2
 - proto: FlippoLighter
   entities:
@@ -110148,35 +110180,6 @@ entities:
     - type: Transform
       pos: 6.5989666,-6.4250817
       parent: 2
-- proto: HeadSkeleton
-  entities:
-  - uid: 16489
-    components:
-    - type: MetaData
-      desc: Beware.
-      name: evil skull
-    - type: Transform
-      parent: 16488
-    - type: Physics
-      canCollide: False
-    - type: WarpPoint
-      location: Evil Skull
-    - type: PointLight
-      energy: 5
-      color: '#FF0000FF'
-      radius: 1.3
-    - type: Artifact
-      activationSound: !type:SoundPathSpecifier
-        params:
-          variation: 0.1
-          volume: 3
-        path: /Audio/Voice/Skeleton/skeleton_scream.ogg
-      nodesMax: 13
-      nodesMin: 5
-      nodeTree: []
-    - type: InsideEntityStorage
-    missingComponents:
-    - Gibbable
 - proto: HeatExchanger
   entities:
   - uid: 16490
@@ -113468,8 +113471,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8968438
-        - 7.1357465
+        - 1.8977377
+        - 7.139109
         - 0
         - 0
         - 0
@@ -128759,8 +128762,11 @@ entities:
   - uid: 19523
     components:
     - type: Transform
+      anchored: False
       pos: 14.5,6.5
       parent: 2
+    - type: Physics
+      bodyType: Dynamic
 - proto: Sink
   entities:
   - uid: 19524
@@ -155254,7 +155260,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -159708.83
+      secondsUntilStateChange: -160127.22
       state: Opening
     - type: Airlock
       autoClose: False

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -103,6 +103,7 @@
     ShiningSpringStealObjective: 1
     ShipyardComputerCircuitboardStealObjective: 1
     SecPillCanisterStealObjective: 1
+    EvilSkullArtifactItemStealObjective: 1
 
 - type: weightedRandom
   id: ThiefObjectiveGroupStructure

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -1,0 +1,69 @@
+﻿#this is copied from the BaseXenoArtifactItem prototyped instead of parenting because I needed to remove the random sprites and using RemoveComp sounds scary
+- type: entity
+  parent: BaseItem
+  id: EvilSkullArtifactItem
+  name: evil skull
+  suffix: Hummingbird thief objective
+  description: Beware.
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Skeleton/parts.rsi
+    state: skull_icon
+  - type: Damageable
+  - type: Physics
+    bodyType: Dynamic
+  - type: CollisionWake
+    enabled: false
+  - type: InteractionOutline
+  - type: Reactive
+    groups:
+      Acidic: [Touch]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemMask
+        layer:
+        - Opaque
+        restitution: 0.3  # fite me
+        friction: 0.2
+  - type: Artifact
+    activationSound: !type:SoundPathSpecifier
+      params:
+        variation: 0.125
+      path: /Audio/Voice/Skeleton/skeleton_scream.ogg
+    nodesMax: 13
+    nodesMin: 5
+  - type: UserInterface #needs to be here for certain effects
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.TransferAmountUiKey.Key:
+        type: TransferAmountBoundUserInterface
+      enum.InstrumentUiKey.Key:
+        type: InstrumentBoundUserInterface
+      enum.IntercomUiKey.Key:
+        type: IntercomBoundUserInterface
+  - type: Appearance
+  - type: Item
+    size: Normal
+  - type: Actions
+  - type: Speech
+    speechSounds: Alto
+    speechVerb: Skeleton
+  - type: SkeletonAccent
+  - type: Vocal
+    sounds:
+      Male: Skeleton
+      Female: Skeleton
+      Unsexed: Skeleton
+  - type: PointLight
+    energy: 5
+    color: '#FF0000FF'
+    radius: 1.3
+  - type: StealTarget
+    stealGroup: EvilSkullArtifactItem

--- a/Resources/Prototypes/_Impstation/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/stealTargetGroups.yml
@@ -270,3 +270,10 @@
   sprite:
     sprite: _Impstation/Objects/Specific/Chemistry/pills_canister.rsi
     state: pill_canister-hos
+    
+- type: stealTargetGroup
+  id: EvilSkullArtifactItem
+  name: steal-target-groups-evil-skull
+  sprite:
+    sprite: Mobs/Species/Skeleton/parts.rsi
+    state: skull_icon

--- a/Resources/Prototypes/_Impstation/Objectives/thief.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/thief.yml
@@ -3,6 +3,7 @@
   id: FinFinStealObjective
   components:
   - type: StealCondition
+    verifyMapExistence: true
     stealGroup: AnimalFinFin
   - type: Objective
     difficulty: 2
@@ -449,3 +450,16 @@
     stealGroup: SeedExtractor
   - type: Objective
     difficulty: 0.5
+
+- type: entity
+  parent: BaseThiefStealObjective
+  id: EvilSkullArtifactItemStealObjective
+  components:
+  - type: NotJobRequirement
+    job: Chaplain
+  - type: StealCondition
+    verifyMapExistence: true
+    stealGroup: EvilSkullArtifactItem
+    descriptionText: objective-condition-thief-evil-skull-description
+  - type: Objective
+    difficulty: 0.6 #a little harder than the bible, it glows red and there's only on, and it's an artifact


### PR DESCRIPTION
There was a suggestion to add map-specific thief objectives, which I thought would be neat. This PR is kind of a mess since it changes some prototypes while also making map changes. Makes a new evil skull prototype for Hummingbird, which can roll as a thief objective. Other Hummingbird updates: gravity gen windoor to be command lock instead of engineering lock to be consistent with other maps. Moves latejoin spawn markers to arrivals instead of cryo so latejoiners with cryo spawn properly spawn in cryo (don't ask). Also makes Fin-Fin's steal objective check to see if he's present on the map before assigning it.

**Changelog**

:cl:
- tweak: Thieves should no longer be assigned Fin-Fin as a steal objective if he is not present on the map.
- add: The evil skull on Hummingbird can now be assigned as a thief objective.
