### PR TITLE
mailinator component

### DIFF
--- a/Content.Shared/_Impstation/Mailinator/MailinatorComponent.cs
+++ b/Content.Shared/_Impstation/Mailinator/MailinatorComponent.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Impstation.Mailinator;
+
+[RegisterComponent]
+public sealed partial class MailinatorComponent : Component
+{
+    // TODO: yml-definable whitelist of valid targets instead of MailinatorTargetComponent.
+
+    /// <summary>
+    /// The verb. Duh.
+    /// This should be a LocId but my adderall is wearing off.
+    /// </summary>
+    [DataField]
+    public string VerbText = "Send to nearest Mail Telepad";
+
+    /// <summary>
+    /// The VFX spawned when the verb is used.
+    /// </summary>
+    [DataField]
+    public EntProtoId BeamInFx = "MailTelepadVFX";
+
+    /// <summary>
+    /// Length of the doafter.
+    /// </summary>
+    [DataField]
+    public TimeSpan DoAfterLength = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// The sounds that are played centered at the mailinator and its target respectively when the verb is used.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier DepartureSound = new SoundPathSpecifier("/Audio/Effects/teleport_departure.ogg");
+    [DataField]
+    public SoundSpecifier ArrivalSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
+}

--- a/Content.Shared/_Impstation/Mailinator/MailinatorSystem.cs
+++ b/Content.Shared/_Impstation/Mailinator/MailinatorSystem.cs
@@ -1,0 +1,127 @@
+
+using Content.Shared.Verbs;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Coordinates;
+using Content.Shared.Climbing.Events;
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+using Content.Shared.Popups;
+using Robust.Shared.Timing;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Content.Shared._Impstation.Mailinator;
+
+public sealed class MailinatorSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MailinatorComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<MailinatorComponent, MailinatorDoAfterEvent>(OnMailinatorDoAfter);
+    }
+
+    /// <summary>
+    /// Adds the verb for teleporting the item to the nearest ent with MailinatorTargetComponent.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="args"></param>
+    private void OnGetVerbs(Entity<MailinatorComponent> entity, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            return;
+
+        var user = args.User;
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Text = entity.Comp.VerbText,
+            Priority = 100,
+            Act = () =>
+            {
+                var doAfter = new DoAfterArgs(EntityManager, user, entity.Comp.DoAfterLength, new MailinatorDoAfterEvent(), entity.Owner)
+                {
+                    BreakOnMove = true,
+                    BlockDuplicate = true,
+                    BreakOnDamage = true,
+                    CancelDuplicate = true
+                };
+
+                _doAfterSystem.TryStartDoAfter(doAfter);
+            }
+        });
+    }
+
+    private void OnMailinatorDoAfter(Entity<MailinatorComponent> entity, ref MailinatorDoAfterEvent args)
+    {
+        var mailinatorCoords = _transformSystem.GetMapCoordinates(entity.Owner);
+
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        if (TryGetNearestMailTelepad(mailinatorCoords, out var target, out var targetCoords) && TeleportEntity(entity, targetCoords.Value))
+        {
+            Spawn(entity.Comp.BeamInFx, Transform(entity.Owner).Coordinates);
+            _audio.PlayPredicted(entity.Comp.DepartureSound, entity.Owner, args.User);
+
+            Spawn(entity.Comp.BeamInFx, Transform(target.Value.Owner).Coordinates);
+            _audio.PlayPredicted(entity.Comp.ArrivalSound, target.Value.Owner, args.User);
+        }
+        else
+        {
+            _popup.PopupEntity("No valid destinations in range.", args.User);
+        }
+    }
+
+
+    private bool TeleportEntity(Entity<MailinatorComponent> entity, EntityCoordinates target)
+    {
+        var mailinatorCoords = Transform(entity.Owner).Coordinates;
+        var onSameMap = _transformSystem.GetMapId(mailinatorCoords) == _transformSystem.GetMapId(target);
+
+        if (!onSameMap)
+            return false;
+
+        _transformSystem.SetCoordinates(entity.Owner, target);
+        return true;
+    }
+
+    public bool TryGetNearestMailTelepad(MapCoordinates coordinates, [NotNullWhen(true)] out Entity<MailinatorTargetComponent>? target, [NotNullWhen(true)] out EntityCoordinates? targetCoords)
+    {
+        target = null;
+        targetCoords = null;
+        var minDistance = float.PositiveInfinity;
+
+        var enumerator = EntityQueryEnumerator<MailinatorTargetComponent, TransformComponent>();
+        while (enumerator.MoveNext(out var uid, out var targetComp, out var xform))
+        {
+            if (coordinates.MapId != xform.MapID)
+                continue;
+
+            var coords = _transformSystem.GetWorldPosition(xform);
+            var distanceSquared = (coordinates.Position - coords).LengthSquared();
+            if (!float.IsInfinity(minDistance) && distanceSquared >= minDistance)
+                continue;
+
+            minDistance = distanceSquared;
+            target = (uid, targetComp);
+            targetCoords = new EntityCoordinates(target.Value, target.Value.Owner.ToCoordinates().Position);
+        }
+
+        return target != null;
+    }
+}
+
+/// <summary>
+/// Is relayed after the doafter finishes.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class MailinatorDoAfterEvent : SimpleDoAfterEvent { }

--- a/Content.Shared/_Impstation/Mailinator/MailinatorTargetComponent.cs
+++ b/Content.Shared/_Impstation/Mailinator/MailinatorTargetComponent.cs
@@ -1,0 +1,9 @@
+// using
+
+namespace Content.Shared._Impstation.Mailinator;
+
+[RegisterComponent]
+public sealed partial class MailinatorTargetComponent : Component
+{
+    //TODO: make this a whitelist definable in MailinatorComponent
+}

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/mailTeleporter.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/mailTeleporter.yml
@@ -5,6 +5,7 @@
   description: Teleports mail addressed to the crew of this station.
   components:
   - type: MailTeleporter
+  - type: MailinatorTarget
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_Impstation/Mail/mailinator.yml
+++ b/Resources/Prototypes/_Impstation/Mail/mailinator.yml
@@ -1,0 +1,7 @@
+- type: entity
+  parent: BoxCardboard
+  id: MailTeleportBox
+  name: mailinator
+  description: A cardboard box which is capable of autonomously teleporting to the nearest Mail Telepad.
+  components:
+    - type: Mailinator


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

adds two new components, mailinator and mailinatortarget. entities with mailinator get a context menu verb allowing them to teleport to the nearest entity with mailinatortarget.

no changelog because nothing with mailinator is obtainable by players currently. admins can play with it if they want though 

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
