### PR TITLE
revert reboot timer

### DIFF
--- a/Resources/ConfigPresets/Impstation/impstation.toml
+++ b/Resources/ConfigPresets/Impstation/impstation.toml
@@ -9,7 +9,7 @@ lobbyduration = 300
 [server]
 # TODO
 # rules_file = "ImpstationRuleset"
-uptime_restart_minutes = 720
+uptime_restart_minutes = 240
 
 [chat]
 # Message Of The Day


### PR DESCRIPTION
turns out, there was a reason we reboot so frequently!

changes the restart timer back to 4 hours from 12. reverts #1291