### PR TITLE
Minor derelict tweaks and fixes

### DIFF
--- a/Resources/Maps/_Impstation/Ruins/keyhole-court.yml
+++ b/Resources/Maps/_Impstation/Ruins/keyhole-court.yml
@@ -175,7 +175,8 @@ entities:
           1,2:
             0: 65535
           1,3:
-            0: 32767
+            0: 30719
+            2: 2048
           1,4:
             0: 3
             1: 21888
@@ -240,6 +241,21 @@ entities:
           moles:
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.6852
+          - 81.57766
           - 0
           - 0
           - 0
@@ -2815,8 +2831,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -2833,24 +2849,24 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 544
-          - 543
-          - 542
-          - 541
-          - 540
-          - 539
-          - 538
-          - 537
-          - 536
-          - 535
-          - 534
-          - 533
-          - 532
-          - 531
-          - 530
-          - 529
-          - 528
           - 527
+          - 528
+          - 529
+          - 530
+          - 531
+          - 532
+          - 533
+          - 534
+          - 535
+          - 536
+          - 537
+          - 538
+          - 539
+          - 540
+          - 541
+          - 542
+          - 543
+          - 544
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -5150,12 +5166,22 @@ entities:
     - type: Transform
       pos: 1.5,15.5
       parent: 1
+  - uid: 1139
+    components:
+    - type: Transform
+      pos: 2.5,19.5
+      parent: 1
 - proto: OxygenCanister
   entities:
   - uid: 572
     components:
     - type: Transform
       pos: 2.5,16.5
+      parent: 1
+  - uid: 1138
+    components:
+    - type: Transform
+      pos: 2.5,18.5
       parent: 1
 - proto: PlasticFlapsAirtightClear
   entities:

--- a/Resources/Maps/_Impstation/Ruins/shuttle-repair-bay.yml
+++ b/Resources/Maps/_Impstation/Ruins/shuttle-repair-bay.yml
@@ -257,6 +257,28 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+- proto: AirCanister
+  entities:
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
 - proto: AirlockEngineeringLocked
   entities:
   - uid: 55
@@ -1928,6 +1950,20 @@ entities:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
+- proto: ClosetEmergencyFilledRandom
+  entities:
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+- proto: ClosetEmergencyN2FilledRandom
+  entities:
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
 - proto: ClosetToolFilled
   entities:
   - uid: 213
@@ -2578,6 +2614,62 @@ entities:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
+- proto: PosterContrabandAtmosiaDeclarationIndependence
+  entities:
+  - uid: 595
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,17.5
+      parent: 1
+- proto: PosterContrabandHackingGuide
+  entities:
+  - uid: 594
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+- proto: PosterContrabandPower
+  entities:
+  - uid: 590
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+- proto: PosterContrabandTools
+  entities:
+  - uid: 593
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 1
+- proto: PosterLegitBuild
+  entities:
+  - uid: 582
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+- proto: PosterLegitJustAWeekAway
+  entities:
+  - uid: 592
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 1
+- proto: PosterLegitSafetyMothHardhat
+  entities:
+  - uid: 591
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
 - proto: Poweredlight
   entities:
   - uid: 380
@@ -2783,6 +2875,14 @@ entities:
     components:
     - type: Transform
       pos: -1.6664095,10.576264
+      parent: 1
+- proto: SignAtmos
+  entities:
+  - uid: 583
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,13.5
       parent: 1
 - proto: SMESBasic
   entities:

--- a/Resources/Maps/_Impstation/Ruins/snowy-sauna.yml
+++ b/Resources/Maps/_Impstation/Ruins/snowy-sauna.yml
@@ -1518,6 +1518,16 @@ entities:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
 - proto: CableApcExtension
   entities:
   - uid: 205
@@ -2051,66 +2061,66 @@ entities:
     - type: Transform
       pos: 3.411498,5.504635
       parent: 1
-- proto: FloraRockSolid02
+- proto: FloraRockSolid
   entities:
   - uid: 390
     components:
     - type: Transform
       pos: 1.4954431,-3.4608064
       parent: 1
-- proto: FloraRockSolid03
-  entities:
   - uid: 391
     components:
     - type: Transform
       pos: 1.5266931,0.49231863
       parent: 1
