### PR TITLE
Fix map rotations not being random.

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -228,9 +228,7 @@ public sealed class GameMapManager : IGameMapManager
         Debug.Assert(eligible.Length != 0, $"couldn't select a map with {nameof(GetFirstInRotationQueue)}()! No eligible maps and no fallback maps!");
 
         // Choose a random map from all eligible maps
-        var selected = eligible[_random.Next(eligible.Length)];
-
-        return selected.proto;
+        return eligible[_random.Next(eligible.Length)].proto;
     }
 
     private void EnqueueMap(string mapProtoName)

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -219,7 +219,7 @@ public sealed class GameMapManager : IGameMapManager
 
         var eligible = CurrentlyEligibleMaps()
             .Select(x => (proto: x, weight: GetMapRotationQueuePriority(x.ID)))
-            .OrderByDescending(x => x.weight)
+            .Where(x => x.weight > 0)
             .ToArray();
 
         _log.Info($"eligible queue: {string.Join(", ", eligible.Select(x => (x.proto.ID, x.weight)))}");
@@ -227,10 +227,10 @@ public sealed class GameMapManager : IGameMapManager
         // YML "should" be configured with at least one fallback map
         Debug.Assert(eligible.Length != 0, $"couldn't select a map with {nameof(GetFirstInRotationQueue)}()! No eligible maps and no fallback maps!");
 
-        var weight = eligible[0].weight;
-        return eligible.Where(x => x.Item2 == weight)
-            .MinBy(x => x.proto.ID)
-            .proto;
+        // Choose a random map from all eligible maps
+        var selected = eligible[_random.Next(eligible.Length)];
+
+        return selected.proto;
     }
 
     private void EnqueueMap(string mapProtoName)


### PR DESCRIPTION
Fixes a blatant.. "Feature" from upstream where ties between maps with the same priority are broken with alphabetical order, this is really egregious with maps like Xeno or Train.

**Changelog**
:cl:
- fix: Your favorite maps should roll more often, if you liked maps with high letters, like train, or xeno 

