### PR TITLE
fixed clownspiders throwing an error every frame they move

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2546,9 +2546,16 @@
     - type: Sprite
       drawdepth: Mobs
       layers:
-      - map: ["enum.DamageStateVisualLayers.Base"]
+      - map: ["enum.DamageStateVisualLayers.Base", "movement"]
         state: clown
         sprite: Mobs/Animals/clownspider.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: clown
+      noMovementLayers:
+        movement:
+          state: clown
     - type: Butcherable
       spawned:
         - id: MaterialBananium1


### PR DESCRIPTION
this does not give them a 'moving' sprite, it just prevents it from throwing an error because it inherits from MobSpiderAngryBase which expects a movement sprite. The sprite given is the same when moving and not moving


:cl:
- fix: clownspiders no longer throw an error every frame, should very very very slightly improve performance
