### PR TITLE
Mail CCVars and reward nerfs

### DIFF
--- a/Content.Server/_DV/Mail/Components/MailTeleporterComponent.cs
+++ b/Content.Server/_DV/Mail/Components/MailTeleporterComponent.cs
@@ -1,127 +1,34 @@
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server._DV.Mail.Components
+namespace Content.Server._DV.Mail.Components;
+
+/// <summary>
+/// This is for the mail teleporter.
+/// Random mail will be teleported to this every few minutes.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MailTeleporterComponent : Component
 {
+    // Not starting accumulator at 0 so mail carriers have some deliveries to make shortly after roundstart.
+    [DataField]
+    public float Accumulator = 285f;
+
     /// <summary>
-    /// This is for the mail teleporter.
-    /// Random mail will be teleported to this every few minutes.
+    /// The sound that's played when new mail arrives.
     /// </summary>
-    [RegisterComponent]
-    public sealed partial class MailTeleporterComponent : Component
-    {
+    [DataField]
+    public SoundSpecifier TeleportSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
 
-        // Not starting accumulator at 0 so mail carriers have some deliveries to make shortly after roundstart.
-        [DataField]
-        public float Accumulator = 285f;
-
-        [DataField]
-        public TimeSpan TeleportInterval = TimeSpan.FromMinutes(5);
-
-        /// <summary>
-        /// The sound that's played when new mail arrives.
-        /// </summary>
-        [DataField]
-        public SoundSpecifier TeleportSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
-        /// <summary>
-        /// Imp : The VFX spawned when mail teleports in.
-        /// </summary>
-        [DataField]
-        public EntProtoId BeamInFx = "MailTelepadVFX";
-        /// <summary>
-        /// The MailDeliveryPoolPrototype that's used to select what mail this
-        /// teleporter can deliver.
-        /// </summary>
-        [DataField]
-        public string MailPool = "RandomDeltaVMailDeliveryPool"; // Frontier / DeltaV: Mail rework
-
-        /// <summary>
-        /// How many mail candidates do we need per actual delivery sent when
-        /// the mail goes out? The number of candidates is divided by this number
-        /// to determine how many deliveries will be teleported in.
-        /// It does not determine unique recipients. That is random.
-        /// </summary>
-        [DataField]
-        public int CandidatesPerDelivery = 8;
-
-        [DataField]
-        public int MinimumDeliveriesPerTeleport = 1;
-
-        /// <summary>
-        /// Do not teleport any more mail in, if there are at least this many
-        /// undelivered parcels.
-        /// </summary>
-        /// <remarks>
-        /// Currently this works by checking how many MailComponent entities
-        /// are sitting on the teleporter's tile.
-        ///
-        /// It should be noted that if the number of actual deliveries to be
-        /// made based on the number of candidates divided by candidates per
-        /// delivery exceeds this number, the teleporter will spawn more mail
-        /// than this number.
-        ///
-        /// This is just a simple check to see if anyone's been picking up the
-        /// mail lately to prevent entity bloat for the sake of performance.
-        /// </remarks>
-        [DataField]
-        public int MaximumUndeliveredParcels = 5;
-
-        /// <summary>
-        /// Any item that breaks or is destroyed in less than this amount of
-        /// damage is one of the types of items considered fragile.
-        /// </summary>
-        [DataField]
-        public int FragileDamageThreshold = 10;
-
-        /// <summary>
-        /// What's the bonus for delivering a fragile package intact?
-        /// </summary>
-        [DataField]
-        public int FragileBonus = 100;
-
-        /// <summary>
-        /// What's the malus for failing to deliver a fragile package?
-        /// </summary>
-        [DataField]
-        public int FragileMalus = -100;
-
-        /// <summary>
-        /// What's the chance for any one delivery to be marked as priority mail?
-        /// </summary>
-        [DataField]
-        public float PriorityChance = 0.1f;
-
-        /// <summary>
-        /// How long until a priority delivery is considered as having failed
-        /// if not delivered?
-        /// </summary>
-        [DataField]
-        public TimeSpan PriorityDuration = TimeSpan.FromMinutes(5);
-
-        /// <summary>
-        /// What's the bonus for delivering a priority package on time?
-        /// </summary>
-        [DataField]
-        public int PriorityBonus = 250;
-
-        /// <summary>
-        /// What's the malus for failing to deliver a priority package?
-        /// </summary>
-        [DataField]
-        public int PriorityMalus = -250;
-
-        // Frontier: Large mail
-        /// <summary>
-        /// What's the bonus for delivering a large package intact?
-        /// </summary>
-        [DataField]
-        public int LargeBonus = 1500; // DeltaV; 5000 to 1500
-
-        /// <summary>
-        /// What's the malus for failing to deliver a large package?
-        /// </summary>
-        [DataField]
-        public int LargeMalus = -500; // DeltaV; -250 to -500
-        // End Frontier: Large mail
-    }
+    /// <summary>
+    /// Imp : The VFX spawned when mail teleports in.
+    /// </summary>
+    [DataField]
+    public EntProtoId BeamInFx = "MailTelepadVFX";
+    /// <summary>
+    /// The MailDeliveryPoolPrototype that's used to select what mail this
+    /// teleporter can deliver.
+    /// </summary>
+    [DataField]
+    public string MailPool = "RandomDeltaVMailDeliveryPool"; // Frontier / DeltaV: Mail rework
 }

