### PR TITLE
supermatter atmos devices

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Atmospherics/thresholds.yml
@@ -1,0 +1,15 @@
+- type: alarmThreshold
+  id: supermatterTemperature
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 626.3
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.5
+
+- type: alarmThreshold
+  id: supermatterPressure
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 550 # HazardHighPressure from Atmospherics.cs
+  lowerBound: !type:AlarmThresholdSetting
+    threshold: 0
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.5

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Structures/Specific/Atmospherics/supermatter.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Structures/Specific/Atmospherics/supermatter.yml
@@ -1,0 +1,39 @@
+- type: entity
+  abstract: true
+  parent: AirSensorBase
+  id: AirSensorSupermatterBase
+  suffix: Supermatter
+  components:
+  - type: AtmosMonitor
+    temperatureThresholdId: supermatterTemperature
+    pressureThresholdId: supermatterPressure
+    gasThresholdPrototypes:
+      Oxygen: ignore
+      Nitrogen: ignore
+      CarbonDioxide: ignore
+      Plasma: stationPlasma # dangerous
+      Tritium: stationTritium # VERY dangerous
+      WaterVapor: ignore
+      Ammonia: ignore
+      NitrousOxide: ignore
+      Frezon: ignore
+
+- type: entity
+  parent: [AirSensorSupermatterBase, AirSensor]
+  id: AirSensorSupermatter
+
+- type: entity
+  parent: [AirSensorSupermatterBase, GasVentPump]
+  id: GasVentPumpSupermatter
+
+- type: entity
+  parent: [AirSensorSupermatterBase, GasVentScrubber]
+  id: GasVentScrubberSupermatter
+
+- type: entity
+  id: AirAlarmSupermatter
+  parent: AirAlarm
+  suffix: Supermatter
+  components:
+  - type: AccessReader
+    access: [["Atmospherics"], ["Engineering"]]

--- a/Resources/Prototypes/_EinsteinEngines/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Recipes/Lathes/electronics.yml
@@ -1,0 +1,4 @@
+- type: latheRecipe
+  parent: BaseCircuitboardRecipe
+  id: SupermatterComputerCircuitboard
+  result: SupermatterComputerCircuitboard

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Wallmounts/air_alarm.yml
@@ -1,7 +1,0 @@
-- type: entity
-  id: AirAlarmSupermatter
-  parent: AirAlarm
-  suffix: Supermatter
-  components:
-  - type: AccessReader
-    access: [["Atmospherics"], ["Engineering"]]

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/electronics.yml
@@ -25,8 +25,3 @@
   parent: BaseCircuitboardRecipe
   id: ServiceTechFabCircuitboard
   result: ServiceTechFabCircuitboard
-
-- type: latheRecipe
-  parent: BaseCircuitboardRecipe
-  id: SupermatterComputerCircuitboard
-  result: SupermatterComputerCircuitboard


### PR DESCRIPTION
added air sensors, vents, and scrubbers with thresholds (somewhat) tuned for the supermatter. pressure doesn't _actually_ matter for the supermatter, gas moles do, but there's no way to track that so whatever. temperature values are set to values that the supermatter doesn't currently match up with, but will as soon as i get around to fixing up the sm more

**Changelog**
pr for mappers, no changelog