### PR TITLE
corpse flap fix

### DIFF
--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -39,7 +39,7 @@ public sealed class StandingStateSystem : EntitySystem
         StandingStateComponent? standingState = null,
         AppearanceComponent? appearance = null,
         HandsComponent? hands = null,
-        bool intentional = true)
+        bool intentional = false)
     {
         // TODO: This should actually log missing comps...
         if (!Resolve(uid, ref standingState, false))


### PR DESCRIPTION
fixes corpses being unable to go under flaps. turns out most of the time, going down is unintentional. who knew? this might break something else but i doubt it. but its not impossible

**Changelog**
:cl:
- fix: Corpses no longer collide with plastic flaps.