### PR TITLE
gray accent regex + uap fix

### DIFF
--- a/Content.Server/_Impstation/Speech/Components/GrayAccentComponent.cs
+++ b/Content.Server/_Impstation/Speech/Components/GrayAccentComponent.cs
@@ -1,10 +1,6 @@
-﻿namespace Content.Server.Speech.Components;
+namespace Content.Server.Speech.Components;
 
-/// <summary>
-///     Ayyy
-/// </summary>
 [RegisterComponent]
 public sealed partial class GrayAccentComponent : Component
 {
-
 }

--- a/Content.Server/_Impstation/Speech/EntitySystems/GrayAccentSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/GrayAccentSystem.cs
@@ -1,15 +1,19 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 
 namespace Content.Server.Speech.EntitySystems;
 
 public sealed class GrayAccentComponentAccentSystem : EntitySystem
 {
-    private static readonly Regex RegexLowerS = new("s+");
-    private static readonly Regex RegexUpperS = new("S+");
-    private static readonly Regex RegexInternalX = new(@"(\w)x");
-    private static readonly Regex RegexLowerEndX = new(@"\bx([\-|r|R]|\b)");
-    private static readonly Regex RegexUpperEndX = new(@"\bX([\-|r|R]|\b)");
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+
+    private static readonly Regex RegexAmContraction = new(@"([a-z])'[Mm]\b");
+    private static readonly Regex RegexAmContractionUpper = new(@"([A-Z])'[Mm]\b");
+    private static readonly Regex RegexAreContraction = new(@"([a-z])'[Rr][Ee]\b");
+    private static readonly Regex RegexAreContractionUpper = new(@"([A-Z])'[Rr][Ee]\b");
+    private static readonly Regex RegexThuiLower = new(@"(.)\b[Tt]hui\b");
+    private static readonly Regex RegexThuiUpperLeft = new(@"(\b[A-Z]+.)\b[Tt]hui\b");
+    private static readonly Regex RegexThuiUpperRight = new(@"\b[Tt]hui\b(.[A-Z]+\b)");
 
     public override void Initialize()
     {
@@ -20,6 +24,16 @@ public sealed class GrayAccentComponentAccentSystem : EntitySystem
     private void OnAccent(EntityUid uid, GrayAccentComponent component, AccentGetEvent args)
     {
         var message = args.Message;
+
+        message = _replacement.ApplyReplacements(message, "gray_accent");
+
+        message = RegexAmContraction.Replace(message, "$1-wa");
+        message = RegexAmContractionUpper.Replace(message, "$1-WA");
+        message = RegexAreContraction.Replace(message, "$1zz");
+        message = RegexAreContractionUpper.Replace(message, "$1ZZ");
+        message = RegexThuiLower.Replace(message, "$1thui");
+        message = RegexThuiUpperLeft.Replace(message, "$1THUI");
+        message = RegexThuiUpperRight.Replace(message, "THUI$1");
 
         args.Message = message;
     }

--- a/Resources/Locale/en-US/_Impstation/accent/gray.ftl
+++ b/Resources/Locale/en-US/_Impstation/accent/gray.ftl
@@ -1,8 +1,8 @@
 accent-gray-words-1 = the
 accent-gray-words-replace-1 = thusd
 
-accent-gray-words-2 = we're
-accent-gray-words-replace-2 = gleepzz
+accent-gray-words-2 = we
+accent-gray-words-replace-2 = gleep
 
 accent-gray-words-3 = go
 accent-gray-words-replace-3 = glorm
@@ -46,647 +46,635 @@ accent-gray-words-replace-15 = jumba
 accent-gray-words-16 = she
 accent-gray-words-replace-16 = jambu
 
-accent-gray-words-17 = you're
-accent-gray-words-replace-17 = mozz
+accent-gray-words-17 = at
+accent-gray-words-replace-17 = tii
 
-accent-gray-words-18 = at
-accent-gray-words-replace-18 = tii
+accent-gray-words-18 = on
+accent-gray-words-replace-18 = gimbo
 
-accent-gray-words-19 = on
-accent-gray-words-replace-19 = gimbo
+accent-gray-words-19 = game
+accent-gray-words-replace-19 = dom jot
 
-accent-gray-words-20 = game
-accent-gray-words-replace-20 = dom jot
+accent-gray-words-20 = power
+accent-gray-words-replace-20 = gramba
 
-accent-gray-words-21 = power
-accent-gray-words-replace-21 = gramba
+accent-gray-words-21 = not
+accent-gray-words-replace-21 = yaer
 
-accent-gray-words-22 = not
-accent-gray-words-replace-22 = yaer
+accent-gray-words-22 = make
+accent-gray-words-replace-22 = gnarp
 
-accent-gray-words-23 = make
-accent-gray-words-replace-23 = gnarp
+accent-gray-words-23 = drink
+accent-gray-words-replace-23 = sipsi
 
-accent-gray-words-24 = drink
-accent-gray-words-replace-24 = sipsi
+accent-gray-words-24 = engine
+accent-gray-words-replace-24 = vroma
 
-accent-gray-words-25 = engine
-accent-gray-words-replace-25 = vroma
+accent-gray-words-25 = spider
+accent-gray-words-replace-25 = eitei
 
-accent-gray-words-26 = spider
-accent-gray-words-replace-26 = eitei
+accent-gray-words-26 = bad
+accent-gray-words-replace-26 = deni
 
-accent-gray-words-27 = bad
-accent-gray-words-replace-27 = deni
+accent-gray-words-27 = syndicate
+accent-gray-words-replace-27 = booma
 
-accent-gray-words-28 = syndicate
-accent-gray-words-replace-28 = booma
+accent-gray-words-28 = syndie
+accent-gray-words-replace-28 = nuuka
 
-accent-gray-words-29 = syndie
-accent-gray-words-replace-29 = nuuka
+accent-gray-words-29 = nukie
+accent-gray-words-replace-29 = doomba
 
-accent-gray-words-30 = nukie
-accent-gray-words-replace-30 = doomba
+accent-gray-words-30 = from
+accent-gray-words-replace-30 = lorf
 
-accent-gray-words-31 = from
-accent-gray-words-replace-31 = lorf
+accent-gray-words-31 = fire
+accent-gray-words-replace-31 = tssshi
 
-accent-gray-words-32 = fire
-accent-gray-words-replace-32 = tssshi
+accent-gray-words-32 = ship
+accent-gray-words-replace-32 = glorm-vroma
 
-accent-gray-words-33 = ship
-accent-gray-words-replace-33 = glorm-vroma
+accent-gray-words-33 = fuck
+accent-gray-words-replace-33 = pisk
 
-accent-gray-words-34 = fuck
-accent-gray-words-replace-34 = pisk
+accent-gray-words-34 = fucking
+accent-gray-words-replace-34 = piskun
 
-accent-gray-words-35 = fucking
-accent-gray-words-replace-35 = piskun
+accent-gray-words-35 = damn
+accent-gray-words-replace-35 = douda
 
-accent-gray-words-36 = damn
-accent-gray-words-replace-36 = douda
+accent-gray-words-36 = bot
+accent-gray-words-replace-36 = beepi
 
-accent-gray-words-37 = bot
-accent-gray-words-replace-37 = beepi
+accent-gray-words-37 = borg
+accent-gray-words-replace-37 = beepimo
 
-accent-gray-words-38 = borg
-accent-gray-words-replace-38 = beepimo
+accent-gray-words-38 = say
+accent-gray-words-replace-38 = woota
 
-accent-gray-words-39 = say
-accent-gray-words-replace-39 = woota
+accent-gray-words-39 = state
+accent-gray-words-replace-39 = wotua
 
-accent-gray-words-40 = state
-accent-gray-words-replace-40 = wotua
+accent-gray-words-40 = slime
+accent-gray-words-replace-40 = sqoshi
 
-accent-gray-words-41 = slime
-accent-gray-words-replace-41 = sqoshi
+accent-gray-words-41 = ninja
+accent-gray-words-replace-41 = snekorf
 
-accent-gray-words-42 = ninja
-accent-gray-words-replace-42 = snekorf
+accent-gray-words-42 = dragon
+accent-gray-words-replace-42 = tsshi-suni
 
-accent-gray-words-43 = dragon
-accent-gray-words-replace-43 = tsshi-suni
+accent-gray-words-43 = lizard
+accent-gray-words-replace-43 = suni
 
-accent-gray-words-44 = lizard
-accent-gray-words-replace-44 = suni
+accent-gray-words-44 = space
+accent-gray-words-replace-44 = erth
 
-accent-gray-words-45 = space
-accent-gray-words-replace-45 = erth
+accent-gray-words-45 = peace
+accent-gray-words-replace-45 = kieel
 
-accent-gray-words-46 = peace
-accent-gray-words-replace-46 = kieel
+accent-gray-words-46 = come
+accent-gray-words-replace-46 = ouu
 
-accent-gray-words-47 = come
-accent-gray-words-replace-47 = ouu
+accent-gray-words-47 = music
+accent-gray-words-replace-47 = dreen
 
-accent-gray-words-48 = music
-accent-gray-words-replace-48 = dreen
+accent-gray-words-48 = sex
+accent-gray-words-replace-48 = oo-moo
 
-accent-gray-words-49 = sex
-accent-gray-words-replace-49 = oo-moo
+accent-gray-words-49 = chill
+accent-gray-words-replace-49 = mox
 
-accent-gray-words-50 = chill
-accent-gray-words-replace-50 = mox
+accent-gray-words-50 = bounties
+accent-gray-words-replace-50 = bogos
 
-accent-gray-words-51 = bounties
-accent-gray-words-replace-51 = bogos
+accent-gray-words-51 = shoot
+accent-gray-words-replace-51 = beba
 
-accent-gray-words-52 = shoot
-accent-gray-words-replace-52 = beba
+accent-gray-words-52 = mine
+accent-gray-words-replace-52 = keboo
 
-accent-gray-words-53 = mine
-accent-gray-words-replace-53 = keboo
+accent-gray-words-53 = cargo
+accent-gray-words-replace-53 = meilmo
 
-accent-gray-words-54 = cargo
-accent-gray-words-replace-54 = meilmo
+accent-gray-words-54 = rat
+accent-gray-words-replace-54 = cheezi
 
-accent-gray-words-55 = rat
-accent-gray-words-replace-55 = cheezi
+accent-gray-words-55 = tell
+accent-gray-words-replace-55 = glumpi
 
-accent-gray-words-56 = tell
-accent-gray-words-replace-56 = glumpi
+accent-gray-words-56 = told
+accent-gray-words-replace-56 = glumph
 
-accent-gray-words-57 = told
-accent-gray-words-replace-57 = glumph
+accent-gray-words-57 = look
+accent-gray-words-replace-57 = schui
 
-accent-gray-words-58 = look
-accent-gray-words-replace-58 = schui
+accent-gray-words-58 = by
+accent-gray-words-replace-58 = goiip
 
-accent-gray-words-59 = by
-accent-gray-words-replace-59 = goiip
+accent-gray-words-59 = human
+accent-gray-words-replace-59 = stupee
 
-accent-gray-words-60 = human
-accent-gray-words-replace-60 = stupee
+accent-gray-words-60 = moth
+accent-gray-words-replace-60 = ortimesi
 
-accent-gray-words-61 = moth
-accent-gray-words-replace-61 = ortimesi
+accent-gray-words-61 = artifact
+accent-gray-words-replace-61 = waba-ku
 
-accent-gray-words-62 = artifact
-accent-gray-words-replace-62 = waba-ku
+accent-gray-words-62 = machine
+accent-gray-words-replace-62 = waba-beepi
 
-accent-gray-words-63 = machine
-accent-gray-words-replace-63 = waba-beepi
+accent-gray-words-63 = uplink
+accent-gray-words-replace-63 = brimbi
 
-accent-gray-words-64 = uplink
-accent-gray-words-replace-64 = brimbi
+accent-gray-words-64 = mess
+accent-gray-words-replace-64 = finni
 
-accent-gray-words-65 = mess
-accent-gray-words-replace-65 = finni
+accent-gray-words-65 = understand
+accent-gray-words-replace-65 = indurstandar
 
-accent-gray-words-66 = understand
-accent-gray-words-replace-66 = indurstandar
+accent-gray-words-66 = away
+accent-gray-words-replace-66 = gloef
 
-accent-gray-words-67 = away
-accent-gray-words-replace-67 = gloef
+accent-gray-words-67 = pet
+accent-gray-words-replace-67 = dinne
 
-accent-gray-words-68 = pet
-accent-gray-words-replace-68 = dinne
+accent-gray-words-68 = tesla
+accent-gray-words-replace-68 = chalkee
 
-accent-gray-words-69 = tesla
-accent-gray-words-replace-69 = chalkee
+accent-gray-words-69 = oh
+accent-gray-words-replace-69 = bweee
 
-accent-gray-words-70 = oh
-accent-gray-words-replace-70 = bweee
+accent-gray-words-70 = my
+accent-gray-words-replace-70 = keb
 
-accent-gray-words-71 = my
-accent-gray-words-replace-71 = keb
+accent-gray-words-71 = johan
+accent-gray-words-replace-71 = clune
 
-accent-gray-words-72 = johan
-accent-gray-words-replace-72 = clune
+accent-gray-words-72 = clown
+accent-gray-words-replace-72 = slipi
 
-accent-gray-words-73 = clown
-accent-gray-words-replace-73 = slipi
+accent-gray-words-73 = god
+accent-gray-words-replace-73 = geena
 
-accent-gray-words-74 = god
-accent-gray-words-replace-74 = geena
+accent-gray-words-74 = they
+accent-gray-words-replace-74 = jamga
 
-accent-gray-words-75 = they
-accent-gray-words-replace-75 = jamga
+accent-gray-words-75 = coming
+accent-gray-words-replace-75 = ouuti
 
-accent-gray-words-76 = coming
-accent-gray-words-replace-76 = ouuti
+accent-gray-words-76 = what's
+accent-gray-words-replace-76 = sebon
 
-accent-gray-words-77 = what's
-accent-gray-words-replace-77 = sebon
+accent-gray-words-77 = it's
+accent-gray-words-replace-77 = eif
 
-accent-gray-words-78 = it's
-accent-gray-words-replace-78 = eif
+accent-gray-words-78 = it
+accent-gray-words-replace-78 = ei
 
-accent-gray-words-79 = it
-accent-gray-words-replace-79 = ei
+accent-gray-words-79 = thank
+accent-gray-words-replace-79 = graba
 
-accent-gray-words-80 = thank
-accent-gray-words-replace-80 = graba
+accent-gray-words-80 = thanks
+accent-gray-words-replace-80 = graba-u
 
-accent-gray-words-81 = thanks
-accent-gray-words-replace-81 = graba-u
+accent-gray-words-81 = should
+accent-gray-words-replace-81 = mobie
 
-accent-gray-words-82 = should
-accent-gray-words-replace-82 = mobie
+accent-gray-words-82 = want
+accent-gray-words-replace-82 = tek
 
-accent-gray-words-83 = want
-accent-gray-words-replace-83 = tek
+accent-gray-words-83 = your
+accent-gray-words-replace-83 = mou
 
-accent-gray-words-84 = your
-accent-gray-words-replace-84 = mou
+accent-gray-words-84 = be
+accent-gray-words-replace-84 = zooti
 
-accent-gray-words-85 = be
-accent-gray-words-replace-85 = zooti
+accent-gray-words-85 = grab
+accent-gray-words-replace-85 = flomi
 
-accent-gray-words-86 = grab
-accent-gray-words-replace-86 = flomi
+accent-gray-words-86 = good
+accent-gray-words-replace-86 = zigeef
 
-accent-gray-words-87 = good
-accent-gray-words-replace-87 = zigeef
+accent-gray-words-87 = even
+accent-gray-words-replace-87 = too
 
-accent-gray-words-88 = even
-accent-gray-words-replace-88 = too
+accent-gray-words-88 = odd
+accent-gray-words-replace-88 = tee
 
-accent-gray-words-89 = odd
-accent-gray-words-replace-89 = tee
+accent-gray-words-89 = our
+accent-gray-words-replace-89 = milx
 
-accent-gray-words-90 = our
-accent-gray-words-replace-90 = milx
+accent-gray-words-90 = motherfucker
+accent-gray-words-replace-90 = jambupisk
 
-accent-gray-words-91 = motherfucker
-accent-gray-words-replace-91 = jambupisk
+accent-gray-words-91 = was
+accent-gray-words-replace-91 = thikee
 
-accent-gray-words-92 = was
-accent-gray-words-replace-92 = thikee
+accent-gray-words-92 = out
+accent-gray-words-replace-92 = embinum
 
-accent-gray-words-93 = out
-accent-gray-words-replace-93 = embinum
+accent-gray-words-93 = for
+accent-gray-words-replace-93 = jazee
 
-accent-gray-words-94 = for
-accent-gray-words-replace-94 = jazee
+accent-gray-words-94 = up
+accent-gray-words-replace-94 = vru
 
-accent-gray-words-95 = up
-accent-gray-words-replace-95 = vru
+accent-gray-words-95 = down
+accent-gray-words-replace-95 = keb
 
-accent-gray-words-96 = down
-accent-gray-words-replace-96 = keb
+accent-gray-words-96 = who
+accent-gray-words-replace-96 = wamba
 
-accent-gray-words-97 = i'm
-accent-gray-words-replace-97 = thui-wa
+accent-gray-words-97 = isn't
+accent-gray-words-replace-97 = modeni
 
-accent-gray-words-98 = who
-accent-gray-words-replace-98 = wamba
+accent-gray-words-98 = cool
+accent-gray-words-replace-98 = not
 
-accent-gray-words-99 = isn't
-accent-gray-words-replace-99 = modeni
+accent-gray-words-99 = hot
+accent-gray-words-replace-99 = fum
 
-accent-gray-words-100 = cool
-accent-gray-words-replace-100 = not
+accent-gray-words-100 = cold
+accent-gray-words-replace-100 = noot
 
-accent-gray-words-101 = hot
-accent-gray-words-replace-101 = fum
+accent-gray-words-101 = always
+accent-gray-words-replace-101 = splorp
 
-accent-gray-words-102 = cold
-accent-gray-words-replace-102 = noot
+accent-gray-words-102 = way
+accent-gray-words-replace-102 = sporp
 
-accent-gray-words-103 = always
-accent-gray-words-replace-103 = splorp
+accent-gray-words-103 = ways
+accent-gray-words-replace-103 = spop
 
-accent-gray-words-104 = way
-accent-gray-words-replace-104 = sporp
+accent-gray-words-104 = are
+accent-gray-words-replace-104 = zazz
 
-accent-gray-words-105 = ways
-accent-gray-words-replace-105 = spop
+accent-gray-words-105 = pussy
+accent-gray-words-replace-105 = pushee
 
-accent-gray-words-106 = are
-accent-gray-words-replace-106 = zazz
+accent-gray-words-106 = dick
+accent-gray-words-replace-106 = deek
 
-accent-gray-words-107 = pussy
-accent-gray-words-replace-107 = pushee
+accent-gray-words-107 = today
+accent-gray-words-replace-107 = tronk
 
-accent-gray-words-108 = dick
-accent-gray-words-replace-108 = deek
+accent-gray-words-108 = to
+accent-gray-words-replace-108 = blagh
 
-accent-gray-words-109 = today
-accent-gray-words-replace-109 = tronk
+accent-gray-words-109 = too
+accent-gray-words-replace-109 = blaagh
 
-accent-gray-words-110 = to
-accent-gray-words-replace-110 = blagh
+accent-gray-words-110 = one
+accent-gray-words-replace-110 = zat
 
-accent-gray-words-111 = too
-accent-gray-words-replace-111 = blaagh
+accent-gray-words-111 = two
+accent-gray-words-replace-111 = blag
 
-accent-gray-words-112 = one
-accent-gray-words-replace-112 = zat
+accent-gray-words-112 = three
+accent-gray-words-replace-112 = zim
 
-accent-gray-words-113 = two
-accent-gray-words-replace-113 = blag
+accent-gray-words-113 = four
+accent-gray-words-replace-113 = flii
 
-accent-gray-words-114 = three
-accent-gray-words-replace-114 = zim
+accent-gray-words-114 = five
+accent-gray-words-replace-114 = jorp
 
-accent-gray-words-115 = four
-accent-gray-words-replace-115 = flii
+accent-gray-words-115 = six
+accent-gray-words-replace-115 = jurm
 
-accent-gray-words-116 = five
-accent-gray-words-replace-116 = jorp
+accent-gray-words-116 = seven
+accent-gray-words-replace-116 = beben
 
-accent-gray-words-117 = six
-accent-gray-words-replace-117 = jurm
+accent-gray-words-117 = eight
+accent-gray-words-replace-117 = toie
 
-accent-gray-words-118 = seven
-accent-gray-words-replace-118 = beben
+accent-gray-words-118 = nine
+accent-gray-words-replace-118 = tin
 
-accent-gray-words-119 = eight
-accent-gray-words-replace-119 = toie
+accent-gray-words-119 = ten
+accent-gray-words-replace-119 = plod
 
-accent-gray-words-120 = nine
-accent-gray-words-replace-120 = tin
+accent-gray-words-120 = you
+accent-gray-words-replace-120 = mo
 
-accent-gray-words-121 = ten
-accent-gray-words-replace-121 = plod
+accent-gray-words-121 = i
+accent-gray-words-replace-121 = thui
 
-accent-gray-words-122 = you
-accent-gray-words-replace-122 = mo
+accent-gray-words-122 = a
+accent-gray-words-replace-122 = pu
 
-accent-gray-words-123 = i
-accent-gray-words-replace-123 = thui
+accent-gray-words-123 = all
+accent-gray-words-replace-123 = ziip
 
-accent-gray-words-124 = im
-accent-gray-words-replace-124 = thui-wa
+accent-gray-words-124 = also
+accent-gray-words-replace-124 = frup
 
-accent-gray-words-125 = we
-accent-gray-words-replace-125 = gleep
+accent-gray-words-125 = and
+accent-gray-words-replace-125 = pib
 
-accent-gray-words-126 = a
-accent-gray-words-replace-126 = pu
+accent-gray-words-126 = as
+accent-gray-words-replace-126 = quz
 
-accent-gray-words-127 = all
-accent-gray-words-replace-127 = ziip
+accent-gray-words-127 = because
+accent-gray-words-replace-127 = woglump
 
-accent-gray-words-128 = also
-accent-gray-words-replace-128 = frup
+accent-gray-words-128 = but
+accent-gray-words-replace-128 = yii
 
-accent-gray-words-129 = and
-accent-gray-words-replace-129 = pib
+accent-gray-words-129 = can
+accent-gray-words-replace-129 = yim
 
-accent-gray-words-130 = as
-accent-gray-words-replace-130 = quz
+accent-gray-words-130 = could
+accent-gray-words-replace-130 = bormpt
 
-accent-gray-words-131 = because
-accent-gray-words-replace-131 = woglump
+accent-gray-words-131 = day
+accent-gray-words-replace-131 = twii
 
-accent-gray-words-132 = but
-accent-gray-words-replace-132 = yii
+accent-gray-words-132 = do
+accent-gray-words-replace-132 = zii
 
-accent-gray-words-133 = can
-accent-gray-words-replace-133 = yim
+accent-gray-words-133 = find
+accent-gray-words-replace-133 = bli
 
-accent-gray-words-134 = could
-accent-gray-words-replace-134 = bormpt
+accent-gray-words-134 = then
+accent-gray-words-replace-134 = zwep
 
-accent-gray-words-135 = day
-accent-gray-words-replace-135 = twii
+accent-gray-words-135 = hi
+accent-gray-words-replace-135 = ooo
 
-accent-gray-words-136 = do
-accent-gray-words-replace-136 = zii
+accent-gray-words-136 = hey
+accent-gray-words-replace-136 = oom
 
-accent-gray-words-137 = find
-accent-gray-words-replace-137 = bli
+accent-gray-words-137 = yes
+accent-gray-words-replace-137 = yeta
 
-accent-gray-words-138 = then
-accent-gray-words-replace-138 = zwep
+accent-gray-words-138 = no
+accent-gray-words-replace-138 = lopi
 
-accent-gray-words-139 = hi
-accent-gray-words-replace-139 = ooo
+accent-gray-words-139 = true
+accent-gray-words-replace-139 = mu
 
-accent-gray-words-140 = hey
-accent-gray-words-replace-140 = oom
+accent-gray-words-140 = wow
+accent-gray-words-replace-140 = mee
 
-accent-gray-words-141 = yes
-accent-gray-words-replace-141 = yeta
+accent-gray-words-141 = yeah
+accent-gray-words-replace-141 = zwee
 
-accent-gray-words-142 = no
-accent-gray-words-replace-142 = lopi
+accent-gray-words-142 = yay
+accent-gray-words-replace-142 = zwoo
 
-accent-gray-words-143 = true
-accent-gray-words-replace-143 = mu
+accent-gray-words-143 = nope
+accent-gray-words-replace-143 = lupi
 
-accent-gray-words-144 = wow
-accent-gray-words-replace-144 = mee
+accent-gray-words-144 = where
+accent-gray-words-replace-144 = uumi
 
-accent-gray-words-145 = yeah
-accent-gray-words-replace-145 = zwee
+accent-gray-words-145 = how
+accent-gray-words-replace-145 = ouli
 
-accent-gray-words-146 = yay
-accent-gray-words-replace-146 = zwoo
+accent-gray-words-146 = why
+accent-gray-words-replace-146 = euni
 
-accent-gray-words-147 = nope
-accent-gray-words-replace-147 = lupi
+accent-gray-words-147 = okay
+accent-gray-words-replace-147 = zwu
 
-accent-gray-words-148 = where
-accent-gray-words-replace-148 = uumi
+accent-gray-words-148 = whats
+accent-gray-words-replace-148 = sebon
 
-accent-gray-words-149 = how
-accent-gray-words-replace-149 = ouli
+accent-gray-words-149 = what
+accent-gray-words-replace-149 = seben
 
-accent-gray-words-150 = why
-accent-gray-words-replace-150 = euni
+accent-gray-words-150 = it
+accent-gray-words-replace-150 = ei
 
-accent-gray-words-151 = okay
-accent-gray-words-replace-151 = zwu
+accent-gray-words-151 = this
+accent-gray-words-replace-151 = glump
 
-accent-gray-words-152 = whats
-accent-gray-words-replace-152 = sebon
+accent-gray-words-152 = bounty
+accent-gray-words-replace-152 = bogo
 
-accent-gray-words-153 = what
-accent-gray-words-replace-153 = seben
+accent-gray-words-153 = fucker
+accent-gray-words-replace-153 = pisku
 
-accent-gray-words-154 = it
-accent-gray-words-replace-154 = ei
+accent-gray-words-154 = going
+accent-gray-words-replace-154 = glormun
 
-accent-gray-words-155 = this
-accent-gray-words-replace-155 = glump
+accent-gray-words-155 = having
+accent-gray-words-replace-155 = buugo
 
-accent-gray-words-156 = bounty
-accent-gray-words-replace-156 = bogo
+accent-gray-words-156 = has
+accent-gray-words-replace-156 = beeg
 
-accent-gray-words-157 = fucker
-accent-gray-words-replace-157 = pisku
+accent-gray-words-157 = fixed
+accent-gray-words-replace-157 = yuumba
 
-accent-gray-words-158 = going
-accent-gray-words-replace-158 = glormun
+accent-gray-words-158 = fixing
+accent-gray-words-replace-158 = yoombun
 
-accent-gray-words-159 = having
-accent-gray-words-replace-159 = buugo
+accent-gray-words-159 = helped
+accent-gray-words-replace-159 = tuupa
 
-accent-gray-words-160 = has
-accent-gray-words-replace-160 = beeg
+accent-gray-words-160 = helping
+accent-gray-words-replace-160 = toupun
 
-accent-gray-words-161 = fixed
-accent-gray-words-replace-161 = yuumba
+accent-gray-words-161 = stopped
+accent-gray-words-replace-161 = nitbul
 
-accent-gray-words-162 = fixing
-accent-gray-words-replace-162 = yoombun
+accent-gray-words-162 = stopping
+accent-gray-words-replace-162 = nitbun
 
-accent-gray-words-163 = helped
-accent-gray-words-replace-163 = tuupa
+accent-gray-words-163 = said
+accent-gray-words-replace-163 = wuuta
 
-accent-gray-words-164 = helping
-accent-gray-words-replace-164 = toupun
+accent-gray-words-164 = saying
+accent-gray-words-replace-164 = wootun
 
-accent-gray-words-165 = stopped
-accent-gray-words-replace-165 = nitbul
+accent-gray-words-165 = yours
+accent-gray-words-replace-165 = moue
 
-accent-gray-words-166 = stopping
-accent-gray-words-replace-166 = nitbun
+accent-gray-words-166 = telling
+accent-gray-words-replace-166 = glumpun
 
-accent-gray-words-167 = said
-accent-gray-words-replace-167 = wuuta
+accent-gray-words-167 = looked
+accent-gray-words-replace-167 = schuu
 
-accent-gray-words-168 = saying
-accent-gray-words-replace-168 = wootun
+accent-gray-words-168 = looking
+accent-gray-words-replace-168 = schuiun
 
-accent-gray-words-169 = yours
-accent-gray-words-replace-169 = moue
+accent-gray-words-169 = made
+accent-gray-words-replace-169 = gnurp
 
-accent-gray-words-170 = telling
-accent-gray-words-replace-170 = glumpun
+accent-gray-words-170 = making
+accent-gray-words-replace-170 = gnarpun
 
-accent-gray-words-171 = looked
-accent-gray-words-replace-171 = schuu
+accent-gray-words-171 = grabbed
+accent-gray-words-replace-171 = flumi
 
-accent-gray-words-172 = looking
-accent-gray-words-replace-172 = schuiun
+accent-gray-words-172 = grabbing
+accent-gray-words-replace-172 = flumun
 
-accent-gray-words-173 = made
-accent-gray-words-replace-173 = gnurp
+accent-gray-words-173 = found
+accent-gray-words-replace-173 = blu
 
-accent-gray-words-174 = making
-accent-gray-words-replace-174 = gnarpun
+accent-gray-words-174 = finding
+accent-gray-words-replace-174 = blin
 
-accent-gray-words-175 = grabbed
-accent-gray-words-replace-175 = flumi
+accent-gray-words-175 = gone
+accent-gray-words-replace-175 = glurm
 
-accent-gray-words-176 = grabbing
-accent-gray-words-replace-176 = flumun
+accent-gray-words-176 = drinking
+accent-gray-words-replace-176 = sipsun
 
-accent-gray-words-177 = found
-accent-gray-words-replace-177 = blu
+accent-gray-words-177 = drunk
+accent-gray-words-replace-177 = supsi
 
-accent-gray-words-178 = finding
-accent-gray-words-replace-178 = blin
+accent-gray-words-178 = came
+accent-gray-words-replace-178 = uoo
 
-accent-gray-words-179 = gone
-accent-gray-words-replace-179 = glurm
+accent-gray-words-179 = shooting
+accent-gray-words-replace-179 = bebun
 
-accent-gray-words-180 = drinking
-accent-gray-words-replace-180 = sipsun
+accent-gray-words-180 = shot
+accent-gray-words-replace-180 = buba
 
-accent-gray-words-181 = drunk
-accent-gray-words-replace-181 = supsi
+accent-gray-words-181 = powered
+accent-gray-words-replace-181 = grumba
 
-accent-gray-words-182 = came
-accent-gray-words-replace-182 = uoo
+accent-gray-words-182 = powering
+accent-gray-words-replace-182 = grambun
 
-accent-gray-words-183 = shooting
-accent-gray-words-replace-183 = bebun
+accent-gray-words-183 = spaced
+accent-gray-words-replace-183 = urth
 
-accent-gray-words-184 = shot
-accent-gray-words-replace-184 = buba
+accent-gray-words-184 = spacing
+accent-gray-words-replace-184 = erthun
 
-accent-gray-words-185 = powered
-accent-gray-words-replace-185 = grumba
+accent-gray-words-185 = messy
+accent-gray-words-replace-185 = fanni
 
-accent-gray-words-186 = powering
-accent-gray-words-replace-186 = grambun
+accent-gray-words-186 = thanking
+accent-gray-words-replace-186 = grabun
 
-accent-gray-words-187 = spaced
-accent-gray-words-replace-187 = urth
+accent-gray-words-187 = thanked
+accent-gray-words-replace-187 = gruba
 
-accent-gray-words-188 = spacing
-accent-gray-words-replace-188 = erthun
+accent-gray-words-188 = captains
+accent-gray-words-replace-188 = leedars
 
-accent-gray-words-189 = messy
-accent-gray-words-replace-189 = fanni
+accent-gray-words-189 = foods
+accent-gray-words-replace-189 = kibeabs
 
-accent-gray-words-190 = thanking
-accent-gray-words-replace-190 = grabun
+accent-gray-words-190 = waters
+accent-gray-words-replace-190 = sipas
 
-accent-gray-words-191 = thanked
-accent-gray-words-replace-191 = gruba
+accent-gray-words-191 = engines
+accent-gray-words-replace-191 = vromas
 
-accent-gray-words-192 = captains
-accent-gray-words-replace-192 = leedars
+accent-gray-words-192 = spiders
+accent-gray-words-replace-192 = eiteis
 
-accent-gray-words-193 = foods
-accent-gray-words-replace-193 = kibeabs
+accent-gray-words-193 = syndicates
+accent-gray-words-replace-193 = boomas
 
-accent-gray-words-194 = waters
-accent-gray-words-replace-194 = sipas
+accent-gray-words-194 = syndies
+accent-gray-words-replace-194 = nuukas
 
-accent-gray-words-195 = engines
-accent-gray-words-replace-195 = vromas
+accent-gray-words-195 = nukies
+accent-gray-words-replace-195 = me-doombas
 
-accent-gray-words-196 = spiders
-accent-gray-words-replace-196 = eiteis
+accent-gray-words-196 = fires
+accent-gray-words-replace-196 = tssshis
 
-accent-gray-words-197 = syndicates
-accent-gray-words-replace-197 = boomas
+accent-gray-words-197 = ships
+accent-gray-words-replace-197 = glorm-vromas
 
-accent-gray-words-198 = syndies
-accent-gray-words-replace-198 = nuukas
+accent-gray-words-198 = bots
+accent-gray-words-replace-198 = beepis
 
-accent-gray-words-199 = nukies
-accent-gray-words-replace-199 = me-doombas
+accent-gray-words-199 = borgs
+accent-gray-words-replace-199 = beepimos
 
-accent-gray-words-200 = fires
-accent-gray-words-replace-200 = tssshis
+accent-gray-words-200 = slimes
+accent-gray-words-replace-200 = sqoshis
 
-accent-gray-words-201 = ships
-accent-gray-words-replace-201 = glorm-vromas
+accent-gray-words-201 = ninjas
+accent-gray-words-replace-201 = snekorfi
 
-accent-gray-words-202 = bots
-accent-gray-words-replace-202 = beepis
+accent-gray-words-202 = dragons
+accent-gray-words-replace-202 = tssi-sunis
 
-accent-gray-words-203 = borgs
-accent-gray-words-replace-203 = beepimos
+accent-gray-words-203 = lizards
+accent-gray-words-replace-203 = sunis
 
-accent-gray-words-204 = slimes
-accent-gray-words-replace-204 = sqoshis
+accent-gray-words-204 = rats
+accent-gray-words-replace-204 = cheezis
 
-accent-gray-words-205 = ninjas
-accent-gray-words-replace-205 = snekorfi
+accent-gray-words-205 = humans
+accent-gray-words-replace-205 = stupees
 
-accent-gray-words-206 = dragons
-accent-gray-words-replace-206 = tssi-sunis
+accent-gray-words-206 = moths
+accent-gray-words-replace-206 = ortimesis
 
-accent-gray-words-207 = lizards
-accent-gray-words-replace-207 = sunis
+accent-gray-words-207 = artifacts
+accent-gray-words-replace-207 = waba-kus
 
-accent-gray-words-208 = rats
-accent-gray-words-replace-208 = cheezis
+accent-gray-words-208 = machines
+accent-gray-words-replace-208 = waba-beepis
 
-accent-gray-words-209 = humans
-accent-gray-words-replace-209 = stupees
+accent-gray-words-209 = uplinks
+accent-gray-words-replace-209 = brimbis
 
-accent-gray-words-210 = moths
-accent-gray-words-replace-210 = ortimesis
+accent-gray-words-210 = pets
+accent-gray-words-replace-210 = dinnes
 
-accent-gray-words-211 = artifacts
-accent-gray-words-replace-211 = waba-kus
+accent-gray-words-211 = teslas
+accent-gray-words-replace-211 = chalkees
 
-accent-gray-words-212 = machines
-accent-gray-words-replace-212 = waba-beepis
+accent-gray-words-212 = clowns
+accent-gray-words-replace-212 = slipis
 
-accent-gray-words-213 = uplinks
-accent-gray-words-replace-213 = brimbis
+accent-gray-words-213 = gods
+accent-gray-words-replace-213 = geenas
 
-accent-gray-words-214 = pets
-accent-gray-words-replace-214 = dinnes
+accent-gray-words-214 = pussies
+accent-gray-words-replace-214 = pushees
 
-accent-gray-words-215 = teslas
-accent-gray-words-replace-215 = chalkees
+accent-gray-words-215 = dicks
+accent-gray-words-replace-215 = deeks
 
-accent-gray-words-216 = clowns
-accent-gray-words-replace-216 = slipis
+accent-gray-words-216 = days
+accent-gray-words-replace-216 = twiis
 
-accent-gray-words-217 = gods
-accent-gray-words-replace-217 = geenas
+accent-gray-words-217 = fucked
+accent-gray-words-replace-217 = pusk
 
-accent-gray-words-218 = pussies
-accent-gray-words-replace-218 = pushees
+accent-gray-words-218 = petting
+accent-gray-words-replace-218 = dinnun
 
-accent-gray-words-219 = dicks
-accent-gray-words-replace-219 = deeks
+accent-gray-words-219 = petted
+accent-gray-words-replace-219 = dunne
 
-accent-gray-words-220 = days
-accent-gray-words-replace-220 = twiis
+accent-gray-words-220 = botted
+accent-gray-words-replace-220 = buupi
 
-accent-gray-words-221 = fucked
-accent-gray-words-replace-221 = pusk
+accent-gray-words-221 = botting
+accent-gray-words-replace-221 = beepun
 
-accent-gray-words-222 = petting
-accent-gray-words-replace-222 = dinnun
+accent-gray-words-222 = damned
+accent-gray-words-replace-222 = duuda
 
-accent-gray-words-223 = petted
-accent-gray-words-replace-223 = dunne
+accent-gray-words-223 = damning
+accent-gray-words-replace-223 = doudun
 
-accent-gray-words-224 = botted
-accent-gray-words-replace-224 = buupi
+accent-gray-words-224 = gaming
+accent-gray-words-replace-224 = dom-un
 
-accent-gray-words-225 = botting
-accent-gray-words-replace-225 = beepun
+accent-gray-words-225 = gamed
+accent-gray-words-replace-225 = dum jut
 
-accent-gray-words-226 = damned
-accent-gray-words-replace-226 = duuda
+accent-gray-words-226 = hello
+accent-gray-words-replace-226 = oum
 
-accent-gray-words-227 = damning
-accent-gray-words-replace-227 = doudun
-
-accent-gray-words-229 = gaming
-accent-gray-words-replace-229 = dom-un
-
-accent-gray-words-230 = gamed
-accent-gray-words-replace-230 = dum jut
-
-accent-gray-words-231 = hello
-accent-gray-words-replace-231 = oum
-
-accent-gray-words-232 = tesloose
-accent-gray-words-replace-232 = tellzoos
+accent-gray-words-227 = tesloose
+accent-gray-words-replace-227 = tellzoos

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -140,7 +140,7 @@
     - Adrenaline
     - Feminized # DeltaV - Hormone system
     - Masculinized # DeltaV - Hormone system
-    - GrayLanguage
+    - GrayLanguage # imp
   - type: Body
     prototype: Human
     requiredLegs: 2

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -140,6 +140,7 @@
     - Adrenaline
     - Feminized # DeltaV - Hormone system
     - Masculinized # DeltaV - Hormone system
+    - GrayLanguage
   - type: Body
     prototype: Human
     requiredLegs: 2

--- a/Resources/Prototypes/_Impstation/Accents/gray_replacements.yml
+++ b/Resources/Prototypes/_Impstation/Accents/gray_replacements.yml
@@ -1,5 +1,5 @@
 - type: accent
-  id: gray
+  id: gray_accent
   wordReplacements:
     accent-gray-words-1: accent-gray-words-replace-1
     accent-gray-words-2: accent-gray-words-replace-2
@@ -228,8 +228,3 @@
     accent-gray-words-225: accent-gray-words-replace-225
     accent-gray-words-226: accent-gray-words-replace-226
     accent-gray-words-227: accent-gray-words-replace-227
-    accent-gray-words-228: accent-gray-words-replace-228
-    accent-gray-words-229: accent-gray-words-replace-229
-    accent-gray-words-230: accent-gray-words-replace-230
-    accent-gray-words-231: accent-gray-words-replace-231
-    accent-gray-words-232: accent-gray-words-replace-232

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/gray.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/gray.yml
@@ -58,8 +58,6 @@
         color: "#00ff04"
   - type: Bloodstream
     bloodReagent: Radium
-  - type: ReplacementAccent
-    accent: gray
   - type: Inventory
     speciesId: gray
     templateId: gray

--- a/Resources/Prototypes/_Impstation/Reagents/Consumable/Drink/alchohol.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/Consumable/Drink/alchohol.yml
@@ -460,6 +460,9 @@
   metabolisms:
     Drink:
       effects:
+        - !type:GenericStatusEffect
+          key: GrayLanguage
+          component: GrayAccent
         - !type:SatiateThirst
           factor: 2
         - !type:AdjustReagent

--- a/Resources/Prototypes/_Impstation/status_effects.yml
+++ b/Resources/Prototypes/_Impstation/status_effects.yml
@@ -1,0 +1,2 @@
+- type: statusEffect
+  id: GrayLanguage # thui beego pu suggestion


### PR DESCRIPTION
`GrayAccent` is now a real accent system, meaning grays are no longer reliant on `ReplacementAccent` (which should hopefully fix cognizine issues). contractions are handled with regex so they've been cut from the gray accent ftl, and thui now respects capitalisation of words around it. thui is also said in lowercase in most cases instead of having the first letter capitalised. we are removing english grammar from grays little by little

also u.a.p. works: resolves #1512

**Changelog**
:cl:
- add: U.A.P. works properly. Mo blaagh yim speak like cheego.
- tweak: The Gray language has been slightly adjusted for consistency and capitalization.
