### PR TITLE
Add a courier color to the Departmental palette for the decal spawner

### DIFF
--- a/Resources/Prototypes/Palettes/departmental.yml
+++ b/Resources/Prototypes/Palettes/departmental.yml
@@ -15,5 +15,6 @@
     virology: "#43990996"
     atmospherics: "#3eb38896"
     salvage: "#8d1c9996"
+    courier: "#3C44AA96" #imp edit
     neutral: "#D4D4D496"
     neutralLight: "#D4D4D428"


### PR DESCRIPTION
Based on the 'blue' color from the Sixteen palette with the alpha changed to 58. I found this color matched the color of the courier locker really nicely, so I have been using it in my own maps.

No changelog, mapper touy.
