### PR TITLE
Banana extension + Add accessreader to courier hardsuit locker

### DIFF
--- a/Resources/Maps/_Impstation/banana.yml
+++ b/Resources/Maps/_Impstation/banana.yml
@@ -47,11 +47,11 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAABAAAAAAABAAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAAQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAACQAAAAAACQAAAAAACQAAAAAAhQAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAhQAAAAAACQAAAAAACQAAAAAACQAAAAAAhQAAAAAAhAAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAhQAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAhQAAAAAABAAAAAAABAAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAABQAAAAAABQAAAAAABQAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAhQAAAAAABQAAAAAABQAAAAAABQAAAAAAhQAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAhQAAAAAABgAAAAAABgAAAAAABgAAAAAAhQAAAAAAAAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAhQAAAAAAhAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAhQAAAAAABQAAAAAABQAAAAAABQAAAAAAhQAAAAAAhQAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAhQAAAAAAhQAAAAAABgAAAAAAAQAAAAAAhQAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
@@ -205,7 +205,6 @@ entities:
             id: BrickLineOverlayE
           decals:
             233: 4,-7
-            234: 4,-6
         - node:
             color: '#89347ECD'
             id: BrickLineOverlayN
@@ -267,8 +266,9 @@ entities:
           decals:
             122: -9,2
             168: -20,2
-            183: 5,2
             301: -2,2
+            738: 9,2
+            739: 8,3
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteCornerNe
@@ -281,6 +281,11 @@ entities:
             id: BrickTileWhiteCornerNe
           decals:
             691: -7,10
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteCornerNe
+          decals:
+            725: 8,-5
         - node:
             color: '#D381C996'
             id: BrickTileWhiteCornerNe
@@ -312,6 +317,7 @@ entities:
             133: -24,2
             300: 4,2
             548: -7,2
+            744: 5,3
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteCornerNw
@@ -325,6 +331,11 @@ entities:
             id: BrickTileWhiteCornerNw
           decals:
             695: -11,10
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteCornerNw
+          decals:
+            724: 6,-5
         - node:
             color: '#D381C996'
             id: BrickTileWhiteCornerNw
@@ -351,9 +362,9 @@ entities:
             id: BrickTileWhiteCornerSe
           decals:
             109: -9,-2
-            184: 5,-3
             452: -30,-17
             477: -21,-18
+            737: 9,-3
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteCornerSe
@@ -367,6 +378,11 @@ entities:
           decals:
             685: -9,4
             696: -7,8
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteCornerSe
+          decals:
+            723: 8,-8
         - node:
             color: '#D381C996'
             id: BrickTileWhiteCornerSe
@@ -412,6 +428,11 @@ entities:
           decals:
             684: -11,4
         - node:
+            color: '#A4610696'
+            id: BrickTileWhiteCornerSw
+          decals:
+            722: 6,-8
+        - node:
             color: '#D381C996'
             id: BrickTileWhiteCornerSw
           decals:
@@ -439,11 +460,17 @@ entities:
             124: -9,1
             305: -2,0
             543: -20,1
+            740: 8,2
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteInnerNe
           decals:
             516: -17,5
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteInnerNe
+          decals:
+            718: 4,-6
         - node:
             color: '#DE3A3A96'
             id: BrickTileWhiteInnerNe
@@ -470,12 +497,18 @@ entities:
             170: -18,1
             304: 4,0
             474: -23,-15
+            736: 5,2
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteInnerNw
           decals:
             497: -15,5
             517: -18,5
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteInnerNw
+          decals:
+            720: 6,-6
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteInnerNw
@@ -499,6 +532,11 @@ entities:
             id: BrickTileWhiteInnerSe
           decals:
             582: -17,5
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteInnerSe
+          decals:
+            717: 4,-6
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteInnerSe
@@ -526,6 +564,11 @@ entities:
           decals:
             490: -15,5
             518: -18,7
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteInnerSw
+          decals:
+            719: 6,-6
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteInnerSw
@@ -565,11 +608,11 @@ entities:
             164: -21,-4
             165: -21,-3
             166: -21,-2
-            178: 5,-2
-            179: 5,-1
-            180: 5,0
-            181: 5,1
             302: -2,1
+            730: 9,-2
+            731: 9,-1
+            732: 9,0
+            733: 9,1
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteLineE
@@ -594,6 +637,12 @@ entities:
             687: -9,6
             688: -9,7
             690: -7,9
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteLineE
+          decals:
+            712: 8,-7
+            713: 8,-6
         - node:
             color: '#D381C996'
             id: BrickTileWhiteLineE
@@ -676,6 +725,8 @@ entities:
             545: -3,2
             546: -6,2
             547: -5,2
+            734: 7,3
+            735: 6,3
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteLineN
@@ -694,6 +745,12 @@ entities:
             692: -8,10
             693: -9,10
             694: -10,10
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteLineN
+          decals:
+            714: 7,-5
+            715: 5,-6
         - node:
             color: '#D381C996'
             id: BrickTileWhiteLineN
@@ -767,6 +824,10 @@ entities:
             570: -13,-1
             571: -12,-1
             572: -20,-1
+            726: 5,-3
+            727: 6,-3
+            728: 7,-3
+            729: 8,-3
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteLineS
@@ -783,6 +844,12 @@ entities:
             id: BrickTileWhiteLineS
           decals:
             689: -8,8
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteLineS
+          decals:
+            711: 7,-8
+            716: 5,-6
         - node:
             color: '#D381C996'
             id: BrickTileWhiteLineS
@@ -859,6 +926,11 @@ entities:
             681: -11,7
             682: -11,6
             683: -11,5
+        - node:
+            color: '#A4610696'
+            id: BrickTileWhiteLineW
+          decals:
+            743: 6,-7
         - node:
             color: '#D381C996'
             id: BrickTileWhiteLineW
@@ -980,16 +1052,25 @@ entities:
           0,3:
             1: 15
           -1,3:
-            1: 124
+            1: 125
           1,0:
-            0: 59255
+            0: 61439
           1,2:
             0: 257
-            1: 12338
+            1: 12534
           1,-1:
-            0: 30590
+            0: 65528
           1,1:
-            1: 26336
+            0: 3816
+            1: 24576
+          2,0:
+            0: 63351
+          2,1:
+            1: 64192
+          2,2:
+            1: 53
+          2,-1:
+            0: 30591
           0,-3:
             0: 20480
           0,-2:
@@ -1000,10 +1081,14 @@ entities:
             0: 64716
             3: 816
           1,-2:
-            0: 4369
-            1: 3268
+            0: 57309
           1,-3:
-            1: 17472
+            1: 3200
+          2,-3:
+            1: 50544
+          2,-2:
+            0: 4369
+            1: 3208
           -4,-4:
             1: 17510
             0: 12288
@@ -1058,6 +1143,7 @@ entities:
             1: 40878
           -5,3:
             0: 255
+            1: 8192
           -4,4:
             1: 31
           -3,1:
@@ -1065,7 +1151,7 @@ entities:
           -3,2:
             0: 3839
           -3,3:
-            1: 3874
+            1: 4010
           -2,1:
             0: 36863
           -2,2:
@@ -1095,10 +1181,10 @@ entities:
             0: 29
             1: 61184
           -8,3:
-            1: 58129
+            1: 62225
             0: 206
           -9,3:
-            1: 243
+            1: 61683
           -7,0:
             0: 30719
           -7,1:
@@ -1129,6 +1215,8 @@ entities:
             0: 65262
           -6,4:
             1: 239
+          -5,4:
+            1: 255
           -8,-4:
             0: 49407
             1: 4096
@@ -1142,14 +1230,14 @@ entities:
             1: 4369
             0: 52236
           -9,-3:
-            1: 17604
+            1: 50372
           -8,-2:
             1: 4369
             0: 52428
           -9,-2:
             1: 19652
           -9,-1:
-            1: 60484
+            1: 60492
           -7,-4:
             0: 61695
           -7,-3:
@@ -1177,10 +1265,14 @@ entities:
           -10,1:
             1: 13090
             0: 34952
+          -11,2:
+            1: 34952
           -10,2:
-            1: 18147
+            1: 18403
+          -11,3:
+            1: 2184
           -10,3:
-            1: 12
+            1: 63884
           -8,-6:
             1: 279
             0: 47648
@@ -1200,12 +1292,12 @@ entities:
           -7,-5:
             0: 2032
           -6,-7:
-            1: 12032
+            1: 44800
           -6,-6:
             1: 15
             0: 65280
           -5,-7:
-            1: 36608
+            1: 44800
           -5,-6:
             1: 15
             0: 65280
@@ -1213,8 +1305,6 @@ entities:
             1: 12544
           -4,-6:
             1: 8754
-          -5,4:
-            1: 255
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -1326,7 +1416,7 @@ entities:
     - type: RadiationGridResistance
     - type: BecomesStation
       id: Banana
-  - uid: 2631
+  - uid: 2933
     components:
     - type: MetaData
       name: grid
@@ -1365,7 +1455,7 @@ entities:
         nodes: []
 - proto: AirAlarm
   entities:
-  - uid: 4
+  - uid: 3
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1373,30 +1463,30 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1513
-      - 1538
-      - 1100
-      - 1101
-      - 1102
-      - 1122
-  - uid: 5
+      - 1673
+      - 1700
+      - 1221
+      - 1222
+      - 1223
+      - 1243
+  - uid: 4
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1514
-      - 1548
-      - 1152
-      - 1153
-      - 1154
-      - 1092
-      - 1091
-      - 1102
-      - 1101
-      - 1100
-  - uid: 6
+      - 1674
+      - 1710
+      - 1276
+      - 1277
+      - 1278
+      - 1213
+      - 1212
+      - 1223
+      - 1222
+      - 1221
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1404,17 +1494,17 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1125
-      - 1126
-      - 1095
-      - 1123
-      - 1124
-      - 1127
-      - 1539
-      - 1523
-      - 1563
-      - 1533
-  - uid: 7
+      - 1246
+      - 1247
+      - 1216
+      - 1244
+      - 1245
+      - 1248
+      - 1701
+      - 1682
+      - 1725
+      - 1692
+  - uid: 6
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1422,22 +1512,22 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1127
-      - 1536
-  - uid: 8
+      - 1248
+      - 1698
+  - uid: 7
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1528
-      - 1558
-      - 1095
-      - 1123
-      - 1124
-      - 1096
-  - uid: 9
+      - 1687
+      - 1720
+      - 1216
+      - 1244
+      - 1245
+      - 1217
+  - uid: 8
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1445,13 +1535,13 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1128
-      - 1096
-      - 1097
-      - 1556
-      - 1524
-      - 1166
-  - uid: 10
+      - 1249
+      - 1217
+      - 1218
+      - 1718
+      - 1683
+      - 1290
+  - uid: 9
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1459,9 +1549,9 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1088
-      - 1553
-  - uid: 11
+      - 1209
+      - 1715
+  - uid: 10
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1469,15 +1559,15 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1099
-      - 1155
-      - 1156
-      - 1157
-      - 1158
-      - 1163
-      - 1543
-      - 1517
-  - uid: 12
+      - 1220
+      - 1279
+      - 1280
+      - 1281
+      - 1282
+      - 1287
+      - 1705
+      - 1677
+  - uid: 11
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1485,15 +1575,15 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1097
-      - 1162
-      - 1164
-      - 1099
-      - 1098
-      - 1525
-      - 1537
-      - 1166
-  - uid: 13
+      - 1218
+      - 1286
+      - 1288
+      - 1220
+      - 1219
+      - 1684
+      - 1699
+      - 1290
+  - uid: 12
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1501,34 +1591,34 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1161
-      - 1160
-      - 1159
-      - 1109
-      - 1110
-      - 1111
-      - 1554
-      - 1518
-      - 1143
-      - 1142
-      - 1165
-      - 1147
-      - 1168
-      - 1167
-  - uid: 14
+      - 1285
+      - 1284
+      - 1283
+      - 1230
+      - 1231
+      - 1232
+      - 1716
+      - 1678
+      - 1267
+      - 1266
+      - 1289
+      - 1271
+      - 1292
+      - 1291
+  - uid: 13
     components:
     - type: Transform
       pos: -28.5,-2.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1519
-      - 1547
-      - 1817
-      - 1165
-      - 1142
-      - 1143
-  - uid: 15
+      - 1679
+      - 1709
+      - 1260
+      - 1289
+      - 1266
+      - 1267
+  - uid: 14
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1536,24 +1626,24 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1146
-      - 1145
-      - 1144
-      - 1147
-      - 1557
-      - 1527
-  - uid: 16
+      - 1270
+      - 1269
+      - 1268
+      - 1271
+      - 1719
+      - 1686
+  - uid: 15
     components:
     - type: Transform
       pos: -17.5,-13.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1121
-      - 1107
-      - 1521
-      - 1560
-  - uid: 17
+      - 1242
+      - 1228
+      - 1681
+      - 1722
+  - uid: 16
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1561,24 +1651,24 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1530
-      - 1551
-      - 1107
-      - 1139
-      - 1140
-      - 1141
-      - 1105
-      - 1129
-  - uid: 18
+      - 1689
+      - 1713
+      - 1228
+      - 1263
+      - 1264
+      - 1265
+      - 1226
+      - 1250
+  - uid: 17
     components:
     - type: Transform
       pos: -26.5,-16.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1552
-      - 1105
-  - uid: 19
+      - 1714
+      - 1226
+  - uid: 18
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1586,22 +1676,22 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1550
-      - 1108
-  - uid: 20
+      - 1712
+      - 1229
+  - uid: 19
     components:
     - type: Transform
       pos: -30.5,-13.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1135
-      - 1136
-      - 1531
-      - 1561
-      - 1106
-      - 1103
-  - uid: 21
+      - 1254
+      - 1255
+      - 1690
+      - 1723
+      - 1227
+      - 1224
+  - uid: 20
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1609,17 +1699,16 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1133
-      - 1134
-      - 1115
-      - 1089
-      - 1113
-      - 1114
-      - 1090
-      - 1112
-      - 1542
-      - 1522
-  - uid: 22
+      - 1252
+      - 1253
+      - 1236
+      - 1210
+      - 1234
+      - 1235
+      - 1211
+      - 1233
+      - 1704
+  - uid: 21
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1627,47 +1716,51 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1520
-      - 1549
-      - 1111
-      - 1110
-      - 1109
-      - 1103
-      - 1106
-      - 1141
-      - 1140
-      - 1139
-      - 1121
-  - uid: 23
+      - 1680
+      - 1711
+      - 1232
+      - 1231
+      - 1230
+      - 1224
+      - 1227
+      - 1265
+      - 1264
+      - 1263
+      - 1242
+  - uid: 22
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1138
-      - 1151
-      - 1150
-      - 1149
-      - 1544
-      - 1526
-      - 1155
-      - 1156
-      - 1157
-      - 1158
-      - 1163
-      - 1132
-      - 1130
-      - 1115
-      - 1113
-      - 1114
-      - 1089
-      - 1162
-      - 1164
-      - 1515
-      - 1540
-      - 1137
-  - uid: 24
+      - 1301
+      - 1300
+      - 1299
+      - 1298
+      - 1297
+      - 1287
+      - 1282
+      - 1281
+      - 1280
+      - 1279
+      - 1235
+      - 1234
+      - 1210
+      - 1236
+      - 1685
+      - 1706
+      - 1702
+      - 1675
+      - 1257
+      - 1256
+      - 1275
+      - 1274
+      - 1273
+      - 1286
+      - 1288
+      - 1302
+  - uid: 23
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1675,24 +1768,24 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1154
-      - 1153
-      - 1152
-      - 1151
-      - 1150
-      - 1149
-      - 1516
-      - 1541
-  - uid: 25
+      - 1278
+      - 1277
+      - 1276
+      - 1275
+      - 1274
+      - 1273
+      - 1676
+      - 1703
+  - uid: 24
     components:
     - type: Transform
       pos: -27.5,-19.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1555
-      - 1129
-  - uid: 2532
+      - 1717
+      - 1250
+  - uid: 25
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1700,18 +1793,61 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1529
-      - 1559
-      - 2782
-      - 151
-      - 2230
-      - 1144
-      - 1145
-      - 1168
-      - 1167
+      - 1688
+      - 1721
+      - 1262
+      - 1251
+      - 1261
+      - 1268
+      - 1269
+      - 1292
+      - 1291
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1296
+      - 1726
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 2441
+      - 1293
+      - 1295
+      - 1694
+      - 1727
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1302
+      - 1301
+      - 1300
+      - 1299
+      - 1298
+      - 1297
+      - 1258
+      - 1259
+      - 1296
+      - 1293
+      - 1695
+      - 1728
 - proto: AirAlarmDecapoid
   entities:
-  - uid: 26
+  - uid: 29
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1719,12 +1855,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1564
-      - 1534
-      - 1138
+      - 1729
+      - 1696
+      - 1257
 - proto: AirAlarmVox
   entities:
-  - uid: 27
+  - uid: 30
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1732,16 +1868,16 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1116
-      - 1117
-      - 1112
-      - 1090
-      - 1118
-      - 1119
-      - 1120
-      - 1532
-      - 1546
-  - uid: 28
+      - 1237
+      - 1238
+      - 1233
+      - 1211
+      - 1239
+      - 1240
+      - 1241
+      - 1691
+      - 1708
+  - uid: 31
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1749,19 +1885,19 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1137
-      - 1535
-      - 1565
+      - 1256
+      - 1697
+      - 1730
 - proto: AirlockBrigGlassLocked
   entities:
-  - uid: 2594
+  - uid: 32
     components:
     - type: Transform
       pos: -17.5,-5.5
       parent: 2
 - proto: AirlockCaptainLocked
   entities:
-  - uid: 29
+  - uid: 33
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1769,7 +1905,7 @@ entities:
       parent: 2
 - proto: AirlockCargoGlassLocked
   entities:
-  - uid: 30
+  - uid: 34
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1777,42 +1913,54 @@ entities:
       parent: 2
 - proto: AirlockChemistryGlassLocked
   entities:
-  - uid: 31
+  - uid: 35
     components:
     - type: Transform
       pos: -15.5,5.5
       parent: 2
 - proto: AirlockCommandGlassLocked
   entities:
-  - uid: 32
+  - uid: 36
     components:
     - type: Transform
       pos: -22.5,-17.5
       parent: 2
-  - uid: 33
+  - uid: 37
     components:
     - type: Transform
       pos: -21.5,-17.5
       parent: 2
-  - uid: 34
+  - uid: 38
     components:
     - type: Transform
       pos: -24.5,-20.5
       parent: 2
-  - uid: 35
+  - uid: 39
     components:
     - type: Transform
       pos: -20.5,-17.5
       parent: 2
+- proto: AirlockCourierGlassLocked
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
 - proto: AirlockEngineeringGlassLocked
   entities:
-  - uid: 37
+  - uid: 42
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 2
-  - uid: 38
+  - uid: 43
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1820,19 +1968,19 @@ entities:
       parent: 2
 - proto: AirlockEngineeringLocked
   entities:
-  - uid: 36
+  - uid: 44
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,5.5
       parent: 2
-  - uid: 39
+  - uid: 45
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,3.5
       parent: 2
-  - uid: 40
+  - uid: 46
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1840,7 +1988,7 @@ entities:
       parent: 2
 - proto: AirlockExternal
   entities:
-  - uid: 41
+  - uid: 47
     components:
     - type: Transform
       pos: -9.5,-2.5
@@ -1849,17 +1997,17 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2571:
+        2882:
         - DoorStatus: DoorBolt
 - proto: AirlockExternalCargoLocked
   entities:
-  - uid: 42
+  - uid: 48
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 2
-  - uid: 43
+  - uid: 49
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1867,7 +2015,7 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassEngineeringLocked
   entities:
-  - uid: 44
+  - uid: 50
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1877,9 +2025,9 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        45:
+        51:
         - DoorStatus: DoorBolt
-  - uid: 45
+  - uid: 51
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1889,31 +2037,31 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        44:
+        50:
         - DoorStatus: DoorBolt
 - proto: AirlockExternalGlassShuttleArrivals
   entities:
-  - uid: 46
+  - uid: 52
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 7.5,3.5
+      pos: 11.5,-3.5
       parent: 2
-  - uid: 47
+  - uid: 53
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 7.5,-3.5
+      pos: 11.5,3.5
       parent: 2
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
-  - uid: 48
+  - uid: 54
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-16.5
       parent: 2
-  - uid: 49
+  - uid: 55
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1921,72 +2069,78 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleShipyard
   entities:
-  - uid: 50
+  - uid: 56
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 51
+  - uid: 57
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 2
 - proto: AirlockFreezerLocked
   entities:
-  - uid: 52
+  - uid: 58
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
 - proto: AirlockGlass
   entities:
-  - uid: 53
+  - uid: 59
     components:
     - type: Transform
       pos: -23.5,-15.5
       parent: 2
-  - uid: 54
+  - uid: 60
     components:
     - type: Transform
       pos: -23.5,-14.5
       parent: 2
 - proto: AirlockHeadOfPersonnelLocked
   entities:
-  - uid: 55
+  - uid: 61
     components:
     - type: Transform
       pos: -17.5,-17.5
       parent: 2
 - proto: AirlockHydroGlassLocked
   entities:
-  - uid: 56
+  - uid: 62
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
 - proto: AirlockJanitorLocked
   entities:
-  - uid: 57
+  - uid: 63
     components:
     - type: Transform
       pos: -23.5,-12.5
       parent: 2
 - proto: AirlockMaint
   entities:
-  - uid: 58
+  - uid: 64
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 2
 - proto: AirlockMedicalGlass
   entities:
-  - uid: 59
+  - uid: 66
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,3.5
       parent: 2
-  - uid: 60
+  - uid: 67
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1994,13 +2148,13 @@ entities:
       parent: 2
 - proto: AirlockMedicalGlassLocked
   entities:
-  - uid: 61
+  - uid: 68
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,5.5
       parent: 2
-  - uid: 62
+  - uid: 69
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2008,7 +2162,7 @@ entities:
       parent: 2
 - proto: AirlockMedicalMorgueLocked
   entities:
-  - uid: 63
+  - uid: 70
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2016,7 +2170,7 @@ entities:
       parent: 2
 - proto: AirlockSalvageGlassLocked
   entities:
-  - uid: 64
+  - uid: 71
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2024,13 +2178,13 @@ entities:
       parent: 2
 - proto: AirlockScienceGlassLocked
   entities:
-  - uid: 65
+  - uid: 72
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-8.5
       parent: 2
-  - uid: 66
+  - uid: 73
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2038,405 +2192,405 @@ entities:
       parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
-  - uid: 67
+  - uid: 74
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-8.5
       parent: 2
-  - uid: 68
+  - uid: 75
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-8.5
       parent: 2
-  - uid: 69
+  - uid: 76
     components:
     - type: Transform
       pos: -19.5,-7.5
       parent: 2
 - proto: AirlockServiceGlassLocked
   entities:
-  - uid: 70
+  - uid: 77
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 2
-  - uid: 71
+  - uid: 78
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
 - proto: AlwaysPoweredWallLight
   entities:
-  - uid: 72
+  - uid: 79
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
 - proto: APCBasic
   entities:
-  - uid: 75
+  - uid: 80
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,3.5
       parent: 2
-  - uid: 76
+  - uid: 81
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,6.5
       parent: 2
-  - uid: 77
+  - uid: 82
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,4.5
       parent: 2
-  - uid: 78
+  - uid: 83
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 2
-  - uid: 79
+  - uid: 84
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,-10.5
       parent: 2
-  - uid: 80
+  - uid: 85
     components:
     - type: Transform
       pos: -29.5,-13.5
       parent: 2
-  - uid: 81
+  - uid: 86
     components:
     - type: Transform
       pos: -19.5,-17.5
       parent: 2
-  - uid: 82
+  - uid: 87
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 83
+  - uid: 88
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-7.5
       parent: 2
-  - uid: 84
+  - uid: 89
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-2.5
       parent: 2
-  - uid: 85
-    components:
-    - type: Transform
-      pos: -26.5,-19.5
-      parent: 2
-  - uid: 86
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,10.5
-      parent: 2
-  - uid: 87
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-3.5
-      parent: 2
-  - uid: 88
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-1.5
-      parent: 2
-  - uid: 89
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -30.5,-11.5
-      parent: 2
   - uid: 90
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,-2.5
+      pos: -26.5,-19.5
       parent: 2
   - uid: 91
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-11.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,-2.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -11.5,6.5
       parent: 2
-  - uid: 871
+  - uid: 97
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,10.5
       parent: 2
-  - uid: 2687
+  - uid: 98
     components:
     - type: Transform
       pos: -30.5,-17.5
       parent: 2
 - proto: APECircuitboard
   entities:
-  - uid: 92
+  - uid: 99
     components:
     - type: Transform
       pos: -24.35849,-5.373108
       parent: 2
 - proto: ArrivalsShuttleTimer
   entities:
-  - uid: 1068
+  - uid: 100
     components:
     - type: Transform
-      pos: 5.5,4.5
+      pos: 9.5,4.5
       parent: 2
 - proto: Ashtray
   entities:
-  - uid: 94
+  - uid: 101
     components:
     - type: Transform
       pos: 2.6412992,3.5011878
       parent: 2
 - proto: AstroNavCartridge
   entities:
-  - uid: 1946
+  - uid: 102
     components:
     - type: Transform
       pos: -12.35553,-8.245056
       parent: 2
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 95
+  - uid: 103
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-16.5
       parent: 2
-  - uid: 96
+  - uid: 104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-5.5
       parent: 2
-  - uid: 97
+  - uid: 105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
       parent: 2
-  - uid: 98
+  - uid: 106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 2
-  - uid: 99
-    components:
-    - type: Transform
-      pos: -4.5,7.5
-      parent: 2
-  - uid: 100
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-7.5
-      parent: 2
-  - uid: 101
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-6.5
-      parent: 2
-  - uid: 102
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-5.5
-      parent: 2
-  - uid: 103
-    components:
-    - type: Transform
-      pos: 2.5,-8.5
-      parent: 2
-  - uid: 104
-    components:
-    - type: Transform
-      pos: 0.5,-8.5
-      parent: 2
-  - uid: 105
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-3.5
-      parent: 2
-  - uid: 106
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,3.5
-      parent: 2
   - uid: 107
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,8.5
+      pos: -4.5,7.5
       parent: 2
   - uid: 108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -33.5,-14.5
+      pos: -5.5,-7.5
       parent: 2
   - uid: 109
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
       parent: 2
   - uid: 110
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-5.5
       parent: 2
   - uid: 111
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,-14.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,8.5
       parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,3.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-3.5
+      parent: 2
 - proto: AtmosFixDecapoidMarker
   entities:
-  - uid: 112
+  - uid: 120
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
-  - uid: 113
+  - uid: 121
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 114
+  - uid: 122
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 115
+  - uid: 123
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
 - proto: AtmosFixFreezerMarker
   entities:
-  - uid: 116
+  - uid: 124
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
-  - uid: 117
+  - uid: 125
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
-  - uid: 118
+  - uid: 126
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 2
-  - uid: 119
+  - uid: 127
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 2
-  - uid: 120
+  - uid: 128
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 121
+  - uid: 129
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 122
+  - uid: 130
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 2
-  - uid: 123
+  - uid: 131
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
-  - uid: 124
+  - uid: 132
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 125
+  - uid: 133
     components:
     - type: Transform
       pos: -27.5,9.5
       parent: 2
-  - uid: 126
+  - uid: 134
     components:
     - type: Transform
       pos: -27.5,8.5
       parent: 2
-  - uid: 127
+  - uid: 135
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
 - proto: AtmosFixVoxMarker
   entities:
-  - uid: 128
+  - uid: 136
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 2
-  - uid: 129
+  - uid: 137
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 2
-  - uid: 130
+  - uid: 138
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 131
+  - uid: 139
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 2
 - proto: Autolathe
   entities:
-  - uid: 132
+  - uid: 140
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 133
+  - uid: 141
     components:
     - type: Transform
       pos: -29.5,-4.5
       parent: 2
 - proto: BarSpoon
   entities:
-  - uid: 134
+  - uid: 142
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2444,7 +2598,7 @@ entities:
       parent: 2
 - proto: BaseGasCondenser
   entities:
-  - uid: 2586
+  - uid: 143
     components:
     - type: Transform
       anchored: False
@@ -2454,52 +2608,52 @@ entities:
       bodyType: Dynamic
 - proto: Beaker
   entities:
-  - uid: 135
+  - uid: 144
     components:
     - type: Transform
       pos: -12.6813965,6.543274
       parent: 2
-  - uid: 137
+  - uid: 145
     components:
     - type: Transform
       pos: -7.6037903,6.6693115
       parent: 2
 - proto: Bed
   entities:
-  - uid: 138
+  - uid: 146
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
 - proto: BedsheetCaptain
   entities:
-  - uid: 139
+  - uid: 147
     components:
     - type: Transform
       pos: -26.5,-17.5
       parent: 2
 - proto: BedsheetMedical
   entities:
-  - uid: 140
+  - uid: 148
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,7.5
       parent: 2
-  - uid: 141
+  - uid: 149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,7.5
       parent: 2
-  - uid: 142
+  - uid: 150
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 2
 - proto: BedsheetRed
   entities:
-  - uid: 143
+  - uid: 151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2507,28 +2661,28 @@ entities:
       parent: 2
 - proto: BenchSofaCorpLeft
   entities:
-  - uid: 144
+  - uid: 152
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
 - proto: BenchSofaCorpMiddle
   entities:
-  - uid: 145
+  - uid: 153
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
 - proto: BenchSofaCorpRight
   entities:
-  - uid: 1062
+  - uid: 154
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
 - proto: Bible
   entities:
-  - uid: 147
+  - uid: 155
     components:
     - type: Transform
       pos: -23.362152,7.8450623
@@ -2571,92 +2725,92 @@ entities:
           friction: 0.4
 - proto: Biogenerator
   entities:
-  - uid: 148
+  - uid: 156
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 2
 - proto: BlastDoor
   entities:
-  - uid: 149
+  - uid: 157
     components:
     - type: Transform
       pos: -30.5,-6.5
       parent: 2
-  - uid: 150
+  - uid: 158
     components:
     - type: Transform
       pos: -30.5,-7.5
       parent: 2
 - proto: BlockGameArcade
   entities:
-  - uid: 152
+  - uid: 159
     components:
     - type: Transform
       pos: -17.5,-2.5
       parent: 2
 - proto: BoozeDispenser
   entities:
-  - uid: 153
+  - uid: 160
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
 - proto: BorgCharger
   entities:
-  - uid: 154
+  - uid: 161
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
 - proto: BorgSpawnerTckTck
   entities:
-  - uid: 155
+  - uid: 162
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 2
 - proto: BoxBodyBag
   entities:
-  - uid: 156
+  - uid: 163
     components:
     - type: Transform
       pos: -23.683558,8.777045
       parent: 2
 - proto: BoxCardboard
   entities:
-  - uid: 163
+  - uid: 164
     components:
     - type: Transform
       pos: -31.213348,4.4559326
       parent: 2
     - type: Storage
       storedItems:
-        164:
+        165:
           position: 0,0
           _rotation: South
-        165:
+        166:
           position: 1,0
           _rotation: South
-        166:
+        167:
           position: 2,0
           _rotation: South
-        167:
+        168:
           position: 0,1
           _rotation: South
-        168:
+        169:
           position: 1,1
           _rotation: South
-        169:
+        170:
           position: 2,1
           _rotation: South
-        170:
+        171:
           position: 0,2
           _rotation: South
-        171:
+        172:
           position: 1,2
           _rotation: South
-        172:
+        173:
           position: 2,2
           _rotation: South
     - type: ContainerContainer
@@ -2665,7 +2819,6 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 164
           - 165
           - 166
           - 167
@@ -2674,32 +2827,19 @@ entities:
           - 170
           - 171
           - 172
+          - 173
     - type: Label
       currentLabel: frank food
 - proto: BoxCleanerGrenades
   entities:
-  - uid: 173
+  - uid: 174
     components:
     - type: Transform
       pos: -24.184052,-11.660706
       parent: 2
-- proto: BoxFolderBlack
-  entities:
-  - uid: 174
-    components:
-    - type: Transform
-      pos: 4.6686945,-4.9433904
-      parent: 2
-- proto: BoxFolderBlue
-  entities:
-  - uid: 175
-    components:
-    - type: Transform
-      pos: 4.8405695,-5.1465154
-      parent: 2
 - proto: BrigTimer
   entities:
-  - uid: 176
+  - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2707,44 +2847,52 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        2594:
+        32:
         - Start: Close
         - Timer: Open
 - proto: Bucket
   entities:
-  - uid: 177
+  - uid: 176
     components:
     - type: Transform
       pos: -6.239624,8.745972
       parent: 2
-  - uid: 178
+  - uid: 177
     components:
     - type: Transform
       pos: -25.00998,-11.3342285
       parent: 2
 - proto: ButtonFrameCaution
   entities:
-  - uid: 136
+  - uid: 178
     components:
     - type: Transform
       pos: -11.5,10.5
       parent: 2
-  - uid: 180
+  - uid: 179
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
 - proto: ButtonFrameExit
   entities:
-  - uid: 182
+  - uid: 180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,6.5
       parent: 2
+- proto: ButtonFrameGrey
+  entities:
+  - uid: 2939
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 2
 - proto: ButtonFrameJanitor
   entities:
-  - uid: 183
+  - uid: 181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2752,3651 +2900,3756 @@ entities:
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 184
+  - uid: 182
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 185
+  - uid: 183
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 2
-  - uid: 186
+  - uid: 184
     components:
     - type: Transform
       pos: -29.5,-13.5
       parent: 2
-  - uid: 187
+  - uid: 185
     components:
     - type: Transform
       pos: -25.5,5.5
       parent: 2
-  - uid: 188
+  - uid: 186
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 2
-  - uid: 189
+  - uid: 187
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 2
-  - uid: 190
+  - uid: 188
     components:
     - type: Transform
       pos: -27.5,-14.5
       parent: 2
-  - uid: 191
+  - uid: 189
     components:
     - type: Transform
       pos: -28.5,-14.5
       parent: 2
-  - uid: 192
+  - uid: 190
     components:
     - type: Transform
       pos: -29.5,-14.5
       parent: 2
-  - uid: 193
+  - uid: 191
     components:
     - type: Transform
       pos: -29.5,-15.5
       parent: 2
-  - uid: 194
+  - uid: 192
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 195
+  - uid: 193
     components:
     - type: Transform
       pos: -31.5,-15.5
       parent: 2
-  - uid: 196
+  - uid: 194
     components:
     - type: Transform
       pos: -32.5,-15.5
       parent: 2
-  - uid: 197
+  - uid: 195
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
-  - uid: 198
+  - uid: 196
     components:
     - type: Transform
       pos: -19.5,-17.5
       parent: 2
-  - uid: 199
+  - uid: 197
     components:
     - type: Transform
       pos: -19.5,-18.5
+      parent: 2
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -20.5,-18.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -21.5,-18.5
       parent: 2
   - uid: 200
     components:
     - type: Transform
-      pos: -20.5,-18.5
+      pos: -22.5,-18.5
       parent: 2
   - uid: 201
     components:
     - type: Transform
-      pos: -21.5,-18.5
+      pos: -23.5,-18.5
       parent: 2
   - uid: 202
     components:
     - type: Transform
-      pos: -22.5,-18.5
+      pos: -24.5,-18.5
       parent: 2
   - uid: 203
     components:
     - type: Transform
-      pos: -23.5,-18.5
+      pos: -18.5,-18.5
       parent: 2
   - uid: 204
     components:
     - type: Transform
-      pos: -24.5,-18.5
+      pos: -17.5,-18.5
       parent: 2
   - uid: 205
     components:
     - type: Transform
-      pos: -18.5,-18.5
+      pos: -17.5,-17.5
       parent: 2
   - uid: 206
     components:
     - type: Transform
-      pos: -17.5,-18.5
+      pos: -17.5,-16.5
       parent: 2
   - uid: 207
     components:
     - type: Transform
-      pos: -17.5,-17.5
+      pos: -17.5,-14.5
       parent: 2
   - uid: 208
     components:
     - type: Transform
-      pos: -17.5,-16.5
+      pos: -17.5,-15.5
       parent: 2
   - uid: 209
     components:
     - type: Transform
-      pos: -17.5,-14.5
+      pos: -6.5,3.5
       parent: 2
   - uid: 210
     components:
     - type: Transform
-      pos: -17.5,-15.5
+      pos: -3.5,4.5
       parent: 2
   - uid: 211
     components:
     - type: Transform
-      pos: -6.5,3.5
+      pos: -20.5,-18.5
       parent: 2
   - uid: 212
     components:
     - type: Transform
-      pos: -3.5,4.5
+      pos: -20.5,-19.5
       parent: 2
   - uid: 213
     components:
     - type: Transform
-      pos: -20.5,-18.5
+      pos: -20.5,-20.5
       parent: 2
   - uid: 214
     components:
     - type: Transform
-      pos: -20.5,-19.5
+      pos: -20.5,-21.5
       parent: 2
   - uid: 215
     components:
     - type: Transform
-      pos: -20.5,-20.5
+      pos: -21.5,-21.5
       parent: 2
   - uid: 216
     components:
     - type: Transform
-      pos: -20.5,-21.5
+      pos: -22.5,-21.5
       parent: 2
   - uid: 217
     components:
     - type: Transform
-      pos: -21.5,-21.5
+      pos: -6.5,4.5
       parent: 2
   - uid: 218
     components:
     - type: Transform
-      pos: -22.5,-21.5
+      pos: 5.5,3.5
       parent: 2
   - uid: 219
     components:
     - type: Transform
-      pos: -6.5,4.5
+      pos: -26.5,-14.5
       parent: 2
   - uid: 220
     components:
     - type: Transform
-      pos: 5.5,3.5
+      pos: -25.5,-14.5
       parent: 2
   - uid: 221
     components:
     - type: Transform
-      pos: -26.5,-14.5
+      pos: -24.5,-14.5
       parent: 2
   - uid: 222
     components:
     - type: Transform
-      pos: -25.5,-14.5
+      pos: -23.5,-14.5
       parent: 2
   - uid: 223
     components:
     - type: Transform
-      pos: -24.5,-14.5
+      pos: -23.5,-15.5
       parent: 2
   - uid: 224
     components:
     - type: Transform
-      pos: -23.5,-14.5
+      pos: -22.5,-14.5
       parent: 2
   - uid: 225
     components:
     - type: Transform
-      pos: -23.5,-15.5
+      pos: -22.5,-13.5
       parent: 2
   - uid: 226
     components:
     - type: Transform
-      pos: -22.5,-14.5
+      pos: -22.5,-12.5
       parent: 2
   - uid: 227
     components:
     - type: Transform
-      pos: -22.5,-13.5
+      pos: -16.5,-2.5
       parent: 2
   - uid: 228
     components:
     - type: Transform