-- proto: FloraTreeConifer01
-  entities:
-  - uid: 103
-    components:
-    - type: Transform
-      pos: -6.1648893,7.491646
-      parent: 1
-  - uid: 112
-    components:
-    - type: Transform
-      pos: 5.535765,-6.5426564
-      parent: 1
-- proto: FloraTreeConifer02
-  entities:
-  - uid: 104
-    components:
-    - type: Transform
-      pos: 7.5564733,7.976021
-      parent: 1
-- proto: FloraTreeConifer03
+- proto: FloraTreeConifer
   entities:
   - uid: 102
     components:
     - type: Transform
       pos: -6.4029756,-5.1642146
       parent: 1
-- proto: FloraTreeSnow01
-  entities:
-  - uid: 388
+  - uid: 103
     components:
     - type: Transform
-      pos: 3.916739,7.8591757
+      pos: -6.1648893,7.491646
       parent: 1
-- proto: FloraTreeSnow02
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 7.5564733,7.976021
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 5.535765,-6.5426564
+      parent: 1
+- proto: FloraTreeSnow
   entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 8.2727165,-4.126254
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -8.563887,-0.14195466
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -6.3138866,3.4898095
+      parent: 1
   - uid: 107
     components:
     - type: Transform
       pos: -1.6871753,8.34718
       parent: 1
-- proto: FloraTreeSnow03
-  entities:
-  - uid: 105
+  - uid: 109
     components:
     - type: Transform
-      pos: -8.563887,-0.14195466
+      pos: 9.400868,3.8586073
       parent: 1
   - uid: 147
     components:
@@ -2118,26 +2128,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 7.9080772,1.8336542
       parent: 1
-- proto: FloraTreeSnow04
-  entities:
-  - uid: 2
+  - uid: 388
     components:
     - type: Transform
-      pos: 8.2727165,-4.126254
-      parent: 1
-- proto: FloraTreeSnow05
-  entities:
-  - uid: 106
-    components:
-    - type: Transform
-      pos: -6.3138866,3.4898095
-      parent: 1
-- proto: FloraTreeSnow06
-  entities:
-  - uid: 109
-    components:
-    - type: Transform
-      pos: 9.400868,3.8586073
+      pos: 3.916739,7.8591757
       parent: 1
 - proto: FoodBoxDonut
   entities:
@@ -2872,19 +2866,29 @@ entities:
     - type: Transform
       pos: -12.5,-5.5
       parent: 1
-- proto: LiquidNitrogenCanister
+- proto: NitrogenCanister
   entities:
   - uid: 152
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-- proto: LiquidOxygenCanister
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+- proto: OxygenCanister
   entities:
   - uid: 40
     components:
     - type: Transform
       pos: 7.5,-1.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
       parent: 1
 - proto: PosterContrabandBeachStarYamamoto
   entities:
@@ -3186,6 +3190,18 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,5.5
+      parent: 1
+- proto: SpaceHeater
+  entities:
+  - uid: 652
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
       parent: 1
 - proto: StairWood
   entities:
@@ -3806,26 +3822,41 @@ entities:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        bucket: !type:ContainerSlot {}
   - uid: 53
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        bucket: !type:ContainerSlot {}
   - uid: 76
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        bucket: !type:ContainerSlot {}
   - uid: 124
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        bucket: !type:ContainerSlot {}
   - uid: 129
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        bucket: !type:ContainerSlot {}
 - proto: WoodenBench
   entities:
   - uid: 90

--- a/Resources/Maps/_Impstation/Ruins/spooky-garden-bubble.yml
+++ b/Resources/Maps/_Impstation/Ruins/spooky-garden-bubble.yml
@@ -38,7 +38,7 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAgwAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAhAAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAhAAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAKwAAAAADKwAAAAACKwAAAAACAQAAAAAAKwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAAAKwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAABKwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAAAKwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAVAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAgwAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAhAAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAhAAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAAAAKwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAKwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAAAKwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAABKwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAAAKwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAVAAAAAAA
           version: 6
         1,0:
           ind: 1,0
@@ -204,57 +204,77 @@ entities:
           -1,1:
             0: 3839
           0,2:
-            0: 19
+            1: 223
           -1,2:
