### PR TITLE
Fixed multitool defibrillator functionality after upstream change

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -213,6 +213,7 @@
     playFailureSound: false
     playSuccessSound: false
     playReadySound: false
+  - type: UseDelay
 
 - type: entity
   name: network configurator


### PR DESCRIPTION
Broken by introduction of usedelay timer system into Defibrillator system. This change should only affect the defib part of the multitool (hopefully) due to the ability to define separate UseDelays for a single entity prototype via systemIDs passed in system methods. 


<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Multitools should work as defibs for small critters once more.