### PR TITLE
revert "tranquilizer shells are useful now"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -133,7 +133,7 @@
     solutions:
       ammo:
         reagents:
-        - ReagentId: Nocturine
+        - ReagentId: ChloralHydrate
           Quantity: 7
   - type: SolutionTransfer
     maxTransferAmount: 7


### PR DESCRIPTION
reverts #640. i dont know why we merged a syndicate chem into the security arsenal, and being able to guaranteed sleep someone in 2 shots is so silly

**Changelog**
:cl:
- tweak: Tranquilizer shells have chloral hydrate instead of nocturine in them.