### PR TITLE
Clown waddling now appears for other players

### DIFF
--- a/Content.Shared/_Wizden/Movement/Systems/SharedWaddleAnimationSystem.cs
+++ b/Content.Shared/_Wizden/Movement/Systems/SharedWaddleAnimationSystem.cs
@@ -66,7 +66,6 @@ public abstract class SharedWaddleAnimationSystem : EntitySystem
         entity.Comp.IsCurrentlyWaddling = true;
 
         RaiseNetworkEvent(new StartedWaddlingEvent(GetNetEntity(entity.Owner)));
-
     }
 
     private void OnStood(Entity<WaddleAnimationComponent> entity, ref StoodEvent args)

--- a/Content.Shared/_Wizden/Movement/Systems/SharedWaddleAnimationSystem.cs
+++ b/Content.Shared/_Wizden/Movement/Systems/SharedWaddleAnimationSystem.cs
@@ -44,7 +44,7 @@ public abstract class SharedWaddleAnimationSystem : EntitySystem
         // If the waddler is currently moving, make them start waddling
         if ((moverComponent.HeldMoveButtons & MoveButtons.AnyDirection) == MoveButtons.AnyDirection)
         {
-            StopWaddling(entity);
+            RaiseNetworkEvent(new StartedWaddlingEvent(GetNetEntity(entity.Owner)));
         }
     }
 

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -28,6 +28,7 @@
           - Sharp
   #begin imp edit
   - type: ItemToggle
+    activated: true
     onUse: false
     onActivate: false
     soundActivate: 


### PR DESCRIPTION
Fixes clown waddling only appearing to the person waddling. There are still some issues with clown waddling (because of course there would be), but I want to at least put this in the game while it gets figured out.

Known Issues:
- Toggling waddling off while waddling does not stop the animation for other players until the waddler stops moving.
- Waddling while prone sometimes makes you appear standing when you stop moving, but only from the waddler's perspective.
- Pressing the walk key has some weird interactions with the waddle system. Pressing the key will sometimes make you waddle in place, for example.

**Changelog**

:cl:
- fix: Clown waddling now appears for other players. Consequently, clown shoes now start toggled on.
