### PR TITLE
Track what purchases antags make

### DIFF
--- a/Content.Shared/Mind/MindComponent.cs
+++ b/Content.Shared/Mind/MindComponent.cs
@@ -1,8 +1,11 @@
+using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind.Components;
+using Content.Shared.Store;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Mind;
 
@@ -27,6 +30,11 @@ public sealed partial class MindComponent : Component
 {
     [DataField, AutoNetworkedField]
     public List<EntityUid> Objectives = new();
+
+    /// <summary>
+    /// imp edit - list of things that have been bought by this mind.
+    /// </summary>
+    public List<(string, IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2>)> Purchases = new();
 
     /// <summary>
     ///     List of entities assigned to this mind's target objectives, if applicable.

--- a/Content.Shared/Objectives/Components/ObjectiveComponent.cs
+++ b/Content.Shared/Objectives/Components/ObjectiveComponent.cs
@@ -41,6 +41,12 @@ public sealed partial class ObjectiveComponent : Component
     /// </summary>
     [DataField]
     public SpriteSpecifier? Icon;
+
+    /// <summary>
+    /// imp edit - used to mark objectives that are "trivial" w/r/t their TC cost, like DAGD or escape alive and unrestrained
+    /// </summary>
+    [DataField]
+    public bool Trivial;
 }
 
 /// <summary>

--- a/Content.Shared/Objectives/ObjectiveInfo.cs
+++ b/Content.Shared/Objectives/ObjectiveInfo.cs
@@ -15,4 +15,4 @@ namespace Content.Shared.Objectives;
 /// If anything is null it will be logged and return null.
 /// </remarks>
 [Serializable, NetSerializable]
-public record struct ObjectiveInfo(string Title, string Description, SpriteSpecifier Icon, float Progress);
+public record struct ObjectiveInfo(string Title, string Description, SpriteSpecifier Icon, float Progress, bool Trivial = true);

--- a/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
+++ b/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
@@ -127,7 +127,7 @@ public abstract class SharedObjectivesSystem : EntitySystem
             return null;
         }
 
-        return new ObjectiveInfo(title, description, comp.Icon, progress);
+        return new ObjectiveInfo(title, description, comp.Icon, progress, comp.Trivial);
     }
 
     /// <summary>

--- a/Content.Shared/Roles/MindRoleComponent.cs
+++ b/Content.Shared/Roles/MindRoleComponent.cs
@@ -40,6 +40,18 @@ public sealed partial class MindRoleComponent : BaseMindRoleComponent
     /// </summary>
     [DataField]
     public ProtoId<JobPrototype>? JobPrototype { get; set; }
+
+    /// <summary>
+    /// imp edit - should purchases made by this role be tracked?
+    /// </summary>
+    [DataField]
+    public bool TrackPurchases;
+
+    /// <summary>
+    /// imp edit - if true, the player with this role will get complimented for not spending anything
+    /// </summary>
+    [DataField]
+    public bool GetsNoSpendtext;
 }
 
 // Why does this base component actually exist? It does make auto-categorization easy, but before that it was useless?

--- a/Resources/Locale/en-US/_Impstation/objectives/roundend.ftl
+++ b/Resources/Locale/en-US/_Impstation/objectives/roundend.ftl
@@ -1,0 +1,26 @@
+roundend-spend-summary-spent =
+    {$gender ->
+    [male] He
+    [female] She
+    [neuter] It
+    *[other] They
+    } spent
+roundend-spend-summary-bought =
+    {$gender ->
+    [male] He
+    [female] She
+    [neuter] It
+    *[other] They
+    } bought
+roundend-spent-nothing-success = And spent nothing! Wow!
+roundend-spent-nothing-failure = And spent nothing! Did {$gender  ->
+    [male] he
+    [female] she
+    [neuter] it
+    *[other] they
+    } forget {$gender ->
+    [male] he
+    [female] she
+    [neuter] it
+    *[other] they
+    } had a job to do?

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -56,6 +56,7 @@
     icon:
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
+    trivial: true #imp edit
   - type: EscapeShuttleCondition
 
 - type: entity
@@ -74,6 +75,7 @@
       components:
       - EscapeShuttleCondition
       - StealCondition
