### PR TITLE
Give visitors proper accesses (and other relevant tweaks)

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
@@ -130,6 +130,7 @@ entities:
     - type: MovedGrids
     - type: Broadphase
     - type: OccluderTree
+    - type: LoadedMap
 - proto: AirlockShuttle
   entities:
   - uid: 2
@@ -248,12 +249,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 8
+          - 9
+          - 7
           - 6
           - 37
-          - 36
-          - 7
-          - 9
-          - 8
 - proto: ClothingOuterSuitEmergency
   entities:
   - uid: 7
@@ -291,13 +291,6 @@ entities:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-- proto: Gyroscope
-  entities:
-  - uid: 32
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
 - proto: HandheldGPSBasic
   entities:
   - uid: 8
@@ -307,15 +300,13 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: JawsOfLife
+- proto: MiniGyroscope
   entities:
-  - uid: 36
+  - uid: 30
     components:
     - type: Transform
-      parent: 5
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: -0.5,-2.5
+      parent: 1
 - proto: NTVisitorSpawner
   entities:
   - uid: 20
@@ -359,6 +350,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
 - proto: WallShuttle
   entities:
   - uid: 26
@@ -386,12 +382,7 @@ entities:
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 30
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 31
+  - uid: 32
     components:
     - type: Transform
       rot: -1.5707963267948966 rad

--- a/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
@@ -15,7 +15,7 @@ entities:
     - type: MetaData
       name: Evacuation pod
     - type: Transform
-      parent: invalid
+      parent: 35
     - type: MapGrid
       chunks:
         0,0:
@@ -59,20 +59,36 @@ entities:
       data:
         tiles:
           0,-1:
-            0: 4368
-            1: 32
+            0: 4112
+            1: 256
+            2: 32
           0,0:
-            1: 2
+            2: 2
           -1,0:
-            1: 8
+            2: 8
           -1,-1:
-            1: 128
+            2: 128
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.813705
+          - 82.06108
           - 0
           - 0
           - 0
@@ -102,6 +118,18 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: NavMap
+  - uid: 35
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
 - proto: AirlockShuttle
   entities:
   - uid: 2
@@ -202,8 +230,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
+        - 1.8968438
+        - 7.1357465
         - 0
         - 0
         - 0
@@ -220,13 +248,22 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 7
           - 6
-          - 8
+          - 37
+          - 36
+          - 7
           - 9
+          - 8
 - proto: ClothingOuterSuitEmergency
   entities:
   - uid: 7
+    components:
+    - type: Transform
+      parent: 5
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 37
     components:
     - type: Transform
       parent: 5
@@ -264,6 +301,15 @@ entities:
 - proto: HandheldGPSBasic
   entities:
   - uid: 8
+    components:
+    - type: Transform
+      parent: 5
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: JawsOfLife
+  entities:
+  - uid: 36
     components:
     - type: Transform
       parent: 5

--- a/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
@@ -130,7 +130,6 @@ entities:
     - type: MovedGrids
     - type: Broadphase
     - type: OccluderTree
-    - type: LoadedMap
 - proto: AirlockShuttle
   entities:
   - uid: 2
@@ -249,11 +248,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 8
           - 9
+          - 8
           - 7
+          - 36
           - 6
-          - 37
 - proto: ClothingOuterSuitEmergency
   entities:
   - uid: 7
@@ -263,7 +262,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 37
+  - uid: 36
     components:
     - type: Transform
       parent: 5
@@ -291,6 +290,13 @@ entities:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
 - proto: HandheldGPSBasic
   entities:
   - uid: 8
@@ -300,13 +306,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: MiniGyroscope
-  entities:
-  - uid: 30
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
 - proto: NTVisitorSpawner
   entities:
   - uid: 20
@@ -350,11 +349,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
-  - uid: 31
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
 - proto: WallShuttle
   entities:
   - uid: 26
@@ -382,7 +376,12 @@ entities:
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 32
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 31
     components:
     - type: Transform
       rot: -1.5707963267948966 rad

--- a/Resources/Maps/_Impstation/Shuttles/ShuttleEvent/disaster_evacpod.yml
+++ b/Resources/Maps/_Impstation/Shuttles/ShuttleEvent/disaster_evacpod.yml
@@ -15,7 +15,7 @@ entities:
     - type: MetaData
       name: Evacuation pod
     - type: Transform
-      parent: invalid
+      parent: 35
     - type: MapGrid
       chunks:
         0,0:
@@ -59,20 +59,36 @@ entities:
       data:
         tiles:
           0,-1:
-            0: 4368
-            1: 32
+            0: 4112
+            1: 256
+            2: 32
           0,0:
-            1: 2
+            2: 2
           -1,0:
-            1: 8
+            2: 8
           -1,-1:
-            1: 128
+            2: 128
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.813705
+          - 82.06108
           - 0
           - 0
           - 0
@@ -102,6 +118,18 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: NavMap
+  - uid: 35
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
 - proto: AirlockShuttle
   entities:
   - uid: 2
@@ -202,8 +230,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
+        - 1.8968438
+        - 7.1357465
         - 0
         - 0
         - 0
@@ -220,13 +248,21 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 7
-          - 6
-          - 8
           - 9
+          - 8
+          - 7
+          - 36
+          - 6
 - proto: ClothingOuterSuitEmergency
   entities:
   - uid: 7
+    components:
+    - type: Transform
+      parent: 5
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 36
     components:
     - type: Transform
       parent: 5

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -23,8 +23,28 @@
     - type: GhostRole
       name: job-name-captain
       description: ghost-role-information-command-description
+      playTimeTracker: JobCaptain # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Engineering
+          time: 54000 # 15 hours
+        - !type:DepartmentTimeRequirement
+          department: Medical
+          time: 54000 # 15 hours
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 54000 # 15 hours
+        - !type:DepartmentTimeRequirement #imp
+          department: Cargo
+          time: 54000 # 15 hours
+        - !type:DepartmentTimeRequirement #imp
+          department: Science
+          time: 54000 # 15 hours
+        - !type:DepartmentTimeRequirement
+          department: Command
+          time: 72000 # 20 hours, imp
     - type: Loadout
-      prototypes: [ VisitorCaptain, VisitorCaptainAlt ]
+      prototypes: [ VisitorCaptain, VisitorCaptainAlt, VisitorCaptainAltA, VisitorCaptainAltB ] # imp
       roleLoadout: [ RoleSurvivalStandard ]
 
 - type: randomHumanoidSettings
@@ -34,6 +54,19 @@
     - type: GhostRole
       name: job-name-ce
       description: ghost-role-information-command-description
