### PR TITLE
Clown Prestige Loadout Tweak

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -247,7 +247,6 @@ loadout-group-chief-medical-officer-neck = Chief Medical Officer neck
 loadout-group-chief-medical-officer-headset = Chief Medical Officer headset
 
 loadout-group-medical-doctor-head = Medical Doctor head
-loadout-group-medical-doctor-mask = Medical Doctor mask
 loadout-group-medical-doctor-jumpsuit = Medical Doctor jumpsuit
 loadout-group-medical-doctor-neck = Medical Doctor neck
 loadout-group-medical-doctor-outerclothing = Medical Doctor outer clothing

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -282,7 +282,6 @@
   loadouts:
   - BlackShoes
   - WinterBoots
-  - ClownShoesExpert
 
 - type: loadoutGroup
   id: BartenderHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -245,6 +245,7 @@
   minLimit: 0
   loadouts:
   - PassengerFace
+  - MaskClown
 
 - type: loadoutGroup
   id: PassengerGloves
@@ -282,6 +283,7 @@
   loadouts:
   - BlackShoes
   - WinterBoots
+  - ClownShoesExpert
 
 - type: loadoutGroup
   id: BartenderHead
@@ -1740,14 +1742,7 @@
   minLimit: 0
   loadouts:
   - SterileMask
-
-- type: loadoutGroup
-  id: MedicalDoctorMask
-  name: loadout-group-medical-doctor-mask
-  minLimit: 0
-  loadouts:
-  - SterileMask
-  - DoctorClown
+  - DoctorClown # imp
 
 - type: loadoutGroup
   id: MedicalInternJumpsuit
@@ -1914,6 +1909,7 @@
   - LeatherShoes
   - BlackShoes
   - WhiteShoes
+  - ClownShoesExpert
 
 - type: loadoutGroup
   id: BoxerJumpsuit

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -245,7 +245,6 @@
   minLimit: 0
   loadouts:
   - PassengerFace
-  - MaskClown
 
 - type: loadoutGroup
   id: PassengerGloves

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1907,7 +1907,7 @@
   - LeatherShoes
   - BlackShoes
   - WhiteShoes
-  - ClownShoesExpert
+  - ClownShoesExpert # imp
 
 - type: loadoutGroup
   id: BoxerJumpsuit

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -65,7 +65,7 @@
   id: JobBartender
   groups:
   - BartenderHead
-  - BartenderMask
+  - BartenderMask # imp
   - BartenderNeck
   - BartenderJumpsuit
   - BartenderOuterClothing
@@ -83,7 +83,9 @@
 - type: roleLoadout
   id: JobServiceWorker
   groups:
+  - BartenderMask # imp
   - BartenderJumpsuit
+  - BartenderShoes # imp
   - Glasses
   - CommonBackpack
   - Survival
@@ -447,6 +449,7 @@
   id: JobWarden
   groups:
   - WardenHead
+  - SecurityMask # imp
   - WardenNeck
   - WardenJumpsuit
   - WardenOuterClothing
@@ -466,7 +469,7 @@
   id: JobSecurityOfficer
   groups:
   - SecurityHead
-  - SecurityMask
+  - SecurityMask # imp
   - SecurityNeck
   - SecurityJumpsuit
   - SecurityOuterClothing
@@ -557,7 +560,7 @@
   id: JobMedicalDoctor
   groups:
   - MedicalDoctorHead
-  - MedicalDoctorMask
+  - MedicalMask
   - MedicalDoctorNeck
   - MedicalDoctorJumpsuit
   - MedicalDoctorOuterClothing
@@ -657,6 +660,7 @@
 - type: roleLoadout
   id: JobPsychologist
   groups:
+  - MedicalMask
   - PsychologistNeck
   - PsychologistJumpsuit
   - PsychologistShoes

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -294,6 +294,7 @@
 - type: roleLoadout
   id: JobSalvageSpecialist
   groups:
+  - CargoTechnicianMask # imp
   - SalvageSpecialistNeck
   - SalvageSpecialistJumpsuit # imp unspecial
   - SalvageSpecialistOuterClothing
@@ -342,7 +343,7 @@
   id: JobStationEngineer
   groups:
   - StationEngineerHead
-  - StationEngineerMask
+  - StationEngineerMask # imp
   - StationEngineerNeck
   - StationEngineerJumpsuit
   - StationEngineerOuterClothing
@@ -359,6 +360,7 @@
 - type: roleLoadout
   id: JobAtmosphericTechnician
   groups:
+  - StationEngineerMask # imp
   - AtmosphericTechnicianNeck
   - AtmosphericTechnicianJumpsuit
   - AtmosphericTechnicianOuterClothing

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/clown_prestige.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/clown_prestige.yml
@@ -94,14 +94,6 @@
 
 # Civilian
 - type: loadout
-  id: MaskClown
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: ClownExpertTimer
-  equipment:
-    mask: ClothingMaskClown
-
-- type: loadout
   id: ChaplinClown
   effects:
   - !type:GroupLoadoutEffect

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/clown_prestige.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/clown_prestige.yml
@@ -94,6 +94,14 @@
 
 # Civilian
 - type: loadout
+  id: MaskClown
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ClownExpertTimer
+  equipment:
+    mask: ClothingMaskClown
+
+- type: loadout
   id: ChaplinClown
   effects:
   - !type:GroupLoadoutEffect

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -271,7 +271,7 @@
     id: MedicalPDA
     belt: ClothingBeltMedicalFilled
     outerClothing: ClothingOuterWinterMed
-    #head: 
+    #head:
     pocket1: EmergencyOxygenTankFilled
     pocket2: ClothingMaskBreath
     ears: ClothingHeadsetMedical
@@ -316,7 +316,7 @@
     ears: ClothingHeadsetService
     eyes: ClothingEyesHudBeer
 
-- type: loadoutGroup 
+- type: loadoutGroup
   id: SalvageSpecialistJumpsuit
   name: loadout-group-salvage-specialist-jumpsuit
   loadouts:


### PR DESCRIPTION
Adds the prestige clown stuff to a few jobs that didn't have it before, like chemist, paramedic, atmos tech, warden (deliberately did not give to the hos), atmos tech, salvage, service worker and NOT PASSENGER

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The prestige clown gear is now available in a few more job loadouts.