### PR TITLE
ancestor slipping and laying down (monkeys, kobolds)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1345,6 +1345,7 @@
       methods: [ Touch ]
       effects:
       - !type:WashCreamPieReaction
+  - type: LayingDown # imp
 
 
 


### PR DESCRIPTION
resolves #650. adds the LayingDown component to the base ancestor prototype, which monkeys and kobolds inherit from. this lets them lay down on command too when player-controlled. yay!

**Changelog**
:cl:
- fix: Monkeys and kobolds slip properly on soap now. They can lay down at will, too.