### PR TITLE
increase amount of heretics

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -18,8 +18,8 @@
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]
-      max: 5
-      playerRatio: 20
+      max: 6
+      playerRatio: 12 # little less than syndicates. maxes to 6 at >60 pop, previously 4 
       lateJoinAdditional: true
       blacklist:
         components:


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

i never actually changed the amount that spawned when making them main antags. hopefully this makes it so security doesn't lock them down as easily as they do currently. also afaik there haven't been any ascensions yet so it's definitely undertuned

after these changes, there will be 1 heretic per 12 crew, capping at 6 total. 
previously, it was 1 heretic per 20 crew, capping at 4 (technically 5, but we can't get that high at the current 80-pop server cap).

:cl:
- tweak: more players will be assigned as heretics on heretic rounds.