### PR TITLE
minor vox fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -14,8 +14,9 @@
     requiredLegs: 2
   - type:  HumanoidAppearance
     species: Vox
-    hideLayersOnEquip:
-    - HeadSide #imp
+    hideLayersOnEquip: #imp
+    - HeadSide
+    - Hair
     #- type: VoxAccent # Not yet coded
   - type: Speech
     speechVerb: Vox

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -80,8 +80,8 @@
       required: false
     Tail:
       points: 1
-      required: false #imp
-      #defaultMarkings: [ VoxTail ]
+      required: true
+      defaultMarkings: [ VoxTailBack ]
 
 - type: humanoidBaseSprite
   id: MobVoxEyes


### PR DESCRIPTION
hair hidden by helmets + tails are required again
**Changelog**
:cl: crocodilecarousel
- fix: Vox hair now correctly hides under helmets.
