### PR TITLE
Make repairing a broken, emagged recycler unbloody it

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -130,6 +130,10 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 
     private void OnRepaired(Entity<MaterialReclaimerComponent> ent, ref RepairedEvent args)
     {
+        //imp edit, unbloodies a broken recycler
+        if (ent.Comp.Broken)
+            _appearance.SetData(ent.Owner, RecyclerVisuals.Bloody, false);
+        //end imp edit
         SetBroken(ent, false);
     }
 


### PR DESCRIPTION
Currently, emagged recyclers become unemagged when destroyed, but repairing them keeps them bloodied if they have gibbed someone. Not many people know about this mechanic. This change makes it so repairing a destroyed recycler unbloodies it, making it clearer that it is once again safe to use. It also makes it easier for people to forget it was sabotaged in the first place, so people can sabotage it once again, but security should probably be moving the recycler to a secure location if they know someone is running around with an emag :).

https://github.com/user-attachments/assets/25fc95f4-3585-4138-8384-80b49fc4cfda

**Changelog**

:cl:
- add: Repairing a broken recycler now unbloodies it if it has been used to gib someone. (Tip: Destroying a recycler un-emags it!)
