### PR TITLE
Port mid-round antag spawn marker from DeltaV/Nyanotrasen

### DIFF
--- a/Resources/Prototypes/_Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/_Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
@@ -1,0 +1,12 @@
+- type: entity
+  id: SpawnPointLocationMidRoundAntag
+  name: mid-round antag spawn location
+  suffix: Fugitive, Paradox Anomaly
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    sprite: Markers/jobs.rsi
+    layers:
+      - state: green
+      - state: prisoner
+  - type: MidRoundAntagSpawnLocation


### PR DESCRIPTION
Adds in a a spawn marker which is used on DeltaV to spawn fugitive and paradox anomaly ghost roles. This is required so that mappers can manually pick areas for fugitives to spawn in as was intended with #1283. I took the liberty of renaming the entity from "possible spawn location" to "mid-round antag spawn location" with the suffix "Fugitive, Paradox Anomaly" to make it a bit more clear as to what its function is.
