### PR TITLE
air tank throwing and tether bugfix

### DIFF
--- a/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
@@ -48,6 +48,7 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
         SubscribeLocalEvent<TetheredComponent, BuckleAttemptEvent>(OnTetheredBuckleAttempt);
         SubscribeLocalEvent<TetheredComponent, UpdateCanMoveEvent>(OnTetheredUpdateCanMove);
         SubscribeLocalEvent<TetheredComponent, EntGotInsertedIntoContainerMessage>(OnTetheredContainerInserted);
+        SubscribeLocalEvent<TetheredComponent, ThrownEvent>(OnTetheredThrown); // imp
 
         InitializeForce();
     }
@@ -75,6 +76,24 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
     private void OnTetheredUpdateCanMove(EntityUid uid, TetheredComponent component, UpdateCanMoveEvent args)
     {
         args.Cancel();
+    }
+
+    // Imp edit, prevents abusing throwing damage with items that repeatedly throw (i.e. gas tanks)
+    private void OnTetheredThrown(Entity<TetheredComponent> ent, ref ThrownEvent args)
+    {
+        var tetherer = ent.Comp.Tetherer;
+
+        if (TryComp<TetherGunComponent>(tetherer, out var tetherGun))
+        {
+            StopTether(tetherer, tetherGun);
+            return;
+        }
+
+        if (TryComp<ForceGunComponent>(tetherer, out var forceGun))
+        {
+            StopTether(tetherer, forceGun);
+            return;
+        }
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_EinsteinEngines/Damage/Components/DamageOtherOnHitComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Damage/Components/DamageOtherOnHitComponent.cs
@@ -47,6 +47,12 @@ public sealed partial class DamageOtherOnHitComponent : Component
     public float MeleeDamageMultiplier = 1f;
 
     /// <summary>
+    ///   The minimum velocity required to deal damage.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float MinVelocity = 1f;
+
+    /// <summary>
     ///   The sound to play when this entity hits on a throw.
     ///   If null, attempts to retrieve the HitSound from MeleeWeaponComponent.
     /// </summary>


### PR DESCRIPTION
adds a minimum velocity check to throwing damage to prevent very slow items from triggering throwing damage. this is a targeted change for air tanks in particular, which could be set to very low output pressure and spin in place for a very long time, creating a blender

also breaks tether/force gun tethers when a tethered item is thrown. this is also targeted for air tanks: you could just pick up the blender and wave it around. air tanks popping out of tethers also feels pretty natural with my testing but others may feel differently

fixed up some of the throwing code, as well. why was the same component being set as a variable twice? come on

**Changelog**
:cl:
- fix: Air tanks set to low output pressure will no longer create a throwing damage blender.
- tweak: Air tanks now pop out of tethers when they release gas.