### PR TITLE
energy shotgun upstream parity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -740,15 +740,15 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserSpread
-    fireCost: 150 #imp revert
+    fireCost: 150
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: BulletLaserSpread
-      fireCost: 150 #imp revert
-    - proto: BulletLaserHeavySpread #imp revert
-      fireCost: 150 #imp revert
+      fireCost: 150
+    - proto: BulletLaserSpreadNarrow
+      fireCost: 200
     - proto: BulletDisablerSmgSpread
-      fireCost: 150 #imp revert
+      fireCost: 120
   - type: Item
     size: Large
     shape:
@@ -761,9 +761,11 @@
   - type: StealTarget
     stealGroup: WeaponEnergyShotgun
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
-  - type: Battery # THE WORLD RESET
-    maxCharge: 1050
-    startingCharge: 1050
+  - type: Battery
+    maxCharge: 1200
+    startingCharge: 1200
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 25 #takes 42 seconds to fully recharge, the answer to life, the universe and everything
+    autoRechargeRate: 24
+    autoRechargePause: true
+    autoRechargePauseTime: 30

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1035,13 +1035,13 @@
 
 - type: entity
   name: narrow laser barrage
-  id: BulletLaserHeavySpread #imp revert
+  id: BulletLaserSpreadNarrow
   categories: [ HideSpawnMenu ]
   parent: BulletLaser
   components:
   - type: ProjectileSpread
     proto: BulletLaserHeavy
-    count: 4 #60 heat damage if you hit all your shots, but narrower spread
+    count: 4 #52 heat damage if you hit all your shots, but narrower spread
     spread: 10
 
 - type: entity


### PR DESCRIPTION
matches parity with upstream's version of the energy shotgun: i was under the impression we already had these changes but i was wrong. the negative effect of this is mostly felt by antags stealing the energy shotgun, it's better at general use disabling since it has 3 more shots (7 -> 10) which is the majority of its use case for the head of security

**Changelog**
:cl:
- tweak: The energy shotgun now has a 30 second delay before recharging, and can fire more wide and disabler shots before emptying its battery. The amount of narrow shots before emptying has been reduced.