### PR TITLE
shipyard supply channel

### DIFF
--- a/Content.Shared/_DV/Shipyard/ShipyardConsoleComponent.cs
+++ b/Content.Shared/_DV/Shipyard/ShipyardConsoleComponent.cs
@@ -27,5 +27,5 @@ public sealed partial class ShipyardConsoleComponent : Component
     /// Radio channel to send the purchase announcement to.
     /// </summary>
     [DataField]
-    public ProtoId<RadioChannelPrototype> Channel = "Command";
+    public ProtoId<RadioChannelPrototype> Channel = "Supply";
 }


### PR DESCRIPTION
easiest pr of my life. everybody in supply cares when a ship is bought and over half of command doesnt care when a ship is bought. it just make sense.......

**Changelog**
:cl:
- tweak: Shipyard purchases are now announced over supply radio, rather than command.