### PR TITLE
Add kobold spawn marker, migrate prototypes to _Impstation and _Wizden folders

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
@@ -63,19 +63,6 @@
       - MobCorgiMouse
 
 - type: entity
-  name: Finfin Spawner
-  id: SpawnMobFinfin
-  parent: MarkerBase
-  components:
-  - type: Sprite
-    layers:
-      - state: green
-      - state: ai
-  - type: ConditionalSpawner
-    prototypes:
-      - MobFinfin
-
-- type: entity
   name: Possum Morty Spawner
   id: SpawnMobPossumMorty
   parent: MarkerBase
@@ -87,32 +74,6 @@
   - type: ConditionalSpawner
     prototypes:
       - MobPossumMortyOld
-
-- type: entity
-  name: Poppy Spawner
-  id: SpawnMobPoppy
-  parent: MarkerBase
-  components:
-  - type: Sprite
-    layers:
-      - state: green
-      - state: ai
-  - type: ConditionalSpawner
-    prototypes:
-      - MobPossumPoppy
-
-- type: entity
-  name: Goji Spawner
-  id: SpawnMobGoji
-  parent: MarkerBase
-  components:
-  - type: Sprite
-    layers:
-      - state: green
-      - state: ai
-  - type: ConditionalSpawner
-    prototypes:
-      - MobGoji
 
 - type: entity
   name: Raccoon Morticia Spawner
@@ -157,6 +118,7 @@
 - type: entity
   name: Runtime Spawner
   id: SpawnMobCatRuntime
+  #suffix imp edit
   suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
@@ -171,6 +133,7 @@
 - type: entity
   name: Exception Spawner
   id: SpawnMobCatException
+  #suffix imp edit
   suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
@@ -198,6 +161,7 @@
 - type: entity
   name: Floppa Spawner
   id: SpawnMobCatFloppa
+  #suffix imp edit
   suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
@@ -212,6 +176,7 @@
 - type: entity
   name: Bingus Spawner
   id: SpawnMobCatBingus
+  #suffix imp edit
   suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
@@ -252,6 +217,7 @@
 - type: entity
   name: Cat Spawner
   id: SpawnMobCat
+  #suffix imp edit
   suffix: CMO's pet, steal target
   parent: MarkerBase
   components:
@@ -267,7 +233,7 @@
       - MobBingus
       - MobPipi
     rarePrototypes:
-      - MobFinfin
+      - MobFinfin #imp edit
     rareChance: 0.05
 
 - type: entity
@@ -287,7 +253,7 @@
       - MobCatKitten
     rarePrototypes:
       - MobCatSpace
-      - MobFinfin
+      - MobFinfin #imp edit
     rareChance: 0.05
 
 - type: entity
@@ -986,4 +952,3 @@
   - type: ConditionalSpawner
     prototypes:
     - MobReindeerDoe
-

--- a/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
@@ -89,20 +89,6 @@
       - MobRaccoonMorticia
 
 - type: entity
-  name: Drone Spawner
-  id: SpawnMobDrone
-  parent: MarkerBase
-  components:
-  - type: Sprite
-    layers:
-      - state: green
-      - sprite: Mobs/Silicon/drone.rsi
-        state: shell
-  - type: ConditionalSpawner
-    prototypes:
-      - Drone
-
-- type: entity
   name: Fox Renault Spawner
   id: SpawnMobFoxRenault
   parent: MarkerBase

--- a/Resources/Prototypes/_Impstation/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Impstation/Markers/Spawners/mobs.yml
@@ -1,0 +1,54 @@
+- type: entity
+  name: Finfin Spawner
+  id: SpawnMobFinfin
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+      - MobFinfin
+
+- type: entity
+  name: Poppy Spawner
+  id: SpawnMobPoppy
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+      - MobPossumPoppy
+
+- type: entity
+  name: Goji Spawner
+  id: SpawnMobGoji
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+      - MobGoji
+
+- type: entity
+  name: Kobold Spawner
+  id: SpawnMobKobold
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - state: kobold
+      sprite: Mobs/Animals/kobold.rsi
+    - state: outline
+      sprite: Mobs/Animals/kobold.rsi
+  - type: ConditionalSpawner
+    prototypes:
+    - MobKobold

--- a/Resources/Prototypes/_Wizden/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Wizden/Entities/Markers/Spawners/mobs.yml
@@ -1,0 +1,13 @@
+- type: entity
+  name: Drone Spawner
+  id: SpawnMobDrone
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Mobs/Silicon/drone.rsi
+        state: shell
+  - type: ConditionalSpawner
+    prototypes:
+      - Drone


### PR DESCRIPTION
Adds a kobold spawn marker for mappers. Moves spawn markers we've made to the _Impstation folder. Adds a _Wizden folder for the drone map marker to indicate that it's from Wizden, but not from an upstream merge.
