### PR TITLE
Rework vent critters (port from Delta-V)

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,17 +1,50 @@
-﻿using Content.Server.StationEvents.Events;
+using Content.Server.StationEvents.Events;
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Storage;
+using Robust.Shared.Map; // DeltaV
 
 namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(VentCrittersRule))]
 public sealed partial class VentCrittersRuleComponent : Component
 {
-    [DataField("entries")]
-    public List<EntitySpawnEntry> Entries = new();
+    // DeltaV: Replaced by Table
+    //[DataField("entries")]
+    //public List<EntitySpawnEntry> Entries = new();
+
+    /// <summary>
+    /// DeltaV: Table of possible entities to spawn.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityTableSelector Table = default!;
 
     /// <summary>
     /// At least one special entry is guaranteed to spawn
     /// </summary>
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
+
+    /// <summary>
+    /// DeltaV: The location of the vent that got picked.
+    /// </summary>
+    [ViewVariables]
+    public EntityCoordinates? Location;
+
+    /// <summary>
+    /// DeltaV: Base minimum number of critters to spawn.
+    /// </summary>
+    [DataField]
+    public int Min = 2;
+
+    /// <summary>
+    /// DeltaV: Base maximum number of critters to spawn.
+    /// </summary>
+    [DataField]
+    public int Max = 3;
+
+    /// <summary>
+    /// DeltaV: Min and max get multiplied by the player count then divided by this.
+    /// </summary>
+    [DataField]
+    public int PlayerRatio = 25;
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -1,4 +1,8 @@
+using Content.Server.Antag;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Pinpointer;
 using Content.Server.StationEvents.Components;
+using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage;
@@ -9,6 +13,13 @@ using Robust.Shared.Player;
 
 namespace Content.Server.StationEvents.Events;
 
+/// <summary>
+/// DeltaV: Reworked vent critters to spawn a number of mobs at a single telegraphed location.
+/// This gives players time to run away and let sec do their job.
+/// </summary>
+/// <remarks>
+/// This entire file is rewritten, ignore upstream changes.
+/// </remarks>
 public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
 {
     /*
@@ -17,60 +28,86 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
      */
 
     [Dependency] private readonly AnnouncerSystem _announcer = default!;
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] private readonly NavMapSystem _navMap = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private List<EntityCoordinates> _locations = new();
 
     protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
-        base.Added(uid, component, gameRule, args);
-
-        if (!TryGetRandomStation(out var station))
+        PickLocation(component);
+        if (component.Location is not { } coords)
+        {
+            ForceEndSelf(uid, gameRule);
             return;
+        }
+
+        var mapCoords = _transform.ToMapCoordinates(coords);
+        if (!_navMap.TryGetNearestBeacon(mapCoords, out var beacon, out _))
+            return;
+
+        var nearest = beacon?.Comp?.Text!;
 
         _announcer.SendAnnouncement(
             _announcer.GetAnnouncementId(args.RuleId),
             Filter.Broadcast(),
-            "station-event-vent-creatures-announcement",
+            "station-event-vent-creatures-start-announcement-deltav",
             null,
-            Color.Gold
+            Color.Gold,
+            null, null,
+            ("location", nearest)
         );
+
+        base.Added(uid, component, gameRule, args);
     }
 
