### PR TITLE
Courier Fixes and Additions

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -56,6 +56,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "ChiefEngineer",
         "ChiefMedicalOfficer",
         "Command",
+        "Courier", // Imp
         "Cryogenics",
         "Engineering",
         "External",

--- a/Resources/Locale/en-US/_Impstation/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Impstation/access/accesses.ftl
@@ -1,0 +1,1 @@
+id-card-access-level-courier = Courier

--- a/Resources/Locale/en-US/_Impstation/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/_Impstation/navmap-beacons/station-beacons.ftl
@@ -1,1 +1,3 @@
 station-beacon-smengine = Supermatter Engine
+
+station-beacon-mailroom = Mailroom

--- a/Resources/Locale/en-US/_Impstation/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/_Impstation/navmap-beacons/station-beacons.ftl
@@ -1,3 +1,3 @@
 station-beacon-smengine = Supermatter Engine
 
-station-beacon-mailroom = Mailroom
+station-beacon-mailroom = Mail

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Head/soft.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Head/soft.yml
@@ -31,7 +31,7 @@
   name: security cap
 
 - type: entity
-  parent: [ClothingHeadHeadHatBaseFlippable, BaseCommandContraband]
+  parent: ClothingHeadHeadHatBaseFlippable
   id: ClothingHeadHatCouriersoft
   name: courier's cap
   description: A soft, durable cap for couriers.

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/station_beacon.yml
@@ -10,7 +10,7 @@
 - type: entity
   parent: DefaultStationBeaconSupply
   id: DefaultStationBeaconMailroomCourier
-  suffix: Cargo Reception
+  suffix: Cargo Mailroom
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-mailroom

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/station_beacon.yml
@@ -5,3 +5,12 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-smengine
+
+# Courier
+- type: entity
+  parent: DefaultStationBeaconSupply
+  id: DefaultStationBeaconMailroomCourier
+  suffix: Cargo Reception
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-mailroom

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/holopad.yml
@@ -1,7 +1,0 @@
-- type: entity
-  parent: Holopad
-  id: HolopadCargoMailroomCourier
-  suffix: Cargo Mailroom
-  components:
-  - type: Label
-    currentLabel: holopad-cargo-mailroom

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/holopad.yml
@@ -4,4 +4,4 @@
   suffix: Cargo Mailroom
   components:
   - type: Label
-    currentLabel: "Cargo - Mailroom"
+    currentLabel: holopad-cargo-mailroom

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: mail RPDS
-  parent: [ ]WeaponLauncherChinaLake, BaseCargoContraband ]
+  parent: [ WeaponLauncherChinaLake, BaseCargoContraband ]
   id: WeaponMailLake
   description: Rap(b?)id Parcel Delivery System
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: mail RPDS
-  parent: WeaponLauncherChinaLake
+  parent: [ ]WeaponLauncherChinaLake, BaseCargoContraband ]
   id: WeaponMailLake
   description: Rap(b?)id Parcel Delivery System
   components:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -554,3 +554,7 @@ LeftLegBorgCargo: LeftLegBorg
 RightLegBorgCargo: RightLegBorg
 HeadBorgCargo: LightHeadBorg
 TorsoBorgCargo: TorsoBorg
+
+# 2025-01-16
+# impstation: Removal of duplicate holopad Entity, oopsies
+HolopadCargoMailroomCourier: HolopadCargoMailroom


### PR DESCRIPTION
Mailroom beacon has been added mappers, not in cl because nobody cares about that lol
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Courier is now in the ID Computer
