### PR TITLE
Curtains and fancy tables no longer eat all of your carpet

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/curtains.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/curtains.yml
@@ -17,92 +17,65 @@
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetBlack
+            - material: FloorCarpetBlack # imp
+              amount: 1
               doAfter: 1
-              name: black carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-black
         - to: CurtainsBlue
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetBlue
+            - material: FloorCarpetBlue # imp
+              amount: 1
               doAfter: 1
-              name: blue carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-blue
         - to: CurtainsCyan
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetCyan
+            - material: FloorCarpetCyan # imp
+              amount: 1
               doAfter: 1
-              name: cyan carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-cyan
         - to: CurtainsGreen
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetGreen
+            - material: FloorCarpetGreen # imp
+              amount: 1
               doAfter: 1
-              name: green carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-green
         - to: CurtainsOrange
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetOrange
+            - material: FloorCarpetOrange # imp
+              amount: 1
               doAfter: 1
-              name: orange carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-orange
         - to: CurtainsPink
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetPink
+            - material: FloorCarpetPink # imp
+              amount: 1
               doAfter: 1
-              name: pink carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-pink
         - to: CurtainsPurple
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetPurple
+            - material: FloorCarpetPurple # imp
+              amount: 1
               doAfter: 1
-              name: purple carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-purple
         - to: CurtainsRed
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetRed
+            - material: FloorCarpetRed # imp
+              amount: 1
               doAfter: 1
-              name: red carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-red
         - to: CurtainsWhite
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetWhite
+            - material: FloorCarpetWhite # imp
+              amount: 1
               doAfter: 1
-              name: white carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-white
               
     - node: Curtains
       entity: HospitalCurtains

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
@@ -231,76 +231,58 @@
               doAfter: 1
               
         - to: TableFancyBlack
-          steps: 
-            - tag: CarpetBlack
-              name: black carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-black
+          steps:
+            - material: FloorCarpetBlack # imp
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyBlue
-          steps: 
-            - tag: CarpetBlue
-              name: blue carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-blue
+          steps:
+            - material: FloorCarpetBlue # imp
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyCyan
-          steps: 
-            - tag: CarpetCyan
-              name: cyan carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-cyan
+          steps:
+            - material: FloorCarpetCyan # imp
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyGreen
-          steps: 
-            - tag: CarpetGreen
-              name: green carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-green
+          steps:
+            - material: FloorCarpetGreen # imp
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyOrange
-          steps: 
-            - tag: CarpetOrange
-              name: orange carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-orange
+          steps:
+            - material: FloorCarpetOrange # imp
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyPurple
-          steps: 
-            - tag: CarpetPurple
-              name: purple carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-purple
+          steps:
+            - material: FloorCarpetPurple # imp
+              amount: 1
+              doAfter: 1
                 
         - to: TableFancyPink
-          steps: 
-            - tag: CarpetPink
-              name: pink carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-pink
+          steps:
+            - material: FloorCarpetPink # imp
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyRed
-          steps: 
-            - tag: CarpetRed
-              name: red carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-red
+          steps:
+            - material: FloorCarpetRed # imp
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyWhite
-          steps: 
-            - tag: CarpetWhite
-              name: white carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-white
+          steps:
+            - material: FloorCarpetWhite # imp
+              amount: 1
+              doAfter: 1
 
         - to: TableWoodReinforced
           steps:

--- a/Resources/Prototypes/Stacks/floor_tile_stacks.yml
+++ b/Resources/Prototypes/Stacks/floor_tile_stacks.yml
@@ -332,60 +332,70 @@
   id: FloorCarpetRed
   name: red carpet tile
   spawn: FloorCarpetItemRed
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-red } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetBlack
-  name: block carpet tile
+  name: black carpet tile
   spawn: FloorCarpetItemBlack
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-black } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetBlue
   name: blue carpet tile
   spawn: FloorCarpetItemBlue
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-blue } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetGreen
   name: green carpet tile
   spawn: FloorCarpetItemGreen
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-green } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetOrange
   name: orange carpet tile
   spawn: FloorCarpetItemOrange
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-orange } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetSkyBlue
   name: skyblue carpet tile
   spawn: FloorCarpetItemSkyBlue
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-skyblue } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetPurple
   name: purple carpet tile
   spawn: FloorCarpetItemPurple
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-purple } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetPink
   name: pink carpet tile
   spawn: FloorCarpetItemPink
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-pink } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetCyan
   name: cyan carpet tile
   spawn: FloorCarpetItemCyan
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-cyan } # imp
   maxCount: 30
 
 - type: stack
   id: FloorCarpetWhite
   name: white carpet tile
   spawn: FloorCarpetItemWhite
+  icon: { sprite: /Textures/Objects/Tiles/tile.rsi, state: carpet-white } # imp
   maxCount: 30
 
 - type: stack


### PR DESCRIPTION
Resolves https://github.com/impstation/imp-station-14/issues/120

https://github.com/user-attachments/assets/530426e5-5975-48c1-94f9-cc2b8f443934

**Changelog**
:cl:EpicToast
- fix: Making curtains and fancy tables with a stack of carpet will no longer eat the entire stack.