### PR TITLE
make briefings actually use markup'd text

### DIFF
--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -159,7 +159,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             var briefingControl = new ObjectiveBriefingControl();
             var text = new FormattedMessage();
             text.PushColor(Color.Yellow);
-            text.AddText(briefing);
+            text.TryAddMarkup(briefing, out _); //imp edit - make this recognize markup'd text as markup'd text
             briefingControl.Label.SetMessage(text);
             _window.Objectives.AddChild(briefingControl);
         }


### PR DESCRIPTION
Simple one-line change to make the character info menu recognize markup'd text when it's given it.
No CL; not player facing

old
![image](https://github.com/user-attachments/assets/04fec6ae-27af-4346-9ee6-f15aca852d41)

new
![image2](https://github.com/user-attachments/assets/3aa544e4-9104-404f-94cd-913706705172)

