### PR TITLE
crawling adjustments

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
@@ -1,5 +1,6 @@
-﻿using Content.Server.Explosion.Components;
+using Content.Server.Explosion.Components;
 using Content.Server.Weapons.Ranged.Systems;
+using Content.Shared.Weapons.Ranged.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -77,6 +78,7 @@ public sealed class ProjectileGrenadeSystem : EntitySystem
             // slightly uneven, doesn't really change much, but it looks better
             var direction = angle.ToVec().Normalized();
             var velocity = _random.NextVector2(component.MinVelocity, component.MaxVelocity);
+            EnsureComp<TargetedProjectileComponent>(contentUid); // imp - ensure projectile is a TargetedProjectile with no target to hit crawling players
             _gun.ShootProjectile(contentUid, direction, velocity, uid, null);
         }
     }

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -202,6 +202,7 @@ public sealed partial class NPCCombatSystem
                 return;
             }
 
+            _gun.SetTarget(gun, comp.Target);
             _gun.AttemptShoot(uid, gunUid, gun, targetCordinates);
         }
     }

--- a/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
+++ b/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
@@ -28,8 +28,12 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
             return;
 
         var other = args.OtherEntity;
-        if (TryComp(other, out ProjectileComponent? projectile) &&
-            CompOrNull<TargetedProjectileComponent>(other)?.Target != ent)
+
+        if (TryComp(other, out TargetedProjectileComponent? targeted) &&
+            (targeted.Target == null || targeted.Target == ent))
+            return;
+
+        if (TryComp(other, out ProjectileComponent? projectile))
         {
             // Prevents shooting out of while inside of crates
             var shooter = projectile.Shooter;

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -29,7 +29,6 @@ public sealed partial class StandingStateComponent : Component
 public enum StandingState
 {
     Lying,
-    GettingUp,
     Standing,
 }
 // WD EDIT END

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -29,7 +29,7 @@ public sealed class StandingStateSystem : EntitySystem
         if (!Resolve(uid, ref standingState, false))
             return false;
 
-        return standingState.CurrentState is StandingState.Lying or StandingState.GettingUp;
+        return standingState.CurrentState is StandingState.Lying;
     }
 
     public bool Down(EntityUid uid,
@@ -47,7 +47,7 @@ public sealed class StandingStateSystem : EntitySystem
         // Optional component.
         Resolve(uid, ref appearance, ref hands, false);
 
-        if (standingState.CurrentState is StandingState.Lying or StandingState.GettingUp)
+        if (standingState.CurrentState is StandingState.Lying)
             return true;
 
         // This is just to avoid most callers doing this manually saving boilerplate

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -38,7 +38,8 @@ public sealed class StandingStateSystem : EntitySystem
         bool force = true,
         StandingStateComponent? standingState = null,
         AppearanceComponent? appearance = null,
-        HandsComponent? hands = null)
+        HandsComponent? hands = null,
+        bool intentional = true)
     {
         // TODO: This should actually log missing comps...
         if (!Resolve(uid, ref standingState, false))
@@ -76,7 +77,7 @@ public sealed class StandingStateSystem : EntitySystem
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
 
         // Change collision masks to allow going under certain entities like flaps and tables
-        if (TryComp(uid, out FixturesComponent? fixtureComponent))
+        if (TryComp(uid, out FixturesComponent? fixtureComponent) && !intentional)
         {
             foreach (var (key, fixture) in fixtureComponent.Fixtures)
             {

--- a/Content.Shared/Weapons/Ranged/Components/TargetedProjectileComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/TargetedProjectileComponent.cs
@@ -8,5 +8,5 @@ namespace Content.Shared.Weapons.Ranged.Components;
 public sealed partial class TargetedProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public EntityUid Target;
+    public EntityUid? Target;
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -204,6 +204,14 @@ public abstract partial class SharedGunSystem : EntitySystem
     }
 
     /// <summary>
+    /// Sets the targeted entity of the gun. Should be called before attempting to shoot to avoid shooting over the target.
+    /// </summary>
+    public void SetTarget(GunComponent gun, EntityUid target)
+    {
+        gun.Target = target;
+    }
+
+    /// <summary>
     /// Attempts to shoot at the target coordinates. Resets the shot counter after every shot.
     /// </summary>
     public void AttemptShoot(EntityUid user, EntityUid gunUid, GunComponent gun, EntityCoordinates toCoordinates)

--- a/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
+++ b/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
@@ -19,7 +19,10 @@ public sealed partial class LayingDownComponent : Component
     public bool AutoGetUp;
 }
 [Serializable, NetSerializable]
-public sealed class ChangeLayingDownEvent : CancellableEntityEventArgs;
+public sealed class ChangeLayingDownEvent(bool intentional = false) : CancellableEntityEventArgs
+{
+    public bool Intentional = intentional;
+}
 
 [Serializable, NetSerializable]
 public sealed class CheckAutoGetUpEvent(NetEntity user) : CancellableEntityEventArgs

--- a/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
+++ b/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
@@ -7,6 +7,12 @@ namespace Content.Shared._Goobstation.Standing;
 public sealed partial class LayingDownComponent : Component
 {
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan Cooldown { get; set; } = TimeSpan.FromSeconds(2.5);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NextStateChange;
+
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
     public float SpeedModify { get; set; } = .25f;
 
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
+++ b/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
@@ -7,9 +7,6 @@ namespace Content.Shared._Goobstation.Standing;
 public sealed partial class LayingDownComponent : Component
 {
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
-    public float StandingUpTime { get; set; } = 1f;
-
-    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
     public float SpeedModify { get; set; } = .25f;
 
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
+++ b/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class LayingDownComponent : Component
     public TimeSpan Cooldown { get; set; } = TimeSpan.FromSeconds(2.5);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan NextStateChange;
+    public TimeSpan NextLayDown;
 
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
     public float SpeedModify { get; set; } = .25f;

--- a/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
@@ -47,7 +47,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
             return;
         }
 
-        RaiseNetworkEvent(new ChangeLayingDownEvent());
+        RaiseNetworkEvent(new ChangeLayingDownEvent(intentional: true));
     }
 
     private void OnChangeState(ChangeLayingDownEvent ev, EntitySessionEventArgs args)
@@ -82,7 +82,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         if (isDown)
             TryStandUp(uid, layingDown, standing);
         else
-            TryLieDown(uid, layingDown, standing);
+            TryLieDown(uid, layingDown, standing, isIntentional: ev.Intentional);
     }
 
     private void OnRefreshMovementSpeed(EntityUid uid, LayingDownComponent component, RefreshMovementSpeedModifiersEvent args)
