### PR TITLE
Fixes the TC spend summary

### DIFF
--- a/Content.Shared/Roles/MindRoleComponent.cs
+++ b/Content.Shared/Roles/MindRoleComponent.cs
@@ -43,9 +43,10 @@ public sealed partial class MindRoleComponent : BaseMindRoleComponent
 
     /// <summary>
     /// imp edit - should purchases made by this role be tracked?
+    /// Defaults to true because normal jobs are also mindRoles.
     /// </summary>
     [DataField]
-    public bool TrackPurchases;
+    public bool TrackPurchases = true;
 
     /// <summary>
     /// imp edit - if true, the player with this role will get complimented for not spending anything

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -108,7 +108,7 @@
   components:
   - type: MindRole
     antagPrototype: NukeopsCommander
-    trackPurchases: false#imp edit
+    trackPurchases: false #imp edit
     getsNoSpendtext: true #imp edit
 
 # Revolutionaries

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -85,6 +85,7 @@
   - type: MindRole
     exclusiveAntag: true
     antagPrototype: Nukeops
+    trackPurchases: false #imp edit
     getsNoSpendtext: true #imp edit
   - type: NukeopsRole
 
@@ -96,6 +97,7 @@
   components:
   - type: MindRole
     antagPrototype: NukeopsMedic
+    trackPurchases: false #imp edit
     getsNoSpendtext: true #imp edit
 
 - type: entity
@@ -106,6 +108,7 @@
   components:
   - type: MindRole
     antagPrototype: NukeopsCommander
+    trackPurchases: false#imp edit
     getsNoSpendtext: true #imp edit
 
 # Revolutionaries
@@ -150,7 +153,6 @@
   - type: MindRole
     antagPrototype: Traitor
     exclusiveAntag: true
-    trackPurchases: true #imp edit
     getsNoSpendtext: true #imp edit
   - type: TraitorRole
 
@@ -162,7 +164,6 @@
   components:
   - type: MindRole
     antagPrototype: TraitorSleeper
-    trackPurchases: true #imp edit
     getsNoSpendtext: true # imp edit
 
 # Zombie Squad

--- a/Resources/Prototypes/_Goobstation/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/MindRoles/mind_roles.yml
@@ -8,7 +8,6 @@
   - type: MindRole
     antagPrototype: Changeling
     exclusiveAntag: true
-    trackPurchases: true #imp edit
   - type: ChangelingRole
 
 - type: entity
@@ -20,5 +19,4 @@
   - type: MindRole
     antagPrototype: Heretic
     exclusiveAntag: true
-    trackPurchases: true #imp edit
   - type: HereticRole


### PR DESCRIPTION
Pro gamedev tip : test things instead of assuming they'll work
Makes TrackPurchases default to true so that the crew's ordinary jobs don't prevent their traitor roles from tracking what they bought.

Minor fix, no cl.