### PR TITLE
un-broke the examine range for non-ghosts

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Hands.EntitySystems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
+using Content.Shared.Ghost;
 
 namespace Content.Shared.Chemistry.EntitySystems;
 
@@ -861,6 +862,12 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
     private void OnSolutionExaminableVerb(Entity<ExaminableSolutionComponent> entity, ref GetVerbsEvent<ExamineVerb> args)
     {
+        if (!args.CanInteract || !args.CanAccess)
+        {
+            if (!HasComp<GhostComponent>(args.User))
+                return;
+        }
+
         var scanEvent = new SolutionScanEvent();
         RaiseLocalEvent(args.User, scanEvent);
         if (!scanEvent.CanScan)

--- a/Content.Shared/Damage/Systems/DamageExamineSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageExamineSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Verbs;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Ghost;
 
 namespace Content.Shared.Damage.Systems;
 
@@ -23,6 +24,11 @@ public sealed class DamageExamineSystem : EntitySystem
 
     private void OnGetExamineVerbs(EntityUid uid, DamageExaminableComponent component, GetVerbsEvent<ExamineVerb> args)
     {
+        if (!args.CanInteract || !args.CanAccess)
+        {
+            if (!HasComp<GhostComponent>(args.User))
+                return;
+        }
 
         var ev = new DamageExamineEvent(new FormattedMessage(), args.User);
         RaiseLocalEvent(uid, ref ev);


### PR DESCRIPTION
Previously, when making ghosts able to view weapon damage and chemical puddle composition, I did it by deleting the canInteract check. I then realised that that check is important to not let people view things that are behind a window, a door, etc.
This makes it so that ghosts CAN see those stuff, but non-ghosts have the same view restrictions as prior to my last update.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: fixed bug where people could see chemical composition or weapon damage from behind windows.