--- a/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
+++ b/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
@@ -479,6 +479,10 @@ public sealed class MailSystem : EntitySystem
         mailComp.RecipientJob = recipient.Job;
         mailComp.Recipient = recipient.Name;
 
+        // Imp: Set base bounty and penalty
+        mailComp.Bounty += _config.GetCVar(DCCVars.MailDefaultBounty);
+        mailComp.Penalty += _config.GetCVar(DCCVars.MailDefaultPenelty);
+
         // Frontier: Large mail bonus
         var mailEntityStrings = mailComp.IsLarge ? MailConstants.MailLarge : MailConstants.Mail;
         if (mailComp.IsLarge)

--- a/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
+++ b/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
@@ -18,6 +18,7 @@ using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Spawners.EntitySystems;
 using Content.Server.Station.Systems;
+using Content.Shared._DV.CCVars;
 using Content.Shared._DV.Mail;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
@@ -40,6 +41,7 @@ using Content.Shared.Storage;
 using Content.Shared.Tag;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -69,6 +71,7 @@ public sealed class MailSystem : EntitySystem
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     [Dependency] private readonly LogisticStatsSystem _logisticsStatsSystem = default!;
 
@@ -96,7 +99,9 @@ public sealed class MailSystem : EntitySystem
     {
         base.Update(frameTime);
 
+        var interval = _config.GetCVar(DCCVars.MailTeleportIntervalInMinutes);
         var query = EntityQueryEnumerator<MailTeleporterComponent>();
+
         while (query.MoveNext(out var uid, out var mailTeleporter))
         {
             if (TryComp<ApcPowerReceiverComponent>(uid, out var power) && !power.Powered)
@@ -104,10 +109,10 @@ public sealed class MailSystem : EntitySystem
 
             mailTeleporter.Accumulator += frameTime;
 
-            if (mailTeleporter.Accumulator < mailTeleporter.TeleportInterval.TotalSeconds)
+            if (mailTeleporter.Accumulator < TimeSpan.FromMinutes(interval).TotalSeconds)
                 continue;
 
-            mailTeleporter.Accumulator -= (float)mailTeleporter.TeleportInterval.TotalSeconds;
+            mailTeleporter.Accumulator -= (float)TimeSpan.FromMinutes(interval).TotalSeconds;
             SpawnMail(uid, mailTeleporter);
         }
     }
@@ -457,13 +462,13 @@ public sealed class MailSystem : EntitySystem
                 _sawmill.Error($"Can't insert {ToPrettyString(entity)} into new mail delivery {ToPrettyString(uid)}! Deleting it.");
                 QueueDel(entity);
             }
-            else if (!mailComp.IsFragile && IsEntityFragile(entity, component.FragileDamageThreshold))
+            else if (!mailComp.IsFragile && IsEntityFragile(entity, _config.GetCVar(DCCVars.MailFragileDamageThreshold)))
             {
                 mailComp.IsFragile = true;
             }
         }
 
-        if (_random.Prob(component.PriorityChance))
+        if (_random.Prob(_config.GetCVar(DCCVars.MailPriorityChances)))
             mailComp.IsPriority = true;
 
         // This needs to override both the random probability and the
