### PR TITLE
Tck'tck multitool + salv access

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
@@ -303,3 +303,4 @@
     tags:
     - Engineering
     - External
+    - Salvage

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
@@ -12,6 +12,7 @@
     - CableMVStackLingering10
     - CableApcStackLingering10
     - trayScanner
+    - Multitool
     - MicroDrill
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: wire-module }


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Gives the tck'tck a multitool by request, and salvage access since thats mostly where they spawn now.
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Tck'tck's now have a multitool and salvage access.