-            0: 36046
+            1: 8
           1,0:
             0: 65535
           1,1:
             0: 4095
+          1,2:
+            1: 255
           1,-1:
             0: 65535
           2,0:
             0: 65535
           2,1:
             0: 4095
+          2,2:
+            1: 303
           2,-1:
             0: 65535
           3,0:
-            0: 20753
+            0: 4369
+            1: 50244
           3,1:
-            0: 52701
-          2,2:
-            0: 8
+            0: 17
+            1: 25676
           3,2:
-            0: 255
+            1: 3
           3,-1:
-            0: 56656
-          4,1:
             0: 4368
+            1: 52288
+          4,1:
+            1: 16
           -2,0:
-            0: 34952
+            0: 34944
           -2,1:
             0: 8
-          -2,-1:
-            0: 34952
           -1,-1:
-            0: 26208
+            0: 30583
           0,-2:
-            0: 63472
+            0: 30704
           -1,-2:
-            0: 65262
+            0: 3822
           1,-2:
-            0: 63664
+            0: 4080
           2,-2:
-            0: 29440
+            0: 784
+            2: 2
           -2,-2:
-            1: 1228
+            2: 76
+            1: 128
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -470,11 +490,6 @@ entities:
     components:
     - type: Transform
       pos: 9.5,-7.5
-      parent: 1
-  - uid: 386
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
       parent: 1
   - uid: 387
     components:
@@ -703,17 +718,17 @@ entities:
       parent: 1
 - proto: Bed
   entities:
-  - uid: 59
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-- proto: BedsheetSpawner
-  entities:
   - uid: 5
     components:
     - type: Transform
-      pos: -3.5,-2.5
+      pos: -3.5,-3.5
+      parent: 1
+- proto: BedsheetSpawner
+  entities:
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
       parent: 1
 - proto: Bucket
   entities:
@@ -721,6 +736,11 @@ entities:
     components:
     - type: Transform
       pos: -0.09695351,1.2991186
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -1.2538269,-1.501241
       parent: 1
 - proto: CableApcExtension
   entities:
@@ -904,6 +924,11 @@ entities:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
 - proto: CableHV
   entities:
   - uid: 241
@@ -941,6 +966,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-2.5
       parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.3475769,-2.376241
+      parent: 1
 - proto: ClothingOuterGhostSheet
   entities:
   - uid: 355
@@ -950,10 +981,10 @@ entities:
       parent: 1
 - proto: CrateHydroponicsTools
   entities:
-  - uid: 379
+  - uid: 438
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: 4.5,-2.5
       parent: 1
 - proto: CrateStoneGrave
   entities:
@@ -1019,10 +1050,10 @@ entities:
       parent: 1
 - proto: CurtainsBlackOpen
   entities:
-  - uid: 384
+  - uid: 379
     components:
     - type: Transform
-      pos: -3.5,-2.5
+      pos: -3.5,-3.5
       parent: 1
 - proto: DrinkGlass
   entities:
@@ -1268,15 +1299,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,3.5
       parent: 1
-- proto: FloraTreeLarge02
+- proto: FloraTreeLarge
   entities:
   - uid: 63
     components:
     - type: Transform
       pos: 8.453526,4.462367
       parent: 1
-- proto: FloraTreeLarge06
-  entities:
   - uid: 329
     components:
     - type: Transform
@@ -1295,6 +1324,28 @@ entities:
     components:
     - type: Transform
       pos: 7.5,-0.5
+      parent: 1
+- proto: FoodPiePumpkinSlice
+  entities:
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 3.4611773,-1.4842099
+      parent: 1
+- proto: FoodPlateSmall
+  entities:
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 3.4924273,-1.4529599
+      parent: 1
+- proto: Fork
+  entities:
+  - uid: 449
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5236773,-1.2342099
       parent: 1
 - proto: GasFilter
   entities:
@@ -1421,12 +1472,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-5.5
-      parent: 1
-  - uid: 160
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-5.5
       parent: 1
   - uid: 270
     components:
@@ -1605,6 +1650,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 1
+- proto: GasPressurePump
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
 - proto: GasVentPump
   entities:
   - uid: 321
@@ -1639,6 +1692,11 @@ entities:
       parent: 1
 - proto: Grille
   entities:
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
   - uid: 61
     components:
     - type: Transform
