### PR TITLE
Jungle Juice Prevention Act

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Reactions/drinks.yml
@@ -143,6 +143,8 @@
 
 - type: reaction
   id: KingSoda
+  requiredMixerCategories:
+    - Stir
   reactants:
     CoconutWater:
       amount: 1
@@ -183,6 +185,8 @@
 
 - type: reaction
   id: JungleJuice
+  requiredMixerCategories:
+    - Shake
   reactants:
     Beer:
       amount: 0.5


### PR DESCRIPTION
In an effort to stop The Juicening, Jungle Juice and King Soda now require shaking and stirring respectively to make. It's not a full solution but maybe it'll help.

:cl:
- tweak: King Soda and Jungle Juice can no longer be fruitful and multiply.
