### PR TITLE
Things with the ComplexInteraction component can do things without hands, Headslugs now have ComplexInteraction

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Destructible;
 using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Item;
 using Content.Shared.Lock;
 using Content.Shared.Movement.Events;
@@ -358,7 +359,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (!ResolveStorage(target, ref component))
             return false;
 
-        if (!HasComp<HandsComponent>(user))
+        if (!HasComp<HandsComponent>(user) && !HasComp<ComplexInteractionComponent>(user)) // imp edit - can add ComplexInteractionComponent to entities to allow them to do certain actions without hands
             return false;
 
         if (_weldable.IsWelded(target))

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.Destructible;
 using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
-using Content.Shared.Interaction.Components;
+using Content.Shared.Interaction.Components; // imp edit
 using Content.Shared.Item;
 using Content.Shared.Lock;
 using Content.Shared.Movement.Events;

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -19,7 +19,7 @@
     - VimPilot
     - MultitoolDefibrillatorTarget
   - type: Physics
-  - type: ComplexInteraction
+  - type: ComplexInteraction # imp edit
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -19,6 +19,7 @@
     - VimPilot
     - MultitoolDefibrillatorTarget
   - type: Physics
+  - type: ComplexInteraction
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
Mainly so headslugs can open morgues and bodybags to help themselves to a little snack, but also allows other stuff too. They can use camera monitors, for example. I don't think there's anything particularly gamebreaking that comes of it because most of the more busted stuff they would get access to would require hands or the ability to pull stuff. We'll see.

:cl:
- add: Headslugs can now open morgue trays and bodybags to help themselves to a little snack. 

