### PR TITLE
vendor sound update

### DIFF
--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -87,13 +87,13 @@ namespace Content.Shared.VendingMachines
         ///     Sound that plays when ejecting an item
         /// </summary>
         [DataField("soundVend")]
-        // Grabbed from: https://github.com/discordia-space/CEV-Eris/blob/f702afa271136d093ddeb415423240a2ceb212f0/sound/machines/vending_drop.ogg
-        // not sure how to properly attribute, but it's agpl-3 & we are as well so ???
-        public SoundSpecifier SoundVend = new SoundPathSpecifier("/Audio/_Impstation/Machines/vending_drop.ogg")
+        // Grabbed from: https://github.com/tgstation/tgstation/blob/d34047a5ae911735e35cd44a210953c9563caa22/sound/machines/machine_vend.ogg
+        public SoundSpecifier SoundVend = new SoundPathSpecifier("/Audio/Machines/machine_vend.ogg")
         {
             Params = new AudioParams
             {
-                Volume = -2f,
+                Volume = -4f,
+                Variation = 0.15f
             }
         };
 

--- a/Resources/Audio/Machines/attributions.yml
+++ b/Resources/Audio/Machines/attributions.yml
@@ -163,7 +163,7 @@
   - chime.ogg
   - buzz-sigh.ogg
   - buzztwo.ogg
-  - machine_vend.gg
+  - machine_vend.ogg
   license: "CC-BY-SA-3.0"
   copyright: "Taken from TG station."
   source: "https://github.com/tgstation/tgstation/tree/d4f678a1772007ff8d7eddd21cf7218c8e07bfc0"
@@ -172,7 +172,7 @@
   license: "CC0-1.0"
   copyright: "by Ko4erga"
   source: "https://github.com/space-wizards/space-station-14/pull/30431"
-  
+
 - files: ["double_ring.ogg"]
   license: "CC0-1.0"
   copyright: "Created by fspera, converted to OGG and modified by chromiumboy."

--- a/Resources/Audio/_Impstation/Machines/attributions.yml
+++ b/Resources/Audio/_Impstation/Machines/attributions.yml
@@ -1,0 +1,4 @@
+- files: ["vending_drop.ogg"]
+  license: "Custom" #AGPL 3.0 but this is not considered a valid license by the RGA validator
+  copyright: "Taken from CEV Eris."
+  source: "https://github.com/discordia-space/CEV-Eris/blob/f702afa271136d093ddeb415423240a2ceb212f0/sound/machines/vending_drop.ogg"

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -150,6 +150,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: AmmoVendAds
   - type: SpeakOnUIClosed
@@ -344,6 +345,7 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: ClothesMateAds
   - type: SpeakOnUIClosed
@@ -379,6 +381,7 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: ClothesMateAds
   - type: SpeakOnUIClosed
@@ -461,6 +464,7 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: SpeakOnUIClosed
@@ -530,6 +534,7 @@
   components:
   - type: VendingMachine
     pack: SpaceUpInventory
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/spaceup.rsi
     layers:
@@ -552,6 +557,7 @@
   components:
   - type: VendingMachine
     pack: SodaInventory
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/soda.rsi
     layers:
@@ -575,6 +581,7 @@
   components:
   - type: VendingMachine
     pack: StarkistInventory
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/starkist.rsi
     layers:
@@ -607,6 +614,7 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: Speech
@@ -642,6 +650,7 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: SpeakOnUIClosed
@@ -679,6 +688,7 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: SpeakOnUIClosed
@@ -743,6 +753,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: MagiVendAds
   - type: SpeakOnUIClosed
@@ -880,6 +891,7 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: NutriMaxAds
   - type: SpeakOnUIClosed
@@ -955,6 +967,7 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: MegaSeedAds
   - type: SpeakOnUIClosed
@@ -1033,6 +1046,7 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/sustenance.rsi
     layers:
@@ -1144,6 +1158,7 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     initialStockQuality: 0.33
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: BodaAds
   - type: SpeakOnUIClosed
@@ -1178,6 +1193,7 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     screenState: screen
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: AutoDrobeAds
   - type: SpeakOnUIClosed
@@ -1384,6 +1400,7 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/mining.rsi
     layers:
@@ -1504,6 +1521,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: HyDrobeAds
   - type: SpeakOnUIClosed
@@ -1538,6 +1556,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: LawDrobeAds
   - type: SpeakOnUIClosed
@@ -1568,6 +1587,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: SecDrobeAds
   - type: SpeakOnUIClosed
@@ -1602,6 +1622,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: BarDrobeAds
   - type: SpeakOnUIClosed
@@ -1632,6 +1653,7 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/chapdrobe.rsi
     layers:
@@ -1662,6 +1684,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: CargoDrobeAds
   - type: SpeakOnUIClosed
@@ -1696,6 +1719,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: MediDrobeAds
   - type: SpeakOnUIClosed
@@ -1726,6 +1750,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: ChemDrobeAds
   - type: SpeakOnUIClosed
@@ -1757,6 +1782,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: CuraDrobeAds
   - type: SpeakOnUIClosed
@@ -1787,6 +1813,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: AtmosDrobeAds
   - type: SpeakOnUIClosed
@@ -1821,6 +1848,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: EngiDrobeAds
   - type: SpeakOnUIClosed
@@ -1855,6 +1883,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: ChefDrobeAds
   - type: SpeakOnUIClosed
@@ -1885,6 +1914,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: DetDrobeAds
   - type: SpeakOnUIClosed
@@ -1915,6 +1945,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: JaniDrobeAds
   - type: SpeakOnUIClosed
@@ -1949,6 +1980,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: SciDrobeAds
   - type: SpeakOnUIClosed
@@ -1979,6 +2011,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: SyndieDrobeAds
   - type: SpeakOnUIClosed
@@ -2011,6 +2044,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: RoboDrobeAds
   - type: SpeakOnUIClosed
@@ -2041,6 +2075,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: GeneDrobeAds
   - type: SpeakOnUIClosed
@@ -2071,6 +2106,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Advertise
     pack: ViroDrobeAds
   - type: SpeakOnUIClosed
@@ -2101,6 +2137,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/centdrobe.rsi
     layers:
@@ -2167,6 +2204,7 @@
   components:
   - type: VendingMachine
     pack: TankDispenserEVAInventory
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: _Impstation/Structures/Machines/VendingMachines/tankdispenser.rsi #TODO add visualiser for remaining tanks as layers #imp
     state: dispenser
@@ -2180,6 +2218,7 @@
   components:
   - type: VendingMachine
     pack: TankDispenserEngineeringInventory
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: _Impstation/Structures/Machines/VendingMachines/tankdispenser.rsi #TODO add visualiser for remaining tanks as layers
     layers:
@@ -2199,6 +2238,7 @@
     normalState: normal
     denyState: deny
     ejectDelay: 2
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/chemvend.rsi
     layers:
@@ -2228,6 +2268,7 @@
     normalState: normal
     denyState: deny
     ejectDelay: 2
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
   - type: Sprite # imp
     sprite: _Impstation/Structures/Machines/VendingMachines/syndiejuice.rsi
     layers:


### PR DESCRIPTION
restores the vendor sound from space-wizards/space-station-14#28897 BUT i kept the old (our current vending sound) and did a pass where the vendor uses a dispense sound that i felt was situationally appropriate based on what it vends, since vending machine component just supported that already

**Changelog**
:cl:
- tweak: Some vendors have a new dispensing sound.