-      pos: -22.5,-12.5
+      pos: -27.5,-10.5
       parent: 2
   - uid: 229
     components:
     - type: Transform
-      pos: -16.5,-2.5
+      pos: -27.5,-9.5
       parent: 2
   - uid: 230
     components:
     - type: Transform
-      pos: -27.5,-10.5
+      pos: -28.5,-9.5
       parent: 2
   - uid: 231
     components:
     - type: Transform
-      pos: -27.5,-9.5
+      pos: -29.5,-9.5
       parent: 2
   - uid: 232
     components:
     - type: Transform
-      pos: -28.5,-9.5
+      pos: -27.5,-8.5
       parent: 2
   - uid: 233
     components:
     - type: Transform
-      pos: -29.5,-9.5
+      pos: -27.5,-7.5
       parent: 2
   - uid: 234
     components:
     - type: Transform
-      pos: -27.5,-8.5
+      pos: -27.5,-6.5
       parent: 2
   - uid: 235
     components:
     - type: Transform
-      pos: -27.5,-7.5
+      pos: -27.5,-5.5
       parent: 2
   - uid: 236
     components:
     - type: Transform
-      pos: -27.5,-6.5
+      pos: -28.5,-5.5
       parent: 2
   - uid: 237
     components:
     - type: Transform
-      pos: -27.5,-5.5
+      pos: -29.5,-5.5
       parent: 2
   - uid: 238
     components:
     - type: Transform
-      pos: -28.5,-5.5
+      pos: -29.5,-4.5
       parent: 2
   - uid: 239
     components:
     - type: Transform
-      pos: -29.5,-5.5
+      pos: -27.5,-4.5
       parent: 2
   - uid: 240
     components:
     - type: Transform
-      pos: -29.5,-4.5
+      pos: -27.5,-3.5
       parent: 2
   - uid: 241
     components:
     - type: Transform
-      pos: -27.5,-4.5
+      pos: -30.5,-11.5
       parent: 2
   - uid: 242
     components:
     - type: Transform
-      pos: -27.5,-3.5
+      pos: -29.5,-3.5
       parent: 2
   - uid: 243
     components:
     - type: Transform
-      pos: -30.5,-11.5
+      pos: -28.5,-7.5
       parent: 2
   - uid: 244
     components:
     - type: Transform
-      pos: -29.5,-3.5
+      pos: -29.5,-7.5
       parent: 2
   - uid: 245
     components:
     - type: Transform
-      pos: -28.5,-7.5
+      pos: -26.5,-9.5
       parent: 2
   - uid: 246
     components:
     - type: Transform
-      pos: -29.5,-7.5
+      pos: -25.5,-9.5
       parent: 2
   - uid: 247
     components:
     - type: Transform
-      pos: -26.5,-9.5
+      pos: -24.5,-9.5
       parent: 2
   - uid: 248
     components:
     - type: Transform
-      pos: -25.5,-9.5
+      pos: -24.5,-8.5
       parent: 2
   - uid: 249
     components:
     - type: Transform
-      pos: -24.5,-9.5
+      pos: -23.5,-8.5
       parent: 2
   - uid: 250
     components:
     - type: Transform
-      pos: -24.5,-8.5
+      pos: -23.5,-7.5
       parent: 2
   - uid: 251
     components:
     - type: Transform
-      pos: -23.5,-8.5
+      pos: -23.5,-6.5
       parent: 2
   - uid: 252
     components:
     - type: Transform
-      pos: -23.5,-7.5
+      pos: -24.5,6.5
       parent: 2
   - uid: 253
     components:
     - type: Transform
-      pos: -23.5,-6.5
+      pos: -25.5,6.5
       parent: 2
   - uid: 254
     components:
     - type: Transform
-      pos: -24.5,6.5
+      pos: -25.5,7.5
       parent: 2
   - uid: 255
     components:
     - type: Transform
-      pos: -25.5,6.5
+      pos: -25.5,4.5
       parent: 2
   - uid: 256
     components:
     - type: Transform
-      pos: -25.5,7.5
+      pos: -25.5,3.5
       parent: 2
   - uid: 257
     components:
     - type: Transform
-      pos: -25.5,4.5
+      pos: -25.5,2.5
       parent: 2
   - uid: 258
     components:
     - type: Transform
-      pos: -25.5,3.5
+      pos: -25.5,1.5
       parent: 2
   - uid: 259
     components:
     - type: Transform
-      pos: -25.5,2.5
+      pos: -24.5,1.5
       parent: 2
   - uid: 260
     components:
     - type: Transform
-      pos: -25.5,1.5
+      pos: -24.5,0.5
       parent: 2
   - uid: 261
     components:
     - type: Transform
-      pos: -24.5,1.5
+      pos: -25.5,0.5
       parent: 2
   - uid: 262
     components:
     - type: Transform
-      pos: -24.5,0.5
+      pos: -25.5,-0.5
       parent: 2
   - uid: 263
     components:
     - type: Transform
-      pos: -25.5,0.5
+      pos: -25.5,-1.5
       parent: 2
   - uid: 264
     components:
     - type: Transform
-      pos: -25.5,-0.5
+      pos: -11.5,0.5
       parent: 2
   - uid: 265
     components:
     - type: Transform
-      pos: -25.5,-1.5
+      pos: -24.5,4.5
       parent: 2
   - uid: 266
     components:
     - type: Transform
-      pos: -11.5,0.5
+      pos: -23.5,4.5
       parent: 2
   - uid: 267
     components:
     - type: Transform
-      pos: -24.5,4.5
+      pos: -15.5,4.5
       parent: 2
   - uid: 268
     components:
     - type: Transform
-      pos: -23.5,4.5
+      pos: -16.5,4.5
       parent: 2
   - uid: 269
     components:
     - type: Transform
-      pos: -15.5,4.5
+      pos: -17.5,4.5
       parent: 2
   - uid: 270
     components:
     - type: Transform
-      pos: -16.5,4.5
+      pos: -18.5,4.5
       parent: 2
   - uid: 271
     components:
     - type: Transform
-      pos: -17.5,4.5
+      pos: -5.5,1.5
       parent: 2
   - uid: 272
     components:
     - type: Transform
-      pos: -18.5,4.5
+      pos: -19.5,4.5
       parent: 2
   - uid: 273
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -19.5,3.5
       parent: 2
   - uid: 274
     components:
     - type: Transform
-      pos: -19.5,4.5
+      pos: -20.5,3.5
       parent: 2
   - uid: 275
     components:
     - type: Transform
-      pos: -19.5,3.5
+      pos: -2.5,5.5
       parent: 2
   - uid: 276
     components:
     - type: Transform
-      pos: -20.5,3.5
+      pos: -15.5,5.5
       parent: 2
   - uid: 277
     components:
     - type: Transform
-      pos: -2.5,5.5
+      pos: -14.5,5.5
       parent: 2
   - uid: 278
     components:
     - type: Transform
-      pos: -15.5,5.5
+      pos: -13.5,5.5
       parent: 2
   - uid: 279
     components:
     - type: Transform
-      pos: -14.5,5.5
+      pos: -12.5,5.5
       parent: 2
   - uid: 280
     components:
     - type: Transform
-      pos: -13.5,5.5
+      pos: -12.5,4.5
       parent: 2
   - uid: 281
     components:
     - type: Transform
-      pos: -12.5,5.5
+      pos: -13.5,6.5
       parent: 2
   - uid: 282
     components:
     - type: Transform
-      pos: -12.5,4.5
+      pos: -13.5,7.5
       parent: 2
   - uid: 283
     components:
     - type: Transform
-      pos: -13.5,6.5
+      pos: -13.5,8.5
       parent: 2
   - uid: 284
     components:
     - type: Transform
-      pos: -13.5,7.5
+      pos: -12.5,8.5
       parent: 2
   - uid: 285
     components:
     - type: Transform
-      pos: -13.5,8.5
+      pos: -12.5,9.5
       parent: 2
   - uid: 286
     components:
     - type: Transform
-      pos: -12.5,8.5
+      pos: -15.5,6.5
       parent: 2
   - uid: 287
     components:
     - type: Transform
-      pos: -12.5,9.5
+      pos: -15.5,7.5
       parent: 2
   - uid: 288
     components:
     - type: Transform
-      pos: -15.5,6.5
+      pos: -16.5,7.5
       parent: 2
   - uid: 289
     components:
     - type: Transform
-      pos: -15.5,7.5
+      pos: -16.5,8.5
       parent: 2
   - uid: 290
     components:
     - type: Transform
-      pos: -16.5,7.5
+      pos: -6.5,1.5
       parent: 2
   - uid: 291
     components:
     - type: Transform
-      pos: -16.5,8.5
+      pos: -17.5,8.5
       parent: 2
   - uid: 292
     components:
     - type: Transform
-      pos: -6.5,1.5
+      pos: -18.5,8.5
       parent: 2
   - uid: 293
     components:
     - type: Transform
-      pos: -17.5,8.5
+      pos: -19.5,8.5
       parent: 2
   - uid: 294
     components:
     - type: Transform
-      pos: -18.5,8.5
+      pos: -20.5,8.5
       parent: 2
   - uid: 295
     components:
     - type: Transform
-      pos: -19.5,8.5
+      pos: -4.5,6.5
       parent: 2
   - uid: 296
     components:
     - type: Transform
-      pos: -20.5,8.5
+      pos: -21.5,8.5
       parent: 2
   - uid: 297
     components:
     - type: Transform
-      pos: -4.5,6.5
+      pos: -25.5,8.5
       parent: 2
   - uid: 298
     components:
     - type: Transform
-      pos: -21.5,8.5
+      pos: -25.5,9.5
       parent: 2
   - uid: 299
     components:
     - type: Transform
-      pos: -25.5,8.5
+      pos: 4.5,5.5
       parent: 2
   - uid: 300
     components:
     - type: Transform
-      pos: -25.5,9.5
+      pos: 3.5,5.5
       parent: 2
   - uid: 301
     components:
     - type: Transform
-      pos: 4.5,5.5
+      pos: 3.5,6.5
       parent: 2
   - uid: 302
     components:
     - type: Transform
-      pos: 3.5,5.5
+      pos: 2.5,6.5
       parent: 2
   - uid: 303
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: 1.5,6.5
       parent: 2
   - uid: 304
     components:
     - type: Transform
-      pos: 2.5,6.5
+      pos: 0.5,6.5
       parent: 2
   - uid: 305
     components:
     - type: Transform
-      pos: 1.5,6.5
+      pos: -0.5,6.5
       parent: 2
   - uid: 306
     components:
     - type: Transform
-      pos: 0.5,6.5
+      pos: -0.5,5.5
       parent: 2
   - uid: 307
     components:
     - type: Transform
-      pos: -0.5,6.5
+      pos: -4.5,8.5
       parent: 2
   - uid: 308
     components:
     - type: Transform
-      pos: -0.5,5.5
+      pos: -4.5,7.5
       parent: 2
   - uid: 309
     components:
     - type: Transform
-      pos: -4.5,8.5
+      pos: -3.5,5.5
       parent: 2
   - uid: 310
     components:
     - type: Transform
-      pos: -4.5,7.5
+      pos: -4.5,5.5
       parent: 2
   - uid: 311
     components:
     - type: Transform
-      pos: -3.5,5.5
+      pos: -5.5,5.5
       parent: 2
   - uid: 312
     components:
     - type: Transform
-      pos: -4.5,5.5
+      pos: -6.5,5.5
       parent: 2
   - uid: 313
     components:
     - type: Transform
-      pos: -5.5,5.5
+      pos: -8.5,6.5
       parent: 2
   - uid: 314
     components:
     - type: Transform
-      pos: -6.5,5.5
+      pos: -9.5,5.5
       parent: 2
   - uid: 315
     components:
     - type: Transform
-      pos: -8.5,6.5
+      pos: -9.5,6.5
       parent: 2
   - uid: 316
     components:
     - type: Transform
-      pos: -9.5,5.5
+      pos: -9.5,7.5
       parent: 2
   - uid: 317
     components:
     - type: Transform
-      pos: -9.5,6.5
+      pos: -9.5,8.5
       parent: 2
   - uid: 318
     components:
     - type: Transform
-      pos: -9.5,7.5
+      pos: -8.5,8.5
       parent: 2
   - uid: 319
     components:
     - type: Transform
-      pos: -9.5,8.5
+      pos: -6.5,8.5
       parent: 2
   - uid: 320
     components:
     - type: Transform
-      pos: -8.5,8.5
+      pos: -9.5,4.5
       parent: 2
   - uid: 321
     components:
     - type: Transform
-      pos: -6.5,8.5
+      pos: -9.5,3.5
       parent: 2
   - uid: 322
     components:
     - type: Transform
-      pos: -9.5,4.5
+      pos: -9.5,2.5
       parent: 2
   - uid: 323
     components:
     - type: Transform
-      pos: -9.5,3.5
+      pos: -8.5,2.5
       parent: 2
   - uid: 324
     components:
     - type: Transform
-      pos: -9.5,2.5
+      pos: -0.5,4.5
       parent: 2
   - uid: 325
     components:
     - type: Transform
-      pos: -8.5,2.5
+      pos: -21.5,-3.5
       parent: 2
   - uid: 326
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: -0.5,2.5
       parent: 2
   - uid: 327
     components:
     - type: Transform
-      pos: -21.5,-3.5
+      pos: -1.5,2.5
       parent: 2
   - uid: 328
     components:
     - type: Transform
-      pos: -0.5,2.5
+      pos: 3.5,4.5
       parent: 2
   - uid: 329
     components:
     - type: Transform
-      pos: -1.5,2.5
+      pos: 2.5,-3.5
       parent: 2
   - uid: 330
     components:
     - type: Transform
-      pos: 3.5,4.5
+      pos: 2.5,-4.5
       parent: 2
   - uid: 331
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: 1.5,-4.5
       parent: 2
   - uid: 332
     components:
     - type: Transform
-      pos: 2.5,-4.5
+      pos: 0.5,-4.5
       parent: 2
   - uid: 333
     components:
     - type: Transform
-      pos: 1.5,-4.5
+      pos: 1.5,-5.5
       parent: 2
   - uid: 334
     components:
     - type: Transform
-      pos: 0.5,-4.5
+      pos: 1.5,-6.5
       parent: 2
   - uid: 335
     components:
     - type: Transform
-      pos: 1.5,-5.5
+      pos: 1.5,-7.5
       parent: 2
   - uid: 336
     components:
     - type: Transform
-      pos: 1.5,-6.5
+      pos: 0.5,-7.5
       parent: 2
   - uid: 337
     components:
     - type: Transform
-      pos: 1.5,-7.5
+      pos: -0.5,-7.5
       parent: 2
   - uid: 338
     components:
     - type: Transform
-      pos: 0.5,-7.5
+      pos: -0.5,-4.5
       parent: 2
   - uid: 339
     components:
     - type: Transform
-      pos: -0.5,-7.5
+      pos: -1.5,-4.5
       parent: 2
   - uid: 340
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      pos: -1.5,-5.5
       parent: 2
   - uid: 341
     components:
     - type: Transform
-      pos: -1.5,-4.5
+      pos: -2.5,-5.5
       parent: 2
   - uid: 342
     components:
     - type: Transform
-      pos: -1.5,-5.5
+      pos: -3.5,-5.5
       parent: 2
   - uid: 343
     components:
     - type: Transform
-      pos: -2.5,-5.5
+      pos: -3.5,-4.5
       parent: 2
   - uid: 344
     components:
     - type: Transform
-      pos: -3.5,-5.5
+      pos: -4.5,-4.5
       parent: 2
   - uid: 345
     components:
     - type: Transform
-      pos: -3.5,-4.5
+      pos: -3.5,-6.5
       parent: 2
   - uid: 346
     components:
     - type: Transform
-      pos: -4.5,-4.5
+      pos: -3.5,-7.5
       parent: 2
   - uid: 347
     components:
     - type: Transform
-      pos: -3.5,-6.5
+      pos: -5.5,-7.5
       parent: 2
   - uid: 348
     components:
     - type: Transform
-      pos: -3.5,-7.5
+      pos: -5.5,-6.5
       parent: 2
   - uid: 349
     components:
     - type: Transform
-      pos: -5.5,-7.5
+      pos: -5.5,-5.5
       parent: 2
   - uid: 350
     components:
     - type: Transform
-      pos: -5.5,-6.5
+      pos: -21.5,-3.5
       parent: 2
   - uid: 351
     components:
     - type: Transform
-      pos: -5.5,-5.5
+      pos: -12.5,-5.5
       parent: 2
   - uid: 352
     components:
     - type: Transform
-      pos: -21.5,-3.5
+      pos: -12.5,-6.5
       parent: 2
   - uid: 353
     components:
     - type: Transform
-      pos: -12.5,-5.5
+      pos: -11.5,-5.5
       parent: 2
   - uid: 354
     components:
     - type: Transform
-      pos: -12.5,-6.5
+      pos: -11.5,-5.5
       parent: 2
   - uid: 355
     components:
     - type: Transform
-      pos: -11.5,-5.5
+      pos: -10.5,-5.5
       parent: 2
   - uid: 356
     components:
     - type: Transform
-      pos: -11.5,-5.5
+      pos: -9.5,-5.5
       parent: 2
   - uid: 357
     components:
     - type: Transform
-      pos: -10.5,-5.5
+      pos: -9.5,-4.5
       parent: 2
   - uid: 358
     components:
     - type: Transform
-      pos: -9.5,-5.5
+      pos: -9.5,-3.5
       parent: 2
   - uid: 359
     components:
     - type: Transform
-      pos: -9.5,-4.5
+      pos: -8.5,-0.5
       parent: 2
   - uid: 360
     components:
     - type: Transform
-      pos: -9.5,-3.5
+      pos: -14.5,-5.5
       parent: 2
   - uid: 361
     components:
     - type: Transform
-      pos: -8.5,-0.5
+      pos: -14.5,-6.5
       parent: 2
   - uid: 362
     components:
     - type: Transform
-      pos: -14.5,-5.5
+      pos: -14.5,-4.5
       parent: 2
   - uid: 363
     components:
     - type: Transform
-      pos: -14.5,-6.5
+      pos: -14.5,-3.5
       parent: 2
   - uid: 364
     components:
     - type: Transform
-      pos: -14.5,-4.5
+      pos: -14.5,-2.5
       parent: 2
   - uid: 365
     components:
     - type: Transform
-      pos: -14.5,-3.5
+      pos: -13.5,-2.5
       parent: 2
   - uid: 366
     components:
     - type: Transform
-      pos: -14.5,-2.5
+      pos: -11.5,1.5
       parent: 2
   - uid: 367
     components:
     - type: Transform
-      pos: -13.5,-2.5
+      pos: -12.5,-2.5
       parent: 2
   - uid: 368
     components:
     - type: Transform
-      pos: -11.5,1.5
+      pos: -21.5,-4.5
       parent: 2
   - uid: 369
     components:
     - type: Transform
-      pos: -12.5,-2.5
+      pos: 3.5,-4.5
       parent: 2
   - uid: 370
     components:
     - type: Transform
-      pos: -21.5,-4.5
+      pos: 4.5,-4.5
       parent: 2
   - uid: 371
     components:
     - type: Transform
-      pos: 3.5,-4.5
+      pos: 2.5,-1.5
       parent: 2
   - uid: 372
     components:
     - type: Transform
-      pos: 4.5,-4.5
+      pos: 3.5,-1.5
       parent: 2
   - uid: 373
     components:
     - type: Transform
-      pos: 2.5,-1.5
+      pos: 4.5,-1.5
       parent: 2
   - uid: 374
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      pos: 5.5,-1.5
       parent: 2
   - uid: 375
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: 6.5,-1.5
       parent: 2
   - uid: 376
     components:
     - type: Transform
-      pos: 5.5,-1.5
+      pos: 6.5,-2.5
       parent: 2
   - uid: 377
     components:
     - type: Transform
-      pos: 6.5,-1.5
+      pos: 4.5,-5.5
       parent: 2
   - uid: 378
     components:
     - type: Transform
-      pos: 6.5,-2.5
+      pos: 4.5,-6.5
       parent: 2
   - uid: 379
     components:
     - type: Transform
-      pos: 6.5,-3.5
+      pos: 6.5,-0.5
       parent: 2
   - uid: 380
     components:
     - type: Transform
-      pos: 7.5,-3.5
+      pos: 6.5,0.5
       parent: 2
   - uid: 381
     components:
     - type: Transform
-      pos: 6.5,-0.5
+      pos: 6.5,1.5
       parent: 2
   - uid: 382
     components:
     - type: Transform
-      pos: 6.5,0.5
+      pos: 6.5,2.5
       parent: 2
   - uid: 383
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: 6.5,3.5
       parent: 2
   - uid: 384
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: 7.5,3.5
       parent: 2
   - uid: 385
     components:
     - type: Transform
-      pos: 6.5,3.5
+      pos: -26.5,5.5
       parent: 2
   - uid: 386
     components:
     - type: Transform
-      pos: 7.5,3.5
+      pos: -28.5,5.5
       parent: 2
   - uid: 387
     components:
     - type: Transform
-      pos: -26.5,5.5
+      pos: -27.5,5.5
       parent: 2
   - uid: 388
     components:
     - type: Transform
-      pos: -28.5,5.5
+      pos: -29.5,5.5
       parent: 2
   - uid: 389
     components:
     - type: Transform
-      pos: -27.5,5.5
+      pos: -30.5,5.5
       parent: 2
   - uid: 390
     components:
     - type: Transform
-      pos: -29.5,5.5
+      pos: -31.5,5.5
       parent: 2
   - uid: 391
     components:
     - type: Transform
-      pos: -30.5,5.5
+      pos: -32.5,5.5
       parent: 2
   - uid: 392
     components:
     - type: Transform
-      pos: -31.5,5.5
+      pos: -33.5,5.5
       parent: 2
   - uid: 393
     components:
     - type: Transform
-      pos: -32.5,5.5
+      pos: -34.5,5.5
       parent: 2
   - uid: 394
     components:
     - type: Transform
-      pos: -33.5,5.5
+      pos: -35.5,5.5
       parent: 2
   - uid: 395
     components:
     - type: Transform
-      pos: -34.5,5.5
+      pos: -35.5,6.5
       parent: 2
   - uid: 396
     components:
     - type: Transform
-      pos: -35.5,5.5
+      pos: -35.5,7.5
       parent: 2
   - uid: 397
     components:
     - type: Transform
-      pos: -35.5,6.5
+      pos: -35.5,8.5
       parent: 2
   - uid: 398
     components:
     - type: Transform
-      pos: -35.5,7.5
+      pos: -32.5,6.5
       parent: 2
   - uid: 399
     components:
     - type: Transform
-      pos: -35.5,8.5
+      pos: -32.5,7.5
       parent: 2
   - uid: 400
     components:
     - type: Transform
-      pos: -32.5,6.5
+      pos: -32.5,4.5
       parent: 2
   - uid: 401
     components:
     - type: Transform
-      pos: -32.5,7.5
+      pos: -32.5,3.5
       parent: 2
   - uid: 402
     components:
     - type: Transform
-      pos: -32.5,4.5
+      pos: 3.5,-0.5
       parent: 2
   - uid: 403
     components:
     - type: Transform
-      pos: -32.5,3.5
+      pos: 3.5,0.5
       parent: 2
   - uid: 404
     components:
     - type: Transform
-      pos: 3.5,-0.5
+      pos: 3.5,1.5
       parent: 2
   - uid: 405
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: -1.5,1.5
       parent: 2
   - uid: 406
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: -1.5,0.5
       parent: 2
   - uid: 407
     components:
     - type: Transform
-      pos: -1.5,1.5
+      pos: -1.5,-0.5
       parent: 2
   - uid: 408
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -2.5,-0.5
       parent: 2
   - uid: 409
     components:
     - type: Transform
-      pos: -1.5,-0.5
+      pos: -3.5,-0.5
       parent: 2
   - uid: 410
     components:
     - type: Transform
-      pos: -2.5,-0.5
+      pos: -4.5,-0.5
       parent: 2
   - uid: 411
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      pos: -4.5,-1.5
       parent: 2
   - uid: 412
     components:
     - type: Transform
-      pos: -4.5,-0.5
+      pos: -4.5,-2.5
       parent: 2
   - uid: 413
     components:
     - type: Transform
-      pos: -4.5,-1.5
+      pos: -4.5,0.5
       parent: 2
   - uid: 414
     components:
     - type: Transform
-      pos: -4.5,-2.5
+      pos: -4.5,1.5
       parent: 2
   - uid: 415
     components:
     - type: Transform
-      pos: -4.5,0.5
+      pos: -28.5,-11.5
       parent: 2
   - uid: 416
     components:
     - type: Transform
-      pos: -4.5,1.5
+      pos: -10.5,-0.5
       parent: 2
   - uid: 417
     components:
     - type: Transform
-      pos: -28.5,-11.5
+      pos: -9.5,-1.5
       parent: 2
   - uid: 418
     components:
     - type: Transform
-      pos: -10.5,-0.5
+      pos: -9.5,-0.5
       parent: 2
   - uid: 419
     components:
     - type: Transform
-      pos: -9.5,-1.5
+      pos: -11.5,-0.5
       parent: 2
   - uid: 420
     components:
     - type: Transform
-      pos: -9.5,-0.5
+      pos: -23.5,-2.5
       parent: 2
   - uid: 421
     components:
     - type: Transform
-      pos: -11.5,-0.5
+      pos: -21.5,-2.5
       parent: 2
   - uid: 422
     components:
     - type: Transform
-      pos: -23.5,-2.5
+      pos: -16.5,-7.5
       parent: 2
   - uid: 423
     components:
     - type: Transform
-      pos: -21.5,-2.5
+      pos: -17.5,-7.5
       parent: 2
   - uid: 424
     components:
     - type: Transform
-      pos: -16.5,-7.5
+      pos: -17.5,-6.5
       parent: 2
   - uid: 425
     components:
     - type: Transform
-      pos: -17.5,-7.5
+      pos: -17.5,-5.5
       parent: 2
   - uid: 426
     components:
     - type: Transform
-      pos: -17.5,-6.5
+      pos: -17.5,-4.5
       parent: 2
   - uid: 427
     components:
     - type: Transform
-      pos: -17.5,-5.5
+      pos: -17.5,-3.5
       parent: 2
   - uid: 428
     components:
     - type: Transform
-      pos: -17.5,-4.5
+      pos: -17.5,-8.5
       parent: 2
   - uid: 429
     components:
     - type: Transform
-      pos: -17.5,-3.5
+      pos: -17.5,-9.5
       parent: 2
   - uid: 430
     components:
     - type: Transform
-      pos: -17.5,-8.5
+      pos: -17.5,-10.5
       parent: 2
   - uid: 431
     components:
     - type: Transform
-      pos: -17.5,-9.5
+      pos: -17.5,-11.5
       parent: 2
   - uid: 432
     components:
     - type: Transform
-      pos: -17.5,-10.5
+      pos: -16.5,-11.5
       parent: 2
   - uid: 433
     components:
     - type: Transform
-      pos: -17.5,-11.5
+      pos: -16.5,-12.5
       parent: 2
   - uid: 434
     components:
     - type: Transform
-      pos: -16.5,-11.5
+      pos: -17.5,-12.5
       parent: 2
   - uid: 435
     components:
     - type: Transform
-      pos: -16.5,-12.5
+      pos: -14.5,-6.5
       parent: 2
   - uid: 436
     components:
     - type: Transform
-      pos: -17.5,-12.5
-      parent: 2
-  - uid: 440
-    components:
-    - type: Transform
-      pos: -14.5,-6.5
-      parent: 2
-  - uid: 441
-    components:
-    - type: Transform
       pos: -24.5,-18.5
       parent: 2
-  - uid: 442
+  - uid: 437
     components:
     - type: Transform
       pos: -25.5,-18.5
       parent: 2
-  - uid: 443
+  - uid: 438
     components:
     - type: Transform
       pos: -26.5,-17.5
       parent: 2
-  - uid: 444
+  - uid: 439
     components:
     - type: Transform
       pos: -27.5,-18.5
       parent: 2
-  - uid: 445
+  - uid: 440
     components:
     - type: Transform
       pos: -25.5,-17.5
       parent: 2
-  - uid: 446
+  - uid: 441
     components:
     - type: Transform
       pos: -24.5,-12.5
       parent: 2
-  - uid: 447
+  - uid: 442
     components:
     - type: Transform
       pos: -25.5,-12.5
       parent: 2
-  - uid: 448
+  - uid: 443
     components:
     - type: Transform
       pos: -26.5,-12.5
       parent: 2
-  - uid: 449
+  - uid: 444
     components:
     - type: Transform
       pos: -26.5,0.5
       parent: 2
-  - uid: 450
+  - uid: 445
     components:
     - type: Transform
       pos: -27.5,0.5
       parent: 2
-  - uid: 451
+  - uid: 446
     components:
     - type: Transform
       pos: -28.5,0.5
       parent: 2
-  - uid: 452
+  - uid: 447
     components:
     - type: Transform
       pos: -29.5,0.5
       parent: 2
-  - uid: 453
+  - uid: 448
     components:
     - type: Transform
       pos: -21.5,-1.5
       parent: 2
-  - uid: 454
+  - uid: 449
     components:
     - type: Transform
       pos: -21.5,-0.5
       parent: 2
-  - uid: 455
+  - uid: 450
     components:
     - type: Transform
       pos: -21.5,0.5
       parent: 2
-  - uid: 456
+  - uid: 451
     components:
     - type: Transform
       pos: -21.5,1.5
       parent: 2
-  - uid: 457
+  - uid: 452
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
-  - uid: 458
+  - uid: 453
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
-  - uid: 459
+  - uid: 454
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-  - uid: 460
+  - uid: 455
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
-  - uid: 461
+  - uid: 456
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
-  - uid: 462
+  - uid: 457
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
-  - uid: 463
+  - uid: 458
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 2
-  - uid: 464
+  - uid: 459
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 465
+  - uid: 460
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
-  - uid: 466
+  - uid: 461
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 2
-  - uid: 467
+  - uid: 462
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 2
-  - uid: 468
+  - uid: 463
     components:
     - type: Transform
       pos: -22.5,-11.5
       parent: 2
-  - uid: 469
+  - uid: 464
     components:
     - type: Transform
       pos: -22.5,-10.5
       parent: 2
-  - uid: 470
+  - uid: 465
     components:
     - type: Transform
       pos: -22.5,-9.5
       parent: 2
-  - uid: 471
+  - uid: 466
     components:
     - type: Transform
       pos: -23.5,-21.5
       parent: 2
-  - uid: 472
+  - uid: 467
     components:
     - type: Transform
       pos: -16.5,-21.5
       parent: 2
-  - uid: 473
+  - uid: 468
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
-  - uid: 474
+  - uid: 469
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 2
-  - uid: 475
+  - uid: 470
     components:
     - type: Transform
       pos: -12.5,-9.5
       parent: 2
-  - uid: 476
+  - uid: 471
     components:
     - type: Transform
       pos: -12.5,-10.5
       parent: 2
-  - uid: 477
+  - uid: 472
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
-  - uid: 478
+  - uid: 473
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 479
+  - uid: 474
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 2
-  - uid: 480
+  - uid: 475
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 2
-  - uid: 481
+  - uid: 476
     components:
     - type: Transform
       pos: -26.5,9.5
       parent: 2
-  - uid: 482
+  - uid: 477
     components:
     - type: Transform
       pos: -27.5,9.5
       parent: 2
-  - uid: 483
+  - uid: 478
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 2
-  - uid: 484
+  - uid: 479
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 2
-  - uid: 485
+  - uid: 480
     components:
     - type: Transform
       pos: -16.5,-20.5
       parent: 2
-  - uid: 486
+  - uid: 481
     components:
     - type: Transform
       pos: -16.5,-19.5
       parent: 2
-  - uid: 487
+  - uid: 482
     components:
     - type: Transform
       pos: -28.5,-12.5
       parent: 2
-  - uid: 488
+  - uid: 483
     components:
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
-  - uid: 489
+  - uid: 484
     components:
     - type: Transform
       pos: -16.5,-18.5
       parent: 2
-  - uid: 490
+  - uid: 485
     components:
     - type: Transform
       pos: -26.5,-21.5
       parent: 2
-  - uid: 491
+  - uid: 486
     components:
     - type: Transform
       pos: -26.5,-20.5
       parent: 2
-  - uid: 492
+  - uid: 487
     components:
     - type: Transform
       pos: -27.5,-21.5
       parent: 2
-  - uid: 493
+  - uid: 488
     components:
     - type: Transform
       pos: -28.5,-21.5
       parent: 2
-  - uid: 494
+  - uid: 489
     components:
     - type: Transform
       pos: -27.5,-17.5
       parent: 2
-  - uid: 495
+  - uid: 490
     components:
     - type: Transform
       pos: -26.5,-19.5
       parent: 2
-  - uid: 496
+  - uid: 491
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
-  - uid: 497
+  - uid: 492
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 498
+  - uid: 493
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 499
+  - uid: 494
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 2
-  - uid: 500
+  - uid: 495
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-  - uid: 501
+  - uid: 496
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 2
-  - uid: 502
+  - uid: 497
     components:
     - type: Transform
       pos: -27.5,-12.5
       parent: 2
-  - uid: 503
+  - uid: 498
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 2
-  - uid: 504
+  - uid: 499
     components:
     - type: Transform
       pos: -32.5,8.5
       parent: 2
-  - uid: 505
+  - uid: 500
     components:
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
-  - uid: 506
+  - uid: 501
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 2
-  - uid: 507
+  - uid: 502
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 2
-  - uid: 508
+  - uid: 503
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
-  - uid: 509
+  - uid: 504
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 2
-  - uid: 510
+  - uid: 505
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 2
-  - uid: 511
+  - uid: 506
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 2
-  - uid: 512
+  - uid: 507
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 2
-  - uid: 513
+  - uid: 508
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 2
-  - uid: 514
+  - uid: 509
     components:
     - type: Transform
       pos: -22.5,-2.5
       parent: 2
-  - uid: 515
+  - uid: 510
     components:
     - type: Transform
       pos: -17.5,9.5
       parent: 2
-  - uid: 516
+  - uid: 511
     components:
     - type: Transform
       pos: -17.5,10.5
       parent: 2
-  - uid: 517
+  - uid: 512
     components:
     - type: Transform
       pos: -17.5,11.5
       parent: 2
-  - uid: 518
+  - uid: 513
     components:
     - type: Transform
       pos: -18.5,11.5
       parent: 2
-  - uid: 519
+  - uid: 514
     components:
     - type: Transform
       pos: -19.5,11.5
       parent: 2
-  - uid: 520
+  - uid: 515
     components:
     - type: Transform
       pos: -32.5,9.5
       parent: 2
-  - uid: 521
+  - uid: 516
     components:
     - type: Transform
       pos: -32.5,10.5
       parent: 2
-  - uid: 522
+  - uid: 517
     components:
     - type: Transform
       pos: -31.5,10.5
       parent: 2
-  - uid: 523
+  - uid: 518
     components:
     - type: Transform
       pos: -18.5,12.5
       parent: 2
-  - uid: 524
+  - uid: 519
     components:
     - type: Transform
       pos: -18.5,13.5
       parent: 2
-  - uid: 525
+  - uid: 520
     components:
     - type: Transform
       pos: -27.5,6.5
       parent: 2
-  - uid: 526
+  - uid: 521
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 527
+  - uid: 522
     components:
     - type: Transform
       pos: -27.5,8.5
       parent: 2
-  - uid: 528
+  - uid: 523
     components:
     - type: Transform
       pos: -29.5,6.5
       parent: 2
-  - uid: 529
+  - uid: 524
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
-  - uid: 530
+  - uid: 525
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
-  - uid: 531
+  - uid: 526
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 532
+  - uid: 527
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 2
-  - uid: 2624
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 2
+  - uid: 529
     components:
     - type: Transform
       pos: -28.5,10.5
       parent: 2
-  - uid: 2625
+  - uid: 530
     components:
     - type: Transform
       pos: -28.5,11.5
       parent: 2
-  - uid: 2626
+  - uid: 531
     components:
     - type: Transform
       pos: -28.5,12.5
       parent: 2
-  - uid: 2627
+  - uid: 532
     components:
     - type: Transform
       pos: -29.5,12.5
       parent: 2
-  - uid: 2628
+  - uid: 533
     components:
     - type: Transform
       pos: -27.5,12.5
       parent: 2
-  - uid: 2629
+  - uid: 534
     components:
     - type: Transform
       pos: -28.5,13.5
       parent: 2
-  - uid: 2666
-    components:
-    - type: Transform
-      pos: -23.5,-22.5
-      parent: 2
-  - uid: 2691
-    components:
-    - type: Transform
-      pos: -30.5,-17.5
-      parent: 2
-  - uid: 2692
-    components:
-    - type: Transform
-      pos: -30.5,-18.5
-      parent: 2
-  - uid: 2693
-    components:
-    - type: Transform
-      pos: -30.5,-19.5
-      parent: 2
-  - uid: 2694
-    components:
-    - type: Transform
-      pos: -30.5,-20.5
-      parent: 2
-  - uid: 2695
-    components:
-    - type: Transform
-      pos: -31.5,-20.5
-      parent: 2
-  - uid: 2767
-    components:
-    - type: Transform
-      pos: -9.5,9.5
-      parent: 2
-  - uid: 2802
-    components:
-    - type: Transform
-      pos: -16.5,-11.5
-      parent: 2
-  - uid: 2803
-    components:
-    - type: Transform
-      pos: -15.5,-11.5
-      parent: 2
-  - uid: 2804
-    components:
-    - type: Transform
-      pos: -14.5,-11.5
-      parent: 2
-  - uid: 2805
-    components:
-    - type: Transform
-      pos: -14.5,-10.5
-      parent: 2
-  - uid: 2806
-    components:
-    - type: Transform
-      pos: -14.5,-9.5
-      parent: 2
-- proto: CableHV
-  entities:
-  - uid: 533
-    components:
-    - type: Transform
-      pos: -4.5,9.5
-      parent: 2
-  - uid: 534
-    components:
-    - type: Transform
-      pos: -3.5,9.5
-      parent: 2
   - uid: 535
     components:
     - type: Transform
-      pos: -4.5,8.5
+      pos: -23.5,-22.5
       parent: 2
   - uid: 536
     components:
     - type: Transform
-      pos: -4.5,7.5
+      pos: -30.5,-17.5
       parent: 2
   - uid: 537
     components:
     - type: Transform
-      pos: -4.5,6.5
+      pos: -30.5,-18.5
       parent: 2
   - uid: 538
     components:
     - type: Transform
-      pos: -3.5,5.5
+      pos: -30.5,-19.5
       parent: 2
   - uid: 539
     components:
     - type: Transform
-      pos: -4.5,5.5
+      pos: -30.5,-20.5
       parent: 2
   - uid: 540
     components:
     - type: Transform
