### PR TITLE
removed dupe thief beacon

### DIFF
--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -13,5 +13,4 @@
     - ThiefBeacon
     - ToolboxThief
     - ClothingHandsChameleonThief
-    - ThiefBeacon
     - ThiefBusinessCard #imp


### PR DESCRIPTION
shouldve caught this during the upstream merge oops

**Changelog**
:cl:
- fix: Thieves now have the correct amount of beacons.