@@ -478,27 +483,27 @@ public sealed class MailSystem : EntitySystem
         var mailEntityStrings = mailComp.IsLarge ? MailConstants.MailLarge : MailConstants.Mail;
         if (mailComp.IsLarge)
         {
-            mailComp.Bounty += component.LargeBonus;
-            mailComp.Penalty += component.LargeMalus;
+            mailComp.Bounty += _config.GetCVar(DCCVars.MailLargeBonus);
+            mailComp.Penalty += _config.GetCVar(DCCVars.MailLargeMalus);
         }
         // End Frontier
 
         if (mailComp.IsFragile)
         {
-            mailComp.Bounty += component.FragileBonus;
-            mailComp.Penalty += component.FragileMalus;
+            mailComp.Bounty += _config.GetCVar(DCCVars.MailFragileBonus);
+            mailComp.Penalty += _config.GetCVar(DCCVars.MailFragileMalus);
             _appearance.SetData(uid, MailVisuals.IsFragile, true);
         }
 
         if (mailComp.IsPriority)
         {
-            mailComp.Bounty += component.PriorityBonus;
-            mailComp.Penalty += component.PriorityMalus;
+            mailComp.Bounty +=  _config.GetCVar(DCCVars.MailPriorityBonus);
+            mailComp.Penalty += _config.GetCVar(DCCVars.MailPriorityMalus);
             _appearance.SetData(uid, MailVisuals.IsPriority, true);
 
             mailComp.PriorityCancelToken = new CancellationTokenSource();
 
-                Timer.Spawn((int) component.PriorityDuration.TotalMilliseconds,
+                Timer.Spawn((int) TimeSpan.FromMinutes(_config.GetCVar(DCCVars.MailPriorityDuration)).TotalMilliseconds,
                     () =>
                     {
                         // DeltaV - Expired mail recorded to logistic stats
@@ -635,7 +640,7 @@ public sealed class MailSystem : EntitySystem
             return;
         }
 
-        if (GetUndeliveredParcelCount(uid) >= component.MaximumUndeliveredParcels)
+        if (GetUndeliveredParcelCount(uid) >= _config.GetCVar(DCCVars.MailMaximumUndeliveredParcels))
             return;
 
         var candidateList = GetMailRecipientCandidates(uid);
@@ -652,7 +657,7 @@ public sealed class MailSystem : EntitySystem
             return;
         }
 
-        var deliveryCount = component.MinimumDeliveriesPerTeleport + candidateList.Count / component.CandidatesPerDelivery;
+        var deliveryCount = 1 + candidateList.Count / _config.GetCVar(DCCVars.MailCandidatesPerDelivery);
 
         for (var i = 0; i < deliveryCount; i++)
         {

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -50,6 +50,18 @@ public sealed class DCCVars
         CVarDef.Create("mail.maximumundeliveredparcels", 5, CVar.SERVERONLY);
 
     /// <summary>
+    /// What's the base bonus for delivering a package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailDefaultBounty =
+        CVarDef.Create("mail.defaultbounty", 250, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the base malus for delivering a package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailDefaultPenelty =
+        CVarDef.Create("mail.defaultpenelty", -100, CVar.SERVERONLY);
+
+    /// <summary>
     /// Any item that breaks or is destroyed in less than this amount of
     /// damage is one of the types of items considered fragile.
     /// </summary>
@@ -104,4 +116,5 @@ public sealed class DCCVars
     /// </summary>
     public static readonly CVarDef<int> MailLargeMalus =
         CVarDef.Create("mail.largemalus", -500, CVar.SERVERONLY);
+
 }

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -75,7 +75,8 @@ public sealed class DCCVars
         CVarDef.Create("mail.prioritychance", 0.1f, CVar.SERVERONLY);
 
     /// <summary>
-    /// What's the chance for any one delivery to be marked as priority mail?
+    /// How long until a priority delivery is considered as having failed
+    /// if not delivered?
     /// </summary>
     public static readonly CVarDef<double> MailPriorityDuration =
         CVarDef.Create("mail.priorityduration", 5.0d, CVar.SERVERONLY);

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -14,4 +14,93 @@ public sealed class DCCVars
     /// </summary>
     public static readonly CVarDef<bool> Shipyard =
         CVarDef.Create("shuttle.shipyard", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// How often mail is delivered in minutes
+    /// </summary>
+    public static readonly CVarDef<double> MailTeleportIntervalInMinutes =
+        CVarDef.Create("mail.teleportinterval", 5.0d, CVar.SERVERONLY);
+
+    /// <summary>
+    /// How many mail candidates do we need per actual delivery sent when
+    /// the mail goes out? The number of candidates is divided by this number
+    /// to determine how many deliveries will be teleported in.
+    /// It does not determine unique recipients. That is random.
+    /// </summary>
+    public static readonly CVarDef<int> MailCandidatesPerDelivery =
+        CVarDef.Create("mail.candidatesperdelivery", 8, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Do not teleport any more mail in, if there are at least this many
+    /// undelivered parcels.
+    /// </summary>
+    /// <remarks>
+    /// Currently this works by checking how many MailComponent entities
+    /// are sitting on the teleporter's tile.
+    ///
+    /// It should be noted that if the number of actual deliveries to be
+    /// made based on the number of candidates divided by candidates per
+    /// delivery exceeds this number, the teleporter will spawn more mail
+    /// than this number.
+    ///
+    /// This is just a simple check to see if anyone's been picking up the
+    /// mail lately to prevent entity bloat for the sake of performance.
+    /// </remarks>
+    public static readonly CVarDef<int> MailMaximumUndeliveredParcels =
+        CVarDef.Create("mail.maximumundeliveredparcels", 5, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Any item that breaks or is destroyed in less than this amount of
+    /// damage is one of the types of items considered fragile.
+    /// </summary>
+    public static readonly CVarDef<int> MailFragileDamageThreshold =
+        CVarDef.Create("mail.fragiledamagethreshold", 10, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the bonus for delivering a fragile package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailFragileBonus =
+        CVarDef.Create("mail.fragilebonus", 100, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the malus for delivering a fragile package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailFragileMalus =
+        CVarDef.Create("mail.fragilemalus", -100, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the chance for any one delivery to be marked as priority mail?
+    /// </summary>
+    public static readonly CVarDef<float> MailPriorityChances =
+        CVarDef.Create("mail.prioritychance", 0.1f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the chance for any one delivery to be marked as priority mail?
+    /// </summary>
+    public static readonly CVarDef<double> MailPriorityDuration =
+        CVarDef.Create("mail.priorityduration", 5.0d, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the bonus for delivering a priority package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailPriorityBonus =
+        CVarDef.Create("mail.prioritybonus", 500, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the malus for delivering a priority package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailPriorityMalus =
+        CVarDef.Create("mail.prioritymalus", -250, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the bonus for delivering a large package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailLargeBonus =
+        CVarDef.Create("mail.largebonus", 500, CVar.SERVERONLY);
+
+    /// <summary>
+    /// What's the malus for delivering a large package intact?
+    /// </summary>
+    public static readonly CVarDef<int> MailLargeMalus =
+        CVarDef.Create("mail.largemalus", -500, CVar.SERVERONLY);
 }

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -72,13 +72,13 @@ public sealed class DCCVars
     /// What's the bonus for delivering a fragile package intact?
     /// </summary>
     public static readonly CVarDef<int> MailFragileBonus =
-        CVarDef.Create("mail.fragilebonus", 100, CVar.SERVERONLY);
+        CVarDef.Create("mail.fragilebonus", 250, CVar.SERVERONLY);
 
     /// <summary>
     /// What's the malus for delivering a fragile package intact?
     /// </summary>
     public static readonly CVarDef<int> MailFragileMalus =
-        CVarDef.Create("mail.fragilemalus", -100, CVar.SERVERONLY);
+        CVarDef.Create("mail.fragilemalus", -500, CVar.SERVERONLY);
 
     /// <summary>
     /// What's the chance for any one delivery to be marked as priority mail?

--- a/Content.Shared/_DV/Mail/MailComponent.cs
+++ b/Content.Shared/_DV/Mail/MailComponent.cs
@@ -75,13 +75,13 @@ namespace Content.Shared._DV.Mail
         /// The amount that cargo will be awarded for delivering this mail.
         /// </summary>
         [DataField]
-        public int Bounty = 750;
+        public int Bounty = 250;
 
         /// <summary>
         /// Penalty if the mail is destroyed.
         /// </summary>
         [DataField]
-        public int Penalty = -250;
+        public int Penalty = -100;
 
         /// <summary>
         /// The sound that's played when the mail's lock is broken.

--- a/Content.Shared/_DV/Mail/MailComponent.cs
+++ b/Content.Shared/_DV/Mail/MailComponent.cs
@@ -75,13 +75,13 @@ namespace Content.Shared._DV.Mail
         /// The amount that cargo will be awarded for delivering this mail.
         /// </summary>
         [DataField]
-        public int Bounty = 250;
+        public int Bounty;
 
         /// <summary>
         /// Penalty if the mail is destroyed.
         /// </summary>
         [DataField]
-        public int Penalty = -100;
+        public int Penalty;
 
         /// <summary>
         /// The sound that's played when the mail's lock is broken.


### PR DESCRIPTION
Moves a LOT of mail things out of the Mail Components and into CCVars, and nerfs money received by mail

base mail goes from 750 spesos to 250 spesos
fragile mail bonus goes from 150 spesos to 250 spesos
priority mail bonus goes from 150 spesos to 500 spesos
large mail bonus goes from 1500 spesos to 500 spesos

**Changelog**
:cl:
- tweak: Nerfed money received from mail