-      pos: 3.5,5.5
+      pos: -31.5,-20.5
       parent: 2
   - uid: 541
     components:
     - type: Transform
-      pos: -1.5,9.5
+      pos: -9.5,9.5
       parent: 2
   - uid: 542
     components:
     - type: Transform
-      pos: 2.5,5.5
+      pos: -16.5,-11.5
       parent: 2
   - uid: 543
     components:
     - type: Transform
-      pos: 1.5,5.5
+      pos: -15.5,-11.5
       parent: 2
   - uid: 544
     components:
     - type: Transform
-      pos: 0.5,5.5
+      pos: -14.5,-11.5
       parent: 2
   - uid: 545
     components:
     - type: Transform
-      pos: -0.5,5.5
+      pos: -14.5,-10.5
       parent: 2
   - uid: 546
     components:
     - type: Transform
-      pos: -1.5,5.5
+      pos: -14.5,-9.5
       parent: 2
   - uid: 547
     components:
     - type: Transform
-      pos: -2.5,5.5
+      pos: 7.5,-1.5
       parent: 2
   - uid: 548
     components:
     - type: Transform
-      pos: -27.5,1.5
+      pos: 8.5,-1.5
       parent: 2
   - uid: 549
     components:
     - type: Transform
-      pos: -22.5,1.5
+      pos: 9.5,-1.5
       parent: 2
   - uid: 550
     components:
     - type: Transform
-      pos: -28.5,1.5
+      pos: 10.5,-1.5
       parent: 2
   - uid: 551
     components:
     - type: Transform
-      pos: -29.5,0.5
+      pos: 8.5,3.5
       parent: 2
   - uid: 552
     components:
     - type: Transform
-      pos: -29.5,-1.5
+      pos: 9.5,3.5
       parent: 2
   - uid: 553
     components:
     - type: Transform
-      pos: -29.5,-0.5
+      pos: 10.5,3.5
       parent: 2
   - uid: 554
     components:
     - type: Transform
-      pos: -29.5,1.5
+      pos: 10.5,2.5
       parent: 2
   - uid: 555
     components:
     - type: Transform
-      pos: -26.5,-1.5
+      pos: 5.5,-5.5
       parent: 2
   - uid: 556
     components:
     - type: Transform
-      pos: -27.5,-1.5
+      pos: 6.5,-5.5
       parent: 2
   - uid: 557
     components:
     - type: Transform
-      pos: -22.5,5.5
+      pos: 7.5,-5.5
       parent: 2
   - uid: 558
     components:
     - type: Transform
-      pos: -28.5,-0.5
+      pos: 7.5,-6.5
       parent: 2
   - uid: 559
     components:
     - type: Transform
-      pos: -28.5,-1.5
+      pos: 7.5,-4.5
       parent: 2
   - uid: 560
     components:
     - type: Transform
-      pos: -26.5,1.5
+      pos: 7.5,-7.5
       parent: 2
   - uid: 561
     components:
     - type: Transform
-      pos: -26.5,2.5
+      pos: -19.5,13.5
       parent: 2
   - uid: 562
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: -20.5,13.5
       parent: 2
   - uid: 563
     components:
     - type: Transform
-      pos: -25.5,-1.5
+      pos: -21.5,13.5
       parent: 2
   - uid: 564
     components:
     - type: Transform
-      pos: -25.5,-0.5
+      pos: -17.5,13.5
       parent: 2
   - uid: 565
     components:
     - type: Transform
-      pos: -25.5,0.5
+      pos: -16.5,13.5
       parent: 2
   - uid: 566
     components:
     - type: Transform
-      pos: -24.5,0.5
+      pos: -15.5,13.5
       parent: 2
+- proto: CableHV
+  entities:
   - uid: 567
     components:
     - type: Transform
-      pos: -23.5,0.5
+      pos: -4.5,9.5
       parent: 2
   - uid: 568
     components:
     - type: Transform
-      pos: -22.5,0.5
+      pos: -3.5,9.5
       parent: 2
   - uid: 569
     components:
     - type: Transform
-      pos: -21.5,0.5
+      pos: -4.5,8.5
       parent: 2
   - uid: 570
     components:
     - type: Transform
-      pos: -26.5,3.5
+      pos: -4.5,7.5
       parent: 2
   - uid: 571
     components:
     - type: Transform
-      pos: -26.5,4.5
+      pos: -4.5,6.5
       parent: 2
   - uid: 572
     components:
     - type: Transform
-      pos: -26.5,5.5
+      pos: -3.5,5.5
       parent: 2
   - uid: 573
     components:
     - type: Transform
-      pos: -27.5,5.5
+      pos: -4.5,5.5
       parent: 2
   - uid: 574
     components:
     - type: Transform
-      pos: -28.5,5.5
+      pos: 3.5,5.5
       parent: 2
   - uid: 575
     components:
     - type: Transform
-      pos: -29.5,5.5
+      pos: -1.5,9.5
       parent: 2
   - uid: 576
     components:
     - type: Transform
-      pos: -30.5,5.5
+      pos: 2.5,5.5
       parent: 2
   - uid: 577
     components:
     - type: Transform
-      pos: -22.5,2.5
+      pos: 1.5,5.5
       parent: 2
   - uid: 578
     components:
     - type: Transform
-      pos: -22.5,3.5
+      pos: 0.5,5.5
       parent: 2
   - uid: 579
     components:
     - type: Transform
-      pos: -22.5,4.5
+      pos: -0.5,5.5
       parent: 2
   - uid: 580
     components:
     - type: Transform
-      pos: 0.5,10.5
+      pos: -1.5,5.5
       parent: 2
   - uid: 581
     components:
     - type: Transform
-      pos: 1.5,10.5
+      pos: -2.5,5.5
       parent: 2
   - uid: 582
     components:
     - type: Transform
-      pos: 2.5,10.5
+      pos: -27.5,1.5
       parent: 2
   - uid: 583
     components:
     - type: Transform
-      pos: 3.5,10.5
+      pos: -22.5,1.5
       parent: 2
   - uid: 584
     components:
     - type: Transform
-      pos: 4.5,10.5
+      pos: -28.5,1.5
       parent: 2
   - uid: 585
     components:
     - type: Transform
-      pos: 0.5,8.5
+      pos: -29.5,0.5
       parent: 2
   - uid: 586
     components:
     - type: Transform
-      pos: 1.5,8.5
+      pos: -29.5,-1.5
       parent: 2
   - uid: 587
     components:
     - type: Transform
-      pos: 2.5,8.5
+      pos: -29.5,-0.5
       parent: 2
   - uid: 588
     components:
     - type: Transform
-      pos: 3.5,8.5
+      pos: -29.5,1.5
       parent: 2
   - uid: 589
     components:
     - type: Transform
-      pos: 4.5,8.5
+      pos: -26.5,-1.5
       parent: 2
   - uid: 590
     components:
     - type: Transform
-      pos: 2.5,9.5
+      pos: -27.5,-1.5
       parent: 2
   - uid: 591
     components:
     - type: Transform
-      pos: -22.5,6.5
+      pos: -22.5,5.5
       parent: 2
   - uid: 592
     components:
     - type: Transform
-      pos: -2.5,9.5
+      pos: -28.5,-0.5
       parent: 2
   - uid: 593
     components:
     - type: Transform
-      pos: -1.5,8.5
+      pos: -28.5,-1.5
       parent: 2
   - uid: 594
     components:
     - type: Transform
-      pos: -21.5,-0.5
+      pos: -26.5,1.5
       parent: 2
   - uid: 595
     components:
     - type: Transform
-      pos: -21.5,-1.5
+      pos: -26.5,2.5
       parent: 2
   - uid: 596
     components:
     - type: Transform
-      pos: -21.5,-2.5
+      pos: 3.5,1.5
       parent: 2
   - uid: 597
     components:
     - type: Transform
-      pos: -21.5,-3.5
+      pos: -25.5,-1.5
       parent: 2
   - uid: 598
     components:
     - type: Transform
-      pos: -21.5,-4.5
+      pos: -25.5,-0.5
       parent: 2
   - uid: 599
     components:
     - type: Transform
-      pos: -21.5,-5.5
+      pos: -25.5,0.5
       parent: 2
   - uid: 600
     components:
     - type: Transform
-      pos: -21.5,-6.5
+      pos: -24.5,0.5
       parent: 2
   - uid: 601
     components:
     - type: Transform
-      pos: -21.5,-7.5
+      pos: -23.5,0.5
       parent: 2
   - uid: 602
     components:
     - type: Transform
-      pos: -21.5,-8.5
+      pos: -22.5,0.5
       parent: 2
   - uid: 603
     components:
     - type: Transform
-      pos: -21.5,-9.5
+      pos: -21.5,0.5
       parent: 2
   - uid: 604
     components:
     - type: Transform
-      pos: -21.5,-10.5
+      pos: -26.5,3.5
       parent: 2
   - uid: 605
     components:
     - type: Transform
-      pos: -22.5,-8.5
+      pos: -26.5,4.5
       parent: 2
   - uid: 606
     components:
     - type: Transform
-      pos: -23.5,-8.5
+      pos: -26.5,5.5
       parent: 2
   - uid: 607
     components:
     - type: Transform
-      pos: -24.5,-8.5
+      pos: -27.5,5.5
       parent: 2
   - uid: 608
     components:
     - type: Transform
-      pos: -25.5,-8.5
+      pos: -28.5,5.5
       parent: 2
   - uid: 609
     components:
     - type: Transform
-      pos: -26.5,-8.5
+      pos: -29.5,5.5
       parent: 2
   - uid: 610
     components:
     - type: Transform
-      pos: -27.5,-8.5
+      pos: -30.5,5.5
       parent: 2
   - uid: 611
     components:
     - type: Transform
-      pos: -27.5,-9.5
+      pos: -22.5,2.5
       parent: 2
   - uid: 612
     components:
     - type: Transform
-      pos: -28.5,-9.5
+      pos: -22.5,3.5
       parent: 2
   - uid: 613
     components:
     - type: Transform
-      pos: -28.5,-10.5
+      pos: -22.5,4.5
       parent: 2
   - uid: 614
     components:
     - type: Transform
-      pos: -21.5,-11.5
+      pos: 0.5,10.5
       parent: 2
   - uid: 615
     components:
     - type: Transform
-      pos: -21.5,-12.5
+      pos: 1.5,10.5
       parent: 2
   - uid: 616
     components:
     - type: Transform
-      pos: -21.5,-13.5
+      pos: 2.5,10.5
       parent: 2
   - uid: 617
     components:
     - type: Transform
-      pos: -21.5,-14.5
+      pos: 3.5,10.5
       parent: 2
   - uid: 618
     components:
     - type: Transform
-      pos: -21.5,-15.5
+      pos: 4.5,10.5
       parent: 2
   - uid: 619
     components:
     - type: Transform
-      pos: -21.5,-16.5
+      pos: 0.5,8.5
       parent: 2
   - uid: 620
     components:
     - type: Transform
-      pos: -21.5,-17.5
+      pos: 1.5,8.5
       parent: 2
   - uid: 621
     components:
     - type: Transform
-      pos: -21.5,-18.5
+      pos: 2.5,8.5
       parent: 2
   - uid: 622
     components:
     - type: Transform
-      pos: -20.5,-18.5
+      pos: 3.5,8.5
       parent: 2
   - uid: 623
     components:
     - type: Transform
-      pos: -19.5,-18.5
+      pos: 4.5,8.5
       parent: 2
   - uid: 624
     components:
     - type: Transform
-      pos: -18.5,-18.5
+      pos: 2.5,9.5
       parent: 2
   - uid: 625
     components:
     - type: Transform
-      pos: -18.5,-17.5
+      pos: -22.5,6.5
       parent: 2
   - uid: 626
     components:
     - type: Transform
-      pos: -20.5,0.5
+      pos: -2.5,9.5
       parent: 2
   - uid: 627
     components:
     - type: Transform
-      pos: -19.5,0.5
+      pos: -1.5,8.5
       parent: 2
   - uid: 628
     components:
     - type: Transform
-      pos: -18.5,0.5
+      pos: -21.5,-0.5
       parent: 2
   - uid: 629
     components:
     - type: Transform
-      pos: -17.5,0.5
+      pos: -21.5,-1.5
       parent: 2
   - uid: 630
     components:
     - type: Transform
-      pos: -16.5,0.5
+      pos: -21.5,-2.5
       parent: 2
   - uid: 631
     components:
     - type: Transform
-      pos: -15.5,0.5
+      pos: -21.5,-3.5
       parent: 2
   - uid: 632
     components:
     - type: Transform
-      pos: -14.5,0.5
+      pos: -21.5,-4.5
       parent: 2
   - uid: 633
     components:
     - type: Transform
-      pos: -13.5,0.5
+      pos: -21.5,-5.5
       parent: 2
   - uid: 634
     components:
     - type: Transform
-      pos: -12.5,0.5
+      pos: -21.5,-6.5
       parent: 2
   - uid: 635
     components:
     - type: Transform
-      pos: -11.5,0.5
+      pos: -21.5,-7.5
       parent: 2
   - uid: 636
     components:
     - type: Transform
-      pos: -10.5,0.5
+      pos: -21.5,-8.5
       parent: 2
   - uid: 637
     components:
     - type: Transform
-      pos: -9.5,0.5
+      pos: -21.5,-9.5
       parent: 2
   - uid: 638
     components:
     - type: Transform
-      pos: -8.5,0.5
+      pos: -21.5,-10.5
       parent: 2
   - uid: 639
     components:
     - type: Transform
-      pos: -7.5,0.5
+      pos: -22.5,-8.5
       parent: 2
   - uid: 640
     components:
     - type: Transform
-      pos: -6.5,0.5
+      pos: -23.5,-8.5
       parent: 2
   - uid: 641
     components:
     - type: Transform
-      pos: -6.5,-0.5
+      pos: -24.5,-8.5
       parent: 2
   - uid: 642
     components:
     - type: Transform
-      pos: -6.5,-1.5
+      pos: -25.5,-8.5
       parent: 2
   - uid: 643
     components:
     - type: Transform
-      pos: -6.5,-2.5
+      pos: -26.5,-8.5
       parent: 2
   - uid: 644
     components:
     - type: Transform
-      pos: -6.5,-3.5
+      pos: -27.5,-8.5
       parent: 2
   - uid: 645
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: -27.5,-9.5
       parent: 2
   - uid: 646
     components:
     - type: Transform
-      pos: -4.5,0.5
+      pos: -28.5,-9.5
       parent: 2
   - uid: 647
     components:
     - type: Transform
-      pos: -3.5,0.5
+      pos: -28.5,-10.5
       parent: 2
   - uid: 648
     components:
     - type: Transform
-      pos: -2.5,0.5
+      pos: -21.5,-11.5
       parent: 2
   - uid: 649
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -21.5,-12.5
       parent: 2
   - uid: 650
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: -21.5,-13.5
       parent: 2
   - uid: 651
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: -21.5,-14.5
       parent: 2
   - uid: 652
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: -21.5,-15.5
       parent: 2
   - uid: 653
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: -21.5,-16.5
       parent: 2
   - uid: 654
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: -21.5,-17.5
       parent: 2
   - uid: 655
     components:
     - type: Transform
-      pos: 4.5,4.5
+      pos: -21.5,-18.5
       parent: 2
   - uid: 656
     components:
     - type: Transform
-      pos: 3.5,2.5
+      pos: -20.5,-18.5
       parent: 2
   - uid: 657
     components:
     - type: Transform
-      pos: 3.5,3.5
+      pos: -19.5,-18.5
       parent: 2
   - uid: 658
     components:
     - type: Transform
-      pos: 3.5,4.5
+      pos: -18.5,-18.5
       parent: 2
   - uid: 659
     components:
     - type: Transform
-      pos: -22.5,-3.5
+      pos: -18.5,-17.5
       parent: 2
   - uid: 660
     components:
     - type: Transform
-      pos: -23.5,-3.5
+      pos: -20.5,0.5
       parent: 2
   - uid: 661
     components:
     - type: Transform
-      pos: -0.5,8.5
+      pos: -19.5,0.5
       parent: 2
   - uid: 662
     components:
     - type: Transform
-      pos: -22.5,-18.5
+      pos: -18.5,0.5
       parent: 2
   - uid: 663
     components:
     - type: Transform
-      pos: -22.5,-19.5
+      pos: -17.5,0.5
       parent: 2
   - uid: 664
     components:
     - type: Transform
-      pos: -22.5,-20.5
+      pos: -16.5,0.5
       parent: 2
   - uid: 665
     components:
     - type: Transform
-      pos: -23.5,-20.5
+      pos: -15.5,0.5
       parent: 2
   - uid: 666
     components:
     - type: Transform
-      pos: -24.5,-20.5
+      pos: -14.5,0.5
       parent: 2
   - uid: 667
     components:
     - type: Transform
-      pos: -25.5,-20.5
+      pos: -13.5,0.5
       parent: 2
   - uid: 668
     components:
     - type: Transform
-      pos: -25.5,-19.5
+      pos: -12.5,0.5
       parent: 2
   - uid: 669
     components:
     - type: Transform
-      pos: -29.5,-2.5
+      pos: -11.5,0.5
       parent: 2
   - uid: 670
     components:
     - type: Transform
-      pos: -28.5,-2.5
+      pos: -10.5,0.5
       parent: 2
   - uid: 671
     components:
     - type: Transform
-      pos: -31.5,5.5
+      pos: -9.5,0.5
       parent: 2
   - uid: 672
     components:
     - type: Transform
-      pos: -25.5,5.5
+      pos: -8.5,0.5
       parent: 2
   - uid: 673
     components:
     - type: Transform
-      pos: -25.5,6.5
+      pos: -7.5,0.5
       parent: 2
   - uid: 674
     components:
     - type: Transform
-      pos: -25.5,7.5
+      pos: -6.5,0.5
       parent: 2
   - uid: 675
     components:
     - type: Transform
-      pos: -32.5,4.5
+      pos: -6.5,-0.5
       parent: 2
   - uid: 676
     components:
     - type: Transform
-      pos: -32.5,5.5
+      pos: -6.5,-1.5
       parent: 2
   - uid: 677
     components:
     - type: Transform
-      pos: -32.5,3.5
+      pos: -6.5,-2.5
       parent: 2
   - uid: 678
     components:
     - type: Transform
-      pos: -31.5,3.5
+      pos: -6.5,-3.5
       parent: 2
   - uid: 679
     components:
     - type: Transform
-      pos: -33.5,3.5
+      pos: -5.5,0.5
       parent: 2
   - uid: 680
     components:
     - type: Transform
-      pos: -23.5,-21.5
+      pos: -4.5,0.5
       parent: 2
   - uid: 681
     components:
     - type: Transform
-      pos: -23.5,-22.5
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      pos: -2.5,0.5
       parent: 2
   - uid: 683
     components:
     - type: Transform
-      pos: -32.5,-19.5
+      pos: -1.5,0.5
       parent: 2
   - uid: 684
     components:
     - type: Transform
-      pos: -32.5,-20.5
+      pos: -0.5,0.5
       parent: 2
   - uid: 685
     components:
     - type: Transform
-      pos: -32.5,-21.5
+      pos: 0.5,0.5
       parent: 2
   - uid: 686
     components:
     - type: Transform
-      pos: -32.5,-22.5
+      pos: 1.5,0.5
       parent: 2
   - uid: 687
     components:
     - type: Transform
-      pos: -30.5,-22.5
+      pos: 2.5,0.5
       parent: 2
   - uid: 688
     components:
     - type: Transform
-      pos: -30.5,-21.5
+      pos: 3.5,0.5
       parent: 2
   - uid: 689
     components:
     - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 690
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 691
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 692
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 693
+    components:
+    - type: Transform
+      pos: -22.5,-3.5
+      parent: 2
+  - uid: 694
+    components:
+    - type: Transform
+      pos: -23.5,-3.5
+      parent: 2
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 696
+    components:
+    - type: Transform
+      pos: -22.5,-18.5
+      parent: 2
+  - uid: 697
+    components:
+    - type: Transform
+      pos: -22.5,-19.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      pos: -22.5,-20.5
+      parent: 2
+  - uid: 699
+    components:
+    - type: Transform
+      pos: -23.5,-20.5
+      parent: 2
+  - uid: 700
+    components:
+    - type: Transform
+      pos: -24.5,-20.5
+      parent: 2
+  - uid: 701
+    components:
+    - type: Transform
+      pos: -25.5,-20.5
+      parent: 2
+  - uid: 702
+    components:
+    - type: Transform
+      pos: -25.5,-19.5
+      parent: 2
+  - uid: 703
+    components:
+    - type: Transform
+      pos: -29.5,-2.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      pos: -28.5,-2.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      pos: -31.5,5.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -25.5,5.5
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: -25.5,6.5
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -25.5,7.5
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: -32.5,4.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      pos: -32.5,5.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      pos: -32.5,3.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      pos: -31.5,3.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      pos: -33.5,3.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      pos: -23.5,-21.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      pos: -23.5,-22.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      pos: -32.5,-19.5
+      parent: 2
+  - uid: 717
+    components:
+    - type: Transform
+      pos: -32.5,-20.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -32.5,-21.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -32.5,-22.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      pos: -30.5,-22.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -30.5,-21.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
       pos: -30.5,-20.5
       parent: 2
-  - uid: 1674
+  - uid: 723
     components:
     - type: Transform
       pos: -30.5,-18.5
       parent: 2
-  - uid: 2072
+  - uid: 724
     components:
     - type: Transform
       pos: -32.5,-18.5
       parent: 2
-  - uid: 2632
+  - uid: 725
     components:
     - type: Transform
       pos: -30.5,-19.5
       parent: 2
-  - uid: 2674
+  - uid: 726
     components:
     - type: Transform
       pos: -31.5,-19.5
       parent: 2
-  - uid: 2675
+  - uid: 727
     components:
     - type: Transform
       pos: -30.5,-17.5
       parent: 2
-  - uid: 2676
+  - uid: 728
     components:
     - type: Transform
       pos: -30.5,-16.5
       parent: 2
-  - uid: 2677
+  - uid: 729
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 2678
+  - uid: 730
     components:
     - type: Transform
       pos: -29.5,-15.5
       parent: 2
-  - uid: 2679
+  - uid: 731
     components:
     - type: Transform
       pos: -28.5,-15.5
       parent: 2
-  - uid: 2680
+  - uid: 732
     components:
     - type: Transform
       pos: -27.5,-15.5
       parent: 2
-  - uid: 2681
+  - uid: 733
     components:
     - type: Transform
       pos: -26.5,-15.5
       parent: 2
-  - uid: 2682
+  - uid: 734
     components:
     - type: Transform
       pos: -25.5,-15.5
       parent: 2
-  - uid: 2683
+  - uid: 735
     components:
     - type: Transform
       pos: -24.5,-15.5
       parent: 2
-  - uid: 2684
+  - uid: 736
     components:
     - type: Transform
       pos: -23.5,-15.5
       parent: 2
-  - uid: 2685
+  - uid: 737
     components:
     - type: Transform
       pos: -22.5,-15.5
       parent: 2
-  - uid: 2688
+  - uid: 738
     components:
     - type: Transform
       pos: -29.5,-17.5
       parent: 2
 - proto: CableHVStack
   entities:
-  - uid: 690
+  - uid: 739
     components:
     - type: Transform
       pos: -22.49179,5.414856
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 438
+  - uid: 740
     components:
     - type: Transform
       pos: -15.5,-10.5
       parent: 2
-  - uid: 439
+  - uid: 741
     components:
     - type: Transform
       pos: -14.5,-10.5
       parent: 2
-  - uid: 691
+  - uid: 742
     components:
     - type: Transform
       pos: -30.5,-11.5
       parent: 2
-  - uid: 692
+  - uid: 743
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 2
-  - uid: 693
+  - uid: 744
     components:
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
-  - uid: 694
+  - uid: 745
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
-  - uid: 695
+  - uid: 746
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 696
+  - uid: 747
     components:
     - type: Transform
       pos: -28.5,-10.5
       parent: 2
-  - uid: 697
+  - uid: 748
     components:
     - type: Transform
       pos: -27.5,-10.5
       parent: 2
-  - uid: 698
+  - uid: 749
     components:
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
-  - uid: 699
+  - uid: 750
     components:
     - type: Transform
       pos: -28.5,-12.5
       parent: 2
-  - uid: 700
+  - uid: 751
     components:
     - type: Transform
       pos: -27.5,-12.5
       parent: 2
-  - uid: 701
+  - uid: 752
     components:
     - type: Transform
       pos: -27.5,-13.5
       parent: 2
-  - uid: 702
+  - uid: 753
     components:
     - type: Transform
       pos: -18.5,-17.5
       parent: 2
-  - uid: 703
+  - uid: 754
     components:
     - type: Transform
       pos: -19.5,-17.5
       parent: 2
-  - uid: 704
+  - uid: 755
     components:
     - type: Transform
       pos: -22.5,6.5
       parent: 2
-  - uid: 705
+  - uid: 756
     components:
     - type: Transform
       pos: -22.5,5.5
       parent: 2
-  - uid: 706
+  - uid: 757
     components:
     - type: Transform
       pos: -22.5,4.5
       parent: 2
-  - uid: 707
+  - uid: 758
     components:
     - type: Transform
       pos: -23.5,4.5
       parent: 2
-  - uid: 708
+  - uid: 759
     components:
     - type: Transform
       pos: -24.5,4.5
       parent: 2
-  - uid: 709
+  - uid: 760
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
-  - uid: 710
+  - uid: 761
     components:
     - type: Transform
       pos: -25.5,5.5
       parent: 2
-  - uid: 711
+  - uid: 762
     components:
     - type: Transform
       pos: -25.5,6.5
       parent: 2
-  - uid: 712
+  - uid: 763
     components:
     - type: Transform
       pos: -24.5,6.5
       parent: 2
-  - uid: 713
+  - uid: 764
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 2
-  - uid: 714
+  - uid: 765
     components:
     - type: Transform
       pos: -22.5,2.5
       parent: 2
-  - uid: 715
+  - uid: 766
     components:
     - type: Transform
       pos: -22.5,1.5
       parent: 2
-  - uid: 716
+  - uid: 767
     components:
     - type: Transform
       pos: -21.5,1.5
       parent: 2
-  - uid: 717
+  - uid: 768
     components:
     - type: Transform
       pos: -20.5,1.5
       parent: 2
-  - uid: 718
+  - uid: 769
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 2
-  - uid: 719
+  - uid: 770
     components:
     - type: Transform
       pos: -19.5,2.5
       parent: 2
-  - uid: 720
+  - uid: 771
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
-  - uid: 721
+  - uid: 772
     components:
     - type: Transform
       pos: -19.5,4.5
       parent: 2
-  - uid: 722
+  - uid: 773
     components:
     - type: Transform
       pos: -18.5,4.5
       parent: 2
-  - uid: 723
+  - uid: 774
     components:
     - type: Transform
       pos: -17.5,4.5
       parent: 2
-  - uid: 724
+  - uid: 775
     components:
     - type: Transform
       pos: -16.5,4.5
       parent: 2
-  - uid: 725
+  - uid: 776
     components:
     - type: Transform
       pos: -15.5,4.5
       parent: 2
-  - uid: 726
+  - uid: 777
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 2
-  - uid: 727
+  - uid: 778
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
-  - uid: 728
+  - uid: 779
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 729
+  - uid: 780
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 730
+  - uid: 781
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
-  - uid: 731
+  - uid: 782
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 2
-  - uid: 732
+  - uid: 783
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
-  - uid: 733
+  - uid: 784
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 734
+  - uid: 785
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
-  - uid: 735
+  - uid: 786
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 2
-  - uid: 736
+  - uid: 787
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
-  - uid: 737
+  - uid: 788
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
-  - uid: 738
+  - uid: 789
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 2
-  - uid: 739
+  - uid: 790
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 2
-  - uid: 740
+  - uid: 791
     components:
     - type: Transform
       pos: -6.5,4.5
       parent: 2
-  - uid: 741
+  - uid: 792
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
-  - uid: 742
+  - uid: 793
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 2
-  - uid: 743
+  - uid: 794
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 2
-  - uid: 744
+  - uid: 795
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 2
-  - uid: 745
+  - uid: 796
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 746
+  - uid: 797
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
-  - uid: 747
+  - uid: 798
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
-  - uid: 748
+  - uid: 799
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 2
-  - uid: 749
+  - uid: 800
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 2
-  - uid: 750
+  - uid: 801
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 2
-  - uid: 751
+  - uid: 802
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 2
-  - uid: 752
+  - uid: 803
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 753
+  - uid: 804
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 754
+  - uid: 805
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 755
+  - uid: 806
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 756
+  - uid: 807
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 757
+  - uid: 808
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 2
-  - uid: 758
+  - uid: 809
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 2
-  - uid: 759
+  - uid: 810
     components:
     - type: Transform
       pos: -10.5,-5.5
       parent: 2
-  - uid: 760
+  - uid: 811
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
-  - uid: 761
+  - uid: 812
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 2
-  - uid: 762
+  - uid: 813
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
-  - uid: 763
+  - uid: 814
     components:
     - type: Transform
       pos: -20.5,-17.5
       parent: 2
-  - uid: 764
+  - uid: 815
     components:
     - type: Transform
       pos: -20.5,-16.5
       parent: 2
-  - uid: 765
+  - uid: 816
     components:
     - type: Transform
       pos: -20.5,-15.5
       parent: 2
-  - uid: 766
+  - uid: 817
     components:
     - type: Transform
       pos: -20.5,-14.5
       parent: 2
-  - uid: 767
+  - uid: 818
     components:
     - type: Transform
       pos: -20.5,-13.5
       parent: 2
-  - uid: 768
+  - uid: 819
     components:
     - type: Transform
       pos: -20.5,-12.5
       parent: 2
-  - uid: 769
+  - uid: 820
     components:
     - type: Transform
       pos: -20.5,-11.5
       parent: 2
-  - uid: 770
+  - uid: 821
     components:
     - type: Transform
       pos: -20.5,-10.5
       parent: 2
-  - uid: 771
+  - uid: 822
     components:
     - type: Transform
       pos: -20.5,-9.5
       parent: 2
-  - uid: 772
+  - uid: 823
     components:
     - type: Transform
       pos: -20.5,-8.5
       parent: 2
-  - uid: 773
+  - uid: 824
     components:
     - type: Transform
       pos: -20.5,-7.5
       parent: 2
-  - uid: 774
+  - uid: 825
     components:
     - type: Transform
       pos: -19.5,-7.5
       parent: 2
-  - uid: 775
+  - uid: 826
     components:
     - type: Transform
       pos: -18.5,-7.5
       parent: 2
-  - uid: 776
+  - uid: 827
     components:
     - type: Transform
       pos: -17.5,-7.5
       parent: 2
-  - uid: 777
+  - uid: 828
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 2
-  - uid: 778
+  - uid: 829
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 2
-  - uid: 779
+  - uid: 830
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 2
-  - uid: 780
+  - uid: 831
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 2
-  - uid: 781
+  - uid: 832
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 2
-  - uid: 782
+  - uid: 833
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 783
+  - uid: 834
     components:
     - type: Transform
       pos: -23.5,-3.5
       parent: 2
-  - uid: 784
+  - uid: 835
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 2
-  - uid: 785
+  - uid: 836
     components:
     - type: Transform
       pos: -25.5,-19.5
       parent: 2
-  - uid: 786
+  - uid: 837
     components:
     - type: Transform
       pos: -26.5,-19.5
       parent: 2
-  - uid: 787
+  - uid: 838
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 2
-  - uid: 788
+  - uid: 839
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-  - uid: 789
+  - uid: 840
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
-  - uid: 790
+  - uid: 841
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 2
-  - uid: 791
+  - uid: 842
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 2
-  - uid: 792
+  - uid: 843
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 2
-  - uid: 793
+  - uid: 844
     components:
     - type: Transform
       pos: -12.5,-0.5
       parent: 2
-  - uid: 794
+  - uid: 845
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 2
-  - uid: 795
+  - uid: 846
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 2
-  - uid: 796
+  - uid: 847
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
-  - uid: 797
+  - uid: 848
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 2
-  - uid: 798
+  - uid: 849
     components:
     - type: Transform
       pos: -15.5,1.5
       parent: 2
-  - uid: 799
+  - uid: 850
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 2
-  - uid: 800
+  - uid: 851
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 2
-  - uid: 801
+  - uid: 852
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 2
-  - uid: 802
+  - uid: 853
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
-  - uid: 803
+  - uid: 854
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 2
-  - uid: 804
+  - uid: 855
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 2
-  - uid: 805
+  - uid: 856
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 2
-  - uid: 806
+  - uid: 857
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
-  - uid: 807
+  - uid: 858
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 2
-  - uid: 808
+  - uid: 859
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 2
-  - uid: 809
+  - uid: 860
     components:
     - type: Transform
       pos: -11.5,-0.5
       parent: 2
-  - uid: 810
+  - uid: 861
     components:
     - type: Transform
       pos: -29.5,-13.5
       parent: 2
-  - uid: 811
+  - uid: 862
     components:
     - type: Transform
       pos: -29.5,-12.5
       parent: 2
-  - uid: 812
+  - uid: 863
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 2
-  - uid: 813
+  - uid: 864
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
-  - uid: 814
+  - uid: 865
     components:
     - type: Transform
       pos: -9.5,6.5
       parent: 2
-  - uid: 815
+  - uid: 866
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 2
-  - uid: 816
+  - uid: 867
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 2
-  - uid: 817
+  - uid: 868
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
-  - uid: 818
+  - uid: 869
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 2
-  - uid: 819
+  - uid: 870
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 2
-  - uid: 820
+  - uid: 871
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 821
+  - uid: 872
     components:
     - type: Transform
       pos: -16.5,-2.5
       parent: 2
-  - uid: 866
+  - uid: 873
     components:
     - type: Transform
       pos: -13.5,-11.5
       parent: 2
-  - uid: 941
+  - uid: 874
     components:
     - type: Transform
       pos: -13.5,-10.5
       parent: 2
-  - uid: 1696
+  - uid: 875
     components:
     - type: Transform
       pos: -26.5,5.5
       parent: 2
-  - uid: 1851
+  - uid: 876
     components:
     - type: Transform
       pos: -20.5,-6.5
       parent: 2
-  - uid: 1871
+  - uid: 877
     components:
     - type: Transform
       pos: -16.5,-10.5
       parent: 2
-  - uid: 1934
+  - uid: 878
     components:
     - type: Transform
       pos: -20.5,-5.5
       parent: 2
-  - uid: 1977
+  - uid: 879
     components:
     - type: Transform
       pos: -27.5,5.5
       parent: 2
-  - uid: 1978
+  - uid: 880
     components:
     - type: Transform
       pos: -27.5,6.5
       parent: 2
-  - uid: 2022
+  - uid: 881
     components:
     - type: Transform
       pos: -13.5,-9.5
       parent: 2
-  - uid: 2309
+  - uid: 882
     components:
     - type: Transform
       pos: -17.5,-8.5
       parent: 2
-  - uid: 2409
+  - uid: 883
     components:
     - type: Transform
       pos: -17.5,-9.5
       parent: 2
-  - uid: 2555
+  - uid: 884
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
-  - uid: 2619
+  - uid: 885
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 2620
+  - uid: 886
     components:
     - type: Transform
       pos: -27.5,8.5
       parent: 2
-  - uid: 2621
+  - uid: 887
     components:
     - type: Transform
       pos: -27.5,9.5
       parent: 2
-  - uid: 2622
+  - uid: 888
     components:
     - type: Transform
       pos: -27.5,10.5
       parent: 2
-  - uid: 2623
+  - uid: 889
     components:
     - type: Transform
       pos: -28.5,10.5
       parent: 2
-  - uid: 2689
+  - uid: 890
     components:
     - type: Transform
       pos: -29.5,-17.5
       parent: 2
-  - uid: 2690
+  - uid: 891
     components:
     - type: Transform
       pos: -30.5,-17.5
       parent: 2
-  - uid: 2735
+  - uid: 892
     components:
     - type: Transform
       pos: -20.5,-4.5
       parent: 2
-  - uid: 2736
+  - uid: 893
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 2737
+  - uid: 894
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 2738
+  - uid: 895
     components:
     - type: Transform
       pos: -20.5,-18.5
       parent: 2
-  - uid: 2739
+  - uid: 896
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
-  - uid: 2740
+  - uid: 897
     components:
     - type: Transform
       pos: -20.5,-20.5
       parent: 2
-  - uid: 2741
+  - uid: 898
     components:
     - type: Transform
       pos: -20.5,-21.5
       parent: 2
-  - uid: 2742
+  - uid: 899
     components:
     - type: Transform
       pos: -20.5,-22.5
       parent: 2
-  - uid: 2743
+  - uid: 900
     components:
     - type: Transform
       pos: -21.5,-22.5
       parent: 2
-  - uid: 2744
+  - uid: 901
     components:
     - type: Transform
       pos: -19.5,-22.5
       parent: 2
-  - uid: 2745
+  - uid: 902
     components:
     - type: Transform
       pos: -18.5,-22.5
       parent: 2
-  - uid: 2746
+  - uid: 903
     components:
     - type: Transform
       pos: -25.5,-18.5
       parent: 2
-  - uid: 2747
+  - uid: 904
     components:
     - type: Transform
       pos: -26.5,-18.5
       parent: 2
-  - uid: 2748
+  - uid: 905
     components:
     - type: Transform
       pos: -27.5,-18.5
       parent: 2
-  - uid: 2749
+  - uid: 906
     components:
     - type: Transform
       pos: -28.5,-18.5
       parent: 2
-  - uid: 2750
+  - uid: 907
     components:
     - type: Transform
       pos: -27.5,-9.5
       parent: 2
-  - uid: 2751
+  - uid: 908
     components:
     - type: Transform
       pos: -27.5,-8.5
       parent: 2
-  - uid: 2752
+  - uid: 909
     components:
     - type: Transform
       pos: -27.5,-7.5
       parent: 2
-  - uid: 2753
+  - uid: 910
     components:
     - type: Transform
       pos: -27.5,-6.5
       parent: 2
-  - uid: 2754
+  - uid: 911
     components:
     - type: Transform
       pos: -27.5,-5.5
       parent: 2
-  - uid: 2755
+  - uid: 912
     components:
     - type: Transform
       pos: -28.5,-5.5
       parent: 2
-  - uid: 2756
+  - uid: 913
     components:
     - type: Transform
       pos: -29.5,-5.5
       parent: 2
-  - uid: 2757
+  - uid: 914
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 2758
+  - uid: 915
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 2759
+  - uid: 916
     components:
     - type: Transform
       pos: -17.5,5.5
       parent: 2
-  - uid: 2760
+  - uid: 917
     components:
     - type: Transform
       pos: -17.5,6.5
       parent: 2
-  - uid: 2761
+  - uid: 918
     components:
     - type: Transform
       pos: -17.5,7.5
       parent: 2