-    protected override void Started(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    protected override void Ended(EntityUid uid, VentCrittersRuleComponent comp, GameRuleComponent gameRule, GameRuleEndedEvent args)
     {
-        base.Started(uid, component, gameRule, args);
+        if (comp.Location is not { } coords)
+            return;
 
+        var players = _antag.GetTotalPlayerCount(_player.Sessions);
+        var min = Math.Max(comp.Min, comp.Min * players / comp.PlayerRatio);
+        var max = Math.Max(comp.Max, comp.Max * players / comp.PlayerRatio);
+        var count = Math.Max(RobustRandom.Next(min, max), 1);
+        Log.Info($"Spawning {count} critters for {ToPrettyString(uid):rule}");
+        for (int i = 0; i < count; i++)
+        {
+            foreach (var spawn in _entityTable.GetSpawns(comp.Table))
+            {
+                Spawn(spawn, coords);
+            }
+        }
+
+        if (comp.SpecialEntries.Count == 0)
+            return;
+
+        // guaranteed spawn
+        var specialEntry = RobustRandom.Pick(comp.SpecialEntries);
+        Spawn(specialEntry.PrototypeId, coords);
+
+        base.Ended(uid, comp, gameRule, args);
+    }
+
+    private void PickLocation(VentCrittersRuleComponent component)
+    {
         if (!TryGetRandomStation(out var station))
             return;
 
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
-        var validLocations = new List<EntityCoordinates>();
-        while (locations.MoveNext(out _, out _, out var transform))
+        _locations.Clear();
+        while (locations.MoveNext(out var uid, out _, out var transform))
         {
             if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
             {
-                validLocations.Add(transform.Coordinates);
-                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
-                {
-                    Spawn(spawn, transform.Coordinates);
-                }
+                _locations.Add(transform.Coordinates);
             }
         }
 
-        if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)
-        {
-            return;
-        }
-
-        // guaranteed spawn
-        var specialEntry = RobustRandom.Pick(component.SpecialEntries);
-        var specialSpawn = RobustRandom.Pick(validLocations);
-        Spawn(specialEntry.PrototypeId, specialSpawn);
-
-        foreach (var location in validLocations)
-        {
-            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
-            {
-                Spawn(spawn, location);
-            }
-        }
+        if (_locations.Count > 0)
+            component.Location = RobustRandom.Pick(_locations);
     }
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -38,6 +38,8 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
 
     protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
+        base.Added(uid, component, gameRule, args);
+
         PickLocation(component);
         if (component.Location is not { } coords)
         {
@@ -60,12 +62,12 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
             null, null,
             ("location", nearest)
         );
-
-        base.Added(uid, component, gameRule, args);
     }
 
     protected override void Ended(EntityUid uid, VentCrittersRuleComponent comp, GameRuleComponent gameRule, GameRuleEndedEvent args)
     {
+        base.Ended(uid, comp, gameRule, args);
+
         if (comp.Location is not { } coords)
             return;
 
@@ -74,6 +76,7 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         var max = Math.Max(comp.Max, comp.Max * players / comp.PlayerRatio);
         var count = Math.Max(RobustRandom.Next(min, max), 1);
         Log.Info($"Spawning {count} critters for {ToPrettyString(uid):rule}");
+
         for (int i = 0; i < count; i++)
         {
             foreach (var spawn in _entityTable.GetSpawns(comp.Table))
@@ -88,8 +91,6 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         // guaranteed spawn
         var specialEntry = RobustRandom.Pick(comp.SpecialEntries);
         Spawn(specialEntry.PrototypeId, coords);
-
-        base.Ended(uid, comp, gameRule, args);
     }
 
     private void PickLocation(VentCrittersRuleComponent component)

--- a/Content.Server/_Impstation/StationEvents/Components/SilentVentCrittersRuleComponent.cs
+++ b/Content.Server/_Impstation/StationEvents/Components/SilentVentCrittersRuleComponent.cs
@@ -1,0 +1,17 @@
+using Content.Server.StationEvents.Events;
+using Content.Shared.Storage;
+
+namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(SilentVentCrittersRule))]
+public sealed partial class SilentVentCrittersRuleComponent : Component
+{
+    [DataField("entries")]
+    public List<EntitySpawnEntry> Entries = new();
+
+    /// <summary>
+    /// At least one special entry is guaranteed to spawn
+    /// </summary>
+    [DataField("specialEntries")]
+    public List<EntitySpawnEntry> SpecialEntries = new();
+}

