### PR TITLE
Traitors Can No Longer Get The Same Target For Kill and Protect/Help Objectives

### DIFF
--- a/Content.Server/Objectives/Systems/KeepAliveCondition.cs
+++ b/Content.Server/Objectives/Systems/KeepAliveCondition.cs
@@ -50,7 +50,7 @@ public sealed class KeepAliveConditionSystem : EntitySystem
         // Can't have multiple objectives to help/save/kill the same person
         foreach (var objective in args.Mind.Objectives)
         {
-            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective) || HasComp<KillPersonConditionComponent>(objective))
+            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective) || HasComp<KillPersonConditionComponent>(objective)) // imp edit
             {
                 if (TryComp<TargetObjectiveComponent>(objective, out var help))
                 {

--- a/Content.Server/Objectives/Systems/KeepAliveCondition.cs
+++ b/Content.Server/Objectives/Systems/KeepAliveCondition.cs
@@ -47,10 +47,10 @@ public sealed class KeepAliveConditionSystem : EntitySystem
 
         var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).Select(t => t.Id).ToHashSet();
 
-        // Can't have multiple objectives to help/save the same person
+        // Can't have multiple objectives to help/save/kill the same person
         foreach (var objective in args.Mind.Objectives)
         {
-            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective))
+            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective) || HasComp<KillPersonConditionComponent>(objective))
             {
                 if (TryComp<TargetObjectiveComponent>(objective, out var help))
                 {

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -137,7 +137,18 @@ public sealed class KillPersonConditionSystem : EntitySystem
         }
 
         var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).Select(t => t.Id).ToHashSet();
-        args.Mind.ObjectiveTargets.ForEach(p => traitors.Remove(p));
+
+        // Can't have multiple objectives to help/save/kill the same person
+        foreach (var objective in args.Mind.Objectives)
+        {
+            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective) || HasComp<KillPersonConditionComponent>(objective))
+            {
+                if (TryComp<TargetObjectiveComponent>(objective, out var help))
+                {
+                    traitors.RemoveWhere(x => x == help.Target);
+                }
+            }
+        }
 
         // You are the first/only traitor.
         if (traitors.Count == 0)

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -136,6 +136,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return;
         }
 
+        // imp edit
         var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).Select(t => t.Id).ToHashSet();
 
         // Can't have multiple objectives to help/save/kill the same person
@@ -149,7 +150,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
                 }
             }
         }
-
+        // end imp edit
         // You are the first/only traitor.
         if (traitors.Count == 0)
         {


### PR DESCRIPTION
It was funny but it probably shouldn't keep happening.

:cl: 
- fix: Traitors no longer have to kill and save the same people sometimes. 