-  - uid: 2762
+  - uid: 919
     components:
     - type: Transform
       pos: -17.5,8.5
       parent: 2
-  - uid: 2765
+  - uid: 920
     components:
     - type: Transform
       pos: -17.5,12.5
       parent: 2
 - proto: CableMVStack
   entities:
-  - uid: 822
+  - uid: 921
     components:
     - type: Transform
       pos: -22.49179,5.555481
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 823
+  - uid: 922
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 2
-  - uid: 824
+  - uid: 923
     components:
     - type: Transform
       pos: -28.5,-0.5
       parent: 2
-  - uid: 825
+  - uid: 924
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
 - proto: CandleInfinite
   entities:
-  - uid: 826
+  - uid: 925
     components:
     - type: Transform
       pos: -23.778767,7.477115
       parent: 2
-  - uid: 827
+  - uid: 926
     components:
     - type: Transform
       pos: -23.731892,7.727115
       parent: 2
-  - uid: 828
+  - uid: 927
     components:
     - type: Transform
       pos: -23.466267,7.445865
       parent: 2
-  - uid: 829
+  - uid: 928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.7088013,-1.5700989
       parent: 2
-  - uid: 830
+  - uid: 929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6404,13 +6657,13 @@ entities:
       parent: 2
 - proto: CandleRedInfinite
   entities:
-  - uid: 831
+  - uid: 930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5525513,-1.4034424
       parent: 2
-  - uid: 832
+  - uid: 931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6418,7 +6671,7 @@ entities:
       parent: 2
 - proto: CapacitorStockPart
   entities:
-  - uid: 2786
+  - uid: 932
     components:
     - type: Transform
       pos: -12.695068,-10.511749
@@ -6427,68 +6680,68 @@ entities:
       count: 5
 - proto: CardBoxBlack
   entities:
-  - uid: 2644
+  - uid: 933
     components:
     - type: Transform
       pos: -26.44992,2.504425
       parent: 2
 - proto: Carpet
   entities:
-  - uid: 833
+  - uid: 934
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 2
-  - uid: 834
+  - uid: 935
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 2
-  - uid: 835
+  - uid: 936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 2
-  - uid: 836
+  - uid: 937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 2
-  - uid: 837
+  - uid: 938
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 2
-  - uid: 838
+  - uid: 939
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 2
-  - uid: 839
+  - uid: 940
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 2
-  - uid: 840
+  - uid: 941
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 2
-  - uid: 841
+  - uid: 942
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 2
-  - uid: 842
+  - uid: 943
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6496,69 +6749,69 @@ entities:
       parent: 2
 - proto: CarpetBlack
   entities:
-  - uid: 912
+  - uid: 944
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-  - uid: 955
+  - uid: 945
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 2
-  - uid: 1702
+  - uid: 946
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 2
-  - uid: 1734
+  - uid: 947
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
-  - uid: 1756
+  - uid: 948
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
-  - uid: 2081
+  - uid: 949
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
 - proto: CarpetBlue
   entities:
-  - uid: 843
+  - uid: 950
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,-17.5
       parent: 2
-  - uid: 844
+  - uid: 951
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-17.5
       parent: 2
-  - uid: 845
+  - uid: 952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,-17.5
       parent: 2
-  - uid: 846
+  - uid: 953
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-14.5
       parent: 2
-  - uid: 847
+  - uid: 954
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-15.5
       parent: 2
-  - uid: 848
+  - uid: 955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6566,309 +6819,315 @@ entities:
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 849
+  - uid: 956
     components:
     - type: Transform
       pos: -35.5,7.5
       parent: 2
-  - uid: 850
+  - uid: 957
     components:
     - type: Transform
       pos: -35.5,6.5
       parent: 2
-  - uid: 851
+  - uid: 958
     components:
     - type: Transform
       pos: -35.5,5.5
       parent: 2
-  - uid: 852
+  - uid: 959
     components:
     - type: Transform
       pos: -33.5,5.5
       parent: 2
-  - uid: 853
+  - uid: 960
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,5.5
       parent: 2
-  - uid: 854
+  - uid: 961
     components:
     - type: Transform
       pos: -31.5,5.5
       parent: 2
-  - uid: 855
+  - uid: 962
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,5.5
       parent: 2
-  - uid: 856
+  - uid: 963
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,8.5
       parent: 2
-  - uid: 857
+  - uid: 964
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,9.5
       parent: 2
-  - uid: 858
+  - uid: 965
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,5.5
       parent: 2
-  - uid: 860
+  - uid: 966
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 2
-  - uid: 861
+  - uid: 967
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-3.5
       parent: 2
-  - uid: 862
+  - uid: 968
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-2.5
       parent: 2
-  - uid: 863
+  - uid: 969
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-5.5
       parent: 2
-  - uid: 865
+  - uid: 970
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-6.5
       parent: 2
-  - uid: 867
+  - uid: 971
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,0.5
       parent: 2
-  - uid: 868
+  - uid: 972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 2
-  - uid: 869
+  - uid: 973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,3.5
       parent: 2
-  - uid: 870
+  - uid: 974
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,12.5
       parent: 2
-  - uid: 2630
+  - uid: 975
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,12.5
       parent: 2
-  - uid: 2654
+  - uid: 976
     components:
     - type: Transform
       pos: -31.5,11.5
       parent: 2
-  - uid: 2655
+  - uid: 977
     components:
     - type: Transform
       pos: -30.5,12.5
       parent: 2
-  - uid: 2656
+  - uid: 978
     components:
     - type: Transform
       pos: -29.5,12.5
       parent: 2
-  - uid: 2658
+  - uid: 979
     components:
     - type: Transform
       pos: -27.5,12.5
       parent: 2
-  - uid: 2659
+  - uid: 980
     components:
     - type: Transform
       pos: -27.5,13.5
       parent: 2
-  - uid: 2660
+  - uid: 981
     components:
     - type: Transform
       pos: -28.5,13.5
       parent: 2
-  - uid: 2661
+  - uid: 982
     components:
     - type: Transform
       pos: -29.5,13.5
       parent: 2
-  - uid: 2662
+  - uid: 983
     components:
     - type: Transform
       pos: -29.5,11.5
       parent: 2
-  - uid: 2663
+  - uid: 984
     components:
     - type: Transform
       pos: -28.5,11.5
       parent: 2
-  - uid: 2664
+  - uid: 985
     components:
     - type: Transform
       pos: -27.5,11.5
       parent: 2
-  - uid: 2696
+  - uid: 986
     components:
     - type: Transform
       pos: -31.5,-20.5
       parent: 2
-  - uid: 2697
+  - uid: 987
     components:
     - type: Transform
       pos: -31.5,-21.5
       parent: 2
 - proto: Chair
   entities:
-  - uid: 2638
+  - uid: 988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,1.5
       parent: 2
-  - uid: 2639
+  - uid: 989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,1.5
       parent: 2
-  - uid: 2640
+  - uid: 990
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 2
-  - uid: 2641
+  - uid: 991
     components:
     - type: Transform
       pos: -26.5,3.5
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 3
+  - uid: 992
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.15567,-11.420502
       parent: 2
-  - uid: 872
+  - uid: 993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5247045,-4.3581977
       parent: 2
-  - uid: 873
+  - uid: 994
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-15.5
       parent: 2
-  - uid: 875
+  - uid: 995
     components:
     - type: Transform
       pos: -18.459625,-20.421814
       parent: 2
-  - uid: 876
+  - uid: 996
     components:
     - type: Transform
       pos: -21.459625,-20.499939
       parent: 2
-  - uid: 877
+  - uid: 997
     components:
     - type: Transform
       pos: -20.435333,12.449188
       parent: 2
-  - uid: 878
+  - uid: 998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.620422,-10.666077
       parent: 2
-  - uid: 879
+  - uid: 999
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.620422,-9.837952
       parent: 2
-  - uid: 880
+  - uid: 1000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.494568,4.9372253
       parent: 2
-  - uid: 881
+  - uid: 1001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.494568,4.9684753
       parent: 2
-  - uid: 882
+  - uid: 1002
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.281921,7.61557
       parent: 2
-  - uid: 2021
+  - uid: 1003
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.247955,11.355286
       parent: 2
-  - uid: 2652
+  - uid: 1004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.216705,10.574036
       parent: 2
-  - uid: 2699
+  - uid: 1005
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.751099,-6.4845276
       parent: 2
+  - uid: 1006
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.497284,-4.3157654
+      parent: 2
 - proto: ChairWood
   entities:
-  - uid: 883
+  - uid: 1007
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.4996948,-2.4439697
       parent: 2
-  - uid: 884
+  - uid: 1008
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 2
-  - uid: 885
+  - uid: 1009
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 2
-  - uid: 886
+  - uid: 1010
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6876,33 +7135,33 @@ entities:
       parent: 2
 - proto: ChemDispenser
   entities:
-  - uid: 1183
+  - uid: 1011
     components:
     - type: Transform
       pos: -13.5,9.5
       parent: 2
 - proto: ChemistryHotplate
   entities:
-  - uid: 888
+  - uid: 1012
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 2
 - proto: ChemMaster
   entities:
-  - uid: 1595
+  - uid: 1013
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 2355
+  - uid: 1014
     components:
     - type: Transform
       pos: -11.5,8.5
       parent: 2
 - proto: Cigarette
   entities:
-  - uid: 2646
+  - uid: 1015
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6910,85 +7169,90 @@ entities:
       parent: 2
 - proto: CigCartonGreen
   entities:
-  - uid: 890
+  - uid: 1016
     components:
     - type: Transform
       pos: -0.5023804,3.5939026
       parent: 2
 - proto: CircuitImprinter
   entities:
-  - uid: 891
+  - uid: 1017
     components:
     - type: Transform
       pos: -24.5,-9.5
       parent: 2
 - proto: CleanerDispenser
   entities:
-  - uid: 892
+  - uid: 1018
     components:
     - type: Transform
       pos: -24.5,-10.5
       parent: 2
 - proto: ClosetChefFilled
   entities:
-  - uid: 893
+  - uid: 1019
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
 - proto: ClosetFireFilled
   entities:
-  - uid: 894
+  - uid: 1020
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
 - proto: ClosetJanitorFilled
   entities:
-  - uid: 895
+  - uid: 1021
     components:
     - type: Transform
       pos: -25.5,-11.5
       parent: 2
 - proto: ClosetL3JanitorFilled
   entities:
-  - uid: 896
+  - uid: 1022
     components:
     - type: Transform
       pos: -26.5,-11.5
       parent: 2
 - proto: ClosetMaintenanceFilledRandom
   entities:
-  - uid: 897
+  - uid: 1023
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 898
+  - uid: 1024
     components:
     - type: Transform
       pos: -15.5,-3.5
       parent: 2
-  - uid: 2771
+  - uid: 1025
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+  - uid: 2934
     components:
     - type: Transform
       pos: 470.5,461.5
       parent: 1
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 899
+  - uid: 1026
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 2
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 900
+  - uid: 1027
     components:
     - type: Transform
       pos: -31.5,-13.5
       parent: 2
-  - uid: 901
+  - uid: 1028
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6996,12 +7260,12 @@ entities:
       parent: 2
 - proto: ClosetWallEmergencyN2FilledRandom
   entities:
-  - uid: 902
+  - uid: 1029
     components:
     - type: Transform
       pos: -32.5,-13.5
       parent: 2
-  - uid: 903
+  - uid: 1030
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7009,19 +7273,19 @@ entities:
       parent: 2
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 904
+  - uid: 1031
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 906
+  - uid: 1032
     components:
     - type: Transform
       pos: -25.5,-13.5
       parent: 2
 - proto: ClosetWallPink
   entities:
-  - uid: 907
+  - uid: 1033
     components:
     - type: MetaData
       desc: a wall closet containing plasma for backup generators.
@@ -7054,24 +7318,24 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 908
+          - 1034
 - proto: ClothingBeltMedicalFilled
   entities:
-  - uid: 909
+  - uid: 1035
     components:
     - type: Transform
       pos: -15.52121,7.699066
       parent: 2
 - proto: ClothingBeltUtilityEngineering
   entities:
-  - uid: 910
+  - uid: 1036
     components:
     - type: Transform
       pos: -8.307831,-3.3903503
       parent: 2
 - proto: ClothingEyesGlassesChemical
   entities:
-  - uid: 1850
+  - uid: 1037
     components:
     - type: Transform
       pos: -11.474945,5.433441
@@ -7081,7 +7345,7 @@ entities:
         lens_slot: !type:ContainerSlot {}
 - proto: ClothingEyesHudBeer
   entities:
-  - uid: 911
+  - uid: 1038
     components:
     - type: Transform
       pos: 1.1422424,6.4457397
@@ -7091,34 +7355,34 @@ entities:
         lens_slot: !type:ContainerSlot {}
 - proto: ClothingHeadHelmetJustice
   entities:
-  - uid: 2787
+  - uid: 1039
     components:
     - type: Transform
       pos: -15.134888,-11.175476
       parent: 2
 - proto: ComfyChair
   entities:
-  - uid: 913
+  - uid: 1040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-12.5
       parent: 2
-  - uid: 914
+  - uid: 1041
     components:
     - type: Transform
       pos: -18.5,13.5
       parent: 2
 - proto: ComputerAlert
   entities:
-  - uid: 915
+  - uid: 1042
     components:
     - type: Transform
       pos: -24.5,5.5
       parent: 2
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 1822
+  - uid: 1043
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7126,25 +7390,25 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1774:
+        2003:
         - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
 - proto: ComputerCargoBounty
   entities:
-  - uid: 917
+  - uid: 1044
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
 - proto: ComputerCargoOrders
   entities:
-  - uid: 918
+  - uid: 1045
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
 - proto: ComputerComms
   entities:
-  - uid: 919
+  - uid: 1046
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7152,13 +7416,13 @@ entities:
       parent: 2
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 920
+  - uid: 1047
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-21.5
       parent: 2
-  - uid: 921
+  - uid: 1048
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7166,13 +7430,13 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 923
+  - uid: 1049
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-21.5
       parent: 2
-  - uid: 2553
+  - uid: 1050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7180,13 +7444,13 @@ entities:
       parent: 2
 - proto: ComputerId
   entities:
-  - uid: 924
+  - uid: 1051
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-16.5
       parent: 2
-  - uid: 925
+  - uid: 1052
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7194,20 +7458,20 @@ entities:
       parent: 2
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 926
+  - uid: 1053
     components:
     - type: Transform
       pos: -23.5,5.5
       parent: 2
 - proto: ComputerRadar
   entities:
-  - uid: 927
+  - uid: 1054
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-21.5
       parent: 2
-  - uid: 928
+  - uid: 1055
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7215,14 +7479,14 @@ entities:
       parent: 2
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 929
+  - uid: 1056
     components:
     - type: Transform
       pos: -27.5,-3.5
       parent: 2
 - proto: ComputerSalvageExpedition
   entities:
-  - uid: 930
+  - uid: 1057
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7230,7 +7494,7 @@ entities:
       parent: 2
 - proto: ComputerShuttleCargo
   entities:
-  - uid: 931
+  - uid: 1058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7238,20 +7502,20 @@ entities:
       parent: 2
 - proto: ComputerSolarControl
   entities:
-  - uid: 932
+  - uid: 1059
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,10.5
       parent: 2
-  - uid: 2667
+  - uid: 1060
     components:
     - type: Transform
       pos: -31.5,-20.5
       parent: 2
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 933
+  - uid: 1061
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7259,13 +7523,13 @@ entities:
       parent: 2
 - proto: ContainmentFieldGenerator
   entities:
-  - uid: 934
+  - uid: 1062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-11.5
       parent: 2
-  - uid: 935
+  - uid: 1063
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7273,45 +7537,45 @@ entities:
       parent: 2
 - proto: ConveyorBelt
   entities:
-  - uid: 936
+  - uid: 1064
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 2
-  - uid: 937
+  - uid: 1065
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 2
-  - uid: 939
+  - uid: 1066
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 2
-  - uid: 942
+  - uid: 1067
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 2
 - proto: CrateEngineeringMiniJetpack
   entities:
-  - uid: 943
+  - uid: 1068
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 2
 - proto: CrateEngineeringShittle
   entities:
-  - uid: 944
+  - uid: 1069
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
 - proto: CrateGenericSteel
   entities:
-  - uid: 945
+  - uid: 1070
     components:
     - type: MetaData
       name: basic materials crate
@@ -7342,29 +7606,29 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 948
-          - 947
-          - 954
-          - 953
-          - 946
-          - 951
-          - 952
-          - 950
-          - 949
+          - 1073
+          - 1072
+          - 1079
+          - 1078
+          - 1071
+          - 1076
+          - 1077
+          - 1075
+          - 1074
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CrateNPCHamlet
   entities:
-  - uid: 956
+  - uid: 1080
     components:
     - type: Transform
       pos: -16.5,-18.5
       parent: 2
 - proto: CratePirate
   entities:
-  - uid: 957
+  - uid: 1081
     components:
     - type: Transform
       anchored: True
@@ -7378,8 +7642,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 958
-          - 959
+          - 1082
+          - 1083
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -7388,21 +7652,21 @@ entities:
       prevFixedRotation: True
 - proto: CrateServiceJanitorialHardsuit
   entities:
-  - uid: 960
+  - uid: 1084
     components:
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
 - proto: CrateTrashCart
   entities:
-  - uid: 1006
+  - uid: 1085
     components:
     - type: Transform
       pos: -15.5,-4.5
       parent: 2
 - proto: Crematorium
   entities:
-  - uid: 962
+  - uid: 1086
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7410,14 +7674,14 @@ entities:
       parent: 2
 - proto: CrewMonitoringServer
   entities:
-  - uid: 963
+  - uid: 1087
     components:
     - type: Transform
       pos: -26.5,-21.5
       parent: 2
 - proto: CryogenicSleepUnitSpawnerLateJoin
   entities:
-  - uid: 964
+  - uid: 1088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7425,42 +7689,42 @@ entities:
       parent: 2
 - proto: CryoPod
   entities:
-  - uid: 965
+  - uid: 1089
     components:
     - type: Transform
       pos: -19.5,13.5
       parent: 2
 - proto: CryoxadoneBeakerSmall
   entities:
-  - uid: 966
+  - uid: 1090
     components:
     - type: Transform
       pos: -16.654175,11.564209
       parent: 2
 - proto: CurtainsBlue
   entities:
-  - uid: 967
+  - uid: 1091
     components:
     - type: Transform
       pos: -28.5,-18.5
       parent: 2
 - proto: CurtainsGreenOpen
   entities:
-  - uid: 1986
+  - uid: 1092
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 2
 - proto: DebugAPC
   entities:
-  - uid: 969
+  - uid: 1093
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
 - proto: DefaultStationBeacon
   entities:
-  - uid: 970
+  - uid: 1094
     components:
     - type: Transform
       pos: -9.5,-5.5
@@ -7469,61 +7733,61 @@ entities:
       text: Shuttle Bay
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 971
+  - uid: 1095
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 2
 - proto: DefaultStationBeaconBotany
   entities:
-  - uid: 972
+  - uid: 1096
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 2
 - proto: DefaultStationBeaconBridge
   entities:
-  - uid: 973
+  - uid: 1097
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
 - proto: DefaultStationBeaconCaptainsQuarters
   entities:
-  - uid: 974
+  - uid: 1098
     components:
     - type: Transform
       pos: -25.5,-18.5
       parent: 2
 - proto: DefaultStationBeaconCargoBay
   entities:
-  - uid: 975
+  - uid: 1099
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
 - proto: DefaultStationBeaconChemistry
   entities:
-  - uid: 976
+  - uid: 1100
     components:
     - type: Transform
       pos: -13.5,7.5
       parent: 2
 - proto: DefaultStationBeaconCryosleep
   entities:
-  - uid: 977
+  - uid: 1101
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
 - proto: DefaultStationBeaconEngineering
   entities:
-  - uid: 978
+  - uid: 1102
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
-  - uid: 2058
+  - uid: 1103
     components:
     - type: Transform
       pos: -28.5,12.5
@@ -7534,95 +7798,95 @@ entities:
       location: Station anchor
 - proto: DefaultStationBeaconEvac
   entities:
-  - uid: 979
+  - uid: 1104
     components:
     - type: Transform
       pos: -31.5,-15.5
       parent: 2
 - proto: DefaultStationBeaconEVAStorage
   entities:
-  - uid: 980
+  - uid: 1105
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
 - proto: DefaultStationBeaconHOPOffice
   entities:
-  - uid: 981
+  - uid: 1106
     components:
     - type: Transform
       pos: -17.5,-15.5
       parent: 2
 - proto: DefaultStationBeaconJanitorsCloset
   entities:
-  - uid: 982
+  - uid: 1107
     components:
     - type: Transform
       pos: -26.5,-12.5
       parent: 2
 - proto: DefaultStationBeaconKitchen
   entities:
-  - uid: 983
+  - uid: 1108
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
 - proto: DefaultStationBeaconMedbay
   entities:
-  - uid: 984
+  - uid: 1109
     components:
     - type: Transform
       pos: -18.5,8.5
       parent: 2
 - proto: DefaultStationBeaconMorgue
   entities:
-  - uid: 985
+  - uid: 1110
     components:
     - type: Transform
       pos: -23.5,7.5
       parent: 2
 - proto: DefaultStationBeaconSalvage
   entities:
-  - uid: 986
+  - uid: 1111
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
 - proto: DefaultStationBeaconScience
   entities:
-  - uid: 987
+  - uid: 1112
     components:
     - type: Transform
       pos: -27.5,-6.5
       parent: 2
 - proto: DefaultStationBeaconSecurity
   entities:
-  - uid: 988
+  - uid: 1113
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
 - proto: DefaultStationBeaconSolars
   entities:
-  - uid: 989
+  - uid: 1114
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 2
-  - uid: 2698
+  - uid: 1115
     components:
     - type: Transform
       pos: -31.5,-21.5
       parent: 2
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 990
+  - uid: 1116
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,6.5
       parent: 2
-  - uid: 2265
+  - uid: 1117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7630,49 +7894,49 @@ entities:
       parent: 2
 - proto: DeskBell
   entities:
-  - uid: 992
+  - uid: 1118
     components:
     - type: Transform
       pos: 1.7575684,3.651123
       parent: 2
-  - uid: 993
+  - uid: 1119
     components:
     - type: Transform
       pos: -19.610687,-15.173004
       parent: 2
 - proto: DisposalBend
   entities:
-  - uid: 994
+  - uid: 1120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-2.5
       parent: 2
-  - uid: 995
+  - uid: 1121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 2
-  - uid: 996
+  - uid: 1122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-15.5
       parent: 2
-  - uid: 997
+  - uid: 1123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,-15.5
       parent: 2
-  - uid: 998
+  - uid: 1124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,0.5
       parent: 2
-  - uid: 999
+  - uid: 1125
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7680,18 +7944,18 @@ entities:
       parent: 2
 - proto: DisposalJunction
   entities:
-  - uid: 1000
+  - uid: 1126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-12.5
       parent: 2
-  - uid: 1001
+  - uid: 1127
     components:
     - type: Transform
       pos: -13.5,0.5
       parent: 2
-  - uid: 1002
+  - uid: 1128
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7699,270 +7963,270 @@ entities:
       parent: 2
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 1003
+  - uid: 1129
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-0.5
       parent: 2
-  - uid: 1004
+  - uid: 1130
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
 - proto: DisposalPipe
   entities:
-  - uid: 1005
+  - uid: 1131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 2
-  - uid: 1007
+  - uid: 1132
     components:
     - type: Transform
       pos: -14.5,-3.5
       parent: 2
-  - uid: 1008
+  - uid: 1133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-1.5
       parent: 2
-  - uid: 1009
+  - uid: 1134
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
-  - uid: 1010
+  - uid: 1135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-15.5
       parent: 2
-  - uid: 1011
+  - uid: 1136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-15.5
       parent: 2
-  - uid: 1012
+  - uid: 1137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,-15.5
       parent: 2
-  - uid: 1013
+  - uid: 1138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,-15.5
       parent: 2
-  - uid: 1014
+  - uid: 1139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,-15.5
       parent: 2
-  - uid: 1015
+  - uid: 1140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-15.5
       parent: 2
-  - uid: 1016
+  - uid: 1141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-15.5
       parent: 2
-  - uid: 1017
+  - uid: 1142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-14.5
       parent: 2
-  - uid: 1018
+  - uid: 1143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-13.5
       parent: 2
-  - uid: 1019
+  - uid: 1144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-11.5
       parent: 2
-  - uid: 1020
+  - uid: 1145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-10.5
       parent: 2
-  - uid: 1021
+  - uid: 1146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-9.5
       parent: 2
-  - uid: 1022
+  - uid: 1147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-8.5
       parent: 2
-  - uid: 1023
+  - uid: 1148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-7.5
       parent: 2
-  - uid: 1024
+  - uid: 1149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-6.5
       parent: 2
-  - uid: 1025
+  - uid: 1150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-5.5
       parent: 2
-  - uid: 1026
+  - uid: 1151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-4.5
       parent: 2
-  - uid: 1027
+  - uid: 1152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-3.5
       parent: 2
-  - uid: 1028
+  - uid: 1153
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-2.5
       parent: 2
-  - uid: 1029
+  - uid: 1154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-1.5
       parent: 2
-  - uid: 1030
+  - uid: 1155
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-0.5
       parent: 2
-  - uid: 1031
+  - uid: 1156
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,0.5
       parent: 2
-  - uid: 1032
+  - uid: 1157
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,0.5
       parent: 2
-  - uid: 1033
+  - uid: 1158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,0.5
       parent: 2
-  - uid: 1034
+  - uid: 1159
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,0.5
       parent: 2
-  - uid: 1035
+  - uid: 1160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,0.5
       parent: 2
-  - uid: 1036
+  - uid: 1161
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,0.5
       parent: 2
-  - uid: 1037
+  - uid: 1162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,0.5
       parent: 2
-  - uid: 1038
+  - uid: 1163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,1.5
       parent: 2
-  - uid: 1039
+  - uid: 1164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,2.5
       parent: 2
-  - uid: 1040
+  - uid: 1165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,3.5
       parent: 2
-  - uid: 1041
+  - uid: 1166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,1.5
       parent: 2
-  - uid: 1042
+  - uid: 1167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 2
-  - uid: 1043
+  - uid: 1168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,1.5
       parent: 2
-  - uid: 1044
+  - uid: 1169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 2
-  - uid: 1045
+  - uid: 1170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 2
-  - uid: 1046
+  - uid: 1171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 2
-  - uid: 1047
+  - uid: 1172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 2
-  - uid: 1048
+  - uid: 1173
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7970,177 +8234,184 @@ entities:
       parent: 2
 - proto: DisposalTrunk
   entities:
-  - uid: 1049
+  - uid: 1174
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-0.5
       parent: 2
-  - uid: 1050
+  - uid: 1175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-16.5
       parent: 2
-  - uid: 1051
+  - uid: 1176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-12.5
       parent: 2
-  - uid: 1052
+  - uid: 1177
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 2
-  - uid: 1053
+  - uid: 1178
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 1054
+  - uid: 1179
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
 - proto: DisposalUnit
   entities:
-  - uid: 1055
+  - uid: 1180
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 1056
+  - uid: 1181
     components:
     - type: Transform
       pos: -29.5,-16.5
       parent: 2
-  - uid: 1057
+  - uid: 1182
     components:
     - type: Transform
       pos: -20.5,-12.5
       parent: 2
-  - uid: 1058
+  - uid: 1183
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 1059
+  - uid: 1184
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 2
-  - uid: 1060
+  - uid: 1185
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 2
 - proto: DogBed
   entities:
-  - uid: 157
+  - uid: 1186
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 2
-  - uid: 1061
+  - uid: 1187
     components:
     - type: Transform
       pos: -17.5,-14.5
       parent: 2
-  - uid: 1572
+  - uid: 1188
     components:
     - type: Transform
       pos: -14.5,-10.5
       parent: 2
-  - uid: 2704
+  - uid: 1189
     components:
     - type: Transform
       pos: -33.5,2.5
       parent: 2
 - proto: DrinkBeerCan
   entities:
-  - uid: 2645
+  - uid: 1190
     components:
     - type: Transform
       pos: -27.66867,2.879425
       parent: 2
 - proto: DrinkCottonBoolGlass
   entities:
-  - uid: 1063
+  - uid: 1191
     components:
     - type: Transform
       pos: -11.619232,5.685272
       parent: 2
 - proto: DrinkHotCoffee
   entities:
-  - uid: 2108
+  - uid: 1192
     components:
     - type: Transform
       pos: -26.870728,2.8175354
       parent: 2
-  - uid: 2650
+  - uid: 1193
     components:
     - type: Transform
       pos: -16.227417,8.814697
       parent: 2
 - proto: DrinkIrishCarBomb
   entities:
-  - uid: 1075
+  - uid: 1194
     components:
     - type: Transform
       pos: 1.0335999,3.697998
       parent: 2
 - proto: DrinkOrangeJuice
   entities:
-  - uid: 1076
+  - uid: 1195
     components:
     - type: Transform
       pos: 0.46066284,3.664093
       parent: 2
 - proto: DrinkRaktaccinoGlass
   entities:
-  - uid: 1077
+  - uid: 1196
     components:
     - type: Transform
       pos: -2.3842773,-2.246704
       parent: 2
-  - uid: 1078
+  - uid: 1197
     components:
     - type: Transform
       pos: 2.1660156,3.666748
       parent: 2
-  - uid: 1079
+  - uid: 1198
     components:
     - type: Transform
       pos: -2.5561523,-1.8248291
       parent: 2
-  - uid: 1080
+  - uid: 1199
     components:
     - type: Transform
       pos: -6.3760986,-1.6373291
       parent: 2
-  - uid: 1081
+  - uid: 1200
     components:
     - type: Transform
       pos: -6.5948486,-2.168579
       parent: 2
 - proto: DrinkShaker
   entities:
-  - uid: 1082
+  - uid: 1201
     components:
     - type: Transform
       pos: -0.88134766,3.820343
       parent: 2
+- proto: DrinkSpaceUpCan
+  entities:
+  - uid: 1202
+    components:
+    - type: Transform
+      pos: 8.757874,-7.191986
+      parent: 2
 - proto: Emitter
   entities:
-  - uid: 1083
+  - uid: 1203
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
 - proto: FaxMachineBase
   entities:
-  - uid: 1084
+  - uid: 1204
     components:
     - type: Transform
       pos: -17.5,2.5
@@ -8148,7 +8419,7 @@ entities:
     - type: FaxMachine
       name: Main Hall
       destinationAddress: north hallway
-  - uid: 1085
+  - uid: 1205
     components:
     - type: Transform
       pos: 4.5,-4.5
@@ -8156,7 +8427,7 @@ entities:
     - type: FaxMachine
       name: Cargo
       destinationAddress: Cargo
-  - uid: 1086
+  - uid: 1206
     components:
     - type: Transform
       pos: -16.5,-16.5
@@ -8166,14 +8437,14 @@ entities:
       destinationAddress: HoP
 - proto: FaxMachineFlatpack
   entities:
-  - uid: 2770
+  - uid: 1207
     components:
     - type: Transform
       pos: -12.660034,-9.383606
       parent: 2
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 1087
+  - uid: 1208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8181,15 +8452,15 @@ entities:
       parent: 2
 - proto: Firelock
   entities:
-  - uid: 1088
+  - uid: 1209
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
-  - uid: 1089
+      - 9
+  - uid: 1210
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8197,9 +8468,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 23
-  - uid: 1090
+      - 20
+      - 22
+  - uid: 1211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8207,9 +8478,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 27
-  - uid: 1091
+      - 20
+      - 30
+  - uid: 1212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8217,8 +8488,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
-  - uid: 1092
+      - 4
+  - uid: 1213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8226,20 +8497,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
-  - uid: 1093
+      - 4
+  - uid: 1214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,4.5
       parent: 2
-  - uid: 1094
+  - uid: 1215
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,5.5
       parent: 2
-  - uid: 1095
+  - uid: 1216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8247,9 +8518,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 6
-  - uid: 1096
+      - 7
+      - 5
+  - uid: 1217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8257,9 +8528,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 7
       - 8
-      - 9
-  - uid: 1097
+  - uid: 1218
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8267,9 +8538,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 9
-  - uid: 1098
+      - 11
+      - 8
+  - uid: 1219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8277,8 +8548,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-  - uid: 1099
+      - 11
+  - uid: 1220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8286,36 +8557,36 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
       - 11
-  - uid: 1100
+      - 10
+  - uid: 1221
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 3
       - 4
-      - 5
-  - uid: 1101
+  - uid: 1222
     components:
     - type: Transform
       pos: -24.5,1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 3
       - 4
-      - 5
-  - uid: 1102
+  - uid: 1223
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 3
       - 4
-      - 5
-  - uid: 1103
+  - uid: 1224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8323,15 +8594,15 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-      - 22
-  - uid: 1104
+      - 19
+      - 21
+  - uid: 1225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-15.5
       parent: 2
-  - uid: 1105
+  - uid: 1226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8339,9 +8610,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 16
       - 17
-      - 18
-  - uid: 1106
+  - uid: 1227
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8349,9 +8620,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-      - 22
-  - uid: 1107
+      - 19
+      - 21
+  - uid: 1228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8359,9 +8630,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 15
       - 16
-      - 17
-  - uid: 1108
+  - uid: 1229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8369,8 +8640,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
-  - uid: 1109
+      - 18
+  - uid: 1230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8378,9 +8649,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-      - 22
-  - uid: 1110
+      - 12
+      - 21
+  - uid: 1231
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8388,9 +8659,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-      - 22
-  - uid: 1111
+      - 12
+      - 21
+  - uid: 1232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8398,85 +8669,85 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-      - 22
-  - uid: 1112
+      - 12
+      - 21
+  - uid: 1233
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 27
-  - uid: 1113
+      - 20
+      - 30
+  - uid: 1234
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 23
-  - uid: 1114
+      - 20
+      - 22
+  - uid: 1235
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 23
-  - uid: 1115
+      - 20
+      - 22
+  - uid: 1236
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 23
-  - uid: 1116
+      - 20
+      - 22
+  - uid: 1237
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
-  - uid: 1117
+      - 30
+  - uid: 1238
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
-  - uid: 1118
+      - 30
+  - uid: 1239
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
-  - uid: 1119
+      - 30
+  - uid: 1240
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
-  - uid: 1120
+      - 30
+  - uid: 1241
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
-  - uid: 1121
+      - 30
+  - uid: 1242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8484,9 +8755,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 16
-      - 22
-  - uid: 1122
+      - 15
+      - 21
+  - uid: 1243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8494,8 +8765,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-  - uid: 1123
+      - 3
+  - uid: 1244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8503,9 +8774,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 6
-  - uid: 1124
+      - 7
+      - 5
+  - uid: 1245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8513,9 +8784,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 6
-  - uid: 1125
+      - 7
+      - 5
+  - uid: 1246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8523,8 +8794,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 6
-  - uid: 1126
+      - 5
+  - uid: 1247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8532,8 +8803,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 6
-  - uid: 1127
+      - 5
+  - uid: 1248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8541,9 +8812,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 5
       - 6
-      - 7
-  - uid: 1128
+  - uid: 1249
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8551,8 +8822,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-  - uid: 1129
+      - 8
+  - uid: 1250
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8560,11 +8831,11 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
-      - 25
+      - 16
+      - 24
 - proto: FirelockEdge
   entities:
-  - uid: 151
+  - uid: 1251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8572,45 +8843,24 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
-  - uid: 1130
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-3.5
-      parent: 2
-    - type: Door
-      secondsUntilStateChange: -66687.79
-      state: Closing
-    - type: DeviceNetwork
-      deviceLists:
-      - 23
-  - uid: 1132
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,3.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 23
-  - uid: 1133
+      - 25
+  - uid: 1252
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-  - uid: 1134
+      - 20
+  - uid: 1253
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-  - uid: 1135
+      - 20
+  - uid: 1254
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8618,8 +8868,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-  - uid: 1136
+      - 19
+  - uid: 1255
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8627,26 +8877,44 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-  - uid: 1137
+      - 19
+  - uid: 1256
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
-      - 28
-  - uid: 1138
+      - 22
+      - 31
+  - uid: 1257
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
-      - 26
-  - uid: 1817
+      - 22
+      - 29
+  - uid: 1258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 28
+  - uid: 1259
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 28
+  - uid: 1260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8654,8 +8922,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-  - uid: 2230
+      - 13
+  - uid: 1261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8663,8 +8931,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
-  - uid: 2782
+      - 25
+  - uid: 1262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8672,10 +8940,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
+      - 25
 - proto: FirelockGlass
   entities:
-  - uid: 1139
+  - uid: 1263
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8683,9 +8951,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
-      - 22
-  - uid: 1140
+      - 16
+      - 21
+  - uid: 1264
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8693,9 +8961,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
-      - 22
-  - uid: 1141
+      - 16
+      - 21
+  - uid: 1265
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8703,9 +8971,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
-      - 22
-  - uid: 1142
+      - 16
+      - 21
+  - uid: 1266
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8713,9 +8981,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 12
       - 13
-      - 14
-  - uid: 1143
+  - uid: 1267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8723,9 +8991,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 12
       - 13
-      - 14
-  - uid: 1144
+  - uid: 1268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8733,9 +9001,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
-      - 15
-  - uid: 1145
+      - 25
+      - 14
+  - uid: 1269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8743,9 +9011,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
-      - 15
-  - uid: 1146
+      - 25
+      - 14
+  - uid: 1270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8753,8 +9021,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 1147
+      - 14
+  - uid: 1271
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8762,14 +9030,14 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-      - 13
-  - uid: 1148
+      - 14
+      - 12
+  - uid: 1272
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 2
-  - uid: 1149
+  - uid: 1273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8777,9 +9045,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 22
       - 23
-      - 24
-  - uid: 1150
+  - uid: 1274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8787,9 +9055,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 22
       - 23
-      - 24
-  - uid: 1151
+  - uid: 1275
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8797,9 +9065,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 22
       - 23
-      - 24
-  - uid: 1152
+  - uid: 1276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8807,9 +9075,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 24
-  - uid: 1153
+      - 4
+      - 23
+  - uid: 1277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8817,9 +9085,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 24
-  - uid: 1154
+      - 4
+      - 23
+  - uid: 1278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8827,9 +9095,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 24
-  - uid: 1155
+      - 4
+      - 23
+  - uid: 1279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8837,9 +9105,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 23
-  - uid: 1156
+      - 10
+      - 22
+  - uid: 1280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8847,9 +9115,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 23
-  - uid: 1157
+      - 10
+      - 22
+  - uid: 1281
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8857,9 +9125,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 23
-  - uid: 1158
+      - 10
+      - 22
+  - uid: 1282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8867,9 +9135,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 23
-  - uid: 1159
+      - 10
+      - 22
+  - uid: 1283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8877,8 +9145,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-  - uid: 1160
+      - 12
+  - uid: 1284
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8886,8 +9154,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-  - uid: 1161
+      - 12
+  - uid: 1285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8895,8 +9163,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
-  - uid: 1162
+      - 12
+  - uid: 1286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8904,9 +9172,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 23
-  - uid: 1163
+      - 11
+      - 22
+  - uid: 1287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8914,9 +9182,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 23
-  - uid: 1164
+      - 10
+      - 22
+  - uid: 1288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8924,9 +9192,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 23
-  - uid: 1165
+      - 11
+      - 22
+  - uid: 1289
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8934,18 +9202,18 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
+      - 12
       - 13