@@ -1658,11 +1716,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-5.5
-      parent: 1
-  - uid: 105
-    components:
-    - type: Transform
-      pos: -4.5,-4.5
       parent: 1
   - uid: 106
     components:
@@ -2011,12 +2064,22 @@ entities:
     - type: Transform
       pos: 8.5,-6.5
       parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
 - proto: OxygenCanister
   entities:
   - uid: 292
     components:
     - type: Transform
       pos: 9.5,-5.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
       parent: 1
 - proto: PlushieDiona
   entities:
@@ -2034,10 +2097,42 @@ entities:
       parent: 1
 - proto: PortableGeneratorJrPacman
   entities:
-  - uid: 372
+  - uid: 432
     components:
     - type: Transform
-      pos: -3.5,-4.5
+      pos: -2.5,-5.5
+      parent: 1
+- proto: PosterContrabandAmbrosiaVulgaris
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+- proto: PosterLegitFruitBowl
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+- proto: PosterLegitSafetyMothPiping
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
       parent: 1
 - proto: PoweredLightPostSmall
   entities:
@@ -2067,12 +2162,6 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 6
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-2.5
-      parent: 1
   - uid: 146
     components:
     - type: Transform
@@ -2089,6 +2178,18 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
+      parent: 1
+- proto: PumpkinLantern
+  entities:
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 14.50279,4.5813475
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 2.5308466,8.574428
       parent: 1
 - proto: Rack
   entities:
@@ -2362,7 +2463,7 @@ entities:
   - uid: 227
     components:
     - type: Transform
-      pos: -4.5,-4.5
+      pos: -5.5,-5.5
       parent: 1
   - uid: 230
     components:
@@ -2409,17 +2510,26 @@ entities:
       parent: 1
 - proto: Sink
   entities:
-  - uid: 4
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
   - uid: 375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,1.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+- proto: SpaceHeater
+  entities:
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
       parent: 1
 - proto: StorageCanister
   entities:
@@ -2466,6 +2576,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
+- proto: TableWood
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 4.6613235,-5.1966977
+      parent: 1
 - proto: ToolboxMechanicalFilled
   entities:
   - uid: 97
@@ -2473,20 +2597,29 @@ entities:
     - type: Transform
       pos: 4.4992275,-5.446561
       parent: 1
-- proto: VendingMachineSeeds
+- proto: VendingMachineDinnerware
   entities:
-  - uid: 326
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: VendingMachineNutri
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: VendingMachineSeedsUnlocked
+  entities:
+  - uid: 372
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
 - proto: WallCobblebrick
   entities:
-  - uid: 3
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 1
   - uid: 8
     components:
     - type: Transform
@@ -2497,11 +2630,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 1
-  - uid: 13
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
       parent: 1
   - uid: 56
     components:
@@ -2534,10 +2662,30 @@ entities:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
   - uid: 286
     components:
     - type: Transform
       pos: -0.5,-2.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 1
 - proto: WallReinforced
   entities:
@@ -2636,6 +2784,13 @@ entities:
     - type: Transform
       pos: 10.5,-4.5
       parent: 1
+- proto: WeldingFuelTankFull
+  entities:
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
 - proto: Window
   entities:
   - uid: 10
@@ -2660,11 +2815,14 @@ entities:
       parent: 1
 - proto: WoodDoor
   entities:
-  - uid: 55
+  - uid: 384
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: -1.5,-4.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        bucket: !type:ContainerSlot {}
 - proto: Wrench
   entities:
   - uid: 94


### PR DESCRIPTION
Fixes up and tweaks a few of our custom derelicts. Notably the sauna was using liquid oxygen and nitrogen cans! Which probably made things really cold! Also added a bit of extra oxygen and nitrogen to the affected derelicts in case of spacing.
- Sauna: added space heaters and regular oxygen/nitrogen cans
- Garden bubble: added Plasteel Chef and NutriMax vendors, one each oxygen/nitrogen can, a space heater, and a couple posters
- Shuttle bay: added several air cans for adding basic atmos to shuttles, and a few posters
- Keyhole Court: added one each oxygen/nitrogen can

**Changelog**
:cl:
- tweak: Several changes to a few derelicts.