### PR TITLE
Let wand of entrance be usable by mobs with the clumsy component

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/wands.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/wands.yml
@@ -126,6 +126,7 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/Magic/staff_door.ogg
+    clumsyProof: true #imp edit
   - type: BasicEntityAmmoProvider
     proto: ProjectilePolyboltDoor
     capacity: 10


### PR DESCRIPTION
The wand of entrance is one of the funniest wizard items and does not cause direct harm as much as the other wands, so its tragic that if it ends up in the hands of a clown it backfires most of the time. This change lets them use it unhindered.

No changelog since this is just a small admeme related change.