-      - 14
-  - uid: 1166
+  - uid: 1290
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-      - 12
-  - uid: 1167
+      - 8
+      - 11
+  - uid: 1291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8953,9 +9221,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
-      - 13
-  - uid: 1168
+      - 25
+      - 12
+  - uid: 1292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8963,18 +9231,116 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
-      - 13
+      - 25
+      - 12
+  - uid: 1293
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 27
+      - 28
+  - uid: 1295
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 27
+  - uid: 1296
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 26
+      - 28
+  - uid: 1297
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 22
+      - 28
+  - uid: 1298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 22
+      - 28
+  - uid: 1299
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 22
+      - 28
+  - uid: 1300
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 22
+      - 28
+  - uid: 1301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 22
+      - 28
+  - uid: 1302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 22
+      - 28
+  - uid: 2441
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 27
 - proto: FloorDrain
   entities:
-  - uid: 1169
+  - uid: 1303
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1170
+  - uid: 1304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8982,21 +9348,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1171
+  - uid: 1305
     components:
     - type: Transform
       pos: -15.5,-6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1172
+  - uid: 1306
     components:
     - type: Transform
       pos: -24.5,-11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1173
+  - uid: 1307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9006,133 +9372,133 @@ entities:
       fixtures: {}
 - proto: FoodBakedBunHoney
   entities:
-  - uid: 1174
+  - uid: 1308
     components:
     - type: Transform
       pos: -5.0829163,4.475281
       parent: 2
 - proto: FoodBoxPizzaFilled
   entities:
-  - uid: 1175
+  - uid: 1309
     components:
     - type: Transform
       pos: -3.3944511,3.726201
       parent: 2
 - proto: FoodCondimentBottleEnzyme
   entities:
-  - uid: 1177
+  - uid: 1311
     components:
     - type: Transform
-      parent: 1176
+      parent: 1310
     - type: Physics
       canCollide: False
 - proto: FoodPizzaUraniumSlice
   entities:
-  - uid: 164
-    components:
-    - type: Transform
-      parent: 163
-    - type: Physics
-      canCollide: False
   - uid: 165
     components:
     - type: Transform
-      parent: 163
+      parent: 164
     - type: Physics
       canCollide: False
   - uid: 166
     components:
     - type: Transform
-      parent: 163
+      parent: 164
     - type: Physics
       canCollide: False
   - uid: 167
     components:
     - type: Transform
-      parent: 163
+      parent: 164
     - type: Physics
       canCollide: False
   - uid: 168
     components:
     - type: Transform
-      parent: 163
+      parent: 164
     - type: Physics
       canCollide: False
   - uid: 169
     components:
     - type: Transform
-      parent: 163
+      parent: 164
     - type: Physics
       canCollide: False
   - uid: 170
     components:
     - type: Transform
-      parent: 163
+      parent: 164
     - type: Physics
       canCollide: False
   - uid: 171
     components:
     - type: Transform
-      parent: 163
+      parent: 164
     - type: Physics
       canCollide: False
   - uid: 172
     components:
     - type: Transform
-      parent: 163
+      parent: 164
+    - type: Physics
+      canCollide: False
+  - uid: 173
+    components:
+    - type: Transform
+      parent: 164
     - type: Physics
       canCollide: False
 - proto: ForensicScanner
   entities:
-  - uid: 161
+  - uid: 1317
     components:
     - type: Transform
       pos: -19.480316,-10.487793
       parent: 2
 - proto: FuelDispenser
   entities:
-  - uid: 2172
+  - uid: 1318
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 2
 - proto: GasFilter
   entities:
-  - uid: 1184
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,11.5
-      parent: 2
-  - uid: 1185
+  - uid: 1319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,5.5
       parent: 2
-  - uid: 1186
+  - uid: 1320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,5.5
       parent: 2
+  - uid: 1321
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,11.5
+      parent: 2
 - proto: GasMinerNitrogenStation
   entities:
-  - uid: 1187
+  - uid: 1322
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
 - proto: GasMinerOxygenStation
   entities:
-  - uid: 1188
+  - uid: 1323
     components:
     - type: Transform
       pos: -27.5,8.5
       parent: 2
 - proto: GasMixerFlipped
   entities:
-  - uid: 1189
+  - uid: 1324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9143,36 +9509,36 @@ entities:
       inletOneConcentration: 0.78
 - proto: GasOutletInjector
   entities:
-  - uid: 1190
+  - uid: 1325
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 1191
+  - uid: 1326
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
 - proto: GasPassiveVent
   entities:
-  - uid: 1192
+  - uid: 1327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,9.5
       parent: 2
-  - uid: 1193
+  - uid: 1328
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,9.5
       parent: 2
-  - uid: 1194
+  - uid: 1329
     components:
     - type: Transform
       pos: -35.5,10.5
       parent: 2
-  - uid: 2719
+  - uid: 1330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9180,50 +9546,50 @@ entities:
       parent: 2
 - proto: GasPipeBend
   entities:
-  - uid: 1195
+  - uid: 1331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1196
+      color: '#FF0000FF'
+  - uid: 1332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,5.5
       parent: 2
-  - uid: 1197
+  - uid: 1333
     components:
     - type: Transform
       pos: -28.5,9.5
       parent: 2
-  - uid: 1198
+  - uid: 1334
     components:
     - type: Transform
       pos: -26.5,9.5
       parent: 2
-  - uid: 1199
+  - uid: 1335
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,6.5
       parent: 2
-  - uid: 1200
+  - uid: 1336
     components:
     - type: Transform
       pos: -25.5,6.5
       parent: 2
-  - uid: 1201
+  - uid: 1337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1202
+      color: '#FF0000FF'
+  - uid: 1338
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9231,7 +9597,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1203
+  - uid: 1339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9239,13 +9605,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1204
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,13.5
-      parent: 2
-  - uid: 1205
+  - uid: 1340
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9253,15 +9613,15 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1206
+  - uid: 1341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1207
+      color: '#FF0000FF'
+  - uid: 1342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9269,52 +9629,45 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1208
+  - uid: 1343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1209
+      color: '#FF0000FF'
+  - uid: 1344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1210
+      color: '#FF0000FF'
+  - uid: 1345
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1211
+      color: '#FF0000FF'
+  - uid: 1346
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1212
-    components:
-    - type: Transform
-      pos: 3.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1213
+      color: '#FF0000FF'
+  - uid: 1347
     components:
     - type: Transform
       pos: -21.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1214
+      color: '#FF0000FF'
+  - uid: 1348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9322,7 +9675,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1215
+  - uid: 1349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9330,36 +9683,36 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1216
+  - uid: 1350
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1217
+      color: '#FF0000FF'
+  - uid: 1351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,11.5
       parent: 2
-  - uid: 1218
+  - uid: 1352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1219
+      color: '#FF0000FF'
+  - uid: 1353
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1220
+      color: '#FF0000FF'
+  - uid: 1354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9367,15 +9720,15 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1221
+  - uid: 1355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1222
+      color: '#FF0000FF'
+  - uid: 1356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9383,29 +9736,29 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1223
+  - uid: 1357
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1224
+      color: '#FF0000FF'
+  - uid: 1358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1225
+      color: '#FF0000FF'
+  - uid: 1359
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1226
+  - uid: 1360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9413,7 +9766,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1227
+  - uid: 1361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9421,21 +9774,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1228
+  - uid: 1362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,11.5
       parent: 2
-  - uid: 1229
+  - uid: 1363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1230
+      color: '#FF0000FF'
+  - uid: 1364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9443,7 +9796,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 1231
+  - uid: 1365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9451,7 +9804,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 1232
+  - uid: 1366
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9459,7 +9812,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 1233
+  - uid: 1367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9467,7 +9820,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 1234
+  - uid: 1368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9475,25 +9828,31 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 1235
+  - uid: 1369
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
+  - uid: 1370
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,13.5
+      parent: 2
 - proto: GasPipeFourway
   entities:
-  - uid: 1236
+  - uid: 1371
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 1237
+  - uid: 1372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9501,23 +9860,23 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1238
+  - uid: 1373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1239
+      color: '#FF0000FF'
+  - uid: 1374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1240
+      color: '#FF0000FF'
+  - uid: 1375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9525,7 +9884,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1241
+  - uid: 1376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9533,7 +9892,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1242
+  - uid: 1377
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9541,14 +9900,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1243
+  - uid: 1378
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1244
+      color: '#FF0000FF'
+  - uid: 1379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9556,1057 +9915,42 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1245
+  - uid: 1380
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1246
+      color: '#FF0000FF'
+  - uid: 1381
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1247
+      color: '#FF0000FF'
+  - uid: 1382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1248
+      color: '#FF0000FF'
+  - uid: 1383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1249
-    components:
-    - type: Transform
-      pos: -17.5,-17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1250
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,5.5
-      parent: 2
-  - uid: 1251
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,5.5
-      parent: 2
-  - uid: 1252
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -34.5,5.5
-      parent: 2
-  - uid: 1253
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,5.5
-      parent: 2
-  - uid: 1254
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,5.5
-      parent: 2
-  - uid: 1255
-    components:
-    - type: Transform
-      pos: -28.5,8.5
-      parent: 2
-  - uid: 1256
-    components:
-    - type: Transform
-      pos: -28.5,7.5
-      parent: 2
-  - uid: 1257
-    components:
-    - type: Transform
-      pos: -26.5,8.5
-      parent: 2
-  - uid: 1258
-    components:
-    - type: Transform
-      pos: -26.5,7.5
-      parent: 2
-  - uid: 1259
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.5,6.5
-      parent: 2
-  - uid: 1260
-    components:
-    - type: Transform
-      pos: -29.5,6.5
-      parent: 2
-  - uid: 1261
-    components:
-    - type: Transform
-      pos: -27.5,6.5
-      parent: 2
-  - uid: 1262
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,6.5
-      parent: 2
-  - uid: 1263
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,7.5
-      parent: 2
-  - uid: 1264
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,8.5
-      parent: 2
-  - uid: 1265
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,9.5
-      parent: 2
-  - uid: 1266
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1267
-    components:
-    - type: Transform
-      pos: -22.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1268
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1269
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1270
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1271
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1272
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1273
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1274
-    components:
-    - type: Transform
-      pos: -25.5,5.5
-      parent: 2
-  - uid: 1275
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1276
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1277
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1278
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1279
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1280
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1281
-    components:
-    - type: Transform
-      pos: -20.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1282
-    components:
-    - type: Transform
-      pos: -20.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1283
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1284
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1285
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1286
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1287
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1288
-    components:
-    - type: Transform
-      pos: -20.5,-6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1289
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1290
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1291
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1292
-    components:
-    - type: Transform
-      pos: -13.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1293
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1294
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1295
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1296
-    components:
-    - type: Transform
-      pos: -4.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1297
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1298
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1299
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1300
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1301
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1302
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1303
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1304
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1305
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1306
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1307
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1308
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1309
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1310
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1311
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1312
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1313
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1314
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1315
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1316
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1317
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1318
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1319
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1320
-    components:
-    - type: Transform
-      pos: -3.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1321
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1322
-    components:
-    - type: Transform
-      pos: -3.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1323
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1324
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1325
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1326
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1327
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1328
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1329
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1330
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1331
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1332
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1333
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1334
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1335
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1336
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1337
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1338
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1339
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1340
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1341
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1342
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1343
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1344
-    components:
-    - type: Transform
-      pos: -22.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1345
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1346
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1347
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1348
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1349
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1350
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1351
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1352
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1353
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1354
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1355
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1356
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1357
-    components:
-    - type: Transform
-      pos: -20.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1358
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1359
-    components:
-    - type: Transform
-      pos: -22.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1360
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1361
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1362
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1363
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1364
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1365
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1366
-    components:
-    - type: Transform
-      pos: -20.5,-10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1367
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1368
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1369
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1370
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-13.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1371
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1372
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1373
-    components:
-    - type: Transform
-      pos: -22.5,-9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1374
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1375
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-16.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1376
-    components:
-    - type: Transform
-      pos: -20.5,-17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1377
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1378
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1379
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-15.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1380
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.5,-20.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1381
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-20.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1382
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-15.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1383
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-20.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1384
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-14.5
+      pos: -17.5,-17.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -10614,153 +9958,120 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -23.5,-15.5
+      pos: -31.5,5.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -24.5,-15.5
+      pos: -28.5,5.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -24.5,-14.5
+      pos: -34.5,5.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -25.5,-14.5
+      pos: -30.5,5.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -26.5,-14.5
+      pos: -33.5,5.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1390
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-15.5
+      pos: -28.5,8.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -27.5,-15.5
+      pos: -28.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1392
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-15.5
+      pos: -26.5,8.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1393
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-15.5
+      pos: -26.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1394
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-14.5
+      rot: 1.5707963267948966 rad
+      pos: -27.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1395
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-14.5
+      pos: -29.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1396
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,-14.5
+      pos: -27.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1397
     components:
     - type: Transform
-      pos: -16.5,8.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1398
     components:
     - type: Transform
-      pos: -16.5,5.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1399
     components:
     - type: Transform
-      pos: -17.5,9.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,8.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1400
     components:
     - type: Transform
-      pos: -25.5,3.5
+      rot: 3.141592653589793 rad
+      pos: -35.5,9.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -20.5,-2.5
+      pos: -20.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1402
     components:
     - type: Transform
-      pos: -22.5,-2.5
+      pos: -22.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -19.5,1.5
+      pos: -20.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1404
     components:
     - type: Transform
-      pos: -25.5,0.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -10768,31 +10079,31 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,7.5
+      pos: -23.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1406
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,5.5
+      rot: 3.141592653589793 rad
+      pos: -19.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1407
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: -19.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1408
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,1.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -10800,217 +10111,217 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,6.5
+      pos: -24.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -8.5,1.5
+      pos: -24.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1411
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: -26.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1412
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-6.5
+      rot: 3.141592653589793 rad
+      pos: -26.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1413
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-7.5
+      rot: 3.141592653589793 rad
+      pos: -26.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1414
     components:
     - type: Transform
-      pos: -22.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: -25.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1415
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-12.5
+      pos: -20.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1416
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-0.5
+      pos: -20.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1417
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -27.5,-14.5
+      pos: -17.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -23.5,0.5
+      pos: -15.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,-0.5
+      pos: -14.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1421
     components:
     - type: Transform
-      pos: -25.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1422
     components:
     - type: Transform
-      pos: -0.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1423
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
+      pos: -20.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 1423
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 1424
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1425
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1426
     components:
     - type: Transform
-      pos: -22.5,-5.5
+      pos: -13.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1427
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: -16.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1428
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1429
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: -15.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1430
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-18.5
+      pos: -4.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -21.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1432
-    components:
-    - type: Transform
-      pos: -17.5,6.5
+      pos: -14.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 1432
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 1433
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-6.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -9.5,0.5
+      pos: 2.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1435
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -11.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1436
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,-7.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11018,22 +10329,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -25.5,-18.5
+      pos: -9.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1438
     components:
     - type: Transform
-      pos: -19.5,0.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1439
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,12.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11041,315 +10353,316 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -17.5,10.5
+      pos: 1.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1441
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#FF0000FF'
   - uid: 1442
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: -9.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#FF0000FF'
   - uid: 1443
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -9.5,-4.5
+      pos: -9.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#FF0000FF'
   - uid: 1444
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -9.5,-3.5
+      pos: -10.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#0055CCFF'
   - uid: 1445
     components:
     - type: Transform
-      pos: -22.5,3.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,3.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -9.5,-2.5
+      pos: -9.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#FF0000FF'
   - uid: 1447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -8.5,-0.5
+      pos: -9.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#FF0000FF'
   - uid: 1448
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,0.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#0055CCFF'
   - uid: 1449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -6.5,0.5
+      pos: -5.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#0055CCFF'
   - uid: 1450
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,0.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#FF0000FF'
   - uid: 1451
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,0.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#FF0000FF'
   - uid: 1452
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FFD500FF'
+      color: '#0055CCFF'
   - uid: 1453
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1454
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-2.5
+      pos: -3.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-- proto: GasPipeTJunction
-  entities:
+      color: '#0055CCFF'
   - uid: 1455
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,12.5
+      rot: 3.141592653589793 rad
+      pos: -6.5,0.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1456
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-6.5
+      pos: -3.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1457
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,1.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1458
     components:
     - type: Transform
-      pos: -1.5,1.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1459
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,-0.5
+      pos: -3.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1460
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1461
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -32.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 1462
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -17.5,8.5
+      pos: 1.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1464
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1465
     components:
     - type: Transform
-      pos: -19.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -15.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1466
     components:
     - type: Transform
-      pos: -13.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1467
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1468
     components:
     - type: Transform
-      pos: -4.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1469
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1470
     components:
     - type: Transform
-      pos: -6.5,1.5
+      pos: -1.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1471
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,1.5
+      pos: -0.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1472
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-0.5
+      pos: -1.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1473
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-0.5
+      pos: -1.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1474
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-2.5
+      pos: -1.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1475
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-6.5
+      pos: -0.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1476
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,2.5
+      pos: -1.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1477
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-0.5
+      pos: -22.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1478
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-8.5
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1479
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1480
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11357,147 +10670,148 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,-10.5
+      pos: -23.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1482
     components:
     - type: Transform
-      pos: -21.5,2.5
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1483
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-15.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1484
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-14.5
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,-18.5
+      pos: -19.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1486
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-18.5
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -26.5,0.5
+      pos: -18.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1488
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,6.5
+      pos: -18.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,1.5
+      pos: -22.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1490
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1491
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-3.5
+      pos: -20.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 1491
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 1492
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-4.5
+      pos: -22.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,-9.5
+      pos: -25.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1494
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-12.5
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
   - uid: 1495
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-15.5
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1496
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,12.5
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-9.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1497
     components:
     - type: Transform
-      pos: -13.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -25.5,1.5
+      pos: -18.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 1499
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,7.5
+      pos: -20.5,-10.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11505,35 +10819,1248 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,-5.5
+      pos: -20.5,-11.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1501
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1502
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1503
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1504
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1505
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1506
+    components:
+    - type: Transform
+      pos: -22.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1507
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1508
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1509
+    components:
+    - type: Transform
+      pos: -20.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1510
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1511
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1512
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1513
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1514
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1515
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1516
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1517
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1518
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1519
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1520
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1521
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1522
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1523
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1524
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -27.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1525
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -28.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1526
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1527
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -28.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1528
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1529
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1530
+    components:
+    - type: Transform
+      pos: -16.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1531
+    components:
+    - type: Transform
+      pos: -16.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1532
+    components:
+    - type: Transform
+      pos: -17.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1533
+    components:
+    - type: Transform
+      pos: -25.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1534
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1535
+    components:
+    - type: Transform
+      pos: -22.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1536
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1537
+    components:
+    - type: Transform
+      pos: -25.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1538
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1539
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1540
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1541
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1542
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1544
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1545
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1546
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1547
+    components:
+    - type: Transform
+      pos: -22.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1548
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1549
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1550
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1551
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -27.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1552
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1553
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1554
+    components:
+    - type: Transform
+      pos: -25.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1555
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1556
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1557
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1558
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1559
+    components:
+    - type: Transform
+      pos: -22.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1560
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1561
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1562
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1563
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1564
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1565
+    components:
+    - type: Transform
+      pos: -17.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1566
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1567
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1568
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1570
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1571
+    components:
+    - type: Transform
+      pos: -19.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1572
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1573
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1574
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1575
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1576
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1577
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1578
+    components:
+    - type: Transform
+      pos: -22.5,3.5
+      parent: 2
+  - uid: 1579
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1580
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1581
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1582
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1583
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1584
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1585
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFD500FF'
+  - uid: 1586
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1587
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1588
+    components:
+    - type: Transform
+      pos: -25.5,5.5
+      parent: 2
+  - uid: 1589
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1590
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1591
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1592
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1593
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1594
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1595
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1596
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1597
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1598
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1599
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1600
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1601
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1602
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1603
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1604
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1605
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1606
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1607
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1608
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 1609
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1610
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1611
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,12.5
+      parent: 2
+  - uid: 1612
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1613
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1614
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1615
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1616
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -32.5,5.5
+      parent: 2
+  - uid: 1618
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1619
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1621
+    components:
+    - type: Transform
+      pos: -19.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1622
+    components:
+    - type: Transform
+      pos: -13.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1623
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1624
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1625
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1626
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1627
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1628
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1630
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1631
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1632
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1633
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1634
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1635
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1636
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1637
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1638
+    components:
+    - type: Transform
+      pos: -21.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1639
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1640
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1641
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1642
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1643
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1644
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1645
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1646
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1647
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1648
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1649
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1651
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1652
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,12.5
+      parent: 2
+  - uid: 1653
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1654
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1655
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1657
+    components:
+    - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1502
+      color: '#FF0000FF'
+  - uid: 1658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1503
+      color: '#FF0000FF'
+  - uid: 1659
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1504
+      color: '#FF0000FF'
+  - uid: 1660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11541,35 +12068,58 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1505
+  - uid: 1661
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,12.5
       parent: 2
-  - uid: 1506
+  - uid: 1662
     components:
     - type: Transform
-      pos: -26.5,5.5
+      pos: 2.5,-5.5
       parent: 2
-  - uid: 1507
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1663
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
+  - uid: 1664
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1666
+    components:
+    - type: Transform
+      pos: -26.5,5.5
+      parent: 2
 - proto: GasPort
   entities:
-  - uid: 1508
+  - uid: 1667
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFD500FF'
-  - uid: 1509
+  - uid: 1668
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11577,7 +12127,7 @@ entities:
       parent: 2
     - type: Label
       currentLabel: Waste port
-  - uid: 2727
+  - uid: 1669
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11585,14 +12135,14 @@ entities:
       parent: 2
 - proto: GasPressurePump
   entities:
-  - uid: 1510
+  - uid: 1670
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1511
+  - uid: 1671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11602,14 +12152,14 @@ entities:
       color: '#0055CCFF'
 - proto: GasThermoMachineFreezer
   entities:
-  - uid: 1512
+  - uid: 1672
     components:
     - type: Transform
       pos: -20.5,13.5
       parent: 2
 - proto: GasVentPump
   entities:
-  - uid: 1513
+  - uid: 1673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11617,10 +12167,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
+      - 3
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1514
+  - uid: 1674
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11628,10 +12178,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 4
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1515
+  - uid: 1675
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11639,10 +12189,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 22
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1516
+  - uid: 1676
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11650,20 +12200,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24
+      - 23
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1517
+  - uid: 1677
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
+      - 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1518
+  - uid: 1678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11671,10 +12221,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1519
+  - uid: 1679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11682,10 +12232,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 13
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1520
+  - uid: 1680
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11693,31 +12243,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
+      - 21
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1521
+  - uid: 1681
     components:
     - type: Transform
       pos: -17.5,-16.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 16
+      - 15
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1522
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-5.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 21
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1523
+  - uid: 1682
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11725,10 +12264,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 6
+      - 5
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1524
+  - uid: 1683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11736,20 +12275,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 8
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1525
+  - uid: 1684
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 11
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1526
+  - uid: 1685
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11757,10 +12296,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 22
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1527
+  - uid: 1686
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11768,10 +12307,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 14
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1528
+  - uid: 1687
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11779,10 +12318,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
+      - 7
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1529
+  - uid: 1688
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11790,10 +12329,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
+      - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1530
+  - uid: 1689
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11801,10 +12340,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1531
+  - uid: 1690
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11812,10 +12351,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
+      - 19
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1532
+  - uid: 1691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11823,10 +12362,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
+      - 30
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1533
+  - uid: 1692
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11834,12 +12373,42 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 6
+      - 5
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1693
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1694
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 27
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1695
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 28
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentPumpDecapoid
   entities:
-  - uid: 1534
+  - uid: 1696
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11847,10 +12416,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
+      - 29
 - proto: GasVentPumpVox
   entities:
-  - uid: 1535
+  - uid: 1697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11858,12 +12427,12 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
+      - 31
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 1536
+  - uid: 1698
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11871,10 +12440,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 6
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1537
+      color: '#FF0000FF'
+  - uid: 1699
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11882,10 +12451,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 11
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1538
+      color: '#FF0000FF'
+  - uid: 1700
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11893,10 +12462,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
+      - 3
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1539
+      color: '#FF0000FF'
+  - uid: 1701
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11904,30 +12473,30 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 6
+      - 5
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1540
+      color: '#FF0000FF'
+  - uid: 1702
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 22
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1541
+      color: '#FF0000FF'
+  - uid: 1703
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24
+      - 23
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1542
+      color: '#FF0000FF'
+  - uid: 1704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11935,20 +12504,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
+      - 20
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1543
+      color: '#FF0000FF'
+  - uid: 1705
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
+      - 10
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1544
+      color: '#FF0000FF'
+  - uid: 1706
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11956,15 +12525,15 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 22
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1545
+      color: '#FF0000FF'
+  - uid: 1707
     components:
     - type: Transform
       pos: -32.5,6.5
       parent: 2
-  - uid: 1546
+  - uid: 1708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11972,10 +12541,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
+      - 30
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1547
+      color: '#FF0000FF'
+  - uid: 1709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11983,20 +12552,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 13
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1548
+      color: '#FF0000FF'
+  - uid: 1710
     components:
     - type: Transform
       pos: -21.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 4
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1549
+      color: '#FF0000FF'
+  - uid: 1711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12004,10 +12573,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
+      - 21
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1550
+      color: '#FF0000FF'
+  - uid: 1712
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12015,10 +12584,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
+      - 18
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1551
+      color: '#FF0000FF'
+  - uid: 1713
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12026,10 +12595,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 16
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1552
+      color: '#FF0000FF'
+  - uid: 1714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12037,10 +12606,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 18
+      - 17
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1553
+      color: '#FF0000FF'
+  - uid: 1715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12048,10 +12617,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
+      - 9
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1554
+      color: '#FF0000FF'
+  - uid: 1716
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12059,10 +12628,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 12
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1555
+      color: '#FF0000FF'
+  - uid: 1717
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12070,20 +12639,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
+      - 24
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1556
+      color: '#FF0000FF'
+  - uid: 1718
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 8
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1557
+      color: '#FF0000FF'
+  - uid: 1719
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12091,10 +12660,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 14
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1558
+      color: '#FF0000FF'
+  - uid: 1720
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12102,10 +12671,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
+      - 7
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1559
+      color: '#FF0000FF'
+  - uid: 1721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12113,10 +12682,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 2532
+      - 25
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1560
+      color: '#FF0000FF'
+  - uid: 1722
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12124,10 +12693,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 16
+      - 15
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1561
+  - uid: 1723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12135,29 +12704,61 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
+      - 19
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1562
+      color: '#FF0000FF'
+  - uid: 1724
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1563
+      color: '#FF0000FF'
+  - uid: 1725
     components:
     - type: Transform
       pos: -17.5,12.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 6
+      - 5
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
+  - uid: 1726
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 26
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1727
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 27
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1728
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 28
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
 - proto: GasVentScrubberDecapoid
   entities:
-  - uid: 1564
+  - uid: 1729
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12165,12 +12766,12 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
+      - 29
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
 - proto: GasVentScrubberVox
   entities:
-  - uid: 1565
+  - uid: 1730
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12178,20 +12779,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
+      - 31
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#FF0000FF'
 - proto: GasVolumePump
   entities:
-  - uid: 1566
+  - uid: 1731
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1658
+      color: '#FF0000FF'
+  - uid: 1732
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12199,12 +12800,12 @@ entities:
       parent: 2
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 1567
+  - uid: 1733
     components:
     - type: Transform
       pos: -28.5,-0.5
       parent: 2
-  - uid: 1568
+  - uid: 1734
     components:
     - type: Transform
       pos: -29.5,-0.5
@@ -12229,1109 +12830,1171 @@ entities:
     - type: Appearance
 - proto: GravityGenerator
   entities:
-  - uid: 1569
+  - uid: 1735
     components:
     - type: Transform
       pos: -32.5,8.5
       parent: 2
 - proto: GreatWrench
   entities:
-  - uid: 1570
+  - uid: 1736
     components:
     - type: Transform
       pos: -24.482302,-5.3658857
       parent: 2
 - proto: Grille
   entities:
-  - uid: 682
+  - uid: 1737
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 1738
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+  - uid: 1739
     components:
     - type: Transform
       pos: -33.5,-21.5
       parent: 2
-  - uid: 864
+  - uid: 1740
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-11.5
       parent: 2
-  - uid: 905
+  - uid: 1741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-3.5
       parent: 2
-  - uid: 916
+  - uid: 1742
     components:
     - type: Transform
       pos: -33.5,-9.5
       parent: 2
-  - uid: 938
+  - uid: 1743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-9.5
       parent: 2
-  - uid: 940
+  - uid: 1744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-10.5
       parent: 2
-  - uid: 1571
+  - uid: 1745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 2
-  - uid: 1573
+  - uid: 1746
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,14.5
       parent: 2
-  - uid: 1574
+  - uid: 1747
     components:
     - type: Transform
       pos: -32.5,-1.5
       parent: 2
-  - uid: 1575
+  - uid: 1748
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 1576
+  - uid: 1749
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,14.5
       parent: 2
-  - uid: 1577
+  - uid: 1750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,14.5
       parent: 2
-  - uid: 1578
+  - uid: 1751
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,12.5
       parent: 2
-  - uid: 1579
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,2.5
-      parent: 2
-  - uid: 1580
+  - uid: 1752
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
-  - uid: 1581
+  - uid: 1753
     components:
     - type: Transform
       pos: -15.5,-15.5
       parent: 2
-  - uid: 1582
+  - uid: 1754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,2.5
       parent: 2
-  - uid: 1584
+  - uid: 1755
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,10.5
       parent: 2
-  - uid: 1585
+  - uid: 1756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,8.5
       parent: 2
-  - uid: 1586
+  - uid: 1757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,6.5
       parent: 2
-  - uid: 1587
+  - uid: 1758
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,5.5
       parent: 2
-  - uid: 1588
+  - uid: 1759
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,3.5
       parent: 2
-  - uid: 1589
+  - uid: 1760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,4.5
       parent: 2
-  - uid: 1590
+  - uid: 1761
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,9.5
       parent: 2
-  - uid: 1591
+  - uid: 1762
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-12.5
       parent: 2
-  - uid: 1592
+  - uid: 1763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,-9.5
       parent: 2
-  - uid: 1593
+  - uid: 1764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-5.5
       parent: 2
-  - uid: 1594
+  - uid: 1765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-4.5
       parent: 2
-  - uid: 1596
+  - uid: 1766
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-0.5
       parent: 2
-  - uid: 1597
+  - uid: 1767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,13.5
       parent: 2
-  - uid: 1598
+  - uid: 1768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,13.5
       parent: 2
-  - uid: 1599
+  - uid: 1769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,14.5
       parent: 2
-  - uid: 1600
+  - uid: 1770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,14.5
       parent: 2
-  - uid: 1601
+  - uid: 1771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,14.5
       parent: 2
-  - uid: 1602
+  - uid: 1772
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,13.5
       parent: 2
-  - uid: 1603
+  - uid: 1773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,14.5
       parent: 2
-  - uid: 1604
+  - uid: 1774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,14.5
       parent: 2
-  - uid: 1605
+  - uid: 1775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,14.5
       parent: 2
-  - uid: 1606
+  - uid: 1776
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,12.5
       parent: 2
-  - uid: 1607
+  - uid: 1777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,14.5
       parent: 2
-  - uid: 1608
+  - uid: 1778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,13.5
       parent: 2
-  - uid: 1609
+  - uid: 1779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,13.5
       parent: 2
-  - uid: 1610
+  - uid: 1780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,13.5
       parent: 2
-  - uid: 1612
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-10.5
-      parent: 2
-  - uid: 1613
+  - uid: 1781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-9.5
       parent: 2
-  - uid: 1614
+  - uid: 1782
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-23.5
       parent: 2
-  - uid: 1615
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-6.5
-      parent: 2
-  - uid: 1616
+  - uid: 1783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,8.5
       parent: 2
-  - uid: 1617
+  - uid: 1784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-24.5
       parent: 2
-  - uid: 1618
+  - uid: 1785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-24.5
       parent: 2
-  - uid: 1620
+  - uid: 1786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-25.5
       parent: 2
-  - uid: 1621
+  - uid: 1787
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-25.5
       parent: 2
-  - uid: 1622
+  - uid: 1788
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-23.5
       parent: 2
-  - uid: 1624
+  - uid: 1789
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-25.5
       parent: 2
-  - uid: 1626
+  - uid: 1790
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-19.5
       parent: 2
-  - uid: 1627
+  - uid: 1791
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-18.5
       parent: 2
-  - uid: 1628
+  - uid: 1792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-15.5
       parent: 2
-  - uid: 1629
+  - uid: 1793
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-14.5
       parent: 2
-  - uid: 1630
+  - uid: 1794
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,0.5
       parent: 2
-  - uid: 1631
+  - uid: 1795
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-17.5
       parent: 2
-  - uid: 1632
+  - uid: 1796
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-21.5
       parent: 2
-  - uid: 1633
+  - uid: 1797
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,9.5
       parent: 2
-  - uid: 1634
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,6.5
-      parent: 2
-  - uid: 1635
+  - uid: 1798
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
-  - uid: 1636
+  - uid: 1799
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,11.5
       parent: 2
-  - uid: 1637
+  - uid: 1800
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 2
-  - uid: 1638
+  - uid: 1801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,12.5
       parent: 2
-  - uid: 1639
+  - uid: 1802
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-10.5
       parent: 2
-  - uid: 1640
+  - uid: 1803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,8.5
       parent: 2
-  - uid: 1641
+  - uid: 1804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 1642
+  - uid: 1805
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 2
-  - uid: 1643
+  - uid: 1806
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 2
-  - uid: 1644
+  - uid: 1807
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,1.5
+      pos: 9.5,9.5
       parent: 2
-  - uid: 1645
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,1.5
-      parent: 2
-  - uid: 1646
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,0.5
-      parent: 2
-  - uid: 1647
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-1.5
-      parent: 2
-  - uid: 1648
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-2.5
-      parent: 2
-  - uid: 1649
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-0.5
-      parent: 2
-  - uid: 1650
+  - uid: 1808
     components:
     - type: Transform
       pos: -21.5,-22.5
       parent: 2
-  - uid: 1651
+  - uid: 1809
     components:
     - type: Transform
       pos: -20.5,-22.5
       parent: 2
-  - uid: 1652
+  - uid: 1810
     components:
     - type: Transform
       pos: -19.5,-22.5
       parent: 2
-  - uid: 1653
+  - uid: 1811
     components:
     - type: Transform
       pos: -18.5,-22.5
       parent: 2
-  - uid: 1654
+  - uid: 1812
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
-  - uid: 1655
+  - uid: 1813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-18.5
       parent: 2
-  - uid: 1661
-    components:
-    - type: Transform
-      pos: 7.5,5.5
-      parent: 2
-  - uid: 1662
-    components:
-    - type: Transform
-      pos: 7.5,-5.5
-      parent: 2
-  - uid: 1663
+  - uid: 1814
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 1664
+  - uid: 1815
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 1665
+  - uid: 1816
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 1666
+  - uid: 1817
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 1667
+  - uid: 1818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,3.5
       parent: 2
-  - uid: 1668
+  - uid: 1819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,3.5
       parent: 2
-  - uid: 1669
+  - uid: 1820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,3.5
       parent: 2
-  - uid: 1670
+  - uid: 1821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,3.5
       parent: 2
-  - uid: 1671
+  - uid: 1822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,3.5
       parent: 2
-  - uid: 1672
+  - uid: 1823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,3.5
       parent: 2
-  - uid: 1673
+  - uid: 1824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,3.5
       parent: 2
-  - uid: 1675
+  - uid: 1825
     components:
     - type: Transform
       pos: -24.5,-23.5
       parent: 2
-  - uid: 1676
+  - uid: 1826
     components:
     - type: Transform
       pos: -30.5,-23.5
       parent: 2
-  - uid: 1677
+  - uid: 1827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 2
-  - uid: 1678
+  - uid: 1828
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,14.5
       parent: 2
-  - uid: 1679
-    components:
-    - type: Transform
-      pos: 6.5,6.5
-      parent: 2
-  - uid: 1680
-    components:
-    - type: Transform
-      pos: 6.5,7.5
-      parent: 2
-  - uid: 1681
+  - uid: 1829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-7.5
       parent: 2
-  - uid: 1682
+  - uid: 1830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-4.5
       parent: 2
-  - uid: 1684
+  - uid: 1831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-11.5
       parent: 2
-  - uid: 1685
+  - uid: 1832
     components:
     - type: Transform
       pos: -14.5,14.5
       parent: 2
-  - uid: 1686
+  - uid: 1833
     components:
     - type: Transform
       pos: -22.5,14.5
       parent: 2
-  - uid: 1687
+  - uid: 1834
     components:
     - type: Transform
       pos: -20.5,16.5
       parent: 2
-  - uid: 1688
+  - uid: 1835
     components:
     - type: Transform
       pos: -19.5,16.5
       parent: 2
-  - uid: 1689
+  - uid: 1836
     components:
     - type: Transform
       pos: -16.5,16.5
       parent: 2
-  - uid: 1690
+  - uid: 1837
     components:
     - type: Transform
       pos: -17.5,16.5
       parent: 2
-  - uid: 1691
+  - uid: 1838
     components:
     - type: Transform
       pos: -15.5,16.5
       parent: 2
-  - uid: 1692
+  - uid: 1839
     components:
     - type: Transform
       pos: -23.5,16.5
       parent: 2
-  - uid: 1693
+  - uid: 1840
     components:
     - type: Transform
       pos: -24.5,15.5
       parent: 2
-  - uid: 1694
+  - uid: 1841
     components:
     - type: Transform
       pos: -25.5,15.5
       parent: 2
-  - uid: 1695
+  - uid: 1842
     components:
     - type: Transform
       pos: -25.5,13.5
       parent: 2
-  - uid: 1698
+  - uid: 1843
     components:
     - type: Transform
       pos: -13.5,12.5
       parent: 2
-  - uid: 1699
+  - uid: 1844
     components:
     - type: Transform
       pos: -12.5,15.5
       parent: 2
-  - uid: 1700
+  - uid: 1845
     components:
     - type: Transform
       pos: -13.5,16.5
       parent: 2
