### PR TITLE
crawling stand up do-after

### DIFF
--- a/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
+++ b/Content.Shared/_Goobstation/Standing/LayingDownComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._Goobstation.Standing;
 public sealed partial class LayingDownComponent : Component
 {
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan Cooldown { get; set; } = TimeSpan.FromSeconds(2.5);
+    public TimeSpan Cooldown { get; set; } = TimeSpan.FromSeconds(1.5);
 
     [DataField, AutoNetworkedField]
     public TimeSpan NextLayDown;

--- a/Content.Shared/_Goobstation/Standing/StandUpDoAfterEvent.cs
+++ b/Content.Shared/_Goobstation/Standing/StandUpDoAfterEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Goobstation.Standing;
+
+[Serializable, NetSerializable]
+public sealed partial class StandUpDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Resources/Locale/en-US/_Goobstation/laying-down/popup.ftl
+++ b/Resources/Locale/en-US/_Goobstation/laying-down/popup.ftl
@@ -1,1 +1,1 @@
-popup-laying-down-cooldown-stand-up = Cannot stand up yet!
+popup-laying-down-stand-up-cancel = Failed to stand up!


### PR DESCRIPTION
changes the "standing up after laying down" cooldown to utilise a do-after rather than a hard lockout

also reduces the standing up cooldown from 2.5s to 1.5s to match the shortest soap slip, to avoid issues where people with auto get-up disabled are slightly disadvantaged

i didn't test every possible interrupt but moving, being attacked, and hand interactions don't interrupt the do-after which i think should be ideal

**Changelog**
:cl:
- tweak: Standing up from crawling now has a shorter cooldown, and will start a do-after if you are still below the cooldown instead of locking you out.