### PR TITLE
vestine in syndiejuice

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -50,6 +50,7 @@
     JugSugar: 3
     JugSulfur: 1
     JugWeldingFuel: 1
+    VestineChemistryVial: 1 #imp
   emaggedInventory:
     PaxChemistryBottle: 3
     MuteToxinChemistryBottle: 3


### PR DESCRIPTION
primarily intended to buff synth specialist. also a stealth buff to nukies but its only 30u so i dont think anyone will get too fancy, since they can get 60u with 4tc. but we can revert this if its bad

:cl:
- add: syndiejuice has a vial of vestine now! refill it with a chemvend restock.