-  - uid: 1701
+  - uid: 1846
     components:
     - type: Transform
       pos: -21.5,16.5
       parent: 2
-  - uid: 1703
+  - uid: 1847
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 2
-  - uid: 1704
+  - uid: 1848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,16.5
       parent: 2
-  - uid: 1705
+  - uid: 1849
     components:
     - type: Transform
       pos: -32.5,-12.5
       parent: 2
-  - uid: 1706
+  - uid: 1850
     components:
     - type: Transform
       pos: -21.5,17.5
       parent: 2
-  - uid: 1707
-    components:
-    - type: Transform
-      pos: 6.5,-8.5
-      parent: 2
-  - uid: 1708
+  - uid: 1851
     components:
     - type: Transform
       pos: -20.5,17.5
       parent: 2
-  - uid: 1709
+  - uid: 1852
     components:
     - type: Transform
       pos: -17.5,17.5
       parent: 2
-  - uid: 1710
+  - uid: 1853
     components:
     - type: Transform
       pos: -19.5,17.5
       parent: 2
-  - uid: 1711
+  - uid: 1854
     components:
     - type: Transform
       pos: -18.5,17.5
       parent: 2
-  - uid: 1712
+  - uid: 1855
     components:
     - type: Transform
       pos: -16.5,17.5
       parent: 2
-  - uid: 1713
+  - uid: 1856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,5.5
       parent: 2
-  - uid: 1714
+  - uid: 1857
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,6.5
       parent: 2
-  - uid: 1715
+  - uid: 1858
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,7.5
       parent: 2
-  - uid: 1716
+  - uid: 1859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,8.5
       parent: 2
-  - uid: 1717
+  - uid: 1860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,3.5
       parent: 2
-  - uid: 1718
+  - uid: 1861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,1.5
       parent: 2
-  - uid: 1719
+  - uid: 1862
     components:
     - type: Transform
       pos: -30.5,4.5
       parent: 2
-  - uid: 1720
+  - uid: 1863
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,12.5
       parent: 2
-  - uid: 1721
+  - uid: 1864
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,12.5
       parent: 2
-  - uid: 1722
+  - uid: 1865
     components:
     - type: Transform
       pos: -30.5,3.5
       parent: 2
-  - uid: 1723
+  - uid: 1866
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 2
-  - uid: 1725
+  - uid: 1867
     components:
     - type: Transform
       pos: -18.5,-25.5
       parent: 2
-  - uid: 1726
+  - uid: 1868
     components:
     - type: Transform
       pos: -29.5,-24.5
       parent: 2
-  - uid: 1727
+  - uid: 1869
     components:
     - type: Transform
       pos: -26.5,-23.5
       parent: 2
-  - uid: 1728
+  - uid: 1870
     components:
     - type: Transform
       pos: -28.5,-24.5
       parent: 2
-  - uid: 1729
+  - uid: 1871
     components:
     - type: Transform
       pos: -25.5,-25.5
       parent: 2
-  - uid: 1818
+  - uid: 1872
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 2
+  - uid: 1873
     components:
     - type: Transform
       pos: -30.5,-12.5
       parent: 2
-  - uid: 1840
+  - uid: 1874
     components:
     - type: Transform
       pos: -33.5,-8.5
       parent: 2
-  - uid: 1912
+  - uid: 1875
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 2
+  - uid: 1876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-0.5
       parent: 2
-  - uid: 2052
+  - uid: 1877
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 2
+  - uid: 1878
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 2
+  - uid: 1879
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 2
+  - uid: 1880
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 2
+  - uid: 1881
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 2
+  - uid: 1882
     components:
     - type: Transform
       pos: -30.5,15.5
       parent: 2
-  - uid: 2074
+  - uid: 1883
     components:
     - type: Transform
       pos: -33.5,-22.5
       parent: 2
-  - uid: 2075
+  - uid: 1884
     components:
     - type: Transform
       pos: -32.5,-23.5
       parent: 2
-  - uid: 2082
+  - uid: 1885
     components:
     - type: Transform
       pos: -23.5,-23.5
       parent: 2
-  - uid: 2266
+  - uid: 1886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,13.5
       parent: 2
-  - uid: 2287
+  - uid: 1887
     components:
     - type: Transform
       pos: -31.5,-8.5
       parent: 2
-  - uid: 2354
+  - uid: 1888
     components:
     - type: Transform
       pos: -10.5,11.5
       parent: 2
-  - uid: 2546
+  - uid: 1889
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,12.5
       parent: 2
-  - uid: 2549
+  - uid: 1890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,14.5
       parent: 2
-  - uid: 2551
+  - uid: 1891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,12.5
       parent: 2
-  - uid: 2554
+  - uid: 1892
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,13.5
       parent: 2
-  - uid: 2557
+  - uid: 1893
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,14.5
       parent: 2
-  - uid: 2558
+  - uid: 1894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,15.5
       parent: 2
-  - uid: 2559
+  - uid: 1895
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,15.5
       parent: 2
-  - uid: 2560
+  - uid: 1896
     components:
     - type: Transform
       pos: -14.5,-14.5
       parent: 2
-  - uid: 2565
+  - uid: 1897
     components:
     - type: Transform
       pos: -27.5,15.5
       parent: 2
-  - uid: 2569
+  - uid: 1898
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,10.5
       parent: 2
-  - uid: 2581
+  - uid: 1899
     components:
     - type: Transform
       pos: -28.5,15.5
       parent: 2
-  - uid: 2657
+  - uid: 1900
     components:
     - type: Transform
       pos: -33.5,-19.5
       parent: 2
-  - uid: 2665
+  - uid: 1901
     components:
     - type: Transform
       pos: -33.5,-18.5
       parent: 2
-  - uid: 2709
+  - uid: 1902
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 2
-  - uid: 2710
+  - uid: 1903
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 2
-  - uid: 2711
+  - uid: 1904
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
-  - uid: 2718
+  - uid: 1905
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,15.5
       parent: 2
-  - uid: 2726
+  - uid: 1906
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,15.5
       parent: 2
-  - uid: 2728
+  - uid: 1907
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,12.5
       parent: 2
-  - uid: 2793
+  - uid: 1908
     components:
     - type: Transform
       pos: -19.5,-25.5
       parent: 2
-  - uid: 2796
+  - uid: 1909
     components:
     - type: Transform
       pos: -32.5,-6.5
       parent: 2
-  - uid: 2797
+  - uid: 1910
     components:
     - type: Transform
       pos: -32.5,-3.5
       parent: 2
-  - uid: 2798
+  - uid: 1911
     components:
     - type: Transform
       pos: -20.5,-25.5
       parent: 2
-  - uid: 2800
+  - uid: 1912
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,2.5
       parent: 2
-  - uid: 2801
+  - uid: 1913
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,0.5
       parent: 2
-  - uid: 2808
+  - uid: 1914
     components:
     - type: Transform
       pos: -18.5,-24.5
       parent: 2
-  - uid: 2809
+  - uid: 1915
     components:
     - type: Transform
       pos: -20.5,-24.5
       parent: 2
-  - uid: 2810
+  - uid: 1916
     components:
     - type: Transform
       pos: -23.5,-25.5
       parent: 2
-  - uid: 2811
+  - uid: 1917
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 2
-  - uid: 2812
+  - uid: 1918
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 2
-  - uid: 2813
+  - uid: 1919
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 2
-  - uid: 2814
+  - uid: 1920
     components:
     - type: Transform
       pos: -12.5,13.5
       parent: 2
+  - uid: 1921
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 1922
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 1923
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 1924
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 1925
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,1.5
+      parent: 2
+  - uid: 1926
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,2.5
+      parent: 2
+  - uid: 1927
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 2
+  - uid: 1928
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 2
+  - uid: 1929
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 1930
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 2
+  - uid: 1931
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 1932
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 1933
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 1934
+    components:
+    - type: Transform
+      pos: 9.5,-10.5
+      parent: 2
+  - uid: 1935
+    components:
+    - type: Transform
+      pos: 8.5,-8.5
+      parent: 2
+  - uid: 1936
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 1937
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 2
+  - uid: 2381
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 2
 - proto: HandheldGPSBasic
   entities:
-  - uid: 2764
+  - uid: 1938
     components:
     - type: Transform
       pos: -28.299927,6.5138245
       parent: 2
 - proto: HandHeldMassScanner
   entities:
-  - uid: 1731
+  - uid: 1939
     components:
     - type: Transform
       pos: -4.351738,-4.137145
       parent: 2
-  - uid: 1732
+  - uid: 1940
     components:
     - type: Transform
       pos: -4.6998143,-4.27777
       parent: 2
-  - uid: 1733
+  - uid: 1941
     components:
     - type: Transform
       pos: -8.579288,-3.2672858
       parent: 2
 - proto: HolofanProjector
   entities:
-  - uid: 2635
+  - uid: 1942
     components:
     - type: Transform
       pos: -28.641266,6.4356384
       parent: 2
 - proto: Holopad
   entities:
-  - uid: 1907
+  - uid: 1943
     components:
     - type: MetaData
       name: holopad (Janitor)
@@ -13342,7 +14005,7 @@ entities:
       currentLabel: Janitor
     - type: NameModifier
       baseName: holopad
-  - uid: 2774
+  - uid: 1944
     components:
     - type: MetaData
       name: holopad (Shuttle Bay)
@@ -13353,7 +14016,7 @@ entities:
       currentLabel: Shuttle Bay
     - type: NameModifier
       baseName: holopad
-  - uid: 2778
+  - uid: 1945
     components:
     - type: MetaData
       name: holopad (Engineering)
@@ -13364,7 +14027,7 @@ entities:
       currentLabel: Engineering
     - type: NameModifier
       baseName: holopad
-  - uid: 2779
+  - uid: 1946
     components:
     - type: MetaData
       name: holopad (Science)
@@ -13375,7 +14038,7 @@ entities:
       currentLabel: Science
     - type: NameModifier
       baseName: holopad
-  - uid: 2784
+  - uid: 1947
     components:
     - type: MetaData
       name: holopad (Cargo Bay)
@@ -13386,7 +14049,7 @@ entities:
       currentLabel: Cargo Bay
     - type: NameModifier
       baseName: holopad
-  - uid: 2790
+  - uid: 1948
     components:
     - type: MetaData
       name: holopad (Security)
@@ -13397,7 +14060,7 @@ entities:
       currentLabel: Security
     - type: NameModifier
       baseName: holopad
-  - uid: 2799
+  - uid: 1949
     components:
     - type: MetaData
       name: holopad (Kitchen)
@@ -13408,9 +14071,14 @@ entities:
       currentLabel: Kitchen
     - type: NameModifier
       baseName: holopad
+  - uid: 1950
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
 - proto: HolopadCargoBayLongRange
   entities:
-  - uid: 2772
+  - uid: 1951
     components:
     - type: MetaData
       name: long-range holopad (Cargo Bay)
@@ -13423,7 +14091,7 @@ entities:
       baseName: long-range holopad
 - proto: HolopadCommandBridge
   entities:
-  - uid: 2781
+  - uid: 1952
     components:
     - type: MetaData
       name: holopad (Bridge)
@@ -13436,7 +14104,7 @@ entities:
       baseName: holopad
 - proto: HolopadCommandBridgeLongRange
   entities:
-  - uid: 2773
+  - uid: 1953
     components:
     - type: MetaData
       name: long-range holopad (Bridge)
@@ -13449,7 +14117,7 @@ entities:
       baseName: long-range holopad
 - proto: HolopadGeneralEvac
   entities:
-  - uid: 2780
+  - uid: 1954
     components:
     - type: MetaData
       name: holopad (Evac)
@@ -13462,7 +14130,7 @@ entities:
       baseName: holopad
 - proto: HolopadMedicalChemistry
   entities:
-  - uid: 2776
+  - uid: 1955
     components:
     - type: MetaData
       name: holopad (Chemistry)
@@ -13475,7 +14143,7 @@ entities:
       baseName: holopad
 - proto: HolopadMedicalMedbay
   entities:
-  - uid: 2777
+  - uid: 1956
     components:
     - type: MetaData
       name: holopad (Medbay)
@@ -13488,7 +14156,7 @@ entities:
       baseName: holopad
 - proto: HolopadSecurityBrig
   entities:
-  - uid: 2783
+  - uid: 1957
     components:
     - type: MetaData
       name: holopad (Brig)
@@ -13501,7 +14169,7 @@ entities:
       baseName: holopad
 - proto: HolopadServiceBar
   entities:
-  - uid: 2700
+  - uid: 1958
     components:
     - type: MetaData
       name: holopad (Bar)
@@ -13514,7 +14182,7 @@ entities:
       baseName: holopad
 - proto: HolopadServiceBotany
   entities:
-  - uid: 2775
+  - uid: 1959
     components:
     - type: MetaData
       name: holopad (Botany)
@@ -13525,74 +14193,82 @@ entities:
       currentLabel: Botany
     - type: NameModifier
       baseName: holopad
+- proto: HospitalCurtains
+  entities:
+  - uid: 2373
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 2
 - proto: hydroponicsTray
   entities:
-  - uid: 1656
+  - uid: 1960
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 2
-  - uid: 1735
+  - uid: 1961
     components:
     - type: Transform
       pos: -8.5,7.5
       parent: 2
-  - uid: 1736
+  - uid: 1962
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 2
-  - uid: 1737
+  - uid: 1963
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 2
-  - uid: 1738
+  - uid: 1964
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 2
-  - uid: 1739
+  - uid: 1965
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 2
-  - uid: 1740
+  - uid: 1966
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 2
-  - uid: 1775
+  - uid: 1967
     components:
     - type: Transform
       pos: -10.5,8.5
       parent: 2
-  - uid: 2215
+  - uid: 1968
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 2
 - proto: IngotGold
   entities:
-  - uid: 958
+  - uid: 1082
     components:
     - type: Transform
-      parent: 957
+      parent: 1081
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: IngotSilver
   entities:
-  - uid: 959
+  - uid: 1083
     components:
     - type: Transform
-      parent: 957
+      parent: 1081
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: IngotSilver1
   entities:
-  - uid: 1741
+  - uid: 1969
     components:
     - type: Transform
       pos: -12.696228,-9.841797
@@ -13601,7 +14277,7 @@ entities:
       count: 3
 - proto: JanitorialTrolley
   entities:
-  - uid: 1743
+  - uid: 1970
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13609,224 +14285,224 @@ entities:
       parent: 2
 - proto: JetpackMiniFilled
   entities:
-  - uid: 1744
+  - uid: 1971
     components:
     - type: Transform
       pos: -8.278852,-3.2150235
       parent: 2
-  - uid: 1745
+  - uid: 1972
     components:
     - type: Transform
       pos: -8.513227,-3.5743985
       parent: 2
 - proto: Jukebox
   entities:
-  - uid: 1746
+  - uid: 1973
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
 - proto: KitchenElectricGrill
   entities:
-  - uid: 1747
+  - uid: 1974
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 2
 - proto: KitchenKnife
   entities:
-  - uid: 1178
+  - uid: 1312
     components:
     - type: Transform
-      parent: 1176
+      parent: 1310
     - type: Physics
       canCollide: False
-  - uid: 1748
+  - uid: 1975
     components:
     - type: Transform
       pos: -5.3560333,4.55838
       parent: 2
 - proto: KitchenMicrowave
   entities:
-  - uid: 1749
+  - uid: 1976
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 1750
+  - uid: 1977
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 2
-  - uid: 1751
+  - uid: 1978
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
 - proto: KitchenSpike
   entities:
-  - uid: 1752
+  - uid: 1979
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 1879
+  - uid: 1980
     components:
     - type: Transform
       pos: -12.91745,6.844452
       parent: 2
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 1754
+  - uid: 1981
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 2
 - proto: LockerBoozeFilled
   entities:
-  - uid: 1755
+  - uid: 1982
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
 - proto: LockerBotanistFilled
   entities:
-  - uid: 2220
+  - uid: 1983
     components:
     - type: Transform
       pos: -9.5,10.5
       parent: 2
 - proto: LockerCaptainFilledHardsuit
   entities:
-  - uid: 1757
+  - uid: 1984
     components:
     - type: Transform
       pos: -27.5,-17.5
       parent: 2
 - proto: LockerChemistryFilled
   entities:
-  - uid: 1758
+  - uid: 1985
     components:
     - type: Transform
       pos: -14.5,9.5
       parent: 2
 - proto: LockerChiefEngineerFilledHardsuit
   entities:
-  - uid: 1759
+  - uid: 1986
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 2
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 1760
+  - uid: 1987
     components:
     - type: Transform
       pos: -20.5,10.5
       parent: 2
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 1761
+  - uid: 1988
     components:
     - type: Transform
       pos: -29.5,1.5
       parent: 2
 - proto: LockerEvidence
   entities:
-  - uid: 1762
+  - uid: 1989
     components:
     - type: Transform
       pos: -18.5,-6.5
       parent: 2
 - proto: LockerFreezer
   entities:
-  - uid: 1763
+  - uid: 1990
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 2
 - proto: LockerHeadOfPersonnelFilled
   entities:
-  - uid: 1764
+  - uid: 1991
     components:
     - type: Transform
       pos: -18.5,-14.5
       parent: 2
 - proto: LockerHeadOfSecurityFilledHardsuit
   entities:
-  - uid: 2533
+  - uid: 1992
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 2
 - proto: LockerQuarterMasterFilled
   entities:
-  - uid: 1766
+  - uid: 1993
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 2
 - proto: LockerResearchDirectorFilledHardsuit
   entities:
-  - uid: 1767
+  - uid: 1994
     components:
     - type: Transform
       pos: -26.5,-9.5
       parent: 2
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
-  - uid: 1768
+  - uid: 1995
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 2
 - proto: LockerScienceFilled
   entities:
-  - uid: 1769
+  - uid: 1996
     components:
     - type: Transform
       pos: -25.5,-9.5
       parent: 2
 - proto: LockerSecurityFilled
   entities:
-  - uid: 1724
+  - uid: 1997
     components:
     - type: Transform
       pos: -15.5,-9.5
       parent: 2
-  - uid: 1770
+  - uid: 1998
     components:
     - type: Transform
       pos: -16.5,-9.5
       parent: 2
 - proto: LogProbeCartridge
   entities:
-  - uid: 162
+  - uid: 1999
     components:
     - type: Transform
       pos: -19.497437,-9.977631
       parent: 2
 - proto: MachineAnomalyGenerator
   entities:
-  - uid: 1771
+  - uid: 2000
     components:
     - type: Transform
       pos: -25.5,-4.5
       parent: 2
 - proto: MachineAnomalyVessel
   entities:
-  - uid: 1772
+  - uid: 2001
     components:
     - type: Transform
       pos: -29.5,-9.5
       parent: 2
 - proto: MachineAPE
   entities:
-  - uid: 1773
+  - uid: 2002
     components:
     - type: Transform
       anchored: False
@@ -13838,149 +14514,178 @@ entities:
       bodyType: Dynamic
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 1774
+  - uid: 2003
     components:
     - type: Transform
       pos: -29.5,-7.5
       parent: 2
 - proto: MachineCentrifuge
   entities:
-  - uid: 2135
+  - uid: 2004
     components:
     - type: Transform
       pos: -13.5,6.5
       parent: 2
 - proto: MagicDiceBag
   entities:
-  - uid: 2643
+  - uid: 2005
     components:
     - type: Transform
       pos: -27.559296,2.629425
       parent: 2
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 2006
+    components:
+    - type: Transform
+      pos: 8.367249,-7.207611
+      parent: 2
+- proto: MailTeleporter
+  entities:
+  - uid: 2089
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
 - proto: MaterialCloth
   entities:
-  - uid: 1776
+  - uid: 2008
     components:
     - type: Transform
       pos: -16.436615,-15.322025
       parent: 2
 - proto: MaterialDurathread
   entities:
-  - uid: 1777
+  - uid: 2009
     components:
     - type: Transform
       pos: -16.592865,-15.092859
       parent: 2
+- proto: MechEquipmentGrabberSmall
+  entities:
+  - uid: 2010
+    components:
+    - type: Transform
+      pos: 8.55304,-7.493683
+      parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 1778
+  - uid: 2011
     components:
     - type: Transform
       pos: -20.5,7.5
       parent: 2
-  - uid: 1779
+  - uid: 2012
     components:
     - type: Transform
       pos: -18.5,7.5
       parent: 2
-  - uid: 1780
+  - uid: 2013
     components:
     - type: Transform
       pos: -26.5,-17.5
       parent: 2
-  - uid: 1781
+  - uid: 2014
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 2
 - proto: MedicalTechFab
   entities:
-  - uid: 1782
+  - uid: 2015
     components:
     - type: Transform
       pos: -15.5,6.5
       parent: 2
 - proto: MedicatedSuture
   entities:
-  - uid: 1783
+  - uid: 2016
     components:
     - type: Transform
       pos: -16.313232,10.487671
       parent: 2
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 1784
+  - uid: 2017
     components:
     - type: Transform
       pos: -16.281982,10.768921
       parent: 2
 - proto: MedkitFilled
   entities:
-  - uid: 1785
+  - uid: 2018
     components:
     - type: Transform
       pos: -16.297607,11.065796
       parent: 2
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 1786
+  - uid: 2019
     components:
     - type: Transform
       pos: -16.594482,10.925171
       parent: 2
+- proto: Mirror
+  entities:
+  - uid: 2020
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,7.5
+      parent: 2
 - proto: Morgue
   entities:
-  - uid: 1787
+  - uid: 2021
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 2
-  - uid: 1788
+  - uid: 2022
     components:
     - type: Transform
       pos: -23.5,9.5
       parent: 2
 - proto: Multitool
   entities:
-  - uid: 1790
+  - uid: 2023
     components:
     - type: Transform
       pos: -12.760731,-8.397345
       parent: 2
 - proto: NitrogenCanister
   entities:
-  - uid: 1791
+  - uid: 2024
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
-  - uid: 1792
+  - uid: 2025
     components:
     - type: Transform
       pos: -36.5,4.5
       parent: 2
 - proto: OreProcessor
   entities:
-  - uid: 1793
+  - uid: 2026
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
 - proto: OxygenCanister
   entities:
-  - uid: 1794
+  - uid: 2027
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 1795
+  - uid: 2028
     components:
     - type: Transform
       pos: -36.5,5.5
       parent: 2
 - proto: OxygenTankFilled
   entities:
-  - uid: 2791
+  - uid: 2029
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13988,39 +14693,44 @@ entities:
       parent: 2
 - proto: PairedChopsticks
   entities:
-  - uid: 1179
+  - uid: 1313
     components:
     - type: Transform
-      parent: 1176
+      parent: 1310
     - type: Physics
       canCollide: False
 - proto: Paper
   entities:
-  - uid: 1796
+  - uid: 2030
     components:
     - type: Transform
-      pos: 4.2468195,-5.4433904
+      pos: 3.6553345,-3.5075073
       parent: 2
-  - uid: 1797
+  - uid: 2031
+    components:
+    - type: Transform
+      pos: 3.5928345,-3.3668823
+      parent: 2
+  - uid: 2032
     components:
     - type: Transform
       pos: -16.609146,-15.752253
       parent: 2
-  - uid: 1798
+  - uid: 2033
     components:
     - type: Transform
       pos: -16.702896,-15.8564205
       parent: 2
 - proto: PaperCaptainsThoughts
   entities:
-  - uid: 1799
+  - uid: 2034
     components:
     - type: Transform
       pos: -16.24289,-21.431488
       parent: 2
 - proto: PaperOffice
   entities:
-  - uid: 1800
+  - uid: 2035
     components:
     - type: MetaData
       desc: A memo from Centcomm, addressed to the Engineering department.
@@ -14031,11 +14741,20 @@ entities:
     - type: Paper
       stampState: paper_stamp-centcom
       stampedBy:
-      - stampedColor: '#006600FF'
+      - hasIcon: True
+        stampFont: null
+        stampLargeIcon: null
+        stampedColor: '#006600FF'
         stampedName: stamp-component-stamped-name-centcom
-      - stampedColor: '#2F4F4FFF'
+      - hasIcon: True
+        stampFont: null
+        stampLargeIcon: null
+        stampedColor: '#2F4F4FFF'
         stampedName: Syt'u, Fourteenth