--- a/Content.Server/_Impstation/StationEvents/Events/SilentVentCrittersRule.cs
+++ b/Content.Server/_Impstation/StationEvents/Events/SilentVentCrittersRule.cs
@@ -1,0 +1,70 @@
+using Content.Server.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
+using Content.Shared.Storage;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+using Content.Server.Announcements.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed class SilentVentCrittersRule : StationEventSystem<SilentVentCrittersRuleComponent>
+{
+    /*
+     * DO NOT COPY PASTE THIS TO MAKE YOUR MOB EVENT.
+     * USE THE PROTOTYPE.
+     */
+
+    [Dependency] private readonly AnnouncerSystem _announcer = default!;
+
+    protected override void Added(EntityUid uid, SilentVentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        base.Added(uid, component, gameRule, args);
+
+        if (!TryGetRandomStation(out var station))
+            return;
+
+        // no announcement
+    }
+
+    protected override void Started(EntityUid uid, SilentVentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        if (!TryGetRandomStation(out var station))
+            return;
+
+        var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
+        var validLocations = new List<EntityCoordinates>();
+        while (locations.MoveNext(out _, out _, out var transform))
+        {
+            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
+            {
+                validLocations.Add(transform.Coordinates);
+                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
+                {
+                    Spawn(spawn, transform.Coordinates);
+                }
+            }
+        }
+
+        if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)
+        {
+            return;
+        }
+
+        // guaranteed spawn
+        var specialEntry = RobustRandom.Pick(component.SpecialEntries);
+        var specialSpawn = RobustRandom.Pick(validLocations);
+        Spawn(specialEntry.PrototypeId, specialSpawn);
+
+        foreach (var location in validLocations)
+        {
+            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
+            {
+                Spawn(spawn, location);
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/_DV/station-events/events/vent-critters.ftl
+++ b/Resources/Locale/en-US/_DV/station-events/events/vent-critters.ftl
@@ -1,0 +1,1 @@
+﻿station-event-vent-creatures-start-announcement-deltav = Attention. A large influx of unknown life forms has been detected in ventilation systems near {$location}. All personnel should vacate the area immediately.

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -31,15 +31,17 @@
   - type: StationEvent
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 30 # DeltaV: was 50, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
+    min: 10 # DeltaV
+    max: 15 # DeltaV
+    playerRatio: 55 # DeltaV: Higher base values, less player scaling
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobMouse
+      - id: MobMouse1
+      - id: MobMouse2
+    specialEntries:
     - id: MobMouseCancer
       prob: 0.001
 # Events always spawn a critter regardless of Probability https://github.com/space-wizards/space-station-14/issues/28480 I added the Rat King to their own event with a player cap.
@@ -51,18 +53,17 @@
   - type: StationEvent
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
   - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
-    - id: MobMouseCancer
-      prob: 0.001
+    min: 10 # DeltaV
+    max: 20 # DeltaV
+    playerRatio: 70 # DeltaV: Mostly ignore player scaling
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobMouse
+      - id: MobMouse1
+      - id: MobMouse2
     specialEntries:
     - id: SpawnPointGhostRatKing
       prob: 0.001
@@ -73,13 +74,17 @@
   components:
   - type: StationEvent
     weight: 6
-    duration: 50
+    duration: 30 # DeltaV: was 50, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobCockroach
-      prob: 0.03
-    - id: MobMothroach
-      prob: 0.008
+    min: 8 # DeltaV
+    max: 20 # DeltaV
+    playerRatio: 80 # DeltaV: Mostly ignore player scaling
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobCockroach
+        weight: 0.79
+      - id: MobMothroach
+        weight: 0.21
 
 - type: entity
   id: SnailMigrationLowPop
@@ -87,15 +92,16 @@
   components:
   - type: StationEvent
     weight: 6
-    duration: 50
+    duration: 30 # DeltaV: was 50, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobSnail
-      prob: 0.02
-    - id: MobSnailSpeed
-      prob: 0.002
-    - id: MobSnailMoth
-      prob: 0.002
+    min: 4 # DeltaV
+    max: 8 # DeltaV
+    playerRatio: 60 # DeltaV: Somewhat ignore player scaling
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobSnail
+      - id: MobSnailSpeed
+      - id: MobSnailMoth
 
 - type: entity
   id: SnailMigration
@@ -104,18 +110,20 @@
   - type: StationEvent
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30
   - type: VentCrittersRule
-    entries:
-    - id: MobSnail
-      prob: 0.02
-    - id: MobSnailSpeed
-      prob: 0.002
-    - id: MobSnailMoth
-      prob: 0.002
-    - id: MobSnailInstantDeath
-      prob: 0.00001 #  ~ 1:2000 snails
+    playerRatio: 20 # DeltaV: Snails aren't dangerous, but they should be more special
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobSnail
+        weight: 0.84
+      - id: MobSnailSpeed
+        weight: 0.08
+      - id: MobSnailMoth
+        weight: 0.08
+      - id: MobSnailInstantDeath
+        weight: 0.00001
 
 - type: entity
   id: TrashAnimalMigration
@@ -124,15 +132,17 @@
   - type: StationEvent
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 30 # DeltaV: was 50, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobRaccoonGhost
-      prob: 0.02
-    - id: MobPossumGhost
-      prob: 0.02
-    - id: MobMouse
-      prob: 0.02
+    playerRatio: 20
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobRaccoonGhost
+        weight: 0.02
+      - id: MobPossumGhost
+        weight: 0.02
+      - id: MobMouse
+        weight: 0.02
 
 - type: entity
   id: SlimesSpawn
@@ -142,15 +152,13 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobAdultSlimesBlueAngry
-      prob: 0.02
-    - id: MobAdultSlimesGreenAngry
-      prob: 0.02
-    - id: MobAdultSlimesYellowAngry
-      prob: 0.02
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobAdultSlimesBlueAngry
+      - id: MobAdultSlimesGreenAngry
+      - id: MobAdultSlimesYellowAngry
 
 - type: entity
   id: SnakeSpawn
@@ -160,15 +168,13 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobPurpleSnake
-      prob: 0.02
-    - id: MobSmallPurpleSnake
-      prob: 0.02
-    - id: MobCobraSpace
-      prob: 0.02
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobPurpleSnake
+      - id: MobSmallPurpleSnake
+      - id: MobCobraSpace
 
 - type: entity
   id: SpiderSpawn
@@ -178,11 +184,10 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobGiantSpiderAngry
-      prob: 0.05
+    table: # DeltaV: EntityTable instead of spawn entries
+      id: MobGiantSpiderAngry
 
 - type: entity
   id: BrosSpawn
@@ -192,11 +197,10 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: BrosVentSpawner
-      prob: 0.05
+    table: # DeltaV: EntityTable instead of spawn entries
+      id: BrosVentSpawner
 
 - type: entity
   id: SpiderClownSpawn
@@ -206,8 +210,8 @@
     earliestStart: 20
     minimumPlayers: 20
     weight: 1.5
-    duration: 60
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: VentCrittersRule
-    entries:
-    - id: MobClownSpider
-      prob: 0.05
+    playerRatio: 35 # DeltaV: Clown spiders are very robust
+    table: # DeltaV: EntityTable instead of spawn entries
+      id: MobClownSpider

--- a/Resources/Prototypes/_Impstation/GameRules/goblins.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/goblins.yml
@@ -7,7 +7,7 @@
     duration: 1
     minimumPlayers: 15
     maxOccurrences: 1 # six goblins is a lot
-  - type: VentCrittersRule
+  - type: SilentVentCrittersRule
     specialEntries:
     - id: GoblinStowawaysVentSpawner
       prob: 0 # this ensures that only one spawner will be created


### PR DESCRIPTION
Port of https://github.com/DeltaV-Station/Delta-v/pull/2495

Vent critter event now works like this:
- one vent is picked for all mobs to spawn from
- there is a 30-second warning announcement with the location of the vent so that crew can evacuate and sec can mobilize
- number of mobs increases with player count
- alert is the same for hostile (spiders, BROS, etc.) and non-hostile (mice, snails, etc.) mobs

We can tweak the numbers as we go -- there are min/max variables and a "player ratio" that can make them scale slower or quicker from the player count.

![image](https://github.com/user-attachments/assets/d80993d5-26c9-4259-8dac-06240bad62d8)


**Changelog**
:cl:EpicToast
- tweak: Vent creatures now spawn from one vent all at once instead of being spread across the station. Crew members get a 30-second warning announcement saying where they will spawn.