### PR TITLE
Antag currency tracking robustification

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -196,6 +196,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 index = 0; //reset index
 
                 //list things bought
+                //todo figure out how to embed images in these? might need to wait for this UI being turned into an actual UI and not whatever the fuck it currently is
                 var purchasesString = Loc.GetString("roundend-spend-summary-bought", ("gender", genderString)) + " ";
                 foreach (var boughtThing in purchaseCounts)
                 {

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -24,7 +24,11 @@ using Robust.Shared.Map;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared.Humanoid;
+using Content.Shared.Mind;
+using Content.Shared.Roles;
 using Content.Shared.Store.Components;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -37,6 +41,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     [ValidatePrototypeId<CurrencyPrototype>]
     private const string TelecrystalCurrencyPrototype = "Telecrystal";
@@ -106,9 +111,115 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
         var antags =_antag.GetAntagIdentifiers(uid);
 
-        foreach (var (_, sessionData, name) in antags)
+        foreach (var (mind, sessionData, name) in antags)
         {
             args.AddLine(Loc.GetString("nukeops-list-name-user", ("name", name), ("user", sessionData.UserName)));
+
+            //imp edit start
+            //this is mostly replicated from the server ObjectivesSystem, lines 206~312
+            //make sure we have a mindComp
+            if (!TryComp<MindComponent>(mind, out var mindComp))
+                continue;
+
+            //get the operative's gender
+            var genderString = "epicene"; //default to they/them'ing people
+            if (TryComp<HumanoidAppearanceComponent>(mindComp.OwnedEntity!, out var appearance))
+            {
+                genderString = appearance.Gender.ToString().ToLowerInvariant();
+            }
+
+            foreach (var mindRole in mindComp.MindRoles)
+            {
+                //make sure we have a mindRole comp
+                if (!TryComp<MindRoleComponent>(mindRole, out var mindRoleComp))
+                    continue;
+
+                //make sure that the mindRole comp is from some flavour of nukie
+                if (!(mindRoleComp.AntagPrototype == "Nukeops" || mindRoleComp.AntagPrototype == "NukeopsMedic" ||
+                    mindRoleComp.AntagPrototype == "NukeopsCommander"))
+                    continue;
+
+                //get the total costs & how many times each individual thing was bought
+                var costs = new Dictionary<string, int>(); //the total costs
+                var purchaseCounts = new Dictionary<string, int>(); //how many times a given thing was bought
+                //no no-spend text for nukies despite the mindRole saying it gets it because it's annoying :(
+                foreach (var purchase in mindRoleComp.Purchases)
+                {
+                    //get how much was spent
+                    foreach (var key in purchase.Item2.Keys)
+                    {
+                        var currencyName = _prototypeManager.Index(key).DisplayName;
+                        if (!costs.TryGetValue(currencyName, out var cost))
+                        {
+                            cost = 0;
+                        }
+
+                        costs[currencyName] = cost + purchase.Item2[key].Int();
+                    }
+
+                    //get the amount of times each entry was bought
+                    if (!purchaseCounts.TryGetValue(purchase.Item1, out var purchaseCount))
+                    {
+                        purchaseCount = 0;
+                    }
+
+                    purchaseCounts[purchase.Item1] = purchaseCount + 1;
+                }
+
+                var index = 0;
+                var costString = Loc.GetString("roundend-spend-summary-spent", ("gender", genderString)) + " ";
+                //list totals spent
+                //hardcoding english grammar into this probably isn't great but I don't think fluent can do lists?
+                foreach (var costPair in costs) //technically can just get index 0 of the list because it should always have only 1 entry, but let's be safe
+                {
+                    index++;
+                    //if this is the last entry, do a full stop.
+                    if (index == costs.Count)
+                    {
+                        costString += costPair.Value + " " + Loc.GetString(costPair.Key) + ".";
+                        args.AddLine(costString); //appendLine as this is the last entry
+                        continue; //continue early for sanity
+                    }
+
+                    //if this is the second to last entry, use an & instead of a comma
+                    if (index == costs.Count)
+                    {
+                        costString += costPair.Value + " " + Loc.GetString(costPair.Key) + " & ";
+                        continue; // continue early for sanity
+                    }
+
+                    //finally, just do the entry with a comma
+
+                    costString += costPair.Value + " " + Loc.GetString(costPair.Key) + ", ";
+                }
+
+                index = 0; //reset index
+
+                //list things bought
+                var purchasesString = Loc.GetString("roundend-spend-summary-bought", ("gender", genderString)) + " ";
+                foreach (var boughtThing in purchaseCounts)
+                {
+                    index++;
+                    //if this is the last entry, do a full stop.
+                    if (index == purchaseCounts.Count)
+                    {
+                        purchasesString += boughtThing.Value + "x " + Loc.GetString(boughtThing.Key) + ".";
+                        args.AddLine(purchasesString); //appendLine as this is the last entry
+                        continue; //continue early for sanity
+                    }
+
+                    //if this is the second to last entry, use an & instead of a comma
+                    if (index == purchaseCounts.Count - 1)
+                    {
+                        purchasesString += boughtThing.Value + "x " + Loc.GetString(boughtThing.Key) + " & ";
+                        continue; // continue early for sanity
+                    }
+
+                    //finally, just do the entry with a comma
+                    purchasesString += boughtThing.Value + "x " + Loc.GetString(boughtThing.Key) + ", ";
+                }
+            }
+            //imp edit end
         }
     }
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -123,7 +123,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
             //get the operative's gender
             var genderString = "epicene"; //default to they/them'ing people
