### PR TITLE
Maint Lockers Always Containing Enemies Bugfix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -188,6 +188,7 @@
      # Enemy "Loot"
     - !type:NestedSelector
       tableId: MaintEnemyTable
+      prob: 0.01
 
 - type: entity
   id: ClosetMaintenanceFilledRandom


### PR DESCRIPTION
Title. Whoops!
:cl:
- fix: Space ticks and carp will no longer be sleeping in every single maint locker. 
