### PR TITLE
Fix heaters and freezers appearing powered on spawn

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -262,9 +262,11 @@
       - state: freezerOff
       - state: freezerOn
         map: ["enum.PowerDeviceVisualLayers.Powered"]
+        visible: false #imp edit
       - state: freezer-Unshaded
         shader: unshaded
         map: ["freezing"]
+        visible: false #imp edit
       - state: freezerPanelOpen
         map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       - state: pipe
@@ -276,7 +278,7 @@
         enum.PowerDeviceVisualLayers.Powered:
           True: { visible: true }
           False: { visible: false }
-        Freezing:
+        freezing:
           True: { visible: true }
           False: { visible: false }
   - type: GasThermoMachine
@@ -314,9 +316,11 @@
       - state: heaterOff
       - state: heaterOn
         map: ["enum.PowerDeviceVisualLayers.Powered"]
+        visible: false #imp edit
       - state: heater-Unshaded
         shader: unshaded
         map: ["heating"]
+        visible: false #imp edit
       - state: heaterPanelOpen
         map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       - state: pipe


### PR DESCRIPTION
Noticed an upstream PR that fixes this same issue for portable scrubbers. Was a fairly straightforward fix. Works for hellfire freezers and heaters as well.

https://github.com/user-attachments/assets/fa25047d-13e3-40b3-86e7-123b4d6f3879