-            if (TryComp<HumanoidAppearanceComponent>(mindComp.OwnedEntity!, out var appearance))
+            if (TryComp<HumanoidAppearanceComponent>(GetEntity(mindComp.OriginalOwnedEntity!), out var appearance))
             {
                 genderString = appearance.Gender.ToString().ToLowerInvariant();
             }
@@ -142,7 +142,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 //get the total costs & how many times each individual thing was bought
                 var costs = new Dictionary<string, int>(); //the total costs
                 var purchaseCounts = new Dictionary<string, int>(); //how many times a given thing was bought
-                //no no-spend text for nukies despite the mindRole saying it gets it because it's annoying :(
+                //no no-spend text for nukies despite the mindRole saying it gets it because it's annoying to implement :(
                 foreach (var purchase in mindRoleComp.Purchases)
                 {
                     //get how much was spent

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -24,9 +24,9 @@ using Robust.Shared.Map;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Linq;
-using Content.Shared.Humanoid;
-using Content.Shared.Mind;
-using Content.Shared.Roles;
+using Content.Shared.Humanoid; //imp addition
+using Content.Shared.Mind; //imp addition
+using Content.Shared.Roles; //imp addition
 using Content.Shared.Store.Components;
 using Robust.Shared.Prototypes;
 
@@ -41,7 +41,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly TagSystem _tag = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!; //imp addition
 
     [ValidatePrototypeId<CurrencyPrototype>]
     private const string TelecrystalCurrencyPrototype = "Telecrystal";
@@ -111,7 +111,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
         var antags =_antag.GetAntagIdentifiers(uid);
 
-        foreach (var (mind, sessionData, name) in antags)
+        foreach (var (mind, sessionData, name) in antags) //imp edit - replaced an unnamed variable with "mind"
         {
             args.AddLine(Loc.GetString("nukeops-list-name-user", ("name", name), ("user", sessionData.UserName)));
 

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -208,11 +208,12 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
             //so many loops........
 
             //these todos are future maybe fixes, not super necessary
-            //todo will want to do nukie / loneop spend readouts
+            //todo figure out a way to get the starting balance of a given antag
+            //todo figure out a way to fix the double-objective-summary thingimajig
 
             //get the character's gender
             var genderString = "epicene"; //default to they/them'ing people
-            if (TryComp<HumanoidAppearanceComponent>(mind.OwnedEntity!, out var appearance))
+            if (TryComp<HumanoidAppearanceComponent>(GetEntity(mind.OriginalOwnedEntity!), out var appearance))
             {
                 genderString = appearance.Gender.ToString().ToLowerInvariant();
             }

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -12,9 +12,9 @@ using Robust.Shared.Random;
 using System.Linq;
 using System.Text;
 using Content.Server.Objectives.Commands;
-using Content.Shared.Humanoid;
+using Content.Shared.Humanoid; //imp addition
 using Content.Shared.Prototypes;
-using Content.Shared.Roles;
+using Content.Shared.Roles; //imp addition
 using Content.Shared.Roles.Jobs;
 using Robust.Server.Player;
 using Robust.Shared.Utility;

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -54,7 +54,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
     private void OnRoundEndText(RoundEndTextAppendEvent ev)
     {
         // go through each gamerule getting data for the roundend summary.
-        var summaries = new Dictionary<string, Dictionary<string, List<(EntityUid, string)>>>(); //todo look at this again and add a note of what each element is
+        var summaries = new Dictionary<string, Dictionary<string, List<(EntityUid, string)>>>();
         var query = EntityQueryEnumerator<GameRuleComponent>();
         while (query.MoveNext(out var uid, out var gameRule))
         {
@@ -165,8 +165,6 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                 //TO DO:
                 //check for the right group here. Getting the target issuer is easy: objectiveGroup.Key
                 //It should be compared to the type of the group's issuer.
-                //todo specifically, this adds every objective for every gamerule summary; need to put something from the gamerule into the gamerule summary that this can check?
-                //or put the gamerule that added this objective into the objective itself?
                 agentSummary.AppendLine(objectiveGroup.Key);
 
                 foreach (var objective in objectiveGroup)
@@ -211,7 +209,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
 
             //these todos are future maybe fixes, not super necessary
             //todo will want to figure out how to get the starting currency count for an antag
-            //todo will want to fix objectives / spends repeating for a player with multiple antag types from admemery
+                //this will need me to either set it in the mindRole (probably doable on antag creation?)
             //todo will want to do nukie / loneop spend readouts
 
             var genderString = "epicene"; //default to they/them'ing people

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -203,15 +203,14 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                 }
             }
 
-            //imp edit - list the amount of currency this person spent & what they bought
+            //imp edit start - list the amount of currency this person spent & what they bought
             //if they bought nothing, check if they completed their objectives
             //so many loops........
 
             //these todos are future maybe fixes, not super necessary
-            //todo will want to figure out how to get the starting currency count for an antag
-                //this will need me to either set it in the mindRole (probably doable on antag creation?)
             //todo will want to do nukie / loneop spend readouts
 
+            //get the character's gender
             var genderString = "epicene"; //default to they/them'ing people
             if (TryComp<HumanoidAppearanceComponent>(mind.OwnedEntity!, out var appearance))
             {
@@ -255,7 +254,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                     agentSummary.Append(Loc.GetString("roundend-spend-summary-spent", ("gender", genderString)) + " ");
                     //list totals spent
                     //hardcoding english grammar into this probably isn't great but I don't think fluent can do lists?
-                    foreach (var costPair in costs)
+                    foreach (var costPair in costs) //technically can just get index 0 of the list because it should always have only 1 entry, but let's be safe
                     {
                         index++;
                         //if this is the last entry, do a full stop.

--- a/Content.Shared/Mind/MindComponent.cs
+++ b/Content.Shared/Mind/MindComponent.cs
@@ -32,11 +32,6 @@ public sealed partial class MindComponent : Component
     public List<EntityUid> Objectives = new();
 
     /// <summary>
-    /// imp edit - list of things that have been bought by this mind.
-    /// </summary>
-    public List<(string, IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2>)> Purchases = new();
-
-    /// <summary>
     ///     List of entities assigned to this mind's target objectives, if applicable.
     /// </summary>
     public List<EntityUid> ObjectiveTargets = new();

--- a/Content.Shared/Roles/MindRoleComponent.cs
+++ b/Content.Shared/Roles/MindRoleComponent.cs
@@ -65,6 +65,7 @@ public sealed partial class MindRoleComponent : BaseMindRoleComponent
     /// imp edit - the priority for this role to be assigned to "making" a purchase. mostly so we can distinguish between purchases as a traitor and purchases as a nukie
     /// </summary>
     [ViewVariables]
+    [DataField]
     public int PurchasePriority = 0;
 }
 

--- a/Content.Shared/Roles/MindRoleComponent.cs
+++ b/Content.Shared/Roles/MindRoleComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.FixedPoint;
 using Content.Shared.Mind;
+using Content.Shared.Store;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -42,17 +44,28 @@ public sealed partial class MindRoleComponent : BaseMindRoleComponent
     public ProtoId<JobPrototype>? JobPrototype { get; set; }
 
     /// <summary>
-    /// imp edit - should purchases made by this role be tracked?
-    /// Defaults to true because normal jobs are also mindRoles.
+    /// imp edit - the primary currency used by this role. if null, do not track purchases at all.
     /// </summary>
     [DataField]
-    public bool TrackPurchases = true;
+    public ProtoId<CurrencyPrototype>? PrimaryCurrency;
 
     /// <summary>
     /// imp edit - if true, the player with this role will get complimented for not spending anything
     /// </summary>
     [DataField]
     public bool GetsNoSpendtext;
+
+    /// <summary>
+    /// imp edit - list of things that have been bought by this mind.
+    /// </summary>
+    [ViewVariables]
+    public List<(string, IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2>)> Purchases = new();
+
+    /// <summary>
+    /// imp edit - the priority for this role to be assigned to "making" a purchase. mostly so we can distinguish between purchases as a traitor and purchases as a nukie
+    /// </summary>
+    [ViewVariables]
+    public int PurchasePriority = 0;
 }
 
 // Why does this base component actually exist? It does make auto-categorization easy, but before that it was useless?

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -85,8 +85,9 @@
   - type: MindRole
     exclusiveAntag: true
     antagPrototype: Nukeops
-    trackPurchases: false #imp edit
     getsNoSpendtext: true #imp edit
+    primaryCurrency: Telecrystal #imp edit
+    purchasePriority: 1 #imp edit
   - type: NukeopsRole
 
 - type: entity
@@ -97,8 +98,9 @@
   components:
   - type: MindRole
     antagPrototype: NukeopsMedic
-    trackPurchases: false #imp edit
     getsNoSpendtext: true #imp edit
+    primaryCurrency: Telecrystal #imp edit
+    purchasePriority: 2 #imp edit
 
 - type: entity
   parent: MindRoleNukeops
@@ -108,8 +110,9 @@
   components:
   - type: MindRole
     antagPrototype: NukeopsCommander
-    trackPurchases: false #imp edit
     getsNoSpendtext: true #imp edit
+    primaryCurrency: Telecrystal #imp edit
+    purchasePriority: 3 #imp edit
 
 # Revolutionaries
 - type: entity
@@ -154,6 +157,7 @@
     antagPrototype: Traitor
     exclusiveAntag: true
     getsNoSpendtext: true #imp edit
+    primaryCurrency: Telecrystal #imp edit
   - type: TraitorRole
 
 - type: entity
@@ -165,6 +169,7 @@
   - type: MindRole
     antagPrototype: TraitorSleeper
     getsNoSpendtext: true # imp edit
+    primaryCurrency: Telecrystal #imp edit
 
 # Zombie Squad
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/MindRoles/mind_roles.yml
@@ -8,6 +8,7 @@
   - type: MindRole
     antagPrototype: Changeling
     exclusiveAntag: true
+    primaryCurrency: EvolutionPoint #imp edit
   - type: ChangelingRole
 
 - type: entity
@@ -19,4 +20,5 @@
   - type: MindRole
     antagPrototype: Heretic
     exclusiveAntag: true
+    primaryCurrency: KnowledgePoint #imp edit
   - type: HereticRole


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Mostly a technical rewrite of the way antag purchases are tracked, though this does also add the tracking text to nukies & loneops.
Decided to stop trying to fix the repeat-spamming of objectives thing because I just wasn't having fun doing it.

specific technical details - 

Moved the purchases dict from mindComponent to mindRoleComponent.
Replaced the TrackPurchases boolean in mindRoleComponent with a PrimaryCurrency id string; purchases are only tracked if that isn't empty / null.
Added a purchasePriority field to mindRoleComponent to resolve conflicts between multiple antags that use the same primaryCurrency (currently can only happen if a dead traitor goes into a loneop ghostrole).
Updated relevant mindRole prototypes to use the new fields correctly.
Added the purchase readout text to NukeOpsRuleSystem

loneop, spent tc
![loneop](https://github.com/user-attachments/assets/1ab930f6-e740-4c8c-a550-5c86fadb40da)

team of nukies, spent tc
![teamop](https://github.com/user-attachments/assets/0002e6f5-c5a0-48b2-93ab-a5f47c90730f)

**Changelog**
:cl:
- add: Nuclear Operatives now have their TC spend displayed at the end of a round!
- fix: The round end TC summary no longer misgenders the dead. It will still misgender those who have been gibbed, unfortunately.
