### PR TITLE
Radioactive chems for radiation artifact triggers

### DIFF
--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -164,13 +164,6 @@
   - type: ArtifactPressureTrigger
     minPressureThreshold: 50
 
-- type: artifactTrigger
-  id: TriggerHighDamage
-  targetDepth: 3
-  triggerHint: artifact-trigger-hint-physical
-  components:
-  - type: ArtifactDamageTrigger
-    damageThreshold: 500 #make it go boom or w/e
 
 - type: artifactTrigger
   id: TriggerRadiation
@@ -183,6 +176,15 @@
     - Radiation
     damageThreshold: 50
   - type: RadiationReceiver
+    components:
+  - type: Reactive
+    groups:
+      Acidic: [ Touch ]
+    reactions:
+    - reagents: [ Uranium, Tritium, Radium, UnstableMutagen, Phalanximine ]
+      methods: [ Touch ]
+      effects:
+      - !type:ActivateArtifact
 
 - type: artifactTrigger
   id: TriggerHighPressure

--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -177,7 +177,7 @@
     damageThreshold: 50
   - type: RadiationReceiver
     components:
-  - type: Reactive
+  - type: Reactive # IMP: Allow radioactive chems to trigger this
     groups:
       Acidic: [ Touch ]
     reactions:


### PR DESCRIPTION
1. Radioactive chems now trigger radiation artifact triggers
2. Removed a duplicate High damage trigger which should have been removed when I moved it to depth 4 and reduced required damage to 300. This meant there was a 300 damage requirement depth 4 trigger, and a 500 damage requirement depth 3 trigger. The depth 3 one is removed now.

:cl:
- tweak: Artifacts can now get their radiation fix from splashed chems
- tweak: Artifacts should be slightly less masochistic (removed duplicate damage trigger)
