### PR TITLE
Fix double counting of Heretic targets

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
@@ -147,9 +147,12 @@ public sealed partial class HereticSystem : EntitySystem
         }
 
         // add whatever more until satisfied
-        for (int i = 0; i <= ent.Comp.MaxTargets - pickedTargets.Count; i++)
-            if (eligibleTargets.Count > 0)
-                pickedTargets.Add(_rand.PickAndTake<EntityUid>(eligibleTargets));
+        while (ent.Comp.MaxTargets - pickedTargets.Count > 0)
+        {
+            if (eligibleTargets.Count <= 0)
+                break;
+            pickedTargets.Add(_rand.PickAndTake<EntityUid>(eligibleTargets));
+        }
 
         // leave only unique entityuids
         pickedTargets = pickedTargets.Distinct().ToList();

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
@@ -147,7 +147,7 @@ public sealed partial class HereticSystem : EntitySystem
         }
 
         // add whatever more until satisfied
-        while (ent.Comp.MaxTargets - pickedTargets.Count > 0)
+        while (ent.Comp.MaxTargets > pickedTargets.Count)
         {
             if (eligibleTargets.Count <= 0)
                 break;


### PR DESCRIPTION
Heretic targets were (partially) double counted during the adding process, which means that there were somewhat less targets than there should be as defined in HereticComponent.MaxCount.

Specifically, both the increment *i* and the count of picked targets were used: 
  ` i <= ent.Comp.MaxTargets - pickedTargets.Count; i++`
This would both increase the left hand side and decrease the right hand side. 
As one command target is added first, and the comparison is <=, this meant that effectively 2 were not double counted. 
So for a MaxTargets of 5: 
1 command
-> enter for loop
-> 2 targets (incl 1 command), i = 1
-> 3 targets, i = 2,
-> i (2) <= 5-3, so one more
-> 4 targets.

:cl:
- fix: Fix heretic target adding function double counting targets, should now have the correct number of targets in the heart.
