### PR TITLE
Minor rebalance to nullrod, the bible, & the null rod's transformations.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -23,7 +23,8 @@
       collection: Punch
     damage:
       types:
-        Holy: 25
+        Holy: 10 #imp edit. Get rebalanced lol
+        # Holy: 25 #imp edit. 25 Holy? WE HAVE A NULL ROD FOR THAT.
         Blunt: 1
   - type: Prayable
     bibleUserOnly: true

--- a/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
@@ -86,10 +86,6 @@
     size: Small
     shape:
     - 0,0,1,1
-  - type: MeleeWeapon
-    wideAnimationRotation: -135
-    soundHit:
-      collection: MetalThud
   - type: FitsInDispenser
     solution: grail
   - type: SolutionContainerManager

--- a/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
@@ -10,17 +10,8 @@
     state: nullrod_base
   - type: Item
     size: Small
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
   - type: Tag
     tags:
-    - Recyclable
     - NullRod
 
 - type: entity
@@ -31,7 +22,7 @@
   components:
   - type: ChaplainGearMenu
     possibleSets:
-    # - ChaplainGearRosary ## UNFINISHED!
+    # - ChaplainGearRosary ## UNFINISHED! SoonTM.
     - ChaplainGearGrail
     - ChaplainGearGlove
     - ChaplainGearBow
@@ -46,6 +37,7 @@
     damage:
       types:
         Blunt: 15
+        Holy: 15
     soundHit:
       collection: MetalThud
   - type: Clothing
@@ -96,9 +88,6 @@
     - 0,0,1,1
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    damage:
-      types:
-        Blunt: 5
     soundHit:
       collection: MetalThud
   - type: FitsInDispenser
@@ -106,7 +95,7 @@
   - type: SolutionContainerManager
     solutions:
       grail:
-        maxVol: 150
+        maxVol: 200
   - type: MixableSolution
     solution: grail
   - type: RefillableSolution
@@ -157,7 +146,7 @@
   name: divine grasp
   id: NullRodGlove
   parent: [ NullRodBase, ClothingHandsInedibleBase]
-  description: The touch of god! Or goddess. It's up to you, really.
+  description: The touch of god! Or whatever you believe in, really. I don't think the gauntlet cares.
   components:
   - type: Sprite
     sprite: _Impstation/Objects/Misc/nullrod_glove.rsi
@@ -169,17 +158,22 @@
   - type: Clothing
     sprite: _Impstation/Objects/Misc/nullrod_glove.rsi
   - type: StaminaDamageOnHit
-    damage: 22
+    damage: 23
   - type: MeleeWeapon
     attackRate: 0.68
     damage:
       types:
-        Blunt: 10
+        Blunt: 14
+        Holy: 20
     soundHit:
       path: /Audio/_Impstation/Weapons/nullglove.ogg
       params:
         variation: 0.35
     mustBeEquippedToUse: true
+  - type: MeleeThrowOnHit
+    unanchorOnHit: true
+    speed: 7
+    lifetime: 0.2
   - type: Reflect
     reflectProb: .22
     spread: 120
@@ -282,7 +276,7 @@
     - type: BallisticAmmoProvider
       proto: HolyArrow
       mayTransfer: true
-      capacity: 8
+      capacity: 7
       whitelist:
         tags:
         - HolyArrow

--- a/Resources/Prototypes/_Impstation/Objects/Weapons/Guns/Projectiles/holyarrow.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Weapons/Guns/Projectiles/holyarrow.yml
@@ -53,3 +53,4 @@
     damage:
       types:
         Piercing: 31
+        Holy: 20


### PR DESCRIPTION
This makes some slight balance tweaks to the Null Rod's forms, per suggestions that were made over the course of the time since its release, attenuated per my own judgement.
This also extends the Holy Damagetype to the Null Rod, allowing it to fare better against things vulnerable to Holy Damage.. Which barely affects anything at the moment, but it'll be extremely relevant for Cosmic Cult.

P.S. Why the hell did i not know Holy was added as a DamageType in December? I'VE BEEN BLINDSIDED. **BLINDSIDED!**

**Changelog**
:cl:
- tweak: Buffs to the Null Rod's [Divine Grasp] transform.
- tweak: The Null Rod & its forms now also deal Holy Damage to entities vulnerable to Holy.
- tweak: The Bible now deals significantly less Holy Damage.