+      playTimeTracker: JobChiefEngineer # imp
+      requirements: # imp
+        - !type:RoleTimeRequirement
+          role: JobAtmosphericTechnician
+          time: 21600 #6 hrs
+        - !type:RoleTimeRequirement
+          role: JobStationEngineer
+          time: 21600 #6 hrs
+        - !type:DepartmentTimeRequirement
+          department: Engineering
+          time: 72000 #20 hrs, imp
+        - !type:OverallPlaytimeRequirement
+          time: 144000 #40 hrs
     - type: Loadout
       prototypes: [ VisitorCE, VisitorCEAlt ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -45,8 +78,21 @@
     - type: GhostRole
       name: job-name-cmo
       description: ghost-role-information-command-description
+      playTimeTracker: JobChiefMedicalOfficer # imp
+      requirements: # imp
+        - !type:RoleTimeRequirement
+          role: JobChemist
+          time: 21600 #6 hrs, imp. why tf was this so low?
+        - !type:RoleTimeRequirement
+          role: JobMedicalDoctor
+          time: 21600 #6 hrs
+        - !type:DepartmentTimeRequirement
+          department: Medical
+          time: 72000 #20 hrs, imp
+        - !type:OverallPlaytimeRequirement
+          time: 144000 #40 hrs
     - type: Loadout
-      prototypes: [ VisitorCMO, VisitorCMOAlt ]
+      prototypes: [ VisitorCMO, VisitorCMOAlt, VisitorCMOAltA ] # imp
       roleLoadout: [ RoleSurvivalMedical ]
 
 - type: randomHumanoidSettings
@@ -56,6 +102,26 @@
     - type: GhostRole
       name: job-name-hop
       description: ghost-role-information-command-description
+      playTimeTracker: JobHeadOfPersonnel # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Engineering
+          time: 36000 # 10 hours
+        - !type:DepartmentTimeRequirement
+          department: Medical
+          time: 36000 # 10 hours
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 36000 # 10 hrs
+        - !type:DepartmentTimeRequirement #imp
+          department: Cargo
+          time: 36000 # 10 hrs
+        - !type:DepartmentTimeRequirement #imp
+          department: Science
+          time: 36000 # 10 hrs
+        - !type:DepartmentTimeRequirement
+          department: Command
+          time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ VisitorHOP, VisitorHOPAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -67,8 +133,21 @@
     - type: GhostRole
       name: job-name-hos
       description: ghost-role-information-command-description
+      playTimeTracker: JobHeadOfSecurity # imp
+      requirements: # imp
+        - !type:RoleTimeRequirement
+          role: JobWarden
+          time: 10800 #3 hrs
+        - !type:RoleTimeRequirement
+          role: JobSecurityOfficer
+          time: 36000 #10 hrs
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 324000 # 90 hrs
+        - !type:OverallPlaytimeRequirement
+          time: 144000 #40 hrs
     - type: Loadout
-      prototypes: [ VisitorHOS, VisitorHOSAlt ]
+      prototypes: [ VisitorHOS, VisitorHOSAlt, VisitorHOSAltA, VisitorHOSAltB ] # imp
       roleLoadout: [ RoleSurvivalSecurity ]
 
 - type: randomHumanoidSettings
@@ -78,6 +157,13 @@
     - type: GhostRole
       name: job-name-rd
       description: ghost-role-information-command-description
+      playTimeTracker: JobResearchDirector # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Science
+          time: 72000 #20 hrs, imp
+        - !type:OverallPlaytimeRequirement
+          time: 144000 #40 hrs
     - type: Loadout
       prototypes: [ VisitorRD, VisitorRDAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -89,6 +175,19 @@
     - type: GhostRole
       name: job-name-qm
       description: ghost-role-information-command-description
+      playTimeTracker: JobQuartermaster # imp
+      requirements: # imp
+        - !type:RoleTimeRequirement
+          role: JobCargoTechnician
+          time: 21600 #6 hrs
+        - !type:RoleTimeRequirement
+          role: JobSalvageSpecialist
+          time: 10800 #3 hrs (too popular)
+        - !type:DepartmentTimeRequirement
+          department: Cargo
+          time: 72000 #20 hours, imp
+        - !type:OverallPlaytimeRequirement
+          time: 144000 #40 hrs
     - type: Loadout
       prototypes: [ VisitorQM, VisitorQMAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -113,6 +212,10 @@
   components:
     - type: GhostRole
       name: job-name-cadet
+      playTimeTracker: JobSecurityCadet # imp
+      requirements: # imp
+        - !type:OverallPlaytimeRequirement
+          time: 36000 #10 hrs
     - type: Loadout
       prototypes: [ VisitorSecurityCadet, VisitorSecurityCadetAlt ]
       roleLoadout: [ RoleSurvivalSecurity ]
@@ -123,8 +226,12 @@
   components:
     - type: GhostRole
       name: job-name-security
+      playTimeTracker: JobSecurityOfficer # imp
+      requirements: # imp
+        - !type:OverallPlaytimeRequirement
+          time: 36000 #10 hrs
     - type: Loadout
-      prototypes: [ VisitorSecurityOfficer, VisitorSecurityOfficerAlt ]
+      prototypes: [ VisitorSecurityOfficer, VisitorSecurityOfficerAlt, VisitorSecurityOfficerAltA ] # imp
       roleLoadout: [ RoleSurvivalSecurity ]
 
 - type: randomHumanoidSettings
@@ -133,8 +240,13 @@
   components:
     - type: GhostRole
       name: job-name-detective
+      playTimeTracker: JobDetective # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 54000 # 15 hours
     - type: Loadout
-      prototypes: [ VisitorDetective, VisitorDetectiveAlt ]
+      prototypes: [ VisitorDetective, VisitorDetectiveAlt, VisitorDetectiveAltA, VisitorDetectiveAltB ] # imp
       roleLoadout: [ RoleSurvivalSecurity ]
 
 - type: randomHumanoidSettings
@@ -143,6 +255,11 @@
   components:
     - type: GhostRole
       name: job-name-warden
+      playTimeTracker: JobWarden # imp
+      requirements: # imp
+        - !type:RoleTimeRequirement
+          role: JobSecurityOfficer
+          time: 36000 #10 hrs
     - type: Loadout
       prototypes: [ VisitorWarden, VisitorWardenAlt ]
       roleLoadout: [ RoleSurvivalSecurity ]
@@ -166,6 +283,7 @@
   components:
     - type: GhostRole
       name: job-name-cargotech
+      playTimeTracker: JobCargoTechnician # imp
     - type: Loadout
       prototypes: [ VisitorCargoTech, VisitorCargoTechAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -176,6 +294,13 @@
   components:
     - type: GhostRole
       name: job-name-salvagespec
+      playTimeTracker: JobSalvageSpecialist # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Cargo
+          time: 10800 # 3 hrs
+        - !type:OverallPlaytimeRequirement
+          time: 36000 #10 hrs
     - type: Loadout
       prototypes: [ VisitorSalvageSpecialist, VisitorSalvageSpecialistAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -199,6 +324,11 @@
   components:
     - type: GhostRole
       name: job-name-atmostech
+      playTimeTracker: JobAtmosphericTechnician # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Engineering
+          time: 54000 # 15 hrs
     - type: Loadout
       prototypes: [ VisitorAtmosTech, VisitorAtmosTechAlt ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -209,6 +339,10 @@
   components:
     - type: GhostRole
       name: job-name-technical-assistant
+      playTimeTracker: JobTechnicalAssistant # imp
+      requirements: # imp
+        - !type:OverallPlaytimeRequirement
+          time: 3600 #1 hr
     - type: Loadout
       prototypes: [ VisitorTechnicalAssistant, VisitorTechnicalAssistantAlt ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -219,6 +353,10 @@
   components:
     - type: GhostRole
       name: job-name-engineer
+      playTimeTracker: JobStationEngineer # imp
+      requirements: # imp
+        - !type:OverallPlaytimeRequirement
+          time: 3600 #1 hr
     - type: Loadout
       prototypes: [ VisitorEngineer, VisitorEngineerAlt ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -242,6 +380,7 @@
   components:
     - type: GhostRole
       name: job-name-intern
+      playTimeTracker: JobMedicalIntern # imp
     - type: Loadout
       prototypes: [ VisitorMedicalIntern, VisitorMedicalInternAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -252,6 +391,7 @@
   components:
     - type: GhostRole
       name: job-name-doctor
+      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorMedicalDoctor, VisitorMedicalDoctorAlt , VisitorScrubsPurple, VisitorScrubsGreen, VisitorScrubsBlue]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -262,6 +402,13 @@
   components:
     - type: GhostRole
       name: job-name-paramedic
+      playTimeTracker: JobParamedic # imp
+      requirements: # imp
+        - !type:RoleTimeRequirement
+          role: JobMedicalDoctor
+          time: 14400 #4 hrs
+        - !type:OverallPlaytimeRequirement
+          time: 54000 # 15 hrs
     - type: Loadout
       prototypes: [ VisitorParamedic, VisitorParamedicAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -272,6 +419,7 @@
   components:
     - type: GhostRole
       name: ghost-role-information-medical-virologist-name
+      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorVirologist, VisitorVirologistAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -282,6 +430,7 @@
   components:
     - type: GhostRole
       name: ghost-role-information-medical-geneticist-name
+      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorGeneticist, VisitorGeneticistAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -292,6 +441,7 @@
   components:
     - type: GhostRole
       name: job-name-psychologist
+      playTimeTracker: JobPsychologist # imp
     - type: Loadout
       prototypes: [ VisitorPsychologist, VisitorPsychologistAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -302,8 +452,13 @@
   components:
     - type: GhostRole
       name: job-name-chemist
+      playTimeTracker: JobChemist # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Medical
+          time: 14400 #4 hrs
     - type: Loadout
-      prototypes: [ VisitorChemist, VisitorChemistAlt ]
+      prototypes: [ VisitorChemist, VisitorChemistAlt, VisitorChemistAltA ] # imp
       roleLoadout: [ RoleSurvivalMedical ]
 
 - type: randomHumanoidSettings
@@ -312,6 +467,7 @@
   components:
     - type: GhostRole
       name: ghost-role-information-medical-dentist-name
+      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorDentist ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -335,6 +491,7 @@
   components:
     - type: GhostRole
       name: job-name-research-assistant
+      playTimeTracker: JobResearchAssistant # imp
     - type: Loadout
       prototypes: [ VisitorResearchAssistant, VisitorResearchAssistantAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -345,6 +502,7 @@
   components:
     - type: GhostRole
       name: job-name-scientist
+      playTimeTracker: JobScientist # imp
     - type: Loadout
       prototypes: [ VisitorScientist, VisitorScientistAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -368,8 +526,13 @@
   components:
     - type: GhostRole
       name: job-name-bartender
+      playTimeTracker: JobBartender # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Civilian
+          time: 1800
     - type: Loadout
-      prototypes: [ VisitorBartender, VisitorBartenderAlt ]
+      prototypes: [ VisitorBartender, VisitorBartenderAlt, VisitorBartenderAltA, VisitorBartenderAltB ] # imp
       roleLoadout: [ RoleSurvivalStandard ]
 
 - type: randomHumanoidSettings
@@ -378,6 +541,7 @@
   components:
     - type: GhostRole
       name: job-name-botanist
+      playTimeTracker: JobBotanist # imp
     - type: Loadout
       prototypes: [ VisitorBotanist, VisitorBotanistAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -388,6 +552,7 @@
   components:
     - type: GhostRole
       name: job-name-boxer
+      playTimeTracker: JobBoxer # imp
     - type: Loadout
       prototypes: [ VisitorBoxer, VisitorBoxerAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -399,6 +564,7 @@
     - type: BibleUser
     - type: GhostRole
       name: job-name-chaplain
+      playTimeTracker: JobChaplain # imp
     - type: Loadout
       prototypes: [ VisitorChaplain, VisitorChaplainAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -409,6 +575,11 @@
   components:
     - type: GhostRole
       name: job-name-chef
+      playTimeTracker: JobChef # imp
+      requirements: # imp
+        - !type:DepartmentTimeRequirement
+          department: Civilian
+          time: 1800
     - type: Loadout
       prototypes: [ VisitorChef, VisitorChefAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -420,8 +591,9 @@
   components:
     - type: GhostRole
       name: job-name-clown
+      playTimeTracker: JobClown # imp
     - type: Loadout
-      prototypes: [ VisitorClown ]
+      prototypes: [ VisitorClown, VisitorClownAltA, VisitorClownAltB ] # imp
       roleLoadout: [ RoleSurvivalClown ]
     - type: RandomMetadata
       nameSegments:
@@ -433,6 +605,7 @@
   components:
     - type: GhostRole
       name: job-name-janitor
+      playTimeTracker: JobJanitor # imp
     - type: Loadout
       prototypes: [ VisitorJanitor, VisitorJanitorAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -443,6 +616,10 @@
   components:
     - type: GhostRole
       name: job-name-lawyer
+      playTimeTracker: JobLawyer # imp
+      requirements: # imp
+        - !type:OverallPlaytimeRequirement
+          time: 36000 # 10 hrs
     - type: Loadout
       prototypes: [ VisitorLawyerAltA, VisitorLawyerAltB, VisitorLawyerAltC, VisitorLawyerAltD, VisitorLawyerAltE ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -464,6 +641,7 @@
   components:
     - type: GhostRole
       name: job-name-librarian
+      playTimeTracker: JobLibrarian # imp
     - type: Loadout
       prototypes: [ VisitorLibrarian, VisitorLibrarianAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -474,6 +652,7 @@
   components:
     - type: GhostRole
       name: job-name-musician
+      playTimeTracker: JobMusician # imp
     - type: Loadout
       prototypes: [ VisitorMusicianFancyAltA, VisitorMusicianFancyAltB, VisitorMusicianFancyAltC, VisitorMusicianFancyAltD, VisitorMusicianFancyAltE, VisitorMusicianFancyAltF, VisitorMusicianFancyAltG, VisitorMusicianFancyAltH, VisitorMusicianFancyAltI, VisitorMusicianRelaxedAltA, VisitorMusicianRelaxedAltB, VisitorMusicianRelaxedAltC, VisitorMusicianRelaxedAltD, VisitorMusicianRelaxedAltE, VisitorMusicianRelaxedAltF, VisitorMusicianMariachi ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -484,6 +663,7 @@
   components:
     - type: GhostRole
       name: job-name-musician
+      playTimeTracker: JobMusician # imp
     - type: Loadout
       prototypes: [ VisitorMusicianFancyAltA, VisitorMusicianFancyAltB, VisitorMusicianFancyAltC, VisitorMusicianFancyAltD, VisitorMusicianFancyAltE, VisitorMusicianFancyAltF, VisitorMusicianFancyAltG, VisitorMusicianFancyAltH, VisitorMusicianFancyAltI ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -494,6 +674,7 @@
   components:
     - type: GhostRole
       name: job-name-musician
+      playTimeTracker: JobMusician # imp
     - type: Loadout
       prototypes: [ VisitorMusicianRelaxedAltA, VisitorMusicianRelaxedAltB, VisitorMusicianRelaxedAltC, VisitorMusicianRelaxedAltD, VisitorMusicianRelaxedAltE, VisitorMusicianRelaxedAltF, VisitorMusicianMariachi ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -505,6 +686,10 @@
     - type: MimePowers
     - type: GhostRole
       name: job-name-mime
+      playTimeTracker: JobMime # imp
+      requirements: # imp
+        - !type:OverallPlaytimeRequirement
+          time: 14400 #4 hrs
     - type: Loadout
       prototypes: [ VisitorMime, VisitorMimeAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -515,8 +700,9 @@
   components:
     - type: GhostRole
       name: job-name-reporter
+      playTimeTracker: JobReporter # imp
     - type: Loadout
-      prototypes: [ VisitorReporter, VisitorReporterAlt ]
+      prototypes: [ VisitorReporter, VisitorReporterAlt, VisitorReporterAltA ]
       roleLoadout: [ RoleSurvivalStandard ]
 
 - type: randomHumanoidSettings
@@ -525,6 +711,7 @@
   components:
     - type: GhostRole
       name: job-name-serviceworker
+      playTimeTracker: JobServiceWorker # imp
     - type: Loadout
       prototypes: [ VisitorServiceWorker, VisitorServiceWorkerAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -535,6 +722,7 @@
   components:
     - type: GhostRole
       name: job-name-zookeeper
+      playTimeTracker: JobZookeeper # imp
     - type: Loadout
       prototypes: [ VisitorZookeeper, VisitorZookeeperAlt ]
       roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -23,7 +23,6 @@
     - type: GhostRole
       name: job-name-captain
       description: ghost-role-information-command-description
-      playTimeTracker: JobCaptain # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Engineering
@@ -54,7 +53,6 @@
     - type: GhostRole
       name: job-name-ce
       description: ghost-role-information-command-description
-      playTimeTracker: JobChiefEngineer # imp
       requirements: # imp
         - !type:RoleTimeRequirement
           role: JobAtmosphericTechnician
@@ -78,7 +76,6 @@
     - type: GhostRole
       name: job-name-cmo
       description: ghost-role-information-command-description
-      playTimeTracker: JobChiefMedicalOfficer # imp
       requirements: # imp
         - !type:RoleTimeRequirement
           role: JobChemist
@@ -102,7 +99,6 @@
     - type: GhostRole
       name: job-name-hop
       description: ghost-role-information-command-description
-      playTimeTracker: JobHeadOfPersonnel # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Engineering
@@ -133,7 +129,6 @@
     - type: GhostRole
       name: job-name-hos
       description: ghost-role-information-command-description
-      playTimeTracker: JobHeadOfSecurity # imp
       requirements: # imp
         - !type:RoleTimeRequirement
           role: JobWarden
@@ -157,7 +152,6 @@
     - type: GhostRole
       name: job-name-rd
       description: ghost-role-information-command-description
-      playTimeTracker: JobResearchDirector # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Science
@@ -175,7 +169,6 @@
     - type: GhostRole
       name: job-name-qm
       description: ghost-role-information-command-description
-      playTimeTracker: JobQuartermaster # imp
       requirements: # imp
         - !type:RoleTimeRequirement
           role: JobCargoTechnician
@@ -212,7 +205,6 @@
   components:
     - type: GhostRole
       name: job-name-cadet
-      playTimeTracker: JobSecurityCadet # imp
       requirements: # imp
         - !type:OverallPlaytimeRequirement
           time: 36000 #10 hrs
@@ -226,7 +218,6 @@
   components:
     - type: GhostRole
       name: job-name-security
-      playTimeTracker: JobSecurityOfficer # imp
       requirements: # imp
         - !type:OverallPlaytimeRequirement
           time: 36000 #10 hrs
@@ -240,7 +231,6 @@
   components:
     - type: GhostRole
       name: job-name-detective
-      playTimeTracker: JobDetective # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Security
@@ -255,7 +245,6 @@
   components:
     - type: GhostRole
       name: job-name-warden
-      playTimeTracker: JobWarden # imp
       requirements: # imp
         - !type:RoleTimeRequirement
           role: JobSecurityOfficer
@@ -283,7 +272,6 @@
   components:
     - type: GhostRole
       name: job-name-cargotech
-      playTimeTracker: JobCargoTechnician # imp
     - type: Loadout
       prototypes: [ VisitorCargoTech, VisitorCargoTechAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -294,7 +282,6 @@
   components:
     - type: GhostRole
       name: job-name-salvagespec
-      playTimeTracker: JobSalvageSpecialist # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Cargo
@@ -324,7 +311,6 @@
   components:
     - type: GhostRole
       name: job-name-atmostech
-      playTimeTracker: JobAtmosphericTechnician # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Engineering
@@ -339,7 +325,6 @@
   components:
     - type: GhostRole
       name: job-name-technical-assistant
-      playTimeTracker: JobTechnicalAssistant # imp
       requirements: # imp
         - !type:OverallPlaytimeRequirement
           time: 3600 #1 hr
@@ -353,7 +338,6 @@
   components:
     - type: GhostRole
       name: job-name-engineer
-      playTimeTracker: JobStationEngineer # imp
       requirements: # imp
         - !type:OverallPlaytimeRequirement
           time: 3600 #1 hr
@@ -380,7 +364,6 @@
   components:
     - type: GhostRole
       name: job-name-intern
-      playTimeTracker: JobMedicalIntern # imp
     - type: Loadout
       prototypes: [ VisitorMedicalIntern, VisitorMedicalInternAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -391,7 +374,6 @@
   components:
     - type: GhostRole
       name: job-name-doctor
-      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorMedicalDoctor, VisitorMedicalDoctorAlt , VisitorScrubsPurple, VisitorScrubsGreen, VisitorScrubsBlue]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -402,7 +384,6 @@
   components:
     - type: GhostRole
       name: job-name-paramedic
-      playTimeTracker: JobParamedic # imp
       requirements: # imp
         - !type:RoleTimeRequirement
           role: JobMedicalDoctor
@@ -419,7 +400,6 @@
   components:
     - type: GhostRole
       name: ghost-role-information-medical-virologist-name
-      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorVirologist, VisitorVirologistAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -430,7 +410,6 @@
   components:
     - type: GhostRole
       name: ghost-role-information-medical-geneticist-name
-      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorGeneticist, VisitorGeneticistAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -441,7 +420,6 @@
   components:
     - type: GhostRole
       name: job-name-psychologist
-      playTimeTracker: JobPsychologist # imp
     - type: Loadout
       prototypes: [ VisitorPsychologist, VisitorPsychologistAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -452,7 +430,6 @@
   components:
     - type: GhostRole
       name: job-name-chemist
-      playTimeTracker: JobChemist # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Medical
@@ -467,7 +444,6 @@
   components:
     - type: GhostRole
       name: ghost-role-information-medical-dentist-name
-      playTimeTracker: JobMedicalDoctor # imp
     - type: Loadout
       prototypes: [ VisitorDentist ]
       roleLoadout: [ RoleSurvivalMedical ]
@@ -491,7 +467,6 @@
   components:
     - type: GhostRole
       name: job-name-research-assistant
-      playTimeTracker: JobResearchAssistant # imp
     - type: Loadout
       prototypes: [ VisitorResearchAssistant, VisitorResearchAssistantAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -502,7 +477,6 @@
   components:
     - type: GhostRole
       name: job-name-scientist
-      playTimeTracker: JobScientist # imp
     - type: Loadout
       prototypes: [ VisitorScientist, VisitorScientistAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -526,7 +500,6 @@
   components:
     - type: GhostRole
       name: job-name-bartender
-      playTimeTracker: JobBartender # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Civilian
@@ -541,7 +514,6 @@
   components:
     - type: GhostRole
       name: job-name-botanist
-      playTimeTracker: JobBotanist # imp
     - type: Loadout
       prototypes: [ VisitorBotanist, VisitorBotanistAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -552,7 +524,6 @@
   components:
     - type: GhostRole
       name: job-name-boxer
-      playTimeTracker: JobBoxer # imp
     - type: Loadout
       prototypes: [ VisitorBoxer, VisitorBoxerAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -564,7 +535,6 @@
     - type: BibleUser
     - type: GhostRole
       name: job-name-chaplain
-      playTimeTracker: JobChaplain # imp
     - type: Loadout
       prototypes: [ VisitorChaplain, VisitorChaplainAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -575,7 +545,6 @@
   components:
     - type: GhostRole
       name: job-name-chef
-      playTimeTracker: JobChef # imp
       requirements: # imp
         - !type:DepartmentTimeRequirement
           department: Civilian
@@ -591,7 +560,6 @@
   components:
     - type: GhostRole
       name: job-name-clown
-      playTimeTracker: JobClown # imp
     - type: Loadout
       prototypes: [ VisitorClown, VisitorClownAltA, VisitorClownAltB ] # imp
       roleLoadout: [ RoleSurvivalClown ]
@@ -605,7 +573,6 @@
   components:
     - type: GhostRole
       name: job-name-janitor
-      playTimeTracker: JobJanitor # imp
     - type: Loadout
       prototypes: [ VisitorJanitor, VisitorJanitorAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -616,7 +583,6 @@
   components:
     - type: GhostRole
       name: job-name-lawyer
-      playTimeTracker: JobLawyer # imp
       requirements: # imp
         - !type:OverallPlaytimeRequirement
           time: 36000 # 10 hrs
@@ -641,7 +607,6 @@
   components:
     - type: GhostRole
       name: job-name-librarian
-      playTimeTracker: JobLibrarian # imp
     - type: Loadout
       prototypes: [ VisitorLibrarian, VisitorLibrarianAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -652,7 +617,6 @@
   components:
     - type: GhostRole
       name: job-name-musician
-      playTimeTracker: JobMusician # imp
     - type: Loadout
       prototypes: [ VisitorMusicianFancyAltA, VisitorMusicianFancyAltB, VisitorMusicianFancyAltC, VisitorMusicianFancyAltD, VisitorMusicianFancyAltE, VisitorMusicianFancyAltF, VisitorMusicianFancyAltG, VisitorMusicianFancyAltH, VisitorMusicianFancyAltI, VisitorMusicianRelaxedAltA, VisitorMusicianRelaxedAltB, VisitorMusicianRelaxedAltC, VisitorMusicianRelaxedAltD, VisitorMusicianRelaxedAltE, VisitorMusicianRelaxedAltF, VisitorMusicianMariachi ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -663,7 +627,6 @@
   components:
     - type: GhostRole
       name: job-name-musician
-      playTimeTracker: JobMusician # imp
     - type: Loadout
       prototypes: [ VisitorMusicianFancyAltA, VisitorMusicianFancyAltB, VisitorMusicianFancyAltC, VisitorMusicianFancyAltD, VisitorMusicianFancyAltE, VisitorMusicianFancyAltF, VisitorMusicianFancyAltG, VisitorMusicianFancyAltH, VisitorMusicianFancyAltI ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -674,7 +637,6 @@
   components:
     - type: GhostRole
       name: job-name-musician
-      playTimeTracker: JobMusician # imp
     - type: Loadout
       prototypes: [ VisitorMusicianRelaxedAltA, VisitorMusicianRelaxedAltB, VisitorMusicianRelaxedAltC, VisitorMusicianRelaxedAltD, VisitorMusicianRelaxedAltE, VisitorMusicianRelaxedAltF, VisitorMusicianMariachi ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -686,7 +648,6 @@
     - type: MimePowers
     - type: GhostRole
       name: job-name-mime
-      playTimeTracker: JobMime # imp
       requirements: # imp
         - !type:OverallPlaytimeRequirement
           time: 14400 #4 hrs
@@ -700,7 +661,6 @@
   components:
     - type: GhostRole
       name: job-name-reporter
-      playTimeTracker: JobReporter # imp
     - type: Loadout
       prototypes: [ VisitorReporter, VisitorReporterAlt, VisitorReporterAltA ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -711,7 +671,6 @@
   components:
     - type: GhostRole
       name: job-name-serviceworker
-      playTimeTracker: JobServiceWorker # imp
     - type: Loadout
       prototypes: [ VisitorServiceWorker, VisitorServiceWorkerAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -722,7 +681,6 @@
   components:
     - type: GhostRole
       name: job-name-zookeeper
-      playTimeTracker: JobZookeeper # imp
     - type: Loadout
       prototypes: [ VisitorZookeeper, VisitorZookeeperAlt ]
       roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/spawners.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/spawners.yml
@@ -139,6 +139,7 @@
     - RandomHumanoidVisitorSecurityOfficer
     - RandomHumanoidVisitorSecurityCadet
     - RandomHumanoidVisitorDetective
+    - RandomHumanoidVisitorBrigmedic # imp
     rarePrototypes:
     - RandomHumanoidVisitorWarden
     - RandomHumanoidVisitorHOS
@@ -216,6 +217,7 @@
     prototypes:
     - RandomHumanoidVisitorCargoTechnician
     - RandomHumanoidVisitorSalvageSpecialist
+    - RandomHumanoidVisitorCourier # imp
     rarePrototypes:
     - RandomHumanoidVisitorQM
     rareChance: 0.05
@@ -465,6 +467,7 @@
     prototypes:
     - RandomHumanoidVisitorResearchAssistant
     - RandomHumanoidVisitorScientist
+    - RandomHumanoidVisitorRoboticist # imp
     rarePrototypes:
     - RandomHumanoidVisitorRD
     rareChance: 0.05
@@ -848,9 +851,11 @@
     - RandomHumanoidVisitorSecurityCadet
     - RandomHumanoidVisitorSecurityOfficer
     - RandomHumanoidVisitorDetective
+    - RandomHumanoidVisitorBrigmedic # imp
     - RandomHumanoidVisitorWarden
     - RandomHumanoidVisitorCargoTechnician
     - RandomHumanoidVisitorSalvageSpecialist
+    - RandomHumanoidVisitorCourier # imp
     - RandomHumanoidVisitorAtmosTech
     - RandomHumanoidVisitorTechnicalAssistant
     - RandomHumanoidVisitorEngineer
@@ -864,6 +869,7 @@
     - RandomHumanoidVisitorDentist
     - RandomHumanoidVisitorResearchAssistant
     - RandomHumanoidVisitorScientist
+    - RandomHumanoidVisitorRoboticist # imp
     - RandomHumanoidVisitorBartender
     - RandomHumanoidVisitorBotanist
     - RandomHumanoidVisitorBoxer

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -11,7 +11,7 @@
     gloves: ClothingHandsGlovesCaptain
     head: ClothingHeadHatCaptain
     neck: ClothingNeckCloakCap
-    id: VisitorPDA
+    id: CaptainPDA # imp
     belt: WeaponDisabler
     back: ClothingBackpackCaptain
     ears: ClothingHeadsetAltCommand
@@ -22,12 +22,12 @@
   id: VisitorCaptainAlt
   equipment:
     jumpsuit: ClothingUniformJumpsuitCapFormal
-    shoes: ClothingShoesBootsLaceup
+    shoes: ClothingShoesLeather # imp
     eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesCaptain
     head: ClothingHeadHatCapcap
     neck: ClothingNeckMantleCap
-    id: VisitorPDA
+    id: CaptainPDA # imp
     belt: WeaponDisabler
     back: ClothingBackpackSatchelCaptain
     ears: ClothingHeadsetAltCommand
@@ -41,7 +41,7 @@
     shoes: ClothingShoesColorWhite
     head: ClothingHeadHatBeretEngineering
     neck: ClothingNeckCloakCe
-    id: VisitorPDA
+    id: CEPDA # imp
     belt: ClothingBeltChiefEngineerFilled
     back: ClothingBackpackDuffelEngineering
     ears: ClothingHeadsetCE
@@ -55,7 +55,7 @@
     shoes: ClothingShoesColorWhite
     head: ClothingHeadHatBeretEngineering
     neck: ClothingNeckMantleCE
-    id: VisitorPDA
+    id: CEPDA # imp
     belt: ClothingBeltChiefEngineerFilled
     back: ClothingBackpackSatchelEngineering
     ears: ClothingHeadsetCE
@@ -70,7 +70,7 @@
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadMirror
     neck: ClothingCloakCmo
-    id: VisitorPDA
+    id: CMOPDA # imp
     back: ClothingBackpackMedical
     ears: ClothingHeadsetCMO
     belt: ClothingBeltMedicalFilled
@@ -81,15 +81,15 @@
   id: VisitorCMOAlt
   equipment:
     jumpsuit: ClothingUniformJumpsuitCMOTurtle
-    shoes: ClothingShoesColorBrown
+    shoes: ClothingShoesBootsWinterMed # imp
     gloves: ClothingHandsGlovesNitrile
     head: ClothingHeadHatBeretCmo
     neck: ClothingNeckMantleCMO
-    id: VisitorPDA
+    id: CMOPDA # imp
     back: ClothingBackpackSatchelMedical
     ears: ClothingHeadsetCMO
     belt: ClothingBeltMedicalFilled
-    outerClothing: ClothingOuterCoatLabCmo
+    outerClothing: ClothingOuterWinterCMO # imp
     pocket1: WeaponDisabler
 
 - type: startingGear
@@ -99,7 +99,7 @@
     shoes: ClothingShoesLeather
     head: ClothingHeadHatHopcap
     neck: ClothingNeckCloakHop
-    id: VisitorPDA
+    id: HoPPDA # imp
     belt: WeaponDisabler
     back: ClothingBackpackDebug
     ears: ClothingHeadsetAltCommand
@@ -113,7 +113,7 @@
     shoes: ClothingShoesLeather
     head: ClothingHeadHatHopcap
     neck: ClothingNeckMantleHOP
-    id: VisitorPDA
+    id: HoPPDA # imp
     belt: WeaponDisabler
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetAltCommand
@@ -128,7 +128,7 @@
     gloves: ClothingHandsGlovesCombat
     head: ClothingHeadHatHoshat
     neck: ClothingNeckCloakHos
-    id: VisitorPDA
+    id: HoSPDA # imp
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSatchelSecurity
     ears: ClothingHeadsetAltSecurity
@@ -144,10 +144,10 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitHosFormal
     shoes: ClothingShoesBootsCowboyFancyFilled
-    gloves: ClothingHandsGlovesColorWhite
+    gloves: ClothingHandsGlovesCombat # imp
     head: ClothingHeadHatCowboyWhite
     neck: SecurityWhistle
-    id: VisitorPDA
+    id: HoSPDA # imp
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetAltSecurity
@@ -165,7 +165,7 @@
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadHatBeretRND
     neck: ClothingNeckCloakRd
-    id: VisitorPDA
+    id: RnDPDA # imp
     back: ClothingBackpackScience
     ears: ClothingHeadsetRD
     outerClothing: ClothingOuterCoatRD
@@ -179,7 +179,7 @@
     gloves: ClothingHandsGlovesNitrile
     head: ClothingHeadHatBeretRND
     neck: ClothingNeckMantleRD
-    id: VisitorPDA
+    id: RnDPDA # imp
     back: ClothingBackpackSatchelScience
     ears: ClothingHeadsetRD
     outerClothing: ClothingOuterCoatRD
@@ -191,8 +191,8 @@
     jumpsuit: ClothingUniformJumpsuitQMTurtleneck
     shoes: ClothingShoesColorBrown
     head: ClothingHeadHatQMsoft
-    neck: ClothingNeckCloakQm
-    id: VisitorPDA
+    neck: ClothingNeckCloakQmgreatcoat # imp
+    id: QuartermasterPDA # imp
     back: ClothingBackpackCargo
     ears: ClothingHeadsetRD
     outerClothing: ClothingOuterWinterQM
@@ -206,7 +206,7 @@
     shoes: ClothingShoesColorBrown
     head: ClothingHeadHatBeretQM
     neck: ClothingNeckMantleQM
-    id: VisitorPDA
+    id: QuartermasterPDA # imp
     back: ClothingBackpackSatchelCargo
     ears: ClothingHeadsetQM
     outerClothing: ClothingOuterWinterQM
@@ -221,7 +221,7 @@
     jumpsuit: ClothingUniformJumpsuitSec
     shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHelmetBasic
-    id: VisitorPDA
+    id: SecurityCadetPDA # imp
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSecurity
     ears: ClothingHeadsetSecurity
@@ -235,11 +235,11 @@
 - type: startingGear
   id: VisitorSecurityCadetAlt
   equipment:
-    jumpsuit: ClothingUniformJumpsuitSecGrey
+    jumpsuit: ClothingUniformSecurityTrooper # imp
     shoes: ClothingShoesBootsCombatFilled
-    head: ClothingHeadHelmetBasic
+    head: ClothingHeadHelmetJustice # imp
     neck: SecurityWhistle
-    id: VisitorPDA
+    id: SecurityCadetPDA # imp
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSatchelSecurity
     ears: ClothingHeadsetSecurity
@@ -256,7 +256,7 @@
     jumpsuit: ClothingUniformJumpsuitSec
     shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHelmetBasic
-    id: VisitorPDA
+    id: SecurityPDA # imp
     belt: ClothingBeltSecurityWebbingFilled
     back: ClothingBackpackSecurity
     ears: ClothingHeadsetSecurity
@@ -270,11 +270,11 @@
 - type: startingGear
   id: VisitorSecurityOfficerAlt
   equipment:
-    jumpsuit: ClothingUniformJumpsuitSecGrey
+    jumpsuit: ClothingUniformSecurityTrooper # imp
     shoes: ClothingShoesBootsCombatFilled
-    head: ClothingHeadHatCorpsoft
+    head: ClothingHeadHatSecurityTrooper # imp
     neck: SecurityWhistle
-    id: VisitorPDA
+    id: SecurityPDA # imp
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSatchelSecurity
     ears: ClothingHeadsetSecurity
@@ -292,7 +292,7 @@
     shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatFedoraBrown
     neck: ClothingNeckTieDet
-    id: VisitorPDA
+    id: DetectivePDA # imp
     belt: ClothingBeltHolsterFilled
     back: ClothingBackpackSecurity
     ears: ClothingHeadsetSecurity
@@ -311,7 +311,7 @@
     shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatFedoraGrey
     neck: ClothingNeckTieDet
-    id: VisitorPDA
+    id: DetectivePDA # imp
     belt: ClothingBeltHolsterFilled
     back: ClothingBackpackSatchelSecurity
     ears: ClothingHeadsetSecurity
@@ -331,7 +331,7 @@
     gloves: ClothingHandsGlovesCombat
     head: ClothingHeadHatBeretWarden
     neck: SecurityWhistle
-    id: VisitorPDA
+    id: WardenPDA # imp
     belt: ClothingBeltSecurityWebbingFilled
     back: ClothingBackpackSecurity
     ears: ClothingHeadsetSecurity
@@ -350,7 +350,7 @@
     shoes: ClothingShoesBootsCombatFilled
     gloves: ClothingHandsGlovesCombat
     head: ClothingHeadHatWarden
-    id: VisitorPDA
+    id: WardenPDA # imp
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSatchelSecurity
     ears: ClothingHeadsetSecurity
@@ -370,7 +370,7 @@
     jumpsuit: ClothingUniformJumpsuitCargo
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatCargosoft
-    id: VisitorPDA
+    id: CargoPDA # imp
     back: ClothingBackpackCargo
     ears: ClothingHeadsetCargo
     pocket1: AppraisalTool
@@ -384,7 +384,7 @@
     jumpsuit: ClothingUniformJumpsuitCargo
     shoes: ClothingShoesBootsWinterCargo
     head: ClothingHeadHatCargosoft
-    id: VisitorPDA
+    id: CargoPDA # imp
     back: ClothingBackpackDuffelCargo
     ears: ClothingHeadsetCargo
     pocket1: AppraisalTool
@@ -400,7 +400,7 @@
     jumpsuit: ClothingUniformJumpsuitSalvageSpecialist
     shoes: ClothingShoesBootsSalvage
     head: ClothingHeadHatCargosoftFlipped
-    id: VisitorPDA
+    id: SalvagePDA # imp
     belt: ClothingBeltSalvageWebbing
     back: ClothingBackpackSalvage
     ears: ClothingHeadsetCargo
@@ -415,7 +415,7 @@
     jumpsuit: ClothingUniformJumpsuitSalvageSpecialist
     shoes: ClothingShoesBootsSalvage
     head: ClothingHeadHatBrownFlatcap
-    id: VisitorPDA
+    id: SalvagePDA # imp
     belt: ClothingBeltSalvageWebbing
     back: ClothingBackpackDuffelSalvage
     ears: ClothingHeadsetCargo
@@ -434,7 +434,7 @@
     shoes: ClothingShoesColorWhite
     gloves: ClothingHandsGlovesFingerlessInsulated
     head: ClothingHeadHelmetFire
-    id: VisitorPDA
+    id: AtmosPDA # imp
     back: ClothingBackpackDuffelAtmospherics
     ears: ClothingHeadsetEngineering
     eyes: ClothingEyesGlassesMeson
@@ -452,7 +452,7 @@
     gloves: ClothingHandsGlovesColorYellow
     head: ClothingHeadHatHardhatYellow
     neck: ClothingNeckScarfStripedLightBlue
-    id: VisitorPDA
+    id: AtmosPDA # imp
     belt: DoubleEmergencyOxygenTankFilled
     back: ClothingBackpackSatchelAtmospherics
     ears: ClothingHeadsetEngineering
@@ -470,7 +470,7 @@
     shoes: ClothingShoesBootsWork
     gloves: ClothingHandsGlovesColorYellowBudget
     head: ClothingHeadHatWelding
-    id: VisitorPDA
+    id: TechnicalAssistantPDA # imp
     back: ClothingBackpackEngineering
     ears: ClothingHeadsetEngineering
     eyes: ClothingEyesGlassesMeson
@@ -486,7 +486,7 @@
     shoes: ClothingShoesColorBlack
     gloves: ClothingHandsGlovesColorYellowBudget
     head: ClothingHeadHatCone
-    id: VisitorPDA
+    id: TechnicalAssistantPDA # imp
     belt: ClothingBeltUtility
     back: ClothingBackpackSatchelEngineering
     ears: ClothingHeadsetEngineering
@@ -504,7 +504,7 @@
     shoes: ClothingShoesBootsWork
     gloves: ClothingHandsGlovesColorYellow
     head: ClothingHeadHatHardhatYellow
-    id: VisitorPDA
+    id: EngineerPDA # imp
     belt: ClothingBeltUtilityEngineering
     back: ClothingBackpackEngineering
     ears: ClothingHeadsetEngineering
@@ -523,7 +523,7 @@
     shoes: ClothingShoesBootsWork
     gloves: ClothingHandsGlovesColorYellow
     head: ClothingHeadHatBeretEngineering
-    id: VisitorPDA
+    id: EngineerPDA # imp
     belt: ClothingBeltUtilityEngineering
     back: ClothingBackpackDuffelEngineering
     ears: ClothingHeadsetEngineering
@@ -542,7 +542,7 @@
     jumpsuit: ClothingUniformJumpsuitChemistry
     shoes: ClothingShoesColorOrange
     gloves: ClothingHandsGlovesLatex
-    id: VisitorPDA
+    id: ChemistryPDA # imp
     belt: ChemBag
     back: ClothingBackpackChemistry
     ears: ClothingHeadsetMedical
@@ -557,10 +557,11 @@
 - type: startingGear
   id: VisitorChemistAlt
   equipment:
-    jumpsuit: ClothingUniformJumpsuitChemistry
+    jumpsuit: ClothingUniformSpaceJumpsuitChemistry
     shoes: ClothingShoesColorOrange
-    head: ClothingHeadHatPaper
-    id: VisitorPDA
+    gloves: ClothingHandsGlovesNitrile # imp
+    head: ClothingHeadHatBeretSeniorPhysician # imp
+    id: ChemistryPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelChemistry
     ears: ClothingHeadsetMedical
@@ -579,7 +580,7 @@
     shoes: ClothingShoesColorBlue
     gloves: ClothingHandsGlovesNitrile
     head: ClothingHeadBandGrey
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackGenetics
     ears: ClothingHeadsetMedical
@@ -597,7 +598,7 @@
     shoes: ClothingShoesColorBlue
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadHatBeretBrigmedic
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelGenetics
     ears: ClothingHeadsetMedical
@@ -615,7 +616,7 @@
     shoes: ClothingShoesColorGreen
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadMirror
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackVirology
     ears: ClothingHeadsetMedical
@@ -634,7 +635,7 @@
     gloves: ClothingHandsGlovesNitrile
     head: ClothingHeadHatBeretSeniorPhysician
     neck: ClothingNeckStethoscope
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelVirology
     ears: ClothingHeadsetMedical
@@ -653,7 +654,7 @@
     gloves: ClothingHandsGlovesNitrile
     head: ClothingHeadHatCorpsoft
     neck: ClothingNeckStethoscope
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackMedical
     ears: ClothingHeadsetMedical
@@ -672,7 +673,7 @@
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadHatBeretMedic
     neck: ClothingNeckStethoscope
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelMedical
     ears: ClothingHeadsetMedical
@@ -691,7 +692,7 @@
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadHatSurgcapBlue
 #    mask: ClothingMaskBreathMedical # right now this is broken for vox, but maybe some day.
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltStorageWaistbag
     back: NitrousOxideTankFilled
     ears: ClothingHeadsetMedical
@@ -709,7 +710,7 @@
     shoes: ClothingShoesLeather
     head: ClothingHeadHatMagician
     neck: ClothingNeckTieRed
-    id: VisitorPDA
+    id: PsychologistPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetMedical
@@ -726,7 +727,7 @@
     jumpsuit: ClothingUniformJumpsuitPsychologist
     shoes: ClothingShoesLeather
     head: ClothingHeadHatAnimalCat
-    id: VisitorPDA
+    id: PsychologistPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetMedical
@@ -745,7 +746,7 @@
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadHatParamedicsoft
     neck: ClothingNeckStethoscope
-    id: VisitorPDA
+    id: ParamedicPDA # imp
     belt: ClothingBeltMedicalEMTFilled
     back: ClothingBackpackDuffelGenetics
     ears: ClothingHeadsetMedical
@@ -765,7 +766,7 @@
     gloves: ClothingHandsGlovesNitrile
     head: ClothingHeadHatParamedicsoftFlipped
     neck: ClothingNeckStethoscope
-    id: VisitorPDA
+    id: ParamedicPDA # imp
     belt: ClothingBeltMedicalEMTFilled
     back: ClothingBackpackDuffelGenetics
     ears: ClothingHeadsetMedical
@@ -783,7 +784,7 @@
     jumpsuit: ClothingUniformJumpsuitColorWhite
     shoes: ClothingShoesColorWhite
     head: ClothingHeadBandGreen
-    id: VisitorPDA
+    id: MedicalInternPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackDuffelMedical
     ears: ClothingHeadsetMedical
@@ -800,7 +801,7 @@
     jumpsuit: ClothingUniformJumpsuitColorWhite
     shoes: ClothingShoesColorWhite
     head: ClothingHeadBandBlue
-    id: VisitorPDA
+    id: MedicalInternPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackDuffelMedical
     ears: ClothingHeadsetMedical
@@ -818,7 +819,7 @@
     shoes: ClothingShoesColorRed
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadHatSurgcapPurple
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelMedical
     ears: ClothingHeadsetMedical
@@ -836,7 +837,7 @@
     shoes: ClothingShoesColorGreen
     gloves: ClothingHandsGlovesLatex
     head: ClothingHeadHatSurgcapGreen
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelMedical
     ears: ClothingHeadsetMedical
@@ -854,7 +855,7 @@
     shoes: ClothingShoesColorBlue
     gloves: ClothingHandsGlovesNitrile
     head: ClothingHeadHatSurgcapBlue
-    id: VisitorPDA
+    id: MedicalPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelMedical
     ears: ClothingHeadsetMedical
@@ -873,7 +874,7 @@
     jumpsuit: ClothingUniformJumpsuitColorPurple
     shoes: ClothingShoesColorBlack
     head: ClothingHeadPaperSack
-    id: VisitorPDA
+    id: ResearchAssistantPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackScience
     ears: ClothingHeadsetScience
@@ -887,7 +888,7 @@
     jumpsuit: ClothingUniformJumpsuitCasualPurple
     shoes: ClothingShoesColorBlack
     neck: ClothingNeckTieSci
-    id: VisitorPDA
+    id: ResearchAssistantPDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelScience
     ears: ClothingHeadsetScience
@@ -901,7 +902,7 @@
     jumpsuit: ClothingUniformJumpsuitScientistFormal
     shoes: ClothingShoesColorPurple
     head: ClothingHeadHatBeretRND
-    id: VisitorPDA
+    id: SciencePDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackScience
     ears: ClothingHeadsetScience
@@ -916,7 +917,7 @@
     shoes: ClothingShoesBootsWinterSci
     head: ClothingHeadHatPurplesoft
     neck: ClothingNeckTieSci
-    id: VisitorPDA
+    id: SciencePDA # imp
     belt: ClothingBeltMedicalFilled
     back: ClothingBackpackSatchelScience
     ears: ClothingHeadsetScience
@@ -932,7 +933,7 @@
     jumpsuit: ClothingUniformJumpsuitBartender
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatTophat
-    id: VisitorPDA
+    id: BartenderPDA # imp
     back: ClothingBackpack
     suitstorage: WeaponShotgunDoubleBarreledRubber
     ears: ClothingHeadsetService
@@ -948,7 +949,7 @@
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatBowlerHat
     neck: ClothingNeckTieSci
-    id: VisitorPDA
+    id: BartenderPDA # imp
     back: ClothingBackpackSatchel
     ears: ClothingHeadsetService
     eyes: ClothingEyesHudBeer
@@ -962,12 +963,11 @@
     jumpsuit: ClothingUniformJumpsuitHydroponics
     shoes: ClothingShoesColorGreen
     head: ClothingHeadBandGreen
-    id: VisitorPDA
+    id: BotanistPDA # imp
     back: ClothingBackpackDuffelHydroponics
     ears: ClothingHeadsetService
   inhand:
   - HydroponicsToolScythe
-
 
 - type: startingGear
   id: VisitorBotanistAlt
@@ -975,7 +975,7 @@
     jumpsuit: ClothingUniformJumpsuitHydroponics
     shoes: ClothingShoesColorGreen
     head: Bucket
-    id: VisitorPDA
+    id: BotanistPDA # imp
     back: ClothingBackpackHydroponics
     ears: ClothingHeadsetService
     pocket1: HydroponicsToolMiniHoe
@@ -988,7 +988,7 @@
     shoes: ClothingShoesColorBlack
     gloves: ClothingHandsGlovesBoxingBlue
     head: ClothingHeadPaperSackSmile
-    id: VisitorPDA
+    id: BoxerPDA # imp
     ears: ClothingHeadsetService
     pocket1: DrinkVodkaBottleFull
     pocket2: SoapDeluxe
@@ -1000,7 +1000,7 @@
     shoes: ClothingShoesColorBlack
     gloves: ClothingHandsGlovesBoxingRed
     head: ClothingHeadHatSkub
-    id: VisitorPDA
+    id: BoxerPDA # imp
     ears: ClothingHeadsetService
     outerClothing: ClothingOuterSkub
     pocket1: Skub
@@ -1013,7 +1013,7 @@
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatPlaguedoctor
     mask: ClothingMaskPlague
-    id: VisitorPDA
+    id: ChaplainPDA # imp
     belt: Bible
     ears: ClothingHeadsetService
     outerClothing: ClothingOuterPlagueSuit
@@ -1026,7 +1026,7 @@
     jumpsuit: ClothingUniformJumpsuitChaplain
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatHoodNunHood
-    id: VisitorPDA
+    id: ChaplainPDA # imp
     belt: Bible
     ears: ClothingHeadsetService
     outerClothing: ClothingOuterNunRobe
@@ -1040,7 +1040,7 @@
     shoes: ClothingShoesChef
     head: ClothingHeadHatChef
 #    mask: ClothingMaskItalianMoustache # right now this is broken for vox, so its inhand.
-    id: VisitorPDA
+    id: ChefPDA # imp
     back: ClothingBackpackSatchel
     belt: ClothingBeltChefFilled
     ears: ClothingHeadsetService
@@ -1058,7 +1058,7 @@
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatChef
 #    mask: ClothingMaskItalianMoustache # right now this is broken for vox, so its inhand.
-    id: VisitorPDA
+    id: ChefPDA # imp
     back: ClothingBackpack
     belt: ClothingBeltChefFilled
     ears: ClothingHeadsetService
@@ -1074,7 +1074,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitClown
     shoes: ClothingShoesClown
-    id: VisitorPDA
+    id: ClownPDA # imp
     back: ClothingBackpackClown
     ears: ClothingHeadsetService
     mask: ClothingMaskClown
@@ -1088,7 +1088,7 @@
     shoes: ClothingShoesGaloshes
     gloves: ClothingHandsGlovesJanitor
     head: ClothingHeadFishCap
-    id: VisitorPDA
+    id: JanitorPDA # imp
     back: ClothingBackpackSatchel
     belt: ClothingBeltJanitorFilled
     ears: ClothingHeadsetService
@@ -1104,7 +1104,7 @@
     shoes: ClothingShoesGaloshes
     gloves: ClothingHandsGlovesJanitor
     head: ClothingHeadHatHoodBioJanitor
-    id: VisitorPDA
+    id: JanitorPDA # imp
     back: ClothingBackpack
     belt: ClothingBeltJanitorFilled
     ears: ClothingHeadsetService
@@ -1120,7 +1120,7 @@
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatFedoraGrey
     neck: ClothingNeckLawyerbadge
-    id: VisitorPDA
+    id: LawyerPDA # imp
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetSecurity
     pocket1: RubberStampLawyer
@@ -1135,7 +1135,7 @@
     shoes: ClothingShoesLeather
     head: ClothingHeadHatFedoraBrown
     neck: ClothingNeckLawyerbadge
-    id: VisitorPDA
+    id: LawyerPDA # imp
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetSecurity
     pocket1: RubberStampLawyer
@@ -1150,7 +1150,7 @@
     shoes: ClothingShoesColorRed
     head: ClothingHeadHatCowboyBrown
     neck: ClothingNeckLawyerbadge
-    id: VisitorPDA
+    id: LawyerPDA # imp
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
     ears: ClothingHeadsetSecurity
@@ -1168,7 +1168,7 @@
     head: ClothingHeadHatBeaverHat
     neck: ClothingNeckLawyerbadge
     mask: CigarGold
-    id: VisitorPDA
+    id: LawyerPDA # imp
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetSecurity
     outerClothing: ClothingOuterCoatExpensive
@@ -1184,7 +1184,7 @@
     shoes: ClothingShoesLeather
     head: ClothingHeadHatCorpsoft
     neck: ClothingNeckLawyerbadge
-    id: VisitorPDA
+    id: LawyerPDA # imp
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
     ears: ClothingHeadsetSecurity
@@ -1201,7 +1201,7 @@
     gloves: ClothingHandsGlovesLeather
     head: BladedFlatcapBrown
     neck: ClothingNeckLawyerbadge
-    id: VisitorLawyerPDA
+    id: CentcomPDA # imp
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
     eyes: ClothingEyesGlassesSunglasses
@@ -1217,7 +1217,7 @@
     jumpsuit: ClothingUniformJumpsuitLibrarian
     shoes: ClothingShoesBootsLaceup
     neck: ClothingNeckScarfStripedGreen
-    id: VisitorLibrarianPDA
+    id: LibrarianPDA # imp
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
     eyes: ClothingEyesGlassesJamjar
@@ -1233,7 +1233,7 @@
     jumpsuit: ClothingUniformJumpsuitCurator
     shoes: ClothingShoesBootsLaceup
     head: ClothingHeadHatGreyFlatcap
-    id: VisitorPDA
+    id: LibrarianPDA # imp
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
     eyes: ClothingEyesGlasses
@@ -1248,7 +1248,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1262,7 +1262,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1276,7 +1276,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1290,7 +1290,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1304,7 +1304,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1318,7 +1318,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1332,7 +1332,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1346,7 +1346,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchelLeather
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1360,7 +1360,7 @@
   equipment:
     jumpsuit: ClothingUniformRandomShirt
     shoes: ClothingShoesColorBrown
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackDuffel
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1374,7 +1374,7 @@
   equipment:
     jumpsuit: ClothingUniformRandomShirt
     shoes: ClothingShoesColorBlack
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchel
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1388,7 +1388,7 @@
   equipment:
     jumpsuit: ClothingUniformRandomShirt
     shoes: ClothingShoesColorBlack
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpack
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1402,7 +1402,7 @@
   equipment:
     jumpsuit: ClothingUniformRandomShirt
     shoes: ClothingShoesColorBrown
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackDuffel
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1416,7 +1416,7 @@
   equipment:
     jumpsuit: ClothingUniformRandomShirt
     shoes: ClothingShoesColorBlack
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackDuffel
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1430,7 +1430,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     shoes: ClothingShoesBootsLaceup
-    id: VisitorPDA
+    id: MusicianPDA # imp
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
     pocket1: BluntRainbow
@@ -1444,7 +1444,7 @@
     jumpsuit: ClothingUniformRandomShirt
     shoes: ClothingShoesWizard
     head: ClothingHeadRastaHat
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchel
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1459,7 +1459,7 @@
     jumpsuit: ClothingUniformJumpsuitColorTeal
     shoes: ClothingShoesColorBrown
     head: ClothingHeadHatSombrero
-    id: VisitorPDA
+    id: MusicianPDA # imp
     back: ClothingBackpackSatchel
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1477,7 +1477,7 @@
     gloves: ClothingHandsGlovesColorWhite
     head: ClothingHeadBandBlack
     mask: ClothingMaskMime
-    id: VisitorPDA
+    id: MimePDA # imp
     back: ClothingBackpackMime
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1492,7 +1492,7 @@
     gloves: ClothingHandsGlovesColorWhite
     head: ClothingHeadHatAnimalCatBlack
     mask: ClothingMaskMime
-    id: VisitorPDA
+    id: MimePDA # imp
     back: ClothingBackpackMime
     eyes: ClothingEyesGlassesCheapSunglasses
     ears: ClothingHeadsetService
@@ -1507,22 +1507,22 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitReporter
     shoes: ClothingShoesLeather
-    id: VisitorPDA
+    id: ReporterPDA # imp
     back: ClothingBackpackSatchel
     ears: ClothingHeadsetService
     pocket1: MicrophoneInstrument
-    pocket2: BoxFolderClipboard
+    pocket2: TapeRecorderFilled # imp
 
 - type: startingGear
   id: VisitorReporterAlt
   equipment:
     jumpsuit: ClothingUniformJumpsuitJournalist
     shoes: ClothingShoesColorBrown
-    id: VisitorPDA
+    id: ReporterPDA # imp
     back: ClothingBackpackSatchel
     ears: ClothingHeadsetService
     pocket1: MicrophoneInstrument
-    pocket2: BoxFolderClipboard
+    pocket2: TapeRecorderFilled # imp
 
 - type: startingGear
   id: VisitorServiceWorker
@@ -1530,7 +1530,7 @@
     jumpsuit: ClothingUniformJumpsuitBartender
     shoes: ClothingShoesColorBlack
     head: ClothingHeadBandBlue
-    id: VisitorPDA
+    id: ServiceWorkerPDA # imp
     back: ClothingBackpack
     ears: ClothingHeadsetService
     pocket1: Fork
@@ -1542,7 +1542,7 @@
     jumpsuit: ClothingUniformJumpsuitColorBlack
     shoes: ClothingShoesColorBlack
     head: ClothingHeadBandBlack
-    id: VisitorPDA
+    id: ServiceWorkerPDA # imp
     back: ClothingBackpack
     ears: ClothingHeadsetService
     outerClothing: ClothingOuterApronBar
@@ -1555,7 +1555,7 @@
     jumpsuit: ClothingUniformJumpsuitSafari
     shoes: ClothingShoesBootsSalvage
     head: ClothingHeadSafari
-    id: VisitorPDA
+    id: ZookeeperPDA # imp
     belt: ClothingBeltUtility
     back: ClothingBackpackDuffel
     ears: ClothingHeadsetService
@@ -1568,7 +1568,7 @@
     jumpsuit: ClothingUniformJumpsuitSafari
     shoes: ClothingShoesBootsWork
     head: ClothingHeadSafari
-    id: VisitorPDA
+    id: ZookeeperPDA # imp
     belt: ClothingBeltStorageWaistbag
     back: WeaponShotgunDoubleBarreledRubber
     ears: ClothingHeadsetService

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -557,7 +557,7 @@
 - type: startingGear
   id: VisitorChemistAlt
   equipment:
-    jumpsuit: ClothingUniformSpaceJumpsuitChemistry
+    jumpsuit: ClothingUniformSpaceJumpsuitChemist
     shoes: ClothingShoesColorOrange
     gloves: ClothingHandsGlovesNitrile # imp
     head: ClothingHeadHatBeretSeniorPhysician # imp

--- a/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
@@ -10,7 +10,7 @@
 
 - type: preloadedGrid
   id: DisasterEvacPod
-  path: /Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
+  path: /Maps/_Impstation/Shuttles/ShuttleEvent/disaster_evacpod.yml # imp
   copies: 3
 
 # The power of 3 clowns has proved too strong for the players and may need to be 1984ed.

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/roles.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/roles.yml
@@ -1,0 +1,32 @@
+- type: entity
+  id: RandomHumanoidVisitorBrigmedic
+  name: visiting brigmedic ghost role
+  components:
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      state: brigmedic
+    - type: RandomHumanoidSpawner
+      settings: VisitorBrigmedic
+    - type: AutoImplant
+      implants:
+      - MindShieldImplant
+
+- type: entity
+  id: RandomHumanoidVisitorCourier
+  name: visiting courier ghost role
+  components:
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      state: cargo_tech # no courier job in the rsi
+    - type: RandomHumanoidSpawner
+      settings: VisitorCourier
+
+- type: entity
+  id: RandomHumanoidVisitorRoboticist
+  name: visiting roboticist ghost role
+  components:
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      state: roboticist # no courier job in the rsi
+    - type: RandomHumanoidSpawner
+      settings: VisitorRoboticist

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -4,7 +4,6 @@
   components:
     - type: GhostRole
       name: job-name-brigmedic
-      playTimeTracker: JobBrigmedic
       requirements:
         - !type:DepartmentTimeRequirement
           department: Security
@@ -22,7 +21,6 @@
   components:
     - type: GhostRole
       name: job-name-courier
-      playTimeTracker: JobCourier
     - type: Loadout
       prototypes: [ VisitorCourier, VisitorCourierAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -33,7 +31,6 @@
   components:
     - type: GhostRole
       name: job-name-roboticist
-      playTimeTracker: JobScientist
     - type: Loadout
       prototypes: [ VisitorRoboticist, VisitorRoboticistAlt ]
       roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -1,0 +1,39 @@
+- type: randomHumanoidSettings
+  id: VisitorBrigmedic
+  parent: VisitorSecurity
+  components:
+    - type: GhostRole
+      name: job-name-brigmedic
+      playTimeTracker: JobBrigmedic
+      requirements:
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 36000 #10 hrs
+        - !type:DepartmentTimeRequirement
+          department: Medical
+          time: 14400 #4 hrs
+    - type: Loadout
+      prototypes: [ VisitorBrigmedic, VisitorBrigmedicAlt ]
+      roleLoadout: [ RoleSurvivalSecurity ]
+      
+- type: randomHumanoidSettings
+  id: VisitorCourier
+  parent: VisitorCargonian
+  components:
+    - type: GhostRole
+      name: job-name-courier
+      playTimeTracker: JobCourier
+    - type: Loadout
+      prototypes: [ VisitorCourier, VisitorCourierAlt ]
+      roleLoadout: [ RoleSurvivalStandard ]
+
+- type: randomHumanoidSettings
+  id: VisitorRoboticist
+  parent: VisitorScience
+  components:
+    - type: GhostRole
+      name: job-name-roboticist
+      playTimeTracker: JobScientist
+    - type: Loadout
+      prototypes: [ VisitorRoboticist, VisitorRoboticistAlt ]
+      roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/spawners.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/ShuttleRoles/spawners.yml
@@ -1,0 +1,41 @@
+- type: entity
+  name: visiting brigmedic spawner
+  id: VisitorBrigmedicSpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Decoration/banner.rsi
+        state: banner_security
+  - type: RandomSpawner
+    prototypes:
+    - RandomHumanoidVisitorBrigmedic
+
+- type: entity
+  name: visiting courier spawner
+  id: VisitorCourierSpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Decoration/banner.rsi
+        state: banner_cargo
+  - type: RandomSpawner
+    prototypes:
+    - RandomHumanoidVisitorCourier
+
+- type: entity
+  name: visiting roboticist spawner
+  id: VisitorRoboticistSpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Decoration/banner.rsi
+        state: banner_science
+  - type: RandomSpawner
+    prototypes:
+    - RandomHumanoidVisitorRoboticist

--- a/Resources/Prototypes/_Impstation/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1,0 +1,333 @@
+# Command
+
+- type: startingGear
+  id: VisitorCaptainAltA
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCapFormalDress
+    shoes: ClothingShoesHeelsCommandBlack
+    eyes: ClothingEyesGlassesCaptainvisor
+    gloves: ClothingHandsGlovesCaptainflightgloves
+    head: ClothingHeadHatBeretCaptain
+    neck: ClothingNeckCloakCapFormal
+    id: CaptainPDA
+    belt: WeaponDisabler
+    back: ClothingBackpackCaptain
+    ears: ClothingHeadsetAltCommand
+    outerClothing: ClothingOuterArmorCaptainCarapace
+    pocket1: WeaponDisabler
+
+- type: startingGear
+  id: VisitorCaptainAltB
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCaptaineveningattire
+    shoes: ClothingShoesBootsCaptainjumpboots
+    eyes: ClothingEyesGlassesCaptainvisor
+    gloves: ClothingHandsGlovesCaptainflightgloves
+    head: ClothingHeadHatCaptaincrushercap
+    neck: ClothingNeckCloakCaptaingreatcoat
+    id: CaptainPDA
+    belt: WeaponDisabler
+    back: ClothingBackpackSatchelCaptain
+    ears: ClothingHeadsetAltCommand
+    outerClothing: ClothingOuterArmorCaptainCarapace
+    pocket1: WeaponDisabler
+    
+- type: startingGear
+  id: VisitorCMOAltA
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCMO
+    shoes: ClothingShoesColorBrown
+    gloves: ClothingHandsGlovesChemist
+    head: ClothingHeadHatBeretCmo
+    neck: ClothingNeckCloakCmosGreatcloak
+    id: CMOPDA
+    back: ClothingBackpackSatchelMedical
+    ears: ClothingHeadsetCMO
+    belt: ClothingBeltMedicalFilled
+    outerClothing: ClothingOuterCoatCMO
+    pocket1: WeaponDisabler
+
+- type: startingGear
+  id: VisitorHOSAltA
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoSPro
+    shoes: ClothingShoesBootsJackFilled
+    gloves: ClothingHandsGlovesCombat
+    head: ClothingHeadHatHOSsoft
+    neck: ClothingNeckCloakHosgreatcoat
+    id: HoSPDA
+    belt: ClothingBeltSecurityFilled
+    back: ClothingBackpackSatchelLeather
+    ears: ClothingHeadsetAltSecurity
+    eyes: ClothingEyesGlassesSecurity
+    outerClothing: ClothingOuterArmorHoSEliteArmor
+    pocket1: WeaponDisabler
+    pocket2: MagazinePistolSubMachineGunTopMounted
+  inhand:
+  - WeaponSubMachineGunWt550
+
+- type: startingGear
+  id: VisitorHOSAltB
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoSGrey
+    shoes: ClothingShoesBootsCowboyFancyFilled
+    gloves: ClothingHandsGlovesCombat
+    head: ClothingHeadHatBeretHoS
+    neck: ClothingNeckMantleHOS
+    id: HoSPDA
+    belt: ClothingBeltSecurityFilled
+    back: ClothingBackpackSatchelLeather
+    ears: ClothingHeadsetAltSecurity
+    eyes: ClothingEyesGlassesSecurity
+    outerClothing: ClothingOuterWinterHoS
+    pocket1: WeaponDisabler
+    pocket2: MagazinePistolSubMachineGunTopMounted
+  inhand:
+  - WeaponSubMachineGunWt550
+
+# Security
+
+- type: startingGear
+  id: VisitorSecurityOfficerAltA
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSeniorOfficer
+    shoes: ClothingShoesBootsCombatFilled
+    head: ClothingHeadHelmetJustice
+    id: SecurityPDA
+    belt: ClothingBeltSecurityWebbingFilled
+    back: ClothingBackpackSecurity
+    ears: ClothingHeadsetSecurity
+    eyes: ClothingEyesGlassesSecurity
+    outerClothing: ClothingOuterArmorBasic
+    pocket1: WeaponPistolMk58
+    pocket2: MagazinePistol
+  inhand:
+  - FlashlightSeclite
+
+- type: startingGear
+  id: VisitorDetectiveAltA
+  equipment:
+    jumpsuit: ClothingUniformMiamiVice
+    shoes: ClothingShoesBootsCombatFilled
+    neck: ClothingNeckTieDet
+    id: DetectivePDA
+    belt: ClothingBeltHolsterFilled
+    back: ClothingBackpackSecurity
+    ears: ClothingHeadsetSecurity
+    eyes: ClothingEyesGlassesSecurity
+    pocket1: ForensicScanner
+    pocket2: ForensicPad
+  inhand:
+  - FlashlightSeclite
+  - CrayonChalk # imp edit
+
+- type: startingGear
+  id: VisitorDetectiveAltB
+  equipment:
+    jumpsuit: ClothingUniformDetectiveSuit
+    shoes: ClothingShoesBootsCombatFilled
+    head: ClothingHeadHatFedoraBrown
+    neck: ClothingNeckTieDet
+    id: DetectivePDA
+    belt: ClothingBeltHolsterFilled
+    back: ClothingBackpackSatchelSecurity
+    ears: ClothingHeadsetSecurity
+    eyes: ClothingEyesGlassesSecurity
+    outerClothing: ClothingOuterCoatDetectiveLoadout
+    pocket1: ForensicScanner
+    pocket2: ForensicPad
+  inhand:
+  - FlashlightSeclite
+  - CrayonChalk # imp edit
+
+- type: startingGear
+  id: VisitorBrigmedic
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBrigmedic
+    shoes: ClothingShoesBootsJackFilled
+    gloves: ClothingHandsGlovesNitrile
+    head: ClothingHeadHatBrigmedicsoft
+    neck: ClothingNeckStethoscope
+    id: BrigmedicPDA
+    belt: ClothingBeltMedicalFilled
+    back: ClothingBackpackBrigmedic
+    ears: ClothingHeadsetBrigmedic
+    eyes: ClothingEyesHudMedSec
+    outerClothing: ClothingOuterCoatAMG
+    pocket1: PillCanisterTricordrazine
+    pocket2: PillCanisterDermaline
+  inhand:
+  - SyringeEphedrine
+
+- type: startingGear
+  id: VisitorBrigmedicAlt
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBrigmedic
+    shoes: ClothingShoesBootsJackFilled
+    gloves: ClothingHandsGlovesLatex
+    head: ClothingHeadHatBeretBrigmedic
+    neck: ClothingNeckStethoscope
+    id: BrigmedicPDA
+    belt: ClothingBeltMedicalFilled
+    back: ClothingBackpackBrigmedic
+    ears: ClothingHeadsetBrigmedic
+    eyes: ClothingEyesHudMedSec
+    outerClothing: ClothingOuterWinterBrigmedic
+    pocket1: PillCanisterTricordrazine
+    pocket2: PillCanisterDermaline
+  inhand:
+  - SyringeEphedrine
+
+# Cargo
+
+- type: startingGear
+  id: VisitorCourier
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCourier
+    shoes: ClothingShoesLeather
+    head: ClothingHeadHatCouriersoft
+    id: CourierPDA
+    belt: MailBag
+    back: ClothingBackpackCargo
+    ears: ClothingHeadsetCargo
+    pocket1: HoloBellProjector
+  inhand:
+  - DrinkEnergyDrinkCan
+
+- type: startingGear
+  id: VisitorCourierAlt
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCourier
+    shoes: ClothingShoesBootsWinterCourier
+    head: ClothingHeadHatCouriersoftFlipped
+    id: CourierPDA
+    belt: MailBag
+    back: ClothingBackpackCargo
+    ears: ClothingHeadsetCargo
+    outerClothing: ClothingOuterWinterCourier
+    pocket1: HoloBellProjector
+  inhand:
+  - ClothingShoesSkates
+
+# Medical
+
+- type: startingGear
+  id: VisitorChemistAltA
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChemShirt
+    shoes: ClothingShoesEnclosedChem
+    gloves: ClothingHandsGlovesChemist
+    head: ClothingHeadHatBeretMedic
+    id: ChemistryPDA
+    belt: ClothingBeltMedicalFilled
+    back: ClothingBackpackSatchelChemistry
+    ears: ClothingHeadsetMedical
+    eyes: ClothingEyesGlassesChemical
+    outerClothing: ClothingOuterApronChemist
+    pocket1: PillCanisterRandom
+    pocket2: PillCanisterRandom
+  inhand:
+  - PillCanisterRandom
+  - PillCanisterRandom
+
+# Science
+
+- type: startingGear
+  id: VisitorRoboticist
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitRoboticist
+    shoes: ClothingShoesColorBlack
+    gloves: ClothingHandsGlovesRobohands
+    head: ClothingHeadHatBlacksoft
+    id: RoboticsPDA
+    belt: ClothingBeltUtilityBlackFilled
+    back: ClothingBackpackScience
+    ears: ClothingHeadsetScience
+    eyes: ClothingEyesGlasses
+    outerClothing: ClothingOuterCoatRobo
+  inhand:
+  - SciFlash
+
+- type: startingGear
+  id: VisitorRoboticistAlt
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitRoboticist
+    shoes: ClothingShoesBootsWinterRobo
+    gloves: ClothingHandsGlovesFingerless
+    head: ClothingHeadHatBeretRND
+    id: RoboticsPDA
+    belt: ClothingBeltUtilityBlackFilled
+    back: ClothingBackpackScience
+    ears: ClothingHeadsetScience
+    eyes: ClothingEyesGlasses
+    outerClothing: ClothingOuterCoatRobo
+  inhand:
+  - SciFlash
+
+# Civilian
+
+- type: startingGear
+  id: VisitorBartenderAltA
+  equipment:
+    jumpsuit: ClothingUniformNightclubSuit
+    shoes: ClothingShoesColorBlack
+    head: ClothingHeadHatTophat
+    id: BartenderPDA # imp
+    back: ClothingBackpack
+    suitstorage: WeaponShotgunDoubleBarreledRubber
+    ears: ClothingHeadsetService
+    eyes: ClothingEyesGlassesSunglasses
+    outerClothing: ClothingOuterArmorBasicSlim
+    pocket1: DrinkWineBottleFull
+    pocket2: BarSpoon
+
+- type: startingGear
+  id: VisitorBartenderAltB
+  equipment:
+    jumpsuit: ClothingUniformSeniorBartender
+    shoes: ClothingShoesColorBlack
+    head: ClothingHeadHatBowlerHat
+    id: BartenderPDA # imp
+    back: ClothingBackpackSatchel
+    ears: ClothingHeadsetService
+    eyes: ClothingEyesHudBeer
+    pocket1: WeaponShotgunSawn
+    pocket2: DrinkGildlagerBottleFull
+
+- type: startingGear
+  id: VisitorClownAltA
+  equipment:
+    jumpsuit: ClothingUniformCircusClown
+    shoes: ClothingShoesCircus
+    head: ClothingHeadHatCircusClown
+    id: ClownPDA
+    back: ClothingBackpackClown
+    ears: ClothingHeadsetService
+    pocket1: BikeHorn
+    pocket2: ClownRecorder
+  inhand:
+  - ClothingMaskClownNose
+  
+- type: startingGear
+  id: VisitorClownAltB
+  equipment:
+    jumpsuit: ClothingUniformJokester
+    shoes: ClothingShoesJokester
+    outerClothing: ClothingOuterCoatJokester
+    id: ClownPDA
+    back: ClothingBackpackClown
+    ears: ClothingHeadsetService
+    mask: ClothingMaskClown
+    pocket1: BikeHorn
+    pocket2: ClownRecorder
+
+- type: startingGear
+  id: VisitorReporterAltA
+  equipment:
+    jumpsuit: ClothingUniformBrosBlazer
+    shoes: ClothingShoesColorBrown
+    id: ReporterPDA # imp
+    back: ClothingBackpackSatchel
+    ears: ClothingHeadsetService
+    pocket1: MicrophoneInstrument
+    pocket2: TapeRecorderFilled # imp


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8bdf901c-63f3-4076-ae3a-5cc83925a7c6)
![image](https://github.com/user-attachments/assets/5c861c1f-0220-4874-b7b4-ce2ac2c01680)
![image](https://github.com/user-attachments/assets/c9267b07-a838-45b8-b69a-49bf2ce75ef1)


Visitors now spawn with the PDA corresponding to their roles!

Some ghost roles come with playtime requirements (mostly identical to the normal job requirements, but interns don't have a max hour count, and normal department roles like Scientist and Medical Doctor only need general playtime instead of department playtime).

Also, a bunch of Imp-exclusive cosmetics were added to the visitor ghost role pool, and a jaws of life was added to the disaster escape pod to compensate for the removal of externals access from most visitors.

**Changelog**
:cl:EpicToast
- add: Add visitor ghost roles for couriers, brigmedics and roboticists.
- tweak: Visitor ghost roles now spawn with their respective job access.
- tweak: Some visitor ghost roles (command, security, and others) now come with playtime requirements.
- tweak: Visitor ghost roles can now spawn with new cosmetics, such as the BROS blazer or the circus clown outfit.