### PR TITLE
signature font fixes(?) (hopefully?)

### DIFF
--- a/Content.Shared/_DV/Paper/SignatureWriterSystem.cs
+++ b/Content.Shared/_DV/Paper/SignatureWriterSystem.cs
@@ -42,7 +42,7 @@ public sealed class SignatureWriterSystem : EntitySystem
                     Act = () =>
                     {
                         comp.Font = entry.Value;
-                        _popup.PopupPredicted(Loc.GetString("signature-writer-component-font-set", ("color", entry.Key)), args.User, args.User);
+                        _popup.PopupPredicted(Loc.GetString("signature-writer-component-font-set", ("font", entry.Key)), args.User, args.User);
                     }
                 };
 

--- a/Resources/Prototypes/_DV/fonts.yml
+++ b/Resources/Prototypes/_DV/fonts.yml
@@ -1,0 +1,51 @@
+- type: font
+  id: AndTheDoorCreeeaked
+  path: /Fonts/_DV/AndTheDoorCreeeaked/AndTheDoorCreeeaked-Regular.otf
+
+- type: font
+  id: ComicNeue
+  path: /Fonts/_DV/ComicNeue/ComicNeue-Regular.ttf
+
+- type: font
+  id: ComicNeueBold
+  path: /Fonts/_DV/ComicNeue/ComicNeue-Bold.ttf
+
+- type: font
+  id: HachiMaruPop
+  path: /Fonts/_DV/HachiMaruPop/HachiMaruPop-Regular.ttf
+
+- type: font
+  id: KodeMono
+  path: /Fonts/_DV/KodeMono/KodeMono-Regular.ttf
+
+- type: font
+  id: KodeMonoBold
+  path: /Fonts/_DV/KodeMono/KodeMono-Bold.ttf
+
+- type: font
+  id: ReenieBeanie
+  path: /Fonts/_DV/ReenieBeanie/ReenieBeanie-Regular.ttf
+
+- type: font
+  id: Sixtyfour
+  path: /Fonts/_DV/Sixtyfour/Sixtyfour-Regular.ttf
+
+- type: font
+  id: SwampWitch
+  path: /Fonts/_DV/SwampWitch/SwampWitch.ttf
+
+- type: font
+  id: Tangerine
+  path: /Fonts/_DV/Tangerine/Tangerine_Regular.ttf
+
+- type: font
+  id: TangerineBold
+  path: /Fonts/_DV/Tangerine/Tangerine_Bold.ttf
+
+- type: font
+  id: UnifrakturMaguntia
+  path: /Fonts/_DV/UnifrakturMaguntia/UnifrakturMaguntia-Regular.ttf
+
+- type: font
+  id: Wahroonga
+  path: /Fonts/_DV/Wahroonga/Wahroonga-Regular.ttf


### PR DESCRIPTION
fixes a locale issue with cybersun pen font selection, and _maybe_ fixes fonts not being sent from server to client by attaching them to prototypes. i dont know if this actually works: i tested signatures on my localhost with kip and they got downloaded and displayed properly without these prototypes. maybe a caching issue or something? i dont really know

**Changelog**
uncertain if this actually works so no cl