+    trivial: true #imp edit
   - type: DieCondition
 
 #- type: entity

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -70,12 +70,12 @@
     icon:
       sprite: Mobs/Ghosts/ghost_human.rsi
       state: icon
+    trivial: true #imp edit
   - type: ObjectiveBlacklistRequirement
     blacklist:
       components:
       - EscapeShuttleCondition
       - StealCondition
-    trivial: true #imp edit
   - type: DieCondition
 
 #- type: entity

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -85,6 +85,7 @@
   - type: MindRole
     exclusiveAntag: true
     antagPrototype: Nukeops
+    getsNoSpendtext: true #imp edit
   - type: NukeopsRole
 
 - type: entity
@@ -95,6 +96,7 @@
   components:
   - type: MindRole
     antagPrototype: NukeopsMedic
+    getsNoSpendtext: true #imp edit
 
 - type: entity
   parent: MindRoleNukeops
@@ -104,6 +106,7 @@
   components:
   - type: MindRole
     antagPrototype: NukeopsCommander
+    getsNoSpendtext: true #imp edit
 
 # Revolutionaries
 - type: entity
@@ -147,6 +150,8 @@
   - type: MindRole
     antagPrototype: Traitor
     exclusiveAntag: true
+    trackPurchases: true
+    getsNoSpendtext: true #imp edit
   - type: TraitorRole
 
 - type: entity
@@ -157,6 +162,7 @@
   components:
   - type: MindRole
     antagPrototype: TraitorSleeper
+    getsNoSpendtext: true # imp edit
 
 # Zombie Squad
 - type: entity

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -150,7 +150,7 @@
   - type: MindRole
     antagPrototype: Traitor
     exclusiveAntag: true
-    trackPurchases: true
+    trackPurchases: true #imp edit
     getsNoSpendtext: true #imp edit
   - type: TraitorRole
 

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -162,6 +162,7 @@
   components:
   - type: MindRole
     antagPrototype: TraitorSleeper
+    trackPurchases: true #imp edit
     getsNoSpendtext: true # imp edit
 
 # Zombie Squad

--- a/Resources/Prototypes/_Goobstation/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/MindRoles/mind_roles.yml
@@ -8,6 +8,7 @@
   - type: MindRole
     antagPrototype: Changeling
     exclusiveAntag: true
+    trackPurchases: true #imp edit
   - type: ChangelingRole
 
 - type: entity
@@ -19,4 +20,5 @@
   - type: MindRole
     antagPrototype: Heretic
     exclusiveAntag: true
+    trackPurchases: true #imp edit
   - type: HereticRole


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
was suggested, thought I could bash it out in an afternoon, so I did

adds a few fields to ObjectiveComponent, MindRoleComponent & MindComponent, a shit ton of code to ObjectivesSystem & some minor tweaks to StoreSystem.Ui + SharedObjectivesSystem

traitor, spent TC
![image3](https://github.com/user-attachments/assets/d38cefa8-486b-4d93-8f34-6eb8b7d8df45)

traitor, spent no TC, achieved at least 50% of their non-trivial (for now everything except survive & dagd) objectives
![image](https://github.com/user-attachments/assets/deb887c2-1bfc-4664-b6d5-4f489657e60b)

traitor, spent no TC & failed non-trivial objectives
![image2](https://github.com/user-attachments/assets/0e417c98-0d90-43fb-81b3-6e7562326d2d)

changeling, spent some evo points; double-purchasing is from refunds
![image4](https://github.com/user-attachments/assets/c0211d10-3fe0-4334-8018-6f3f86900f19)

changeling, spent no evo points & failed (survive isn't actually a trivial objective, but it does work)
![image5](https://github.com/user-attachments/assets/cda5a4bc-232f-4319-94fd-3bf4f234355c)

Also works for heretics like it does changelings (tracks spent & bought, no no-spend message), but I haven't actually tested it because I have no idea how to test heretic stuff
Does not work for nukies & loneops because they don't actually use objectives (curse you upstream!), though I'll make it work if they ever fix that.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidel

ines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The round summary screen now features a list of everything that traitors, changelings & heretics bought throughout the round.
