### PR TITLE
re-rotate heretic

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,10 +2,11 @@
   id: Secret
   weights:
     # regular gamemodes, gamemodes with 20 population requirement or more
-    Nukeops: 0.15
-    Traitor: 0.50
+    Nukeops: 0.13
+    Traitor: 0.41
     SpyVsSpy: 0.03
-    Changeling: 0.15
+    Changeling: 0.13
+    Heretics: 0.13
     Zombie: 0.02
     Zombieteors: 0.01
     Survival: 0.10


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
![image](https://github.com/user-attachments/assets/9e2093b2-d058-41c0-992e-aa28191eb15f)

this also re-balances the secret weights to compensate for the new gamemode

refer to #1184 for a list of what's changed since de-rotation

:cl:
- tweak: Heretic is back in rotation, now as a main antagonist!