@@ -121,7 +121,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         return true;
     }
 
-    public bool TryLieDown(EntityUid uid, LayingDownComponent? layingDown = null, StandingStateComponent? standingState = null, DropHeldItemsBehavior behavior = DropHeldItemsBehavior.NoDrop)
+    public bool TryLieDown(EntityUid uid, LayingDownComponent? layingDown = null, StandingStateComponent? standingState = null, DropHeldItemsBehavior behavior = DropHeldItemsBehavior.NoDrop, bool isIntentional = false)
     {
         if (!Resolve(uid, ref standingState, false) ||
             !Resolve(uid, ref layingDown, false) ||
@@ -133,7 +133,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
             return false;
         }
 
-        _standing.Down(uid, true, behavior != DropHeldItemsBehavior.NoDrop, false, standingState);
+        _standing.Down(uid, true, behavior != DropHeldItemsBehavior.NoDrop, false, standingState, intentional: isIntentional);
         layingDown.NextLayDown = _timing.CurTime + layingDown.Cooldown;
         return true;
     }

--- a/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
@@ -72,27 +72,17 @@ public abstract class SharedLayingDownSystem : EntitySystem
         if (HasComp<KnockedDownComponent>(uid) || !_mobState.IsAlive(uid))
             return;
 
-        if (_timing.CurTime < layingDown.NextStateChange)
+        var isDown = _standing.IsDown(uid, standing);
+        if (_timing.CurTime < layingDown.NextLayDown && isDown)
         {
-            var loc = standing.CurrentState switch
-            {
-                StandingState.Standing => "popup-laying-down-cooldown-lay-down",
-                StandingState.Lying => "popup-laying-down-cooldown-stand-up",
-                _ => null
-            };
-
-            if (loc != null)
-                _popup.PopupEntity(Loc.GetString(loc), uid, uid);
-
+            _popup.PopupEntity(Loc.GetString("popup-laying-down-cooldown-stand-up"), uid, uid);
             return;
         }
 
-        if (_standing.IsDown(uid, standing))
+        if (isDown)
             TryStandUp(uid, layingDown, standing);
         else
             TryLieDown(uid, layingDown, standing);
-
-        layingDown.NextStateChange = _timing.CurTime + layingDown.Cooldown;
     }
 
     private void OnRefreshMovementSpeed(EntityUid uid, LayingDownComponent component, RefreshMovementSpeedModifiersEvent args)
@@ -144,6 +134,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         }
 
         _standing.Down(uid, true, behavior != DropHeldItemsBehavior.NoDrop, false, standingState);
+        layingDown.NextLayDown = _timing.CurTime + layingDown.Cooldown;
         return true;
     }
 }

--- a/Resources/Locale/en-US/_Goobstation/laying-down/popup.ftl
+++ b/Resources/Locale/en-US/_Goobstation/laying-down/popup.ftl
@@ -1,0 +1,2 @@
+popup-laying-down-cooldown-lay-down = Cannot lay down yet!
+popup-laying-down-cooldown-stand-up = Cannot stand up yet!

--- a/Resources/Locale/en-US/_Goobstation/laying-down/popup.ftl
+++ b/Resources/Locale/en-US/_Goobstation/laying-down/popup.ftl
@@ -1,2 +1,1 @@
-popup-laying-down-cooldown-lay-down = Cannot lay down yet!
 popup-laying-down-cooldown-stand-up = Cannot stand up yet!

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -19,7 +19,6 @@
         mask: # tables should collide with other tables
         - TableMask
         layer:
-        - BulletImpassable # Goobstation - Crawling
         - TableLayer
   - type: SpriteFade
   - type: Sprite
@@ -56,5 +55,4 @@
         mask:
         - TableMask
         layer:
-        - TableLayer 
-        - BulletImpassable # Goobstation - Crawling
+        - TableLayer

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -79,7 +79,6 @@
         - TableMask
         layer:
         - TableLayer
-        - BulletImpassable #Goobstation
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood


### PR DESCRIPTION
fixes up a lot of imbalances and complaints about crawling without (hopefully) removing any whimsy or accidentally adjusting any other systems

this needs prediction added, but i couldn't figure it out. so. whatever

"ranged ai targets crawling people properly" commit uses code from https://github.com/Simple-Station/Einstein-Engines/pull/530

**Changelog**
:cl:
- add: Standing up from prone no longer has a do-after, but standing up after falling over on purpose has a cooldown.
- remove: Crawling no longer lets you go under tables, plastic flaps, and other similar objects.
- fix: Shutters and firelocks can close over tables once again.
- fix: Ranged AI now targets crawling people properly.
- fix: Projectile grenades, such as stinger grenades, can now hit downed and crawling people.