### PR TITLE
Remove mimic random event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -13,7 +13,7 @@
     - id: IonStorm # its calm like 90% of the time smh
     - id: KudzuGrowth
     - id: MassHallucinations
-    - id: MimicVendorRule
+    # - id: MimicVendorRule
     - id: PowerGridCheck
     - id: RandomSentience
     - id: SolarFlare


### PR DESCRIPTION
It's a nothing event that at best makes a high-value vendor inaccessible. We can put it back in when it has anything going for it.

**Changelog**

:cl:
- remove: The vending machine random event has been removed.
