### PR TITLE
Add templar helmet to migration.yml

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -558,3 +558,7 @@ TorsoBorgCargo: TorsoBorg
 # 2025-01-16
 # impstation: Removal of duplicate holopad Entity, oopsies
 HolopadCargoMailroomCourier: HolopadCargoMailroom
+
+# 2025-01-20
+# impstation: Make sure the templar helmet doesn't slink back in and break new maps
+ClothingHeadHelmetTemplar: null


### PR DESCRIPTION
We killed this thing back in #79. Adding this to migration.yml makes sure that if anything we import still refers to it (e.g. Gate) it won't cause errors and won't try to by spawned in-game.

