### PR TITLE
Remove non-functional code from U.A.P.

### DIFF
--- a/Resources/Prototypes/_Impstation/Reagents/Consumable/Drink/alchohol.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/Consumable/Drink/alchohol.yml
@@ -460,9 +460,6 @@
   metabolisms:
     Drink:
       effects:
-        - !type:GenericStatusEffect
-          key: GrayAccent
-          component: GrayAccent
         - !type:SatiateThirst
           factor: 2
         - !type:AdjustReagent


### PR DESCRIPTION
U.A.P. is meant to make the drinker temporarily have the grayspeak accent added to them. However, this is currently not possible with how status effects and the gray speak accent are implemented. This PR removed the part of the reagent's yml that adds the status effect so that it's effect will not appear in the guidebook.

I will also be putting up a draft PR to outline how to fix UAP, but it will also require the gray accent to be reworked into its own component to work, rather than use the ReplacementAccent component.