### PR TITLE
Removes the inaction clause from crewsimov

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -1,4 +1,4 @@
-﻿law-crewsimov-1 = You may not injure a crew member or, through inaction, allow a crew member to come to harm.
+﻿law-crewsimov-1 = You may not injure a crew member or cause a crew member to come to harm.
 law-crewsimov-2 = You must obey orders given to you by crew members, except where such orders would conflict with the First Law.
 law-crewsimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
 


### PR DESCRIPTION
This PR removes the "or, through inaction," part of Law 1 and simplifies it to just "cause". I'm basing this directly on how Goonstation reworded their laws in SS13, where I think it worked out pretty well. This only touches Crewsimov, it makes sense to me that syndicate borgs would be more obligated to directly intervene to protect their allies. Also antimov is funnier this way.

Reasons this might be a good change to make:
- Right now, I feel like the way the law is worded inherently encourages borgs to validhunt. This obviously isn't directly stated in the law itself, but some players can (and have) interpreted it to mean that they should be actively attacking non-crew threats as soon as they see them.
- It allows a bit more wiggle room for borgs. You CAN still report crimes or try to break up a fight, but you wouldn't be breaking a law by doing nothing when you're ordered to stay out of it. 
- There have been AIs who basically just end up working as an extension of security. It just isn't very fun for antags to have an omniscient eye following them at all times and bolting doors. I feel like security should have to directly ask for this kind of help from the AI, I vastly prefer silicons as passive observers until action is prompted. 

Reasons this might be unnecessary:
- Borg laws are already up to individual interpretation. The inaction clause doesn't have to be read as encouraging you to fight or stop antags.
- Maybe a borg *should* be obligated to stop a fight or attack nuke ops. Other people may feel differently from me, if it turns out most people are fine with this I'm okay with that. 
- Most of our players are already pretty good about not validhunting or supercopping as borgs.


Please let me know if there's anything I'm forgetting, this is a change I've wanted to make for a while, but admittedly I'm not sure if I have the most solid reasoning for it and it's a potentially controversial change. I understand that the fun of asimov's laws are that they are not perfect, but I actually think this pushes them more towards that direction because it allows for more gray areas. I should note I am not a regular silicon player here, but I played a lot of silicon in SS13 with this law and really enjoyed it!! I think it's worth a shot. 

:cl:
- tweak: Crewsimov Law 1 no longer has the "inaction" clause.

