### PR TITLE
gray and dwarf accent improvements

### DIFF
--- a/Content.Server/_Impstation/Speech/Components/DwarfAccentComponent.cs
+++ b/Content.Server/_Impstation/Speech/Components/DwarfAccentComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class DwarfAccentComponent : Component
+{
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/DwarfAccentSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/DwarfAccentSystem.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class DwarfAccentComponentSystem : EntitySystem
+{
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+
+    private static readonly Regex RegexAhAmContractionLower = new(@"(?<!^)(?<!\.\s+)\b[Aa]'[Mm]\b");
+    private static readonly Regex RegexAhAmContractionUpperLeft = new(@"(?<=\b[A-Z]+.)\b[Aa]'[Mm]\b");
+    private static readonly Regex RegexAhAmContractionUpperRight = new(@"\b[Aa]'[Mm]\b(?=.[A-Z]+\b)");
+    private static readonly Regex RegexAhLower = new(@"(?<!^)(?<!\.\s+)\b[Aa]h\b");
+    private static readonly Regex RegexAhUpperLeft = new(@"(?<=\b[A-Z]+.)\b[Aa]h\b");
+    private static readonly Regex RegexAhUpperRight = new(@"\b[Aa]h\b(?=.[A-Z]+\b)");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<DwarfAccentComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, DwarfAccentComponent component, AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        message = _replacement.ApplyReplacements(message, "dwarf");
+
+        message = RegexAhAmContractionLower.Replace(message, "a'm");
+        message = RegexAhAmContractionUpperLeft.Replace(message, "A'M");
+        message = RegexAhAmContractionUpperRight.Replace(message, "A'M");
+        message = RegexAhLower.Replace(message, "ah");
+        message = RegexAhUpperLeft.Replace(message, "AH");
+        message = RegexAhUpperRight.Replace(message, "AH");
+
+        args.Message = message;
+    }
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/GrayAccentSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/GrayAccentSystem.cs
@@ -7,13 +7,15 @@ public sealed class GrayAccentComponentAccentSystem : EntitySystem
 {
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
 
-    private static readonly Regex RegexAmContraction = new(@"([a-z])'[Mm]\b");
-    private static readonly Regex RegexAmContractionUpper = new(@"([A-Z])'[Mm]\b");
-    private static readonly Regex RegexAreContraction = new(@"([a-z])'[Rr][Ee]\b");
-    private static readonly Regex RegexAreContractionUpper = new(@"([A-Z])'[Rr][Ee]\b");
-    private static readonly Regex RegexThuiLower = new(@"(.)\b[Tt]hui\b");
-    private static readonly Regex RegexThuiUpperLeft = new(@"(\b[A-Z]+.)\b[Tt]hui\b");
-    private static readonly Regex RegexThuiUpperRight = new(@"\b[Tt]hui\b(.[A-Z]+\b)");
+    private static readonly Regex RegexPuUpperLeft = new(@"(?<=\b[A-Z]+.)\b[Pp]u\b");
+    private static readonly Regex RegexPuUpperRight = new(@"\b[Pp]u\b(?=.[A-Z]+\b)");
+    private static readonly Regex RegexThuiLower = new(@"(?<!^)(?<!\.\s+)\b[Tt]hui\b");
+    private static readonly Regex RegexThuiUpperLeft = new(@"(?<=\b[A-Z]+.)\b[Tt]hui\b");
+    private static readonly Regex RegexThuiUpperRight = new(@"\b[Tt]hui\b(?=.[A-Z]+\b)");
+    private static readonly Regex RegexAmContraction = new(@"(?<=[a-z])'[Mm]\b");
+    private static readonly Regex RegexAmContractionUpper = new(@"(?<=[A-Z])'[Mm]\b");
+    private static readonly Regex RegexAreContraction = new(@"(?<=[a-z])'[Rr][Ee]\b");
+    private static readonly Regex RegexAreContractionUpper = new(@"(?<=[A-Z])'[Rr][Ee]\b");
 
     public override void Initialize()
     {
@@ -27,13 +29,15 @@ public sealed class GrayAccentComponentAccentSystem : EntitySystem
 
         message = _replacement.ApplyReplacements(message, "gray_accent");
 
-        message = RegexAmContraction.Replace(message, "$1-wa");
-        message = RegexAmContractionUpper.Replace(message, "$1-WA");
-        message = RegexAreContraction.Replace(message, "$1zz");
-        message = RegexAreContractionUpper.Replace(message, "$1ZZ");
-        message = RegexThuiLower.Replace(message, "$1thui");
-        message = RegexThuiUpperLeft.Replace(message, "$1THUI");
-        message = RegexThuiUpperRight.Replace(message, "THUI$1");
+        message = RegexPuUpperLeft.Replace(message, "PU");
+        message = RegexPuUpperRight.Replace(message, "PU");
+        message = RegexThuiLower.Replace(message, "thui");
+        message = RegexThuiUpperLeft.Replace(message, "THUI");
+        message = RegexThuiUpperRight.Replace(message, "THUI");
+        message = RegexAmContraction.Replace(message, "-wa");
+        message = RegexAmContractionUpper.Replace(message, "-WA");
+        message = RegexAreContraction.Replace(message, "zz");
+        message = RegexAreContractionUpper.Replace(message, "ZZ");
 
         args.Message = message;
     }

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -48,8 +48,7 @@
       Male: MaleDwarf
       Female: FemaleDwarf
       Unsexed: UnisexDwarf
-  - type: ReplacementAccent
-    accent: dwarf
+  - type: DwarfAccent # imp
   - type: Speech
     speechSounds: Bass
   - type: HumanoidAppearance

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -13,8 +13,7 @@
     - type: MothAccent
     - type: SnalienAccent
     - type: GrayAccent
-    - type: ReplacementAccent
-      accent: dwarf
+    - type: DwarfAccent
     - type: NoContractionsAccent
 
 # 1 Cost
@@ -249,6 +248,6 @@
     - type: LizardAccent
     - type: MothAccent
     - type: GrayAccent
-    - type: ReplacementAccent
-      accent: dwarf
+    - type: DwarfAccent
       # Imp TODO: add cowboy, italian, liar, mobster, and slimes to this list one day since apparently you can only remove one ReplacementAccent at a time without pissing off the linter, maybe we can figure it out later. For now, adding the dwarf accent since that's an accent you can spawn with under current circumstances.
+      # idk about all this but dwarves have their own accent component now yay!!!!


### PR DESCRIPTION
noticed a few issues with the gray accent system on the server, mostly "thui" being lowercased at the start of a second sentence in the same speech line. mqole also requested the thui treatment for "ah" with the dwarf accent so this does that too. yay!

using lookbehinds and lookaheads for the gray accent now, instead of re-inserting a group into the string. regex101 my best friend

![image](https://github.com/user-attachments/assets/7864db89-6795-4ed9-8811-b9870ac6bd04)
![image](https://github.com/user-attachments/assets/ad94910f-f895-405a-a290-256d6c40fdc4)

**Changelog**
:cl:
- tweak: Grays and dwarves have had their accents fixed up a little.