### PR TITLE
No longer RR-ed from one anomaly core

### DIFF
--- a/Resources/Prototypes/_Impstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/medicine.yml
@@ -73,7 +73,7 @@
             Burn: -2
             Airloss: -2
             Toxin: -2
-            Genetic: 5
+            Genetic: 2
       - !type:ModifyBleedAmount
         amount: -1
 


### PR DESCRIPTION
Previously: 5 cellular per 0.5u, therefore 10 per u. Grinding an anomaly core gives 25u. Thats 250 cellular from one core. 1.25 Round Removes from one core. 

Reduced this to 2 cellular/0.5u, 4/u, 100 from one core.

:cl:
- tweak: reduced cellular damage from anomalium
