### PR TITLE
fixed cadets not spawning with tutorial pAIs

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -33,9 +33,10 @@
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled
-    pocket1: WeaponPistolMk58
+    pocket1: TutorialPersonalAI #imp
     pocket2: BookSecurity
   storage:
     back:
     - Flash
     - MagazinePistol
+    - WeaponPistolMk58

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -28,7 +28,6 @@
     eyes: ClothingEyesGlassesSecurity
     ears: ClothingHeadsetSecurity
     pocket1: WeaponPistolMk58
-    pocket2: TutorialPersonalAI #imp
   storage:
     back:
     - Flash


### PR DESCRIPTION
Quick bugfix for tutorial pAIs. They were spawning on officers instead of cadets as intended.

No CL.
There was no other PR. You didn't see it.
