### PR TITLE
Small Oasis update

### DIFF
--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -27,7 +27,7 @@
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
@@ -42,10 +42,11 @@
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            #silicon
             StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
+            Borg: [ 3, 3 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
@@ -61,6 +62,6 @@
             Courier: [ 3, 3 ] #Imp
             #civilian
             Passenger: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]


### PR DESCRIPTION
Adds a bit more to the mail room, readds a bathroom area near the dorms, fixes cargo mail not having a tag associated with it (this disposal/mail pipes system is scary...), adds a few more fugitive spawn points, adds 6 more hydroponics trays (there are smaller stations that have more which I found crazy. I still need to work on the layout a bit more because it's a bit ugly...) I plan on adding a service area with a service techfab somewhere at some point.

Additionally adjusts job slots to cut down science slots and increase reporter, clown, mime, musician, and borg slots by one.

![Oasis-0](https://github.com/user-attachments/assets/9fa2b9f7-40a1-45ac-bdd8-89d7d200c105)