-      - stampedColor: '#2F4F4FFF'
+      - hasIcon: True
+        stampFont: null
+        stampLargeIcon: null
+        stampedColor: '#2F4F4FFF'
         stampedName: Odds-And-Ends
       content: >-
         [color=#f39f27]░░▄▀░░ [head=2]Engineering Memo[/head]
@@ -14069,76 +14788,76 @@ entities:
         ───────────────────────────────────────
 
         Sincerely, CENTCOMM Engineering.
-  - uid: 1801
+  - uid: 2036
     components:
     - type: Transform
       pos: -16.508514,-21.697113
       parent: 2
-  - uid: 1802
+  - uid: 2037
     components:
     - type: Transform
       pos: -19.376312,-15.360504
       parent: 2
 - proto: PartRodMetal
   entities:
-  - uid: 1803
+  - uid: 2038
     components:
     - type: Transform
       pos: -12.477478,-10.044922
       parent: 2
 - proto: Pen
   entities:
-  - uid: 1804
+  - uid: 2039
     components:
     - type: Transform
-      pos: 4.4968195,-5.3027654
+      pos: 3.2959595,-3.5075073
       parent: 2
-  - uid: 1805
+  - uid: 2040
     components:
     - type: Transform
       pos: -19.610687,-15.548004
       parent: 2
 - proto: PenCentcom
   entities:
-  - uid: 1806
+  - uid: 2041
     components:
     - type: Transform
       pos: -23.342499,-21.316711
       parent: 2
 - proto: PhoneInstrument
   entities:
-  - uid: 1807
+  - uid: 2042
     components:
     - type: Transform
       pos: -16.633514,-21.306488
       parent: 2
 - proto: PlasmaCanister
   entities:
-  - uid: 1808
+  - uid: 2043
     components:
     - type: Transform
       pos: -36.5,6.5
       parent: 2
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 437
+  - uid: 2044
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-12.5
       parent: 2
-  - uid: 1131
+  - uid: 2045
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 2
-  - uid: 1810
+  - uid: 2046
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 1811
+  - uid: 2047
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14146,13 +14865,13 @@ entities:
       parent: 2
 - proto: PlasmaWindoorSecureScienceLocked
   entities:
-  - uid: 1812
+  - uid: 2048
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-3.5
       parent: 2
-  - uid: 1813
+  - uid: 2049
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14160,83 +14879,83 @@ entities:
       parent: 2
 - proto: PlasmaWindoorSecureSecurityLocked
   entities:
-  - uid: 159
+  - uid: 2050
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-9.5
       parent: 2
-  - uid: 1814
+  - uid: 2051
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 1815
+  - uid: 2052
     components:
     - type: Transform
       pos: -18.5,-11.5
       parent: 2
 - proto: PlasmaWindowDirectional
   entities:
-  - uid: 874
+  - uid: 2053
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-8.5
       parent: 2
-  - uid: 1819
+  - uid: 2054
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-6.5
       parent: 2
-  - uid: 1820
+  - uid: 2055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-6.5
       parent: 2
-  - uid: 1823
+  - uid: 2056
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
-  - uid: 1824
+  - uid: 2057
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 1825
+  - uid: 2058
     components:
     - type: Transform
       pos: -25.5,10.5
       parent: 2
-  - uid: 1826
+  - uid: 2059
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,10.5
       parent: 2
-  - uid: 1827
+  - uid: 2060
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,10.5
       parent: 2
-  - uid: 1828
+  - uid: 2061
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,10.5
       parent: 2
-  - uid: 2194
+  - uid: 2062
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-6.5
       parent: 2
-  - uid: 2720
+  - uid: 2063
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14244,7 +14963,7 @@ entities:
       parent: 2
 - proto: PlasticFlapsAirtightOpaque
   entities:
-  - uid: 1830
+  - uid: 2064
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14252,70 +14971,70 @@ entities:
       parent: 2
 - proto: PlushieArachind
   entities:
-  - uid: 1831
+  - uid: 2065
     components:
     - type: Transform
       pos: -12.538422,2.5822754
       parent: 2
 - proto: PlushieAtmosian
   entities:
-  - uid: 2642
+  - uid: 2066
     components:
     - type: Transform
       pos: -26.490082,3.566925
       parent: 2
 - proto: PlushieCosmicCult
   entities:
-  - uid: 1832
+  - uid: 2067
     components:
     - type: Transform
-      pos: 6.1757812,-7.0670166
+      pos: 10.806702,-5.5822754
       parent: 2
 - proto: PlushieDecapoid
   entities:
-  - uid: 1833
+  - uid: 2068
     components:
     - type: Transform
       pos: -3.4657288,-2.3069458
       parent: 2
 - proto: PlushieDiona
   entities:
-  - uid: 1834
+  - uid: 2069
     components:
     - type: Transform
       pos: -18.5401,-15.4539795
       parent: 2
 - proto: PlushieFinfin
   entities:
-  - uid: 1835
+  - uid: 2070
     components:
     - type: Transform
       pos: 2.6047668,3.8632812
       parent: 2
 - proto: PlushieGray
   entities:
-  - uid: 1836
+  - uid: 2071
     components:
     - type: Transform
       pos: -6.3056335,-9.643036
       parent: 2
 - proto: PlushieLamp
   entities:
-  - uid: 1837
+  - uid: 2072
     components:
     - type: Transform
       pos: -23.564392,-21.203064
       parent: 2
 - proto: PlushieLizard
   entities:
-  - uid: 1838
+  - uid: 2073
     components:
     - type: Transform
       pos: -18.48291,13.490936
       parent: 2
 - proto: PlushieLizardMirrored
   entities:
-  - uid: 2785
+  - uid: 2074
     components:
     - type: MetaData
       name: lizard plushie (Officer Smolds)
@@ -14328,42 +15047,42 @@ entities:
       baseName: lizard plushie
 - proto: PlushieSlime
   entities:
-  - uid: 179
+  - uid: 2075
     components:
     - type: Transform
       pos: -26.860474,-6.4845276
       parent: 2
 - proto: PlushieVox
   entities:
-  - uid: 1841
+  - uid: 2076
     components:
     - type: Transform
       pos: -5.570587,-2.3172302
       parent: 2
 - proto: PortableGeneratorJrPacman
   entities:
-  - uid: 1842
+  - uid: 2077
     components:
     - type: Transform
       pos: -16.5,-19.5
       parent: 2
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 1843
+  - uid: 2078
     components:
     - type: Transform
       pos: -25.5,7.5
       parent: 2
 - proto: PortableScrubber
   entities:
-  - uid: 1844
+  - uid: 2079
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 2
 - proto: PosterContrabandMissingGloves
   entities:
-  - uid: 1845
+  - uid: 2080
     components:
     - type: MetaData
       desc: "Across the bottom of the poster, its normal writing has been graffiti'd over, instead reading: \"yellows of hand, of glove. electricity\"."
@@ -14373,14 +15092,14 @@ entities:
       parent: 2
 - proto: PosterContrabandSunkist
   entities:
-  - uid: 1846
+  - uid: 2081
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 2
 - proto: PosterLegitEnlist
   entities:
-  - uid: 1847
+  - uid: 2082
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14388,7 +15107,7 @@ entities:
       parent: 2
 - proto: PosterLegitJustAWeekAway
   entities:
-  - uid: 1848
+  - uid: 2083
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14396,13 +15115,13 @@ entities:
       parent: 2
 - proto: PosterLegitSafetyMothEpi
   entities:
-  - uid: 1849
+  - uid: 2084
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,3.5
       parent: 2
-  - uid: 2724
+  - uid: 2085
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14410,7 +15129,7 @@ entities:
       parent: 2
 - proto: PosterLegitSafetyMothHardhat
   entities:
-  - uid: 2027
+  - uid: 2086
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14418,7 +15137,7 @@ entities:
       parent: 2
 - proto: PosterLegitSafetyMothMeth
   entities:
-  - uid: 2725
+  - uid: 2087
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14426,7 +15145,7 @@ entities:
       parent: 2
 - proto: PosterLegitSafetyMothSSD
   entities:
-  - uid: 2259
+  - uid: 2088
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14434,680 +15153,723 @@ entities:
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 1852
+  - uid: 2090
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-  - uid: 1853
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-3.5
-      parent: 2
-  - uid: 1854
+  - uid: 2091
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 2
+  - uid: 2910
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 73
+  - uid: 2092
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,13.5
       parent: 2
-  - uid: 74
+  - uid: 2093
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,13.5
       parent: 2
-  - uid: 889
+  - uid: 2094
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,10.5
       parent: 2
-  - uid: 961
+  - uid: 2095
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-7.5
       parent: 2
-  - uid: 1742
+  - uid: 2096
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-16.5
       parent: 2
-  - uid: 1765
+  - uid: 2097
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-12.5
       parent: 2
-  - uid: 1789
+  - uid: 2098
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-9.5
       parent: 2
-  - uid: 1816
+  - uid: 2099
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,11.5
       parent: 2
-  - uid: 1855
+  - uid: 2100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,6.5
       parent: 2
-  - uid: 1856
+  - uid: 2101
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
-  - uid: 1857
+  - uid: 2102
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-4.5
       parent: 2
-  - uid: 1858
+  - uid: 2103
     components:
     - type: Transform
       pos: -24.5,-3.5
       parent: 2
-  - uid: 1859
+  - uid: 2104
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 2
-  - uid: 1860
+  - uid: 2105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-2.5
       parent: 2
-  - uid: 1861
+  - uid: 2106
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-6.5
       parent: 2
-  - uid: 1864
+  - uid: 2107
     components:
     - type: Transform
       pos: -23.5,-18.5
       parent: 2
-  - uid: 1865
+  - uid: 2108
     components:
     - type: Transform
       pos: -16.5,-18.5
       parent: 2
-  - uid: 1866
+  - uid: 2109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-9.5
       parent: 2
-  - uid: 1867
+  - uid: 2110
     components:
     - type: Transform
       pos: -24.5,-14.5
       parent: 2
-  - uid: 1868
+  - uid: 2111
     components:
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
-  - uid: 1869
+  - uid: 2112
     components:
     - type: Transform
       pos: -16.5,-14.5
       parent: 2
-  - uid: 1870
+  - uid: 2113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-15.5
       parent: 2
-  - uid: 1872
+  - uid: 2114
     components:
     - type: Transform
       pos: -22.5,5.5
       parent: 2
-  - uid: 1873
+  - uid: 2115
     components:
     - type: Transform
       pos: -28.5,6.5
       parent: 2
-  - uid: 1874
+  - uid: 2116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-0.5
       parent: 2
-  - uid: 1875
+  - uid: 2117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,0.5
       parent: 2
-  - uid: 1876
+  - uid: 2118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,4.5
       parent: 2
-  - uid: 1878
+  - uid: 2119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 2
-  - uid: 1880
+  - uid: 2120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,9.5
       parent: 2
-  - uid: 1881
+  - uid: 2121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 2
-  - uid: 1882
+  - uid: 2122
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
-  - uid: 1883
+  - uid: 2123
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 2
-  - uid: 1884
+  - uid: 2124
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 1885
+  - uid: 2125
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
-  - uid: 1886
+  - uid: 2126
     components:
     - type: Transform
       pos: -16.5,-9.5
       parent: 2
-  - uid: 1887
+  - uid: 2127
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 2
-  - uid: 1888
+  - uid: 2128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 2
-  - uid: 1889
+  - uid: 2129
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 1890
+  - uid: 2130
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
-  - uid: 1891
+  - uid: 2131
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
-  - uid: 1893
+  - uid: 2132
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
-  - uid: 1894
+  - uid: 2133
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 1895
+  - uid: 2134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-10.5
       parent: 2
-  - uid: 1896
+  - uid: 2135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
       parent: 2
-  - uid: 1897
+  - uid: 2136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 2
-  - uid: 1898
+  - uid: 2137
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 2
-  - uid: 1899
+  - uid: 2138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 2
-  - uid: 1900
+  - uid: 2139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-2.5
       parent: 2
-  - uid: 1902
+  - uid: 2140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-9.5
       parent: 2
-  - uid: 1904
+  - uid: 2141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-16.5
       parent: 2
-  - uid: 1906
+  - uid: 2142
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-10.5
       parent: 2
-  - uid: 1908
+  - uid: 2143
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,6.5
       parent: 2
-  - uid: 1909
+  - uid: 2144
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,6.5
       parent: 2
-  - uid: 1910
+  - uid: 2145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,7.5
       parent: 2
-  - uid: 1911
+  - uid: 2146
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,4.5
       parent: 2
-  - uid: 1913
+  - uid: 2147
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 2
-  - uid: 1914
+  - uid: 2148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,8.5
       parent: 2
-  - uid: 1915
+  - uid: 2149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,8.5
       parent: 2
-  - uid: 1916
+  - uid: 2150
     components:
     - type: Transform
       pos: -32.5,-14.5
       parent: 2
-  - uid: 1917
+  - uid: 2151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-16.5
       parent: 2
-  - uid: 1918
+  - uid: 2152
     components:
     - type: Transform
       pos: -27.5,9.5
       parent: 2
-  - uid: 1919
+  - uid: 2153
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 2
-  - uid: 1920
+  - uid: 2154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-0.5
       parent: 2
-  - uid: 1922
+  - uid: 2155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 1923
+  - uid: 2156
     components:
     - type: Transform
       pos: -25.5,-11.5
       parent: 2
-  - uid: 1924
+  - uid: 2157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,10.5
       parent: 2
-  - uid: 1925
+  - uid: 2158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,10.5
       parent: 2
-  - uid: 1926
+  - uid: 2159
     components:
     - type: Transform
       pos: -25.5,7.5
       parent: 2
-  - uid: 1927
+  - uid: 2160
     components:
     - type: Transform
       pos: -28.5,-20.5
       parent: 2
-  - uid: 1929
+  - uid: 2161
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,7.5
       parent: 2
-  - uid: 1931
+  - uid: 2162
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-0.5
       parent: 2
-  - uid: 1933
+  - uid: 2163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-0.5
       parent: 2
-  - uid: 2080
+  - uid: 2164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-5.5
       parent: 2
-  - uid: 2219
+  - uid: 2165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-13.5
       parent: 2
-  - uid: 2256
+  - uid: 2166
     components:
     - type: Transform
       pos: -28.5,13.5
       parent: 2
-  - uid: 2701
+  - uid: 2167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-21.5
       parent: 2
-  - uid: 2702
+  - uid: 2168
     components:
     - type: Transform
       pos: -31.5,-18.5
       parent: 2
-  - uid: 2703
+  - uid: 2169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,3.5
       parent: 2
-  - uid: 2705
+  - uid: 2170
     components:
     - type: Transform
       pos: -27.5,-23.5
       parent: 2
-  - uid: 2706
+  - uid: 2171
     components:
     - type: Transform
       pos: -22.5,-23.5
       parent: 2
-  - uid: 2707
+  - uid: 2172
     components:
     - type: Transform
       pos: -17.5,-23.5
       parent: 2
-  - uid: 2712
+  - uid: 2173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,13.5
       parent: 2
-  - uid: 2714
+  - uid: 2174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,13.5
       parent: 2
-  - uid: 2715
+  - uid: 2175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,13.5
       parent: 2
-  - uid: 2716
+  - uid: 2176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,9.5
       parent: 2
-  - uid: 2717
+  - uid: 2177
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 2721
+  - uid: 2178
     components:
     - type: Transform
       pos: -25.5,-20.5
       parent: 2
-  - uid: 2722
+  - uid: 2179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-21.5
       parent: 2
-  - uid: 2723
+  - uid: 2180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-21.5
       parent: 2
-  - uid: 2729
+  - uid: 2181
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 2730
+  - uid: 2182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 2731
+  - uid: 2183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-4.5
       parent: 2
-  - uid: 2732
+  - uid: 2184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,9.5
       parent: 2
-  - uid: 2733
+  - uid: 2185
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 2
-  - uid: 2794
+  - uid: 2186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 2
-  - uid: 2795
+  - uid: 2187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-12.5
       parent: 2
+  - uid: 2188
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 2189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 2190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-3.5
+      parent: 2
+  - uid: 2191
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 2
+  - uid: 2192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
+      parent: 2
 - proto: PoweredlightUV
   entities:
-  - uid: 1935
+  - uid: 2193
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
-  - uid: 1936
+  - uid: 2194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-17.5
       parent: 2
-  - uid: 1964
+  - uid: 2195
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 2
 - proto: PresentRandom
   entities:
-  - uid: 2109
+  - uid: 2196
     components:
     - type: Transform
       pos: -12.938477,2.1693726
       parent: 2
-  - uid: 2257
+  - uid: 2197
     components:
     - type: Transform
       pos: -12.360352,2.0443726
       parent: 2
 - proto: Protolathe
   entities:
-  - uid: 1937
+  - uid: 2198
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 1938
+  - uid: 2199
     components:
     - type: Transform
       pos: -29.5,-5.5
       parent: 2
 - proto: Rack
   entities:
-  - uid: 1939
+  - uid: 2200
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 2
-  - uid: 1940
+  - uid: 2201
     components:
     - type: Transform
       pos: -24.5,-5.5
       parent: 2
-  - uid: 1941
+  - uid: 2202
     components:
     - type: Transform
       pos: -22.5,5.5
       parent: 2
 - proto: RadiationCollectorFullTank
   entities:
-  - uid: 1942
+  - uid: 2203
     components:
     - type: Transform
       pos: -33.5,3.5
       parent: 2
-  - uid: 1943
+  - uid: 2204
     components:
     - type: Transform
       pos: -31.5,3.5
       parent: 2
-  - uid: 1944
+  - uid: 2205
     components:
     - type: Transform
       pos: -32.5,3.5
       parent: 2
 - proto: Railing
   entities:
-  - uid: 1583
+  - uid: 2206
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-23.5
       parent: 2
-  - uid: 2669
+  - uid: 2207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 2
+  - uid: 2208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-23.5
       parent: 2
-  - uid: 2670
+  - uid: 2209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-23.5
       parent: 2
-  - uid: 2671
+  - uid: 2210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-23.5
       parent: 2
+- proto: RailingCorner
+  entities:
+  - uid: 2211
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 2
 - proto: RailingCornerSmall
   entities:
-  - uid: 2672
+  - uid: 2212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-23.5
       parent: 2
-  - uid: 2673
+  - uid: 2213
     components:
     - type: Transform
       pos: -17.5,-23.5
       parent: 2
 - proto: RandomArtifactSpawner
   entities:
-  - uid: 1945
+  - uid: 2214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15115,41 +15877,41 @@ entities:
       parent: 2
 - proto: RandomSpawner
   entities:
-  - uid: 2651
+  - uid: 2215
     components:
     - type: Transform
       pos: -15.5,-4.5
       parent: 2
 - proto: ReagentContainerFlour
   entities:
-  - uid: 1180
+  - uid: 1314
     components:
     - type: Transform
-      parent: 1176
+      parent: 1310
     - type: Physics
       canCollide: False
-  - uid: 1181
+  - uid: 1315
     components:
     - type: Transform
-      parent: 1176
+      parent: 1310
     - type: Physics
       canCollide: False
 - proto: ReagentGrinderIndustrial
   entities:
-  - uid: 158
+  - uid: 2216
     components:
     - type: Transform
       pos: -11.5,9.5
       parent: 2
 - proto: Recycler
   entities:
-  - uid: 1947
+  - uid: 2217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 2
-  - uid: 1948
+  - uid: 2218
     components:
     - type: Transform
       rot: -3.141592653589793 rad
@@ -15157,31 +15919,31 @@ entities:
       parent: 2
 - proto: RegenerativeMesh
   entities:
-  - uid: 1949
+  - uid: 2219
     components:
     - type: Transform
       pos: -16.656982,10.612671
       parent: 2
 - proto: ReinforcedUraniumWindow
   entities:
-  - uid: 1950
+  - uid: 2220
     components:
     - type: Transform
       pos: -30.5,4.5
       parent: 2
-  - uid: 1951
+  - uid: 2221
     components:
     - type: Transform
       pos: -30.5,3.5
       parent: 2
-  - uid: 1952
+  - uid: 2222
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 2
 - proto: RemoteSignallerAdvanced
   entities:
-  - uid: 1953
+  - uid: 2223
     components:
     - type: MetaData
       name: shuttle bay field remote
@@ -15190,91 +15952,91 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1083:
+        1203:
         - Pressed: Toggle
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 1954
+  - uid: 2224
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 2
 - proto: RollerBed
   entities:
-  - uid: 1955
+  - uid: 2225
     components:
     - type: Transform
       pos: -16.533813,4.4702454
       parent: 2
-  - uid: 2792
+  - uid: 2226
     components:
     - type: Transform
       pos: -16.530884,4.8434143
       parent: 2
 - proto: RollingPin
   entities:
-  - uid: 1182
+  - uid: 1316
     components:
     - type: Transform
-      parent: 1176
+      parent: 1310
     - type: Physics
       canCollide: False
-  - uid: 1956
+  - uid: 2227
     components:
     - type: Transform
       pos: -5.5435333,4.62088
       parent: 2
 - proto: RubberStampApproved
   entities:
-  - uid: 1957
+  - uid: 2228
     components:
     - type: Transform
-      pos: 4.7468195,-5.5215154
+      pos: 4.3475037,-4.650421
       parent: 2
-  - uid: 1958
+  - uid: 2229
     components:
     - type: Transform
       pos: -16.22373,-15.710587
       parent: 2
 - proto: RubberStampDenied
   entities:
-  - uid: 1959
+  - uid: 2230
     components:
     - type: Transform
-      pos: 4.5124445,-5.5996404
+      pos: 4.2068787,-4.556671
       parent: 2
-  - uid: 1960
+  - uid: 2231
     components:
     - type: Transform
       pos: -16.390396,-15.877253
       parent: 2
 - proto: SalvageMagnet
   entities:
-  - uid: 1961
+  - uid: 2232
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 2
 - proto: Screen
   entities:
-  - uid: 1962
+  - uid: 2233
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
-  - uid: 2768
+  - uid: 2234
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 2
-  - uid: 2769
+  - uid: 2235
     components:
     - type: Transform
       pos: -23.5,-10.5
       parent: 2
 - proto: SecurityTechFab
   entities:
-  - uid: 1963
+  - uid: 2236
     components:
     - type: Transform
       pos: -18.5,-12.5
@@ -15288,173 +16050,173 @@ entities:
       parent: 2
 - proto: ShardCrystalGreen
   entities:
-  - uid: 1965
+  - uid: 2238
     components:
     - type: Transform
       pos: -31.869598,2.3530884
       parent: 2
-  - uid: 1966
+  - uid: 2239
     components:
     - type: Transform
       pos: -33.419556,2.8837585
       parent: 2
 - proto: SheetGlass
   entities:
-  - uid: 946
+  - uid: 1071
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 947
+  - uid: 1072
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 948
+  - uid: 1073
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1967
+  - uid: 2240
     components:
     - type: Transform
       pos: -22.49598,5.4455404
       parent: 2
-  - uid: 1968
+  - uid: 2241
     components:
     - type: Transform
       pos: -24.43573,-5.293335
       parent: 2
 - proto: SheetPlasma
   entities:
-  - uid: 908
+  - uid: 1034
     components:
     - type: Transform
-      parent: 907
+      parent: 1033
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1969
+  - uid: 2242
     components:
     - type: Transform
       pos: -24.541372,-5.4864893
       parent: 2
 - proto: SheetPlasma1
   entities:
-  - uid: 1970
+  - uid: 2243
     components:
     - type: Transform
       pos: -15.433319,7.4024963
       parent: 2
 - proto: SheetPlasteel
   entities:
-  - uid: 1971
+  - uid: 2244
     components:
     - type: Transform
       pos: -22.413675,5.5141277
       parent: 2
-  - uid: 1972
+  - uid: 2245
     components:
     - type: Transform
       pos: -22.427393,5.527845
       parent: 2
 - proto: SheetPlastic
   entities:
-  - uid: 949
+  - uid: 1074
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 950
+  - uid: 1075
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 951
+  - uid: 1076
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1973
+  - uid: 2246
     components:
     - type: Transform
       pos: -22.482264,5.4866924
       parent: 2
-  - uid: 1974
+  - uid: 2247
     components:
     - type: Transform
       pos: -24.465942,-5.2782288
       parent: 2
 - proto: SheetSteel
   entities:
-  - uid: 952
+  - uid: 1077
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 953
+  - uid: 1078
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 954
+  - uid: 1079
     components:
     - type: Transform
-      parent: 945
+      parent: 1070
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1975
+  - uid: 2248
     components:
     - type: Transform
       pos: -22.427393,5.4729753
       parent: 2
-  - uid: 1976
+  - uid: 2249
     components:
     - type: Transform
       pos: -24.262817,-5.3251038
       parent: 2
 - proto: ShelfKitchen
   entities:
-  - uid: 1176
+  - uid: 1310
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
     - type: Storage
       storedItems:
-        1180:
+        1314:
           position: 0,0
           _rotation: South
-        1181:
+        1315:
           position: 1,0
           _rotation: South
-        1177:
+        1311:
           position: 2,0
           _rotation: South
-        1182:
+        1316:
           position: 3,0
           _rotation: South
-        1178:
+        1312:
           position: 4,0
           _rotation: South
-        1179:
+        1313:
           position: 5,0
           _rotation: South
     - type: ContainerContainer
@@ -15463,279 +16225,300 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1180
-          - 1181
-          - 1177
-          - 1182
-          - 1178
-          - 1179
+          - 1314
+          - 1315
+          - 1311
+          - 1316
+          - 1312
+          - 1313
 - proto: ShuttleWindow
   entities:
-  - uid: 181
+  - uid: 2250
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-10.5
       parent: 2
-  - uid: 1659
+  - uid: 2251
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 2
-  - uid: 1660
+  - uid: 2252
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
-  - uid: 1821
+  - uid: 2253
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 2
+  - uid: 2254
     components:
     - type: Transform
       pos: -30.5,-12.5
       parent: 2
-  - uid: 1862
+  - uid: 2255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-11.5
       parent: 2
-  - uid: 1979
+  - uid: 2256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 1980
+  - uid: 2257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,8.5
       parent: 2
-  - uid: 1981
+  - uid: 2258
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,3.5
       parent: 2
-  - uid: 1983
+  - uid: 2259
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 2
-  - uid: 1984
+  - uid: 2260
     components:
     - type: Transform
       pos: -10.5,11.5
       parent: 2
-  - uid: 1987
+  - uid: 2261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,3.5
       parent: 2
-  - uid: 1988
+  - uid: 2262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,3.5
       parent: 2
-  - uid: 1989
+  - uid: 2263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,3.5
       parent: 2
-  - uid: 1990
+  - uid: 2264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,3.5
       parent: 2
-  - uid: 1991
+  - uid: 2265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,3.5
       parent: 2
-  - uid: 1992
+  - uid: 2266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,3.5
       parent: 2
-  - uid: 1993
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,2.5
-      parent: 2
-  - uid: 1994
+  - uid: 2267
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 1995
+  - uid: 2268
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 1996
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-2.5
-      parent: 2
-  - uid: 1997
+  - uid: 2269
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
-  - uid: 1998
+  - uid: 2270
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 1999
+  - uid: 2271
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 2000
+  - uid: 2272
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
-  - uid: 2001
+  - uid: 2273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 2002
+  - uid: 2274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 2
-  - uid: 2003
+  - uid: 2275
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 2
-  - uid: 2004
+  - uid: 2276
     components:
     - type: Transform
       pos: -28.5,-18.5
       parent: 2
-  - uid: 2005
+  - uid: 2277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-22.5
       parent: 2
-  - uid: 2006
+  - uid: 2278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-22.5
       parent: 2
-  - uid: 2007
+  - uid: 2279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-22.5
       parent: 2
-  - uid: 2008
+  - uid: 2280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-22.5
       parent: 2
-  - uid: 2009
+  - uid: 2281
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-5.5
       parent: 2
-  - uid: 2010
+  - uid: 2282
     components:
     - type: Transform
       pos: -15.5,-15.5
       parent: 2
-  - uid: 2011
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-0.5
-      parent: 2
-  - uid: 2012
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-1.5
-      parent: 2
-  - uid: 2013
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,0.5
-      parent: 2
-  - uid: 2014
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,1.5
-      parent: 2
-  - uid: 2015
+  - uid: 2283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 2
-  - uid: 2016
+  - uid: 2284
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,14.5
       parent: 2
-  - uid: 2017
+  - uid: 2285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,14.5
       parent: 2
-  - uid: 2018
+  - uid: 2286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,14.5
       parent: 2
-  - uid: 2019
+  - uid: 2287
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,14.5
       parent: 2
-  - uid: 2020
+  - uid: 2288
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,14.5
       parent: 2
-  - uid: 2229
+  - uid: 2289
+    components:
+    - type: Transform
+      pos: 8.5,-8.5
+      parent: 2
+  - uid: 2290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-9.5
       parent: 2
-  - uid: 2708
+  - uid: 2291
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 2292
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 2
+  - uid: 2293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,2.5
+      parent: 2
+  - uid: 2294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,1.5
+      parent: 2
+  - uid: 2295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 2296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 2297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 2298
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 2535
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 2
 - proto: SignalButtonDirectional
   entities:
-  - uid: 2023
+  - uid: 2299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15743,41 +16526,51 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        61:
+        68:
         - Pressed: Open
-        62:
+        69:
         - Pressed: Open
+  - uid: 2937
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        65:
+        - Pressed: DoorBolt
 - proto: SignalSwitch
   entities:
-  - uid: 1753
+  - uid: 2300
     components:
     - type: Transform
       pos: -11.5,10.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        158:
+        2216:
         - On: Forward
         - Off: Off
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 2024
+  - uid: 2301
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1947:
+        2217:
         - On: Reverse
         - Off: Off
-        937:
+        1065:
         - On: Reverse
         - Off: Off
-        936:
+        1064:
         - On: Reverse
         - Off: Off
-  - uid: 2025
+  - uid: 2302
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15785,18 +16578,18 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        942:
+        1067:
         - On: Forward
         - Off: Off
-        939:
+        1066:
         - On: Forward
         - Off: Off
-        1948:
+        2218:
         - On: Reverse
         - Off: Off
 - proto: SignAtmos
   entities:
-  - uid: 2026
+  - uid: 2303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15804,21 +16597,29 @@ entities:
       parent: 2
 - proto: SignBar
   entities:
-  - uid: 93
+  - uid: 2304
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 2
+- proto: SignBath
+  entities:
+  - uid: 2305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 2
 - proto: SignBridge
   entities:
-  - uid: 2028
+  - uid: 2306
     components:
     - type: Transform
       pos: -23.5,-16.5
       parent: 2
 - proto: SignCans
   entities:
-  - uid: 2029
+  - uid: 2307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15826,7 +16627,7 @@ entities:
       parent: 2
 - proto: SignCargo
   entities:
-  - uid: 2030
+  - uid: 2308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15834,7 +16635,7 @@ entities:
       parent: 2
 - proto: SignCargoDock
   entities:
-  - uid: 2031
+  - uid: 2309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15842,7 +16643,7 @@ entities:
       parent: 2
 - proto: SignChem
   entities:
-  - uid: 2032
+  - uid: 2310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15850,12 +16651,12 @@ entities:
       parent: 2
 - proto: SignDirectionalEvac
   entities:
-  - uid: 2033
+  - uid: 2311
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 2
-  - uid: 2034
+  - uid: 2312
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15863,13 +16664,13 @@ entities:
       parent: 2
 - proto: SignDisposalSpace
   entities:
-  - uid: 2035
+  - uid: 2313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-4.5
       parent: 2
-  - uid: 2036
+  - uid: 2314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15877,7 +16678,7 @@ entities:
       parent: 2
 - proto: SignDoors
   entities:
-  - uid: 2038
+  - uid: 2315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15885,7 +16686,7 @@ entities:
       parent: 2
 - proto: SignEngineering
   entities:
-  - uid: 2039
+  - uid: 2316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15893,7 +16694,7 @@ entities:
       parent: 2
 - proto: SignEVA
   entities:
-  - uid: 2040
+  - uid: 2317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15901,7 +16702,7 @@ entities:
       parent: 2
 - proto: SignFire
   entities:
-  - uid: 2041
+  - uid: 2318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15909,7 +16710,7 @@ entities:
       parent: 2
 - proto: SignGravity
   entities:
-  - uid: 2042
+  - uid: 2319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15917,21 +16718,29 @@ entities:
       parent: 2
 - proto: SignHead
   entities:
-  - uid: 2043
+  - uid: 2320
     components:
     - type: Transform
       pos: -19.5,-16.5
       parent: 2
 - proto: SignKitchen
   entities:
-  - uid: 2044
+  - uid: 2321
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
+- proto: SignMail
+  entities:
+  - uid: 2698
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-3.5
+      parent: 2
 - proto: SignMorgue
   entities:
-  - uid: 2045
+  - uid: 2323
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15939,14 +16748,14 @@ entities:
       parent: 2
 - proto: SignShipDock
   entities:
-  - uid: 2046
+  - uid: 2324
     components:
     - type: Transform
       pos: -23.5,-13.5
       parent: 2
 - proto: SignVox
   entities:
-  - uid: 2047
+  - uid: 2325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15954,553 +16763,581 @@ entities:
       parent: 2
 - proto: Sink
   entities:
-  - uid: 2048
+  - uid: 2326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 2
-  - uid: 2049
+  - uid: 2327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 2
+- proto: SinkStemlessWater
+  entities:
+  - uid: 2328
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
 - proto: SinkWide
   entities:
-  - uid: 2050
+  - uid: 2329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,4.5
       parent: 2
-  - uid: 2051
+  - uid: 2330
     components:
     - type: Transform
       pos: -24.5,-11.5
       parent: 2
 - proto: SmartFridge
   entities:
-  - uid: 2053
+  - uid: 2331
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 2
 - proto: SMESBasic
   entities:
-  - uid: 2054
+  - uid: 2332
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
-  - uid: 2055
+  - uid: 2333
     components:
     - type: Transform
       pos: -29.5,-1.5
       parent: 2
-  - uid: 2056
+  - uid: 2334
     components:
     - type: Transform
       pos: -28.5,-1.5
       parent: 2
 - proto: SodaDispenser
   entities:
-  - uid: 2057
+  - uid: 2335
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
 - proto: SolarPanel
   entities:
-  - uid: 1611
+  - uid: 2336
     components:
     - type: Transform
       pos: -30.5,-21.5
       parent: 2
-  - uid: 1619
+  - uid: 2337
     components:
     - type: Transform
       pos: -30.5,-19.5
       parent: 2
-  - uid: 1623
+  - uid: 2338
     components:
     - type: Transform
       pos: -32.5,-22.5
       parent: 2
-  - uid: 1625
+  - uid: 2339
     components:
     - type: Transform
       pos: -30.5,-18.5
       parent: 2
-  - uid: 1697
+  - uid: 2340
     components:
     - type: Transform
       pos: -30.5,-20.5
       parent: 2
-  - uid: 1730
+  - uid: 2341
     components:
     - type: Transform
       pos: -30.5,-22.5
       parent: 2
-  - uid: 2059
+  - uid: 2342
     components:
     - type: Transform
       pos: -32.5,-19.5
       parent: 2
-  - uid: 2060
+  - uid: 2343
     components:
     - type: Transform
       pos: -32.5,-18.5
       parent: 2
-  - uid: 2061
+  - uid: 2344
     components:
     - type: Transform
       pos: -32.5,-21.5
       parent: 2
-  - uid: 2062
+  - uid: 2345
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 2
-  - uid: 2063
+  - uid: 2346
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 2
-  - uid: 2064
+  - uid: 2347
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 2065
+  - uid: 2348
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 2
-  - uid: 2066
+  - uid: 2349
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 2
-  - uid: 2067
+  - uid: 2350
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 2
-  - uid: 2068
+  - uid: 2351
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 2
-  - uid: 2069
+  - uid: 2352
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 2070
+  - uid: 2353
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
-  - uid: 2071
+  - uid: 2354
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
-  - uid: 2668
+  - uid: 2355
     components:
     - type: Transform
       pos: -32.5,-20.5
       parent: 2
 - proto: SolarTracker
   entities:
-  - uid: 2073
+  - uid: 2356
     components:
     - type: Transform
       pos: -31.5,-19.5
       parent: 2
-  - uid: 2076
+  - uid: 2357
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
+- proto: SpawnMechRipley
+  entities:
+  - uid: 2358
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
 - proto: SpawnMobCat
   entities:
-  - uid: 2077
+  - uid: 2359
     components:
     - type: Transform
       pos: -19.5,12.5
       parent: 2
 - proto: SpawnMobCorgi
   entities:
-  - uid: 2078
+  - uid: 2360
     components:
     - type: Transform
       pos: -17.5,-14.5
       parent: 2
 - proto: SpawnMobMonkeyPunpun
   entities:
-  - uid: 2079
+  - uid: 2361
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
 - proto: SpawnMobShiva
   entities:
-  - uid: 2788
+  - uid: 2362
     components:
     - type: Transform
       pos: -16.5,-10.5
       parent: 2
 - proto: SpawnMobWalter
   entities:
-  - uid: 2763
+  - uid: 2363
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 2
 - proto: SpawnPointAtmos
   entities:
-  - uid: 2647
+  - uid: 2364
     components:
     - type: Transform
       pos: -26.5,1.5
       parent: 2
 - proto: SpawnPointBartender
   entities:
-  - uid: 2083
+  - uid: 2365
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
 - proto: SpawnPointBorg
   entities:
-  - uid: 2084
+  - uid: 2366
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 2
 - proto: SpawnPointBotanist
   entities:
-  - uid: 2085
+  - uid: 2367
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 2086
+  - uid: 2368
     components:
     - type: Transform
       pos: -26.5,-18.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 2087
+  - uid: 2369
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
 - proto: SpawnPointChef
   entities:
-  - uid: 2088
+  - uid: 2370
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 2
 - proto: SpawnPointChemist
   entities:
-  - uid: 1877
+  - uid: 2371
     components:
     - type: Transform
       pos: -13.5,7.5
       parent: 2
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 2090
+  - uid: 2372
     components:
     - type: Transform
       pos: -18.5,-19.5
       parent: 2
 - proto: SpawnPointClown
   entities:
-  - uid: 2091
+  - uid: 2936
     components:
     - type: Transform
-      pos: 6.5,-0.5
+      pos: 10.5,0.5
+      parent: 2
+- proto: SpawnPointCourier
+  entities:
+  - uid: 2374
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
       parent: 2
 - proto: SpawnPointHeadOfPersonnel
   entities:
-  - uid: 2092
+  - uid: 2375
     components:
     - type: Transform
       pos: -17.5,-15.5
       parent: 2
 - proto: SpawnPointHeadOfSecurity
   entities:
-  - uid: 2093
+  - uid: 2376
     components:
     - type: Transform
       pos: -19.5,-19.5
       parent: 2
 - proto: SpawnPointJanitor
   entities:
-  - uid: 2094
+  - uid: 2377
     components:
     - type: Transform
       pos: -27.5,-12.5
       parent: 2
 - proto: SpawnPointMedicalDoctor
   entities:
-  - uid: 2095
+  - uid: 2378
     components:
     - type: Transform
       pos: -17.5,8.5
       parent: 2
 - proto: SpawnPointMedicalIntern
   entities:
-  - uid: 2096
+  - uid: 2379
     components:
     - type: Transform
       pos: -18.5,8.5
       parent: 2
 - proto: SpawnPointMime
   entities:
-  - uid: 2097
+  - uid: 2935
     components:
     - type: Transform
-      pos: 6.5,0.5
+      pos: 10.5,1.5
       parent: 2
 - proto: SpawnPointMusician
   entities:
-  - uid: 2098
+  - uid: 2938
     components:
     - type: Transform
-      pos: 6.5,-1.5
+      pos: 10.5,-0.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
-  - uid: 2099
+  - uid: 2382
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 2
 - proto: SpawnPointPassenger
   entities:
-  - uid: 2100
+  - uid: 2383
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: 6.5,6.5
       parent: 2
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 2101
+  - uid: 2384
     components:
     - type: Transform
       pos: -21.5,-19.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
-  - uid: 2102
+  - uid: 2385
     components:
     - type: Transform
       pos: -25.5,-6.5
       parent: 2
 - proto: SpawnPointResearchDirector
   entities:
-  - uid: 2103
+  - uid: 2386
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 2104
+  - uid: 2387
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 2
 - proto: SpawnPointScientist
   entities:
-  - uid: 2105
+  - uid: 2388
     components:
     - type: Transform
       pos: -25.5,-7.5
       parent: 2
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 2106
+  - uid: 2389
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 2107
+  - uid: 2390
     components:
     - type: Transform
       pos: -17.5,-11.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 2649
+  - uid: 2391
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 2
 - proto: SpawnPointTechnicalAssistant
   entities:
-  - uid: 2648
+  - uid: 2392
     components:
     - type: Transform
       pos: -27.5,1.5
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 2110
+  - uid: 2393
     components:
     - type: Transform
       pos: -20.5,9.5
       parent: 2
 - proto: StationAnchor
   entities:
-  - uid: 2111
+  - uid: 2394
     components:
     - type: Transform
       pos: -28.5,12.5
       parent: 2
 - proto: StationMap
   entities:
-  - uid: 2112
+  - uid: 2395
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
-  - uid: 2113
+  - uid: 2396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 2
-  - uid: 2114
+  - uid: 2397
     components:
     - type: Transform
       pos: -26.5,-13.5
       parent: 2
 - proto: StoolBar
   entities:
-  - uid: 146
+  - uid: 2398
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 2
-  - uid: 2115
+  - uid: 2399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
       parent: 2
-  - uid: 2116
+  - uid: 2400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 2
-  - uid: 2117
+  - uid: 2401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 2
-  - uid: 2118
+  - uid: 2402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 2
-  - uid: 2734
+  - uid: 2403
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
 - proto: SubstationWallBasic
   entities:
-  - uid: 2119
+  - uid: 2404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 2
-  - uid: 2120
+  - uid: 2405
     components:
     - type: Transform
       pos: -22.5,6.5
       parent: 2
-  - uid: 2121
+  - uid: 2406
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-10.5
       parent: 2
-  - uid: 2122
+  - uid: 2407
     components:
     - type: Transform
       pos: -18.5,-17.5
       parent: 2
-  - uid: 2123
+  - uid: 2408
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 2
-  - uid: 2124
+  - uid: 2409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-3.5
       parent: 2
-  - uid: 2125
+  - uid: 2410
     components:
     - type: Transform
       pos: -25.5,-19.5
       parent: 2
-  - uid: 2126
+  - uid: 2411
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 2
-  - uid: 2686
+  - uid: 2412
     components:
     - type: Transform
       pos: -29.5,-17.5
       parent: 2
+- proto: SuitStorageCourier
+  entities:
+  - uid: 2413
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
 - proto: SuitStorageEVA
   entities:
-  - uid: 2127
+  - uid: 2414
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 2
-  - uid: 2128
+  - uid: 2415
     components:
     - type: Transform
       pos: -10.5,-4.5
       parent: 2
 - proto: SuitStorageSec
   entities:
-  - uid: 922
+  - uid: 2416
     components:
     - type: Transform
       pos: -16.5,-12.5
       parent: 2
-  - uid: 2231
+  - uid: 2417
     components:
     - type: Transform
       pos: -15.5,-12.5
       parent: 2
 - proto: SurveillanceCameraEngineering
   entities:
-  - uid: 2129
+  - uid: 2418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16508,7 +17345,18 @@ entities:
       parent: 2
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 2130
+  - uid: 2419
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraGeneral
+      nameSet: True
+      id: Cargo bay
+  - uid: 2420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16519,7 +17367,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Walkway south
-  - uid: 2131
+  - uid: 2421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16530,7 +17378,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Shuttle Bay
-  - uid: 2132
+  - uid: 2422
     components:
     - type: Transform
       pos: -18.5,-0.5
@@ -16540,7 +17388,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Walkway north
-  - uid: 2133
+  - uid: 2423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16551,7 +17399,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Evac
-  - uid: 2134
+  - uid: 2424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16562,7 +17410,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Science
-  - uid: 2136
+  - uid: 2425
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16573,7 +17421,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Bar
-  - uid: 2137
+  - uid: 2426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16584,7 +17432,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Medbay
-  - uid: 2138
+  - uid: 2427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16595,18 +17443,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Engineering
-  - uid: 2140
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-5.5
-      parent: 2
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraGeneral
-      nameSet: True
-      id: Cargo bay
-  - uid: 2141
+  - uid: 2428
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16617,7 +17454,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Kitchen
-  - uid: 2766
+  - uid: 2429
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16630,7 +17467,7 @@ entities:
       id: Chemlab
 - proto: SurveillanceCameraMedical
   entities:
-  - uid: 2142
+  - uid: 2430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16643,7 +17480,7 @@ entities:
       id: Medical
 - proto: SurveillanceCameraRouterGeneral
   entities:
-  - uid: 2143
+  - uid: 2431
     components:
     - type: MetaData
       name: camera router (General)
@@ -16656,7 +17493,7 @@ entities:
       baseName: camera router
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 2144
+  - uid: 2432
     components:
     - type: MetaData
       name: camera router (Security)
@@ -16669,7 +17506,7 @@ entities:
       baseName: camera router
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 2145
+  - uid: 2433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16680,7 +17517,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Bridge external
-  - uid: 2146
+  - uid: 2434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16691,7 +17528,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Bridge
-  - uid: 2147
+  - uid: 2435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16702,7 +17539,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security
-  - uid: 2148
+  - uid: 2436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16715,7 +17552,7 @@ entities:
       id: Brig
 - proto: SurveillanceCameraService
   entities:
-  - uid: 2149
+  - uid: 2437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16728,7 +17565,7 @@ entities:
       id: Bar
 - proto: SurveillanceCameraWirelessRouterEntertainment
   entities:
-  - uid: 1067
+  - uid: 2438
     components:
     - type: MetaData
       name: wireless camera router (Entertainment)
@@ -16741,7 +17578,7 @@ entities:
       baseName: wireless camera router
 - proto: SurveillanceWirelessCameraPocket
   entities:
-  - uid: 1065
+  - uid: 2439
     components:
     - type: MetaData
       name: handheld quantum camera (Shuttle Bay)
@@ -16752,7 +17589,7 @@ entities:
       currentLabel: Shuttle Bay
     - type: NameModifier
       baseName: handheld quantum camera
-  - uid: 1066
+  - uid: 2440
     components:
     - type: MetaData
       name: handheld quantum camera (Salvage)
@@ -16765,221 +17602,226 @@ entities:
       baseName: handheld quantum camera
 - proto: Table
   entities:
-  - uid: 1839
+  - uid: 2322
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 2442
     components:
     - type: Transform
       pos: -13.5,6.5
       parent: 2
-  - uid: 2150
+  - uid: 2443
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-  - uid: 2151
+  - uid: 2444
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-10.5
       parent: 2
-  - uid: 2152
+  - uid: 2445
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-9.5
       parent: 2
-  - uid: 2153
+  - uid: 2446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-8.5
       parent: 2
-  - uid: 2154
+  - uid: 2447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-4.5
       parent: 2
-  - uid: 2155
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-5.5
-      parent: 2
-  - uid: 2156
+  - uid: 2448
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
-  - uid: 2157
+  - uid: 2449
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
-  - uid: 2158
+  - uid: 2450
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 2159
+  - uid: 2451
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 2
-  - uid: 2160
+  - uid: 2452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,7.5
       parent: 2
-  - uid: 2161
+  - uid: 2453
     components:
     - type: Transform
       pos: -15.5,7.5
       parent: 2
-  - uid: 2162
+  - uid: 2454
     components:
     - type: Transform
       pos: -23.5,7.5
       parent: 2
-  - uid: 2163
+  - uid: 2455
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 2
-  - uid: 2164
+  - uid: 2456
     components:
     - type: Transform
       pos: -19.5,-15.5
       parent: 2
-  - uid: 2165
+  - uid: 2457
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-15.5
       parent: 2
-  - uid: 2166
+  - uid: 2458
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-16.5
       parent: 2
-  - uid: 2167
+  - uid: 2459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 2
-  - uid: 2168
+  - uid: 2460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 2
-  - uid: 2169
+  - uid: 2461
     components:
     - type: Transform
       pos: -19.5,-10.5
       parent: 2
-  - uid: 2170
+  - uid: 2462
     components:
     - type: Transform
       pos: -19.5,-9.5
       parent: 2
-  - uid: 2171
+  - uid: 2463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 2
-  - uid: 2173
+  - uid: 2464
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 2
-  - uid: 2174
+  - uid: 2465
     components:
     - type: Transform
       pos: -16.5,11.5
       parent: 2
-  - uid: 2175
+  - uid: 2466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
-  - uid: 2176
+  - uid: 2467
     components:
     - type: Transform
       pos: -16.5,10.5
       parent: 2
-  - uid: 2633
+  - uid: 2468
     components:
     - type: Transform
       pos: -28.5,6.5
       parent: 2
+  - uid: 2469
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
 - proto: TableCounterMetal
   entities:
-  - uid: 2177
+  - uid: 2470
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 2
-  - uid: 2178
+  - uid: 2471
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
       parent: 2
-  - uid: 2179
+  - uid: 2472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,3.5
       parent: 2
-  - uid: 2180
+  - uid: 2473
     components:
     - type: Transform
       pos: -16.5,-21.5
       parent: 2
-  - uid: 2181
+  - uid: 2474
     components:
     - type: Transform
       pos: -23.5,-21.5
       parent: 2
 - proto: TableCounterWood
   entities:
-  - uid: 2182
+  - uid: 2475
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
-  - uid: 2183
+  - uid: 2476
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 2184
+  - uid: 2477
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 2185
+  - uid: 2478
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
 - proto: TableFancyRed
   entities:
-  - uid: 2186
+  - uid: 2479
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-1.5
       parent: 2
-  - uid: 2187
+  - uid: 2480
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16987,13 +17829,13 @@ entities:
       parent: 2
 - proto: TableFancyWhite
   entities:
-  - uid: 2188
+  - uid: 2481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
       parent: 2
-  - uid: 2189
+  - uid: 2482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17001,65 +17843,72 @@ entities:
       parent: 2
 - proto: TableWood
   entities:
-  - uid: 2636
+  - uid: 2483
     components:
     - type: Transform
       pos: -27.5,2.5
       parent: 2
-  - uid: 2637
+  - uid: 2484
     components:
     - type: Transform
       pos: -26.5,2.5
       parent: 2
 - proto: TelecomServerFilled
   entities:
-  - uid: 2190
+  - uid: 2485
     components:
     - type: Transform
       pos: -25.5,-21.5
       parent: 2
 - proto: ThrusterFlatpack
   entities:
-  - uid: 2191
+  - uid: 2486
     components:
     - type: Transform
       pos: -12.681641,-9.030365
       parent: 2
-  - uid: 2192
+  - uid: 2487
     components:
     - type: Transform
       pos: -12.384766,-8.70224
       parent: 2
-  - uid: 2193
+  - uid: 2488
     components:
     - type: Transform
       pos: -12.378784,-9.149231
       parent: 2
+- proto: ToiletEmpty
+  entities:
+  - uid: 2489
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 2
 - proto: ToyAmongPequeno
   entities:
-  - uid: 1074
+  - uid: 2490
     components:
     - type: Transform
       pos: -14.273163,-10.620331
       parent: 2
 - proto: TwoWayLever
   entities:
-  - uid: 1683
+  - uid: 2491
     components:
     - type: Transform
       pos: -28.5,-5.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        149:
+        157:
         - Left: Close
         - Right: Open
-        150:
+        158:
         - Left: Close
         - Right: Open
 - proto: UniformPrinter
   entities:
-  - uid: 2195
+  - uid: 2492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17067,2087 +17916,2186 @@ entities:
       parent: 2
 - proto: UnstableMutagenChemistryBottle
   entities:
-  - uid: 2196
+  - uid: 2493
     components:
     - type: Transform
       pos: -11.324066,5.591522
       parent: 2
 - proto: UraniumCrabSpawnerFrank
   entities:
-  - uid: 2197
+  - uid: 2494
     components:
     - type: Transform
       pos: -32.5,2.5
       parent: 2
 - proto: UraniumOre1
   entities:
-  - uid: 2198
+  - uid: 2495
     components:
     - type: Transform
       pos: -31.539825,2.5849304
       parent: 2
-  - uid: 2199
+  - uid: 2496
     components:
     - type: Transform
       pos: -33.45111,2.175415
       parent: 2
 - proto: UraniumWindoorSecureEngineeringLocked
   entities:
-  - uid: 2200
+  - uid: 2497
     components:
     - type: Transform
       pos: -33.5,4.5
       parent: 2
-  - uid: 2201
+  - uid: 2498
     components:
     - type: Transform
       pos: -32.5,4.5
       parent: 2
-  - uid: 2202
+  - uid: 2499
     components:
     - type: Transform
       pos: -31.5,4.5
       parent: 2
 - proto: VendingMachineBooze
   entities:
-  - uid: 2203
+  - uid: 2500
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
 - proto: VendingMachineCargoDrobe
   entities:
-  - uid: 2204
+  - uid: 2501
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 2
 - proto: VendingMachineChefvend
   entities:
-  - uid: 2205
+  - uid: 2502
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 2
 - proto: VendingMachineChemDrobe
   entities:
-  - uid: 2206
+  - uid: 2503
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 2
 - proto: VendingMachineChemicals
   entities:
-  - uid: 2207
+  - uid: 2504
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 2
 - proto: VendingMachineClothing
   entities:
-  - uid: 2208
+  - uid: 2505
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 2
+- proto: VendingMachineCourierDrobe
+  entities:
+  - uid: 2506
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 2209
+  - uid: 2507
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
 - proto: VendingMachineDonut
   entities:
-  - uid: 2210
+  - uid: 2508
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 2
 - proto: VendingMachineEngiDrobe
   entities:
-  - uid: 1901
+  - uid: 2509
     components:
     - type: Transform
       pos: -27.5,-1.5
       parent: 2
 - proto: VendingMachineEngivend
   entities:
-  - uid: 2212
+  - uid: 2510
     components:
     - type: Transform
       pos: -26.5,-1.5
       parent: 2
+- proto: VendingMachineGames
+  entities:
+  - uid: 2380
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 2
 - proto: VendingMachineMedical
   entities:
-  - uid: 2213
+  - uid: 2511
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 2214
+  - uid: 2512
     components:
     - type: Transform
       pos: -16.5,12.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
-  - uid: 1985
+  - uid: 2513
     components:
     - type: Transform
       pos: -8.5,10.5
       parent: 2
 - proto: VendingMachineRestockChemVend
   entities:
-  - uid: 2216
+  - uid: 2514
     components:
     - type: Transform
       pos: -16.26355,11.626709
       parent: 2
 - proto: VendingMachineRestockMedical
   entities:
-  - uid: 2217
+  - uid: 2515
     components:
     - type: Transform
       pos: -16.685425,11.829834
       parent: 2
 - proto: VendingMachineSalvage
   entities:
-  - uid: 2218
+  - uid: 2516
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 2
 - proto: VendingMachineSec
   entities:
-  - uid: 1809
+  - uid: 2517
     components:
     - type: Transform
       pos: -14.5,-12.5
       parent: 2
 - proto: VendingMachineSeeds
   entities:
-  - uid: 1657
+  - uid: 2518
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 2
 - proto: VendingMachineSoda
   entities:
-  - uid: 2221
+  - uid: 2519
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:
-  - uid: 2222
+  - uid: 2520
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
 - proto: VendingMachineTankDispenserEngineering
   entities:
-  - uid: 2223
+  - uid: 2521
     components:
     - type: Transform
       pos: -35.5,4.5
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 2224
+  - uid: 2522
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 2
 - proto: VendingMachineWinter
   entities:
-  - uid: 2225
+  - uid: 2523
     components:
     - type: Transform
       pos: -30.5,-16.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 2226
+  - uid: 2524
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 2
-  - uid: 2227
+  - uid: 2525
     components:
     - type: Transform
       pos: -25.5,-1.5
       parent: 2
 - proto: ViolinInstrument
   entities:
-  - uid: 2228
+  - uid: 2526
     components:
     - type: Transform
       pos: -0.12158203,6.3308105
       parent: 2
 - proto: WallmountTelevisionMini
   entities:
-  - uid: 1064
+  - uid: 2527
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 1069
+  - uid: 2528
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-4.5
       parent: 2
-  - uid: 1070
+  - uid: 2529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,11.5
       parent: 2
-  - uid: 1071
+  - uid: 2530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,-19.5
       parent: 2
-  - uid: 2789
+  - uid: 2531
     components:
     - type: Transform
       pos: -16.5,-8.5
       parent: 2
 - proto: WallShuttle
   entities:
-  - uid: 991
+  - uid: 2532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,12.5
       parent: 2
-  - uid: 1903
+  - uid: 2533
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 2
+  - uid: 2534
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 2
+  - uid: 2536
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 2
-  - uid: 1905
+  - uid: 2537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,13.5
       parent: 2
-  - uid: 1921
+  - uid: 2538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,14.5
       parent: 2
-  - uid: 1928
+  - uid: 2539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,14.5
       parent: 2
-  - uid: 1930
+  - uid: 2540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,13.5
       parent: 2
-  - uid: 1932
+  - uid: 2541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,7.5
       parent: 2
-  - uid: 2037
+  - uid: 2542
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,10.5
       parent: 2
-  - uid: 2139
+  - uid: 2543
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,14.5
       parent: 2
-  - uid: 2211
+  - uid: 2544
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,13.5
       parent: 2
-  - uid: 2242
+  - uid: 2545
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,12.5
       parent: 2
-  - uid: 2253
+  - uid: 2546
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,11.5
       parent: 2
-  - uid: 2254
+  - uid: 2547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,11.5
       parent: 2
-  - uid: 2255
+  - uid: 2548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,11.5
       parent: 2
-  - uid: 2258
+  - uid: 2549
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,14.5
       parent: 2
-  - uid: 2260
+  - uid: 2550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,11.5
       parent: 2
-  - uid: 2261
+  - uid: 2551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,11.5
       parent: 2
-  - uid: 2263
+  - uid: 2552
     components:
     - type: Transform
       pos: -13.5,-12.5
       parent: 2
-  - uid: 2264
+  - uid: 2553
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-2.5
       parent: 2
-  - uid: 2267
+  - uid: 2554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,-22.5
       parent: 2
-  - uid: 2268
+  - uid: 2555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-22.5
       parent: 2
-  - uid: 2269
+  - uid: 2556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-22.5
       parent: 2
-  - uid: 2270
+  - uid: 2557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-22.5
       parent: 2
-  - uid: 2271
+  - uid: 2558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-21.5
       parent: 2
-  - uid: 2272
+  - uid: 2559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-17.5
       parent: 2
-  - uid: 2273
+  - uid: 2560
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-18.5
       parent: 2
-  - uid: 2274
+  - uid: 2561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-0.5
       parent: 2
-  - uid: 2275
+  - uid: 2562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-1.5
       parent: 2
-  - uid: 2277
+  - uid: 2563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,9.5
       parent: 2
-  - uid: 2278
+  - uid: 2564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 2
-  - uid: 2279
+  - uid: 2565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 2
-  - uid: 2280
+  - uid: 2566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
       parent: 2
-  - uid: 2282
+  - uid: 2567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 2
-  - uid: 2283
+  - uid: 2568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 2
-  - uid: 2284
+  - uid: 2569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 2
-  - uid: 2285
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-4.5
-      parent: 2
-  - uid: 2288
+  - uid: 2570
     components:
     - type: Transform
       pos: -34.5,8.5
       parent: 2
-  - uid: 2291
+  - uid: 2571
     components:
     - type: Transform
-      pos: 6.5,-4.5
+      rot: 1.5707963267948966 rad
+      pos: 8.5,6.5
       parent: 2
-  - uid: 2292
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 2
-  - uid: 2293
+  - uid: 2572
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-10.5
       parent: 2
-  - uid: 2294
+  - uid: 2573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 2
-  - uid: 2295
+  - uid: 2574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 2
-  - uid: 2296
+  - uid: 2575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-8.5
       parent: 2
-  - uid: 2297
+  - uid: 2576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 2
-  - uid: 2298
+  - uid: 2577
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 2
-  - uid: 2299
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,5.5
-      parent: 2
-  - uid: 2300
+  - uid: 2578
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
-  - uid: 2302
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,4.5
-      parent: 2
-  - uid: 2305
+  - uid: 2579
     components:
     - type: Transform
       pos: -6.5,-12.5
       parent: 2
-  - uid: 2306
+  - uid: 2580
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,0.5
       parent: 2
-  - uid: 2308
+  - uid: 2581
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 2310
+  - uid: 2582
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 2
-  - uid: 2312
+  - uid: 2583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 2
-  - uid: 2315
+  - uid: 2584
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 2
-  - uid: 2316
+  - uid: 2585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 2
-  - uid: 2326
+  - uid: 2586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 2
-  - uid: 2327
+  - uid: 2587
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,11.5
       parent: 2
-  - uid: 2330
+  - uid: 2588
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,11.5
       parent: 2
-  - uid: 2331
+  - uid: 2589
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,11.5
       parent: 2
-  - uid: 2333
+  - uid: 2590
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-17.5
       parent: 2
-  - uid: 2334
+  - uid: 2591
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-17.5
       parent: 2
-  - uid: 2335
+  - uid: 2592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-17.5
       parent: 2
-  - uid: 2337
+  - uid: 2593
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,10.5
       parent: 2
-  - uid: 2338
+  - uid: 2594
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-13.5
       parent: 2
-  - uid: 2339
+  - uid: 2595
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,10.5
       parent: 2
-  - uid: 2342
+  - uid: 2596
     components:
     - type: Transform
       pos: -13.5,-8.5
       parent: 2
-  - uid: 2361
+  - uid: 2597
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-14.5
       parent: 2
-  - uid: 2367
+  - uid: 2598
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,7.5
       parent: 2
-  - uid: 2387
+  - uid: 2599
     components:
     - type: Transform
       pos: -27.5,10.5
       parent: 2
-  - uid: 2396
+  - uid: 2600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-17.5
       parent: 2
-  - uid: 2399
+  - uid: 2601
     components:
     - type: Transform
       pos: -26.5,10.5
       parent: 2
-  - uid: 2400
+  - uid: 2602
     components:
     - type: Transform
       pos: -30.5,10.5
       parent: 2
-  - uid: 2401
+  - uid: 2603
     components:
     - type: Transform
       pos: -28.5,10.5
       parent: 2
-  - uid: 2403
+  - uid: 2604
     components:
     - type: Transform
       pos: -29.5,10.5
       parent: 2
-  - uid: 2413
+  - uid: 2605
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-8.5
       parent: 2
-  - uid: 2419
+  - uid: 2606
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-13.5
       parent: 2
-  - uid: 2431
+  - uid: 2607
     components:
     - type: Transform
       pos: -25.5,-2.5
       parent: 2
-  - uid: 2432
+  - uid: 2608
     components:
     - type: Transform
       pos: -26.5,-2.5
       parent: 2
-  - uid: 2433
+  - uid: 2609
     components:
     - type: Transform
       pos: -27.5,-2.5
       parent: 2
-  - uid: 2434
+  - uid: 2610
     components:
     - type: Transform
       pos: -28.5,-2.5
       parent: 2
-  - uid: 2435
+  - uid: 2611
     components:
     - type: Transform
       pos: -29.5,-2.5
       parent: 2
-  - uid: 2436
+  - uid: 2612
     components:
     - type: Transform
       pos: -30.5,-3.5
       parent: 2
-  - uid: 2437
+  - uid: 2613
     components:
     - type: Transform
       pos: -30.5,-2.5
       parent: 2
-  - uid: 2438
+  - uid: 2614
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-13.5
       parent: 2
-  - uid: 2442
+  - uid: 2615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-19.5
       parent: 2
-  - uid: 2443
+  - uid: 2616
     components:
     - type: Transform
       pos: -34.5,6.5
       parent: 2
-  - uid: 2444
+  - uid: 2617
     components:
     - type: Transform
       pos: -34.5,7.5
       parent: 2
-  - uid: 2445
+  - uid: 2618
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,5.5
       parent: 2
-  - uid: 2446
+  - uid: 2619
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,6.5
       parent: 2
-  - uid: 2447
+  - uid: 2620
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,4.5
       parent: 2
-  - uid: 2448
+  - uid: 2621
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,7.5
       parent: 2
-  - uid: 2449
+  - uid: 2622
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,8.5
       parent: 2
-  - uid: 2450
+  - uid: 2623
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,3.5
       parent: 2
-  - uid: 2451
+  - uid: 2624
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,3.5
       parent: 2
-  - uid: 2452
+  - uid: 2625
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,3.5
       parent: 2
-  - uid: 2460
+  - uid: 2626
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,4.5
       parent: 2
-  - uid: 2461
+  - uid: 2627
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 2
-  - uid: 2466
+  - uid: 2628
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
-  - uid: 2467
+  - uid: 2629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-17.5
       parent: 2
-  - uid: 2469
+  - uid: 2630
     components:
     - type: Transform
       pos: -24.5,-2.5
       parent: 2
-  - uid: 2473
+  - uid: 2631
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-13.5
       parent: 2
-  - uid: 2484
+  - uid: 2632
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-22.5
       parent: 2
-  - uid: 2486
+  - uid: 2633
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-22.5
       parent: 2
-  - uid: 2488
+  - uid: 2634
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-16.5
       parent: 2
-  - uid: 2489
+  - uid: 2635
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-20.5
       parent: 2
-  - uid: 2499
+  - uid: 2636
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-19.5
       parent: 2
-  - uid: 2509
+  - uid: 2637
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-20.5
       parent: 2
-  - uid: 2514
+  - uid: 2638
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-21.5
       parent: 2
-  - uid: 2515
+  - uid: 2639
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-13.5
       parent: 2
-  - uid: 2516
+  - uid: 2640
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-17.5
       parent: 2
-  - uid: 2517
+  - uid: 2641
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-11.5
       parent: 2
-  - uid: 2518
+  - uid: 2642
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-10.5
       parent: 2
-  - uid: 2519
+  - uid: 2643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-9.5
       parent: 2
-  - uid: 2520
+  - uid: 2644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-13.5
       parent: 2
-  - uid: 2521
+  - uid: 2645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-22.5
       parent: 2
-  - uid: 2522
+  - uid: 2646
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,-22.5
       parent: 2
-  - uid: 2523
+  - uid: 2647
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-19.5
       parent: 2
-  - uid: 2524
+  - uid: 2648
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,-22.5
       parent: 2
-  - uid: 2525
+  - uid: 2649
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-22.5
       parent: 2
-  - uid: 2526
+  - uid: 2650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,11.5
       parent: 2
-  - uid: 2528
+  - uid: 2651
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,1.5
       parent: 2
-  - uid: 2529
+  - uid: 2652
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,1.5
       parent: 2
-  - uid: 2530
+  - uid: 2653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,13.5
       parent: 2
-  - uid: 2531
+  - uid: 2654
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,2.5
       parent: 2
-  - uid: 2534
+  - uid: 2655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 2
-  - uid: 2539
+  - uid: 2656
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,11.5
       parent: 2
-  - uid: 2540
+  - uid: 2657
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,11.5
       parent: 2
-  - uid: 2542
+  - uid: 2658
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,12.5
       parent: 2
-  - uid: 2543
+  - uid: 2659
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,14.5
       parent: 2
-  - uid: 2545
+  - uid: 2660
     components:
     - type: Transform
       pos: -31.5,10.5
       parent: 2
-  - uid: 2547
+  - uid: 2661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-8.5
       parent: 2
-  - uid: 2556
+  - uid: 2662
     components:
     - type: Transform
       pos: -12.5,-12.5
       parent: 2
-  - uid: 2713
+  - uid: 2663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,1.5
       parent: 2
+  - uid: 2664
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,4.5
+      parent: 2
+  - uid: 2665
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 2666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-4.5
+      parent: 2
+  - uid: 2667
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-4.5
+      parent: 2
+  - uid: 2668
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 2669
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 2670
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 2
+  - uid: 2671
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 2672
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 2
+  - uid: 2673
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,5.5
+      parent: 2
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 160
+  - uid: 2674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-3.5
       parent: 2
-  - uid: 1073
+  - uid: 2675
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-13.5
       parent: 2
-  - uid: 2232
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-5.5
-      parent: 2
-  - uid: 2233
+  - uid: 2676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,5.5
+      pos: 8.5,7.5
       parent: 2
-  - uid: 2234
+  - uid: 2677
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-12.5
       parent: 2
-  - uid: 2235
+  - uid: 2678
     components:
     - type: Transform
       pos: -22.5,12.5
       parent: 2
-  - uid: 2236
+  - uid: 2679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,1.5
       parent: 2
-  - uid: 2238
+  - uid: 2680
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
-  - uid: 2239
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-3.5
-      parent: 2
-  - uid: 2240
+  - uid: 2681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,11.5
       parent: 2
-  - uid: 2241
+  - uid: 2682
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-22.5
       parent: 2
-  - uid: 2243
+  - uid: 2683
     components:
     - type: Transform
       pos: -31.5,11.5
       parent: 2
-  - uid: 2244
+  - uid: 2684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,12.5
       parent: 2
-  - uid: 2245
+  - uid: 2685
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,11.5
       parent: 2
-  - uid: 2246
+  - uid: 2686
     components:
     - type: Transform
       pos: -27.5,11.5
       parent: 2
-  - uid: 2247
+  - uid: 2687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,3.5
       parent: 2
-  - uid: 2248
+  - uid: 2688
     components:
     - type: Transform
       pos: -30.5,14.5
       parent: 2
-  - uid: 2249
+  - uid: 2689
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,13.5
       parent: 2
-  - uid: 2250
+  - uid: 2690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,13.5
       parent: 2
-  - uid: 2251
+  - uid: 2691
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,14.5
       parent: 2
-  - uid: 2252
+  - uid: 2692
     components:
     - type: Transform
       pos: -34.5,10.5
       parent: 2
+  - uid: 2693
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 2694
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 2695
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-5.5
+      parent: 2
 - proto: WallShuttleInterior
   entities:
-  - uid: 859
+  - uid: 1294
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 2696
     components:
     - type: Transform
       pos: -14.5,-8.5
       parent: 2
-  - uid: 1072
+  - uid: 2697
     components:
     - type: Transform
       pos: -19.5,-13.5
       parent: 2
-  - uid: 2262
+  - uid: 2699
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,9.5
       parent: 2
-  - uid: 2276
+  - uid: 2700
     components:
     - type: Transform
       pos: -30.5,11.5
       parent: 2
-  - uid: 2281
+  - uid: 2701
     components:
     - type: Transform
       pos: -24.5,-21.5
       parent: 2
-  - uid: 2286
+  - uid: 2702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,6.5
       parent: 2
-  - uid: 2289
+  - uid: 2703
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 2
-  - uid: 2290
+  - uid: 2704
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 2
-  - uid: 2301
+  - uid: 2705
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 2706
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 2
-  - uid: 2303
+  - uid: 2707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,7.5
       parent: 2
-  - uid: 2304
+  - uid: 2708
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 2
-  - uid: 2307
+  - uid: 2709
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 2311
+  - uid: 2710
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 2313
+  - uid: 2711
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 2314
+  - uid: 2712
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 2
-  - uid: 2317
+  - uid: 2713
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-2.5
       parent: 2
-  - uid: 2318
+  - uid: 2714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 2
-  - uid: 2319
+  - uid: 2715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 2
-  - uid: 2320
+  - uid: 2716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 2
-  - uid: 2321
+  - uid: 2717
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-3.5
       parent: 2
-  - uid: 2322
+  - uid: 2718
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-3.5
       parent: 2
-  - uid: 2323
+  - uid: 2719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-4.5
       parent: 2
-  - uid: 2324
+  - uid: 2720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 2
-  - uid: 2325
+  - uid: 2721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 2
-  - uid: 2328
+  - uid: 2722
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 2329
+  - uid: 2723
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 2332
+  - uid: 2724
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,10.5
       parent: 2
-  - uid: 2336
+  - uid: 2725
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 2
-  - uid: 2340
+  - uid: 2726
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 2
-  - uid: 2341
+  - uid: 2727
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 2
-  - uid: 2343
+  - uid: 2728
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 2344
+  - uid: 2729
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-  - uid: 2345
+  - uid: 2730
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
-  - uid: 2346
+  - uid: 2731
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
-  - uid: 2347
+  - uid: 2732
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 2348
+  - uid: 2733
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 2
-  - uid: 2349
+  - uid: 2734
     components:
     - type: Transform
       pos: -11.5,10.5
       parent: 2
-  - uid: 2350
+  - uid: 2735
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,3.5
       parent: 2
-  - uid: 2351
+  - uid: 2736
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,4.5
       parent: 2
-  - uid: 2352
+  - uid: 2737
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,6.5
       parent: 2
-  - uid: 2353
+  - uid: 2738
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,7.5
       parent: 2
-  - uid: 2356
+  - uid: 2739
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,3.5
       parent: 2
-  - uid: 2357
+  - uid: 2740
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 2
-  - uid: 2358
+  - uid: 2741
     components:
     - type: Transform
       pos: -15.5,4.5
       parent: 2
-  - uid: 2359
+  - uid: 2742
     components:
     - type: Transform
       pos: -15.5,8.5
       parent: 2
-  - uid: 2360
+  - uid: 2743
     components:
     - type: Transform
       pos: -15.5,9.5
       parent: 2
-  - uid: 2362
+  - uid: 2744
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
-  - uid: 2363
+  - uid: 2745
     components:
     - type: Transform
       pos: -13.5,10.5
       parent: 2
-  - uid: 2364
+  - uid: 2746
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 2
-  - uid: 2365
+  - uid: 2747
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 2
-  - uid: 2366
+  - uid: 2748
     components:
     - type: Transform
       pos: -29.5,-13.5
       parent: 2
-  - uid: 2368
+  - uid: 2749
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,6.5
       parent: 2
-  - uid: 2369
+  - uid: 2750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,6.5
       parent: 2
-  - uid: 2370
+  - uid: 2751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,6.5
       parent: 2
-  - uid: 2371
+  - uid: 2752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,6.5
       parent: 2
-  - uid: 2372
+  - uid: 2753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,5.5
       parent: 2
-  - uid: 2373
+  - uid: 2754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,4.5
       parent: 2
-  - uid: 2374
+  - uid: 2755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,3.5
       parent: 2
-  - uid: 2375
+  - uid: 2756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,10.5
       parent: 2
-  - uid: 2376
+  - uid: 2757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,9.5
       parent: 2
-  - uid: 2377
+  - uid: 2758
     components:
     - type: Transform
       pos: -22.5,10.5
       parent: 2
-  - uid: 2378
+  - uid: 2759
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,7.5
       parent: 2
-  - uid: 2379
+  - uid: 2760
     components:
     - type: Transform
       pos: -23.5,10.5
       parent: 2
-  - uid: 2380
+  - uid: 2761
     components:
     - type: Transform
       pos: -24.5,10.5
       parent: 2
-  - uid: 2381
+  - uid: 2762
     components:
     - type: Transform
       pos: -24.5,9.5
       parent: 2
-  - uid: 2382
+  - uid: 2763
     components:
     - type: Transform
       pos: -24.5,8.5
       parent: 2
-  - uid: 2383
+  - uid: 2764
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 2
-  - uid: 2384
+  - uid: 2765
     components:
     - type: Transform
       pos: -24.5,6.5
       parent: 2
-  - uid: 2385
+  - uid: 2766
     components:
     - type: Transform
       pos: -22.5,6.5
       parent: 2
-  - uid: 2386
+  - uid: 2767
     components:
     - type: Transform
       pos: -23.5,6.5
       parent: 2
-  - uid: 2388
+  - uid: 2768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-1.5
       parent: 2
-  - uid: 2389
+  - uid: 2769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 2
-  - uid: 2390
+  - uid: 2770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-1.5
       parent: 2
-  - uid: 2391
+  - uid: 2771
     components:
     - type: Transform
       pos: -16.5,-3.5
       parent: 2
-  - uid: 2392
+  - uid: 2772
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
-  - uid: 2393
+  - uid: 2773
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 2
-  - uid: 2394
+  - uid: 2774
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 2
-  - uid: 2395
+  - uid: 2775
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 2
-  - uid: 2397
+  - uid: 2776
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
-  - uid: 2398
+  - uid: 2777
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-2.5
       parent: 2
-  - uid: 2402
+  - uid: 2778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,9.5
       parent: 2
-  - uid: 2404
+  - uid: 2779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,9.5
       parent: 2
-  - uid: 2405
+  - uid: 2780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,8.5
       parent: 2
-  - uid: 2406
+  - uid: 2781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-1.5
       parent: 2
-  - uid: 2407
+  - uid: 2782
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-1.5
       parent: 2
-  - uid: 2408
+  - uid: 2783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,-1.5
       parent: 2
-  - uid: 2410
+  - uid: 2784
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-1.5
       parent: 2
-  - uid: 2411
+  - uid: 2785
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-1.5
       parent: 2
-  - uid: 2412
+  - uid: 2786
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,2.5
       parent: 2
-  - uid: 2414
+  - uid: 2787
     components:
     - type: Transform
       pos: -15.5,-8.5
       parent: 2
-  - uid: 2415
+  - uid: 2788
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,8.5
       parent: 2
-  - uid: 2416
+  - uid: 2789
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,9.5
       parent: 2
-  - uid: 2417
+  - uid: 2790
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,8.5
       parent: 2
-  - uid: 2418
+  - uid: 2791
     components:
     - type: Transform
       pos: -30.5,7.5
       parent: 2
-  - uid: 2420
+  - uid: 2792
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 2
-  - uid: 2421
+  - uid: 2793
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 2
-  - uid: 2422
+  - uid: 2794
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
-  - uid: 2423
+  - uid: 2795
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
-  - uid: 2424
+  - uid: 2796
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 2
-  - uid: 2425
+  - uid: 2797
     components:
     - type: Transform
       pos: -24.5,3.5
       parent: 2
-  - uid: 2426
+  - uid: 2798
     components:
     - type: Transform
       pos: -23.5,3.5
       parent: 2
-  - uid: 2427
+  - uid: 2799
     components:
     - type: Transform
       pos: -19.5,-1.5
       parent: 2
-  - uid: 2428
+  - uid: 2800
     components:
     - type: Transform
       pos: -30.5,0.5
       parent: 2
-  - uid: 2429
+  - uid: 2801
     components:
     - type: Transform
       pos: -30.5,-0.5
       parent: 2
-  - uid: 2430
+  - uid: 2802
     components:
     - type: Transform
       pos: -30.5,-1.5
       parent: 2
-  - uid: 2439
+  - uid: 2803
     components:
     - type: Transform
       pos: -31.5,9.5
       parent: 2
-  - uid: 2440
+  - uid: 2804
     components:
     - type: Transform
       pos: -32.5,9.5
       parent: 2
-  - uid: 2441
+  - uid: 2805
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 2
-  - uid: 2453
+  - uid: 2806
     components:
     - type: Transform
       pos: -23.5,-5.5
       parent: 2
-  - uid: 2454
+  - uid: 2807
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
-  - uid: 2455
+  - uid: 2808
     components:
     - type: Transform
       pos: -19.5,-5.5
       parent: 2
-  - uid: 2456
+  - uid: 2809
     components:
     - type: Transform
       pos: -23.5,-3.5
       parent: 2
-  - uid: 2457
+  - uid: 2810
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 2
-  - uid: 2458
+  - uid: 2811
     components:
     - type: Transform
       pos: -23.5,-4.5
       parent: 2
-  - uid: 2459
+  - uid: 2812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-6.5
       parent: 2
-  - uid: 2462
+  - uid: 2813
     components:
     - type: Transform
       pos: -19.5,-11.5
       parent: 2
-  - uid: 2463
+  - uid: 2814
     components:
     - type: Transform
       pos: -16.5,-13.5
       parent: 2
-  - uid: 2464
+  - uid: 2815
     components:
     - type: Transform
       pos: -17.5,-13.5
       parent: 2
-  - uid: 2465
+  - uid: 2816
     components:
     - type: Transform
       pos: -18.5,-13.5
       parent: 2
-  - uid: 2468
+  - uid: 2817
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 2
-  - uid: 2470
+  - uid: 2818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-2.5
       parent: 2
-  - uid: 2471
+  - uid: 2819
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 2
-  - uid: 2472
+  - uid: 2820
     components:
     - type: Transform
       pos: -23.5,-11.5
       parent: 2
-  - uid: 2474
+  - uid: 2821
     components:
     - type: Transform
       pos: -29.5,-10.5
       parent: 2
-  - uid: 2475
+  - uid: 2822
     components:
     - type: Transform
       pos: -28.5,-10.5
       parent: 2
-  - uid: 2476
+  - uid: 2823
     components:
     - type: Transform
       pos: -27.5,-10.5
       parent: 2
-  - uid: 2477
+  - uid: 2824
     components:
     - type: Transform
       pos: -26.5,-10.5
       parent: 2
-  - uid: 2478
+  - uid: 2825
     components:
     - type: Transform
       pos: -25.5,-10.5
       parent: 2
-  - uid: 2479
+  - uid: 2826
     components:
     - type: Transform
       pos: -24.5,-10.5
       parent: 2
-  - uid: 2480
+  - uid: 2827
     components:
     - type: Transform
       pos: -23.5,-10.5
       parent: 2
-  - uid: 2481
+  - uid: 2828
     components:
     - type: Transform
       pos: -23.5,-9.5
       parent: 2
-  - uid: 2482
+  - uid: 2829
     components:
     - type: Transform
       pos: -28.5,-16.5
       parent: 2
-  - uid: 2483
+  - uid: 2830
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 2
-  - uid: 2485
+  - uid: 2831
     components:
     - type: Transform
       pos: -23.5,-13.5
       parent: 2
-  - uid: 2487
+  - uid: 2832
     components:
     - type: Transform
       pos: -24.5,-13.5
       parent: 2
-  - uid: 2490
+  - uid: 2833
     components:
     - type: Transform
       pos: -25.5,-13.5
       parent: 2
-  - uid: 2491
+  - uid: 2834
     components:
     - type: Transform
       pos: -26.5,-13.5
       parent: 2
-  - uid: 2492
+  - uid: 2835
     components:
     - type: Transform
       pos: -27.5,-16.5
       parent: 2
-  - uid: 2493
+  - uid: 2836
     components:
     - type: Transform
       pos: -26.5,-16.5
       parent: 2
-  - uid: 2494
+  - uid: 2837
     components:
     - type: Transform
       pos: -27.5,-13.5
       parent: 2
-  - uid: 2495
+  - uid: 2838
     components:
     - type: Transform
       pos: -25.5,-16.5
       parent: 2
-  - uid: 2496
+  - uid: 2839
     components:
     - type: Transform
       pos: -24.5,-16.5
       parent: 2
-  - uid: 2497
+  - uid: 2840
     components:
     - type: Transform
       pos: -28.5,-13.5
       parent: 2
-  - uid: 2498
+  - uid: 2841
     components:
     - type: Transform
       pos: -23.5,-16.5
       parent: 2
-  - uid: 2500
+  - uid: 2842
     components:
     - type: Transform
       pos: -25.5,-19.5
       parent: 2
-  - uid: 2501
+  - uid: 2843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-19.5
       parent: 2
-  - uid: 2502
+  - uid: 2844
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-17.5
       parent: 2
-  - uid: 2503
+  - uid: 2845
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-16.5
       parent: 2
-  - uid: 2504
+  - uid: 2846
     components:
     - type: Transform
       pos: -19.5,-8.5
       parent: 2
-  - uid: 2505
+  - uid: 2847
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-17.5
       parent: 2
-  - uid: 2506
+  - uid: 2848
     components:
     - type: Transform
       pos: -26.5,-19.5
       parent: 2
-  - uid: 2507
+  - uid: 2849
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-17.5
       parent: 2
-  - uid: 2508
+  - uid: 2850
     components:
     - type: Transform
       pos: -27.5,-19.5
       parent: 2
-  - uid: 2510
+  - uid: 2851
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-14.5
       parent: 2
-  - uid: 2511
+  - uid: 2852
     components:
     - type: Transform
       pos: -16.5,-17.5
       parent: 2
-  - uid: 2512
+  - uid: 2853
     components:
     - type: Transform
       pos: -18.5,-17.5
       parent: 2
-  - uid: 2513
+  - uid: 2854
     components:
     - type: Transform
       pos: -16.5,-8.5
       parent: 2
-  - uid: 2527
+  - uid: 2855
     components:
     - type: Transform
       pos: -19.5,-12.5
       parent: 2
-  - uid: 2535
+  - uid: 2856
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 2
-  - uid: 2536
+  - uid: 2857
     components:
     - type: Transform
       pos: -26.5,7.5
       parent: 2
-  - uid: 2537
+  - uid: 2858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-2.5
       parent: 2
-  - uid: 2538
+  - uid: 2859
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 2
-  - uid: 2541
+  - uid: 2860
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,11.5
       parent: 2
-  - uid: 2544
+  - uid: 2861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,11.5
       parent: 2
-  - uid: 2548
+  - uid: 2862
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,11.5
       parent: 2
-  - uid: 2550
+  - uid: 2863
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,8.5
       parent: 2
+  - uid: 2864
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,4.5
+      parent: 2
+  - uid: 2865
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 2866
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 2
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 1829
+  - uid: 2867
     components:
     - type: Transform
       pos: -17.5,-12.5
       parent: 2
 - proto: WarningN2
   entities:
-  - uid: 2561
+  - uid: 2868
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 2
 - proto: WarningO2
   entities:
-  - uid: 2562
+  - uid: 2869
     components:
     - type: Transform
       pos: -26.5,7.5
       parent: 2
 - proto: WarningWaste
   entities:
-  - uid: 2563
+  - uid: 2870
     components:
     - type: Transform
       pos: -30.5,6.5
       parent: 2
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 1982
+  - uid: 2871
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 2
-  - uid: 2564
+  - uid: 2872
     components:
     - type: Transform
       pos: -27.5,-11.5
       parent: 2
 - proto: WaterVaporCanister
   entities:
-  - uid: 1863
+  - uid: 2873
     components:
     - type: Transform
       anchored: True
@@ -19155,14 +20103,14 @@ entities:
       parent: 2
     - type: Physics
       bodyType: Static
-  - uid: 2566
+  - uid: 2874
     components:
     - type: Transform
       pos: -36.5,7.5
       parent: 2
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 2567
+  - uid: 2875
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19170,39 +20118,45 @@ entities:
       parent: 2
 - proto: WeaponGrapplingGun
   entities:
-  - uid: 2634
+  - uid: 2876
     components:
     - type: Transform
       pos: -28.507477,6.817444
       parent: 2
-  - uid: 2807
+  - uid: 2877
     components:
     - type: Transform
       pos: -8.438782,-3.2566223
       parent: 2
 - proto: WeaponQuadDisabler
   entities:
-  - uid: 2568
+  - uid: 2878
     components:
     - type: Transform
       pos: -25.477905,10.463043
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 1892
+  - uid: 2879
     components:
     - type: Transform
       pos: -29.5,6.5
       parent: 2
 - proto: Windoor
   entities:
-  - uid: 2570
+  - uid: 2880
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 2881
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 2
-  - uid: 2571
+  - uid: 2882
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19212,37 +20166,37 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        41:
+        47:
         - DoorStatus: DoorBolt
-  - uid: 2572
+  - uid: 2883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 2
-  - uid: 2573
+  - uid: 2884
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 2
-  - uid: 2574
+  - uid: 2885
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 2
-  - uid: 2575
+  - uid: 2886
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 2
-  - uid: 2576
+  - uid: 2887
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 2577
+  - uid: 2888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19250,31 +20204,31 @@ entities:
       parent: 2
 - proto: WindoorHydroponicsLocked
   entities:
-  - uid: 2089
+  - uid: 2889
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,8.5
       parent: 2
-  - uid: 2578
+  - uid: 2890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 2579
+  - uid: 2891
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
-  - uid: 2580
+  - uid: 2892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,8.5
       parent: 2
-  - uid: 2653
+  - uid: 2893
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19282,25 +20236,25 @@ entities:
       parent: 2
 - proto: WindoorKitchenLocked
   entities:
-  - uid: 2582
+  - uid: 2894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
-  - uid: 2583
+  - uid: 2895
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
       parent: 2
-  - uid: 2584
+  - uid: 2896
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,3.5
       parent: 2
-  - uid: 2585
+  - uid: 2897
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19308,43 +20262,43 @@ entities:
       parent: 2
 - proto: WindoorSecure
   entities:
-  - uid: 2552
+  - uid: 2898
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-5.5
       parent: 2
-  - uid: 2587
+  - uid: 2899
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 2588
+  - uid: 2900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 2589
+  - uid: 2901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 2
-  - uid: 2590
+  - uid: 2902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-15.5
       parent: 2
-  - uid: 2591
+  - uid: 2903
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-6.5
       parent: 2
-  - uid: 2592
+  - uid: 2904
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19352,29 +20306,34 @@ entities:
       parent: 2
 - proto: WindoorSecureBarLocked
   entities:
-  - uid: 2593
+  - uid: 2905
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
 - proto: WindoorSecureCargoLocked
   entities:
-  - uid: 2595
+  - uid: 2007
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 2906
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 2596
+  - uid: 2907
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
-  - uid: 2597
+  - uid: 2908
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 2598
+  - uid: 2909
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19382,31 +20341,31 @@ entities:
       parent: 2
 - proto: WindoorSecureChemistryLocked
   entities:
-  - uid: 887
+  - uid: 2911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,8.5
       parent: 2
-  - uid: 968
+  - uid: 2912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,9.5
       parent: 2
-  - uid: 2599
+  - uid: 2913
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 2600
+  - uid: 2914
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,6.5
       parent: 2
-  - uid: 2601
+  - uid: 2915
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19414,7 +20373,7 @@ entities:
       parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
-  - uid: 2602
+  - uid: 2916
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19422,13 +20381,13 @@ entities:
       parent: 2
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 2603
+  - uid: 2917
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,6.5
       parent: 2
-  - uid: 2604
+  - uid: 2918
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19436,25 +20395,25 @@ entities:
       parent: 2
 - proto: WindoorSecureSalvageLocked
   entities:
-  - uid: 2605
+  - uid: 2919
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 2606
+  - uid: 2920
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 2607
+  - uid: 2921
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 2
-  - uid: 2608
+  - uid: 2922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19462,7 +20421,7 @@ entities:
       parent: 2
 - proto: WindoorSecureScienceLocked
   entities:
-  - uid: 2609
+  - uid: 2923
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19470,49 +20429,49 @@ entities:
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 2610
+  - uid: 2924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 2
-  - uid: 2611
+  - uid: 2925
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 2
-  - uid: 2612
+  - uid: 2926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 2
-  - uid: 2613
+  - uid: 2927
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-5.5
       parent: 2
-  - uid: 2614
+  - uid: 2928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-5.5
       parent: 2
-  - uid: 2615
+  - uid: 2929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-5.5
       parent: 2
-  - uid: 2616
+  - uid: 2930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-5.5
       parent: 2
-  - uid: 2617
+  - uid: 2931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19520,7 +20479,7 @@ entities:
       parent: 2
 - proto: YarnNoodles
   entities:
-  - uid: 2618
+  - uid: 2932
     components:
     - type: Transform
       pos: -2.4257011,3.601201

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Lockers/suit_storage.yml
@@ -8,3 +8,5 @@
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitCourier
         - id: ClothingMaskBreath
+  - type: AccessReader
+    access: [["Courier"]]

--- a/Resources/Prototypes/_Impstation/Maps/banana.yml
+++ b/Resources/Prototypes/_Impstation/Maps/banana.yml
@@ -33,6 +33,7 @@
             CargoTechnician: [ 1, 1 ]
             SalvageSpecialist: [ 1, 1 ]
             AtmosphericTechnician: [ 1, 1 ]
+            Courier: [ 1, 1 ]
             #service
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Updates Banana to have a mailroom, and fixes the missing access reader on the courier hardsuit locker.

![Banana-0](https://github.com/user-attachments/assets/fc0e408f-f630-4e45-b3b9-a1e1c92bff37)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Fixed the Courier hardsuit locker having no access reader.
- tweak: Added a mailroom and bathroom to Banana.
