### PR TITLE
Small Changes to Sec Jetpacks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -268,7 +268,7 @@
   components:
   - type: Item
     sprite: Objects/Tanks/Jetpacks/security.rsi
-    size: Normal
+    size: Large
   - type: Sprite
     sprite: Objects/Tanks/Jetpacks/security.rsi
   - type: Clothing
@@ -287,12 +287,12 @@
   - type: GasTank
     outputPressure: 42.6
     air:
-      # 13 minutes thrust
-      volume: 5
+      # 8 minutes thrust - imp edit
+      volume: 3
       temperature: 293.15
       moles:
-        - 1.025689525 # oxygen
-        - 1.025689525 # nitrogen
+        - 0.615413715 # oxygen
+        - 0.615413715 # nitrogen
 
 #Empty void
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -276,6 +276,7 @@
     slots:
       - Back
       - SuitStorage
+      - Belt
 
 #Filled security
 - type: entity


### PR DESCRIPTION
After a bunch of additional discussion in discord they're now basically upgraded mini jetpacks. 3L of air down from 5L, can go in the same slots as a mini. Gives them a new niche. Hopefully sec might actually want to use them now. No CL because this is an edit of a previous change that covers the changes. 