### PR TITLE
doubling most command role timers

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -9,10 +9,10 @@
       time: 21600 #6 hrs
     - !type:RoleTimeRequirement
       role: JobSalvageSpecialist
-      time: 10800 #3 hrs
+      time: 10800 #3 hrs (too popular)
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 36000 #10 hours
+      time: 72000 #20 hours, imp
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -13,9 +13,15 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 54000 # 15 hours
+    - !type:DepartmentTimeRequirement #imp
+      department: Cargo
+      time: 54000 # 15 hours
+    - !type:DepartmentTimeRequirement #imp
+      department: Science
+      time: 54000 # 15 hours
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 54000 # 15 hours
+      time: 72000 # 20 hours, imp
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -13,6 +13,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10 hrs
+    - !type:DepartmentTimeRequirement #imp
+      department: Cargo
+      time: 36000 # 10 hrs
+    - !type:DepartmentTimeRequirement #imp
+      department: Science
+      time: 36000 # 10 hrs
     - !type:DepartmentTimeRequirement
       department: Command
       time: 36000 # 10 hours

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -12,7 +12,7 @@
       time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 36000 #10 hrs
+      time: 72000 #20 hrs, imp
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -8,13 +8,13 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobChemist
-      time: 10800 #3 hrs
+      time: 21600 #6 hrs, imp. why tf was this so low?
     - !type:RoleTimeRequirement
       role: JobMedicalDoctor
       time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 36000 #10 hrs
+      time: 72000 #20 hrs, imp
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 36000 #10 hrs
+      time: 72000 #20 hrs, imp
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10


### PR DESCRIPTION
department command > 20h in department (up from 10)
cmo > 6h chemistry (up from 3)
captain > 20h command (up from 15)

hop and captain now also need time in cargo and sci, same amount of hours as with other departments

:cl:
- tweak: Increased the time required to play certain command roles.
