### PR TITLE
Make salvage specialist rolled antag immune

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -12,6 +12,7 @@
   icon: "JobIconShaftMiner"
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm
+  canBeAntag: false #imp edit
   access:
   - Cargo
   - Salvage


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Salvage antags have been a pain point for a very long time, since spawning with a firearm, hardsuit, jetpack, externals access, and an excuse to be missing for half the shift is extremely disproportionately powerful as an antag compared to other roles. It also causes issues for team cohesion when one or more of your salv buddies just disappear at roundstart and leave you alone, often wordlessly.
This PR adds the same prevention check that security has to prevent antag rolling to salvage specialists. This DOES NOT include a mindshield, so you can still rev them all the same.
I believe this is a significantly more elegant solution than other proposed methods (bomb collars, remote trackers, etc.) and should help to keep salvage together as a team by minimizing the forces pulling them apart.
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Salvagers can no longer roll roundstart antags. This does not include a mindshield, so they can still be rev converted,
