### PR TITLE
Reagent color contrast scaling

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -795,9 +795,9 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
-        // IMP, luminosity must be at least 0.3
+        // IMP, luminosity must be at least 0.4, rescale luminosity to 0.6x + 0.4
         var colorHSL = Color.ToHsl(solution.GetColor(PrototypeManager));
-        colorHSL.Z = (float) Math.Max(colorHSL.Z, 0.4);
+        colorHSL.Z = (float) ((colorHSL.Z * 0.6) + 0.4);
 
         var colorHex = Color.FromHsl(colorHSL)
             .ToHexNoAlpha();
@@ -855,7 +855,11 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
                     part = "examinable-solution-recognized-next";
                 }
 
-                msg.Append(Loc.GetString(part, ("color", reagent.SubstanceColor.ToHexNoAlpha()),
+                // IMP, luminosity must be at least 0.4, rescale luminosity to 0.6x + 0.4
+                var recognisedColorHSL = Color.ToHsl(reagent.SubstanceColor);
+                recognisedColorHSL.Z = (float) ((recognisedColorHSL.Z * 0.6) + 0.4);
+
+                msg.Append(Loc.GetString(part, ("color", Color.FromHsl(recognisedColorHSL).ToHexNoAlpha()),
                     ("chemical", reagent.LocalizedName)));
             }
 
@@ -928,7 +932,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         {
             // IMP, luminosity must be at least 0.4
             var colorHSL = Color.ToHsl(proto.SubstanceColor);
-            colorHSL.Z = (float) Math.Max(colorHSL.Z, 0.4);
+            colorHSL.Z = (float) ((colorHSL.Z * 0.6) + 0.4);
 
             msg.PushNewline();
             msg.AddMarkupOrThrow(Loc.GetString("scannable-solution-chemical"

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -795,9 +795,9 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
-        // IMP, luminosity must be at least 0.4, rescale luminosity to 0.6x + 0.4
+        // IMP, luminosity must be at least 0.4 to provide contrast with the textbox.
         var colorHSL = Color.ToHsl(solution.GetColor(PrototypeManager));
-        colorHSL.Z = (float) ((colorHSL.Z * 0.6) + 0.4);
+        colorHSL.Z = RescaleLuminosity((float) colorHSL.Z);
 
         var colorHex = Color.FromHsl(colorHSL)
             .ToHexNoAlpha();
@@ -855,9 +855,9 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
                     part = "examinable-solution-recognized-next";
                 }
 
-                // IMP, luminosity must be at least 0.4, rescale luminosity to 0.6x + 0.4
+                // IMP, luminosity must be at least 0.4 to provide contrast with the textbox.
                 var recognisedColorHSL = Color.ToHsl(reagent.SubstanceColor);
-                recognisedColorHSL.Z = (float) ((recognisedColorHSL.Z * 0.6) + 0.4);
+                recognisedColorHSL.Z = RescaleLuminosity((float) recognisedColorHSL.Z);
 
                 msg.Append(Loc.GetString(part, ("color", Color.FromHsl(recognisedColorHSL).ToHexNoAlpha()),
                     ("chemical", reagent.LocalizedName)));
@@ -909,6 +909,19 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         args.Verbs.Add(verb);
     }
 
+    /// <summary>
+    ///     # IMP Rescale luminosity value of a color to be at least 0.4.
+    //      Values less than 0.5 are scaled to be between 0.4 and 0.5, while values greater than 0.5 are kept the same.
+    //      Assumes all values are between 0 and 1.
+    /// </summary>
+    /// <param name="luminosity">Luminosity component of HSL</param>
+    private float RescaleLuminosity(float luminosity)
+    {
+        if (luminosity > 0.5){
+            return luminosity;
+        }
+        return (float) ((luminosity * 0.2) + 0.4);
+    }
     private FormattedMessage GetSolutionExamine(Solution solution)
     {
         var msg = new FormattedMessage();
@@ -930,9 +943,9 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
         foreach (var (proto, quantity) in sortedReagentPrototypes)
         {
-            // IMP, luminosity must be at least 0.4
+            // IMP, luminosity must be at least 0.4 to provide contrast with the textbox.
             var colorHSL = Color.ToHsl(proto.SubstanceColor);
-            colorHSL.Z = (float) ((colorHSL.Z * 0.6) + 0.4);
+            colorHSL.Z = RescaleLuminosity((float) colorHSL.Z);
 
             msg.PushNewline();
             msg.AddMarkupOrThrow(Loc.GetString("scannable-solution-chemical"


### PR DESCRIPTION
Scale luminosity from 0.4 to 0.5, no change from original luminosity when greater than 0.5. This should keep brighter reagents the same color, while darker reagents are still differentiable from each other yet contrast against background.

![image](https://github.com/user-attachments/assets/0d5629db-662c-41e3-8db9-3011c1c6cd2d)


:cl:
- tweak: Reagent examine text should be more differentiable for solutions with same color but different brightness. 
