### PR TITLE
remove trash animal migration gamerule

### DIFF
--- a/Resources/Prototypes/Announcers/intern.yml
+++ b/Resources/Prototypes/Announcers/intern.yml
@@ -112,8 +112,6 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-    #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/Announcers/medbot.yml
+++ b/Resources/Prototypes/Announcers/medbot.yml
@@ -110,8 +110,6 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-    #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/Announcers/mesavox.yml
+++ b/Resources/Prototypes/Announcers/mesavox.yml
@@ -110,8 +110,6 @@
       path: events/vent_critters.ogg
     - id: spiderSpawn # Some simple spiders are appearing in vents
       path: events/vent_critters.ogg
-    - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-      path: events/vent_critters.ogg
     - id: snailMigration # Adorable little snails are appearing in vents
       path: events/vent_critters.ogg
     - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/Announcers/michael.yml
+++ b/Resources/Prototypes/Announcers/michael.yml
@@ -112,8 +112,6 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-    #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/Announcers/neil.yml
+++ b/Resources/Prototypes/Announcers/neil.yml
@@ -112,8 +112,6 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-    #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/Announcers/sinister.yml
+++ b/Resources/Prototypes/Announcers/sinister.yml
@@ -129,8 +129,6 @@
       collection: SinisterVentcrittersAnnouncements
     - id: spiderSpawn # Some simple spiders are appearing in vents
       collection: SinisterVentcrittersAnnouncements
-    - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-      collection: SinisterVentcrittersAnnouncements
     - id: snailMigration # Adorable little snails are appearing in vents
       collection: SinisterVentcrittersAnnouncements
     - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/Announcers/tiktok.yml
+++ b/Resources/Prototypes/Announcers/tiktok.yml
@@ -112,8 +112,6 @@
       path: events/vent_critters.ogg
     - id: spiderSpawn # Some simple spiders are appearing in vents
       path: events/vent_critters.ogg
-    - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-      path: events/vent_critters.ogg
     - id: snailMigration # Adorable little snails are appearing in vents
       path: events/vent_critters.ogg
     - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/Announcers/voxfem.yml
+++ b/Resources/Prototypes/Announcers/voxfem.yml
@@ -110,8 +110,6 @@
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents
     #   path: events/vent_critters.ogg
-    # - id: trashAnimalMigration # Trash-eating critters are appearing in vents
-    #   path: events/vent_critters.ogg
     # - id: snailMigration # Adorable little snails are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: snailMigrationLowPop # Adorable little snails are appearing in vents

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -7,7 +7,6 @@
     - id: SnailMigrationLowPop
     - id: CockroachMigration
     - id: MouseMigration
-    - id: TrashAnimalMigration
     - id: LuggageMigration # imp special
 
 - type: entityTable
@@ -116,23 +115,6 @@
       prob: 0.002
     - id: MobSnailInstantDeath
       prob: 0.00001 #  ~ 1:2000 snails
-
-- type: entity
-  id: TrashAnimalMigration
-  parent: BaseStationEventShortDelay
-  components:
-  - type: StationEvent
-    earliestStart: 15
-    weight: 6
-    duration: 50
-  - type: VentCrittersRule
-    entries:
-    - id: MobRaccoonGhost
-      prob: 0.02
-    - id: MobPossumGhost
-      prob: 0.02
-    - id: MobMouse
-      prob: 0.02
 
 - type: entity
   id: SlimesSpawn


### PR DESCRIPTION
as title: this was added in an era where ghost roles were a lot less interesting and we were really starved for them, but with our current rotation of ghost role gamerules, raccoons and possums offer very little that's unique

this doesn't totally undo the work of #138: these animals still have accents and tied ghost roles if admins spawn them

**Changelog**
- remove: Raccoons and possums will no longer crawl out of the vents.