### PR TITLE
Add mechs to the hand labeler whitelist

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -23,5 +23,6 @@
       whitelist:
         components:
           - Item
+          - Mech
         tags:
           - Structure


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d1f36ff5-a1af-4e51-9ae8-7c0ea9343fee)

simple as

**Changelog**
:cl:EpicToast
- tweak: You can now label mechs like the Ripley APLU with a hand labeler.