### PR TITLE
Let mops splash contents on mobs when used in melee

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -69,7 +69,9 @@ public sealed partial class PuddleSystem
         if (totalSplit == 0)
             return;
 
-        args.Handled = true;
+        // Skips handling the MeleeHitEvent here to allow spillable melee weapons to also deal damage. Imp addition. 
+        if (!entity.Comp.AllowMeleeDamage)
+            args.Handled = true;
 
         // First update the hit count so anything that is not reactive wont count towards the total!
         foreach (var hit in args.HitEntities)

--- a/Content.Shared/Fluids/Components/SpillableComponent.cs
+++ b/Content.Shared/Fluids/Components/SpillableComponent.cs
@@ -23,6 +23,13 @@ public sealed partial class SpillableComponent : Component
     [DataField]
     public FixedPoint2 MaxMeleeSpillAmount = FixedPoint2.New(20);
 
+    /// Imp addition
+    /// <summary>
+    ///     Should this item be allowed to deal melee damage when spilling?
+    /// </summary>
+    [DataField]
+    public bool AllowMeleeDamage = false;
+
     /// <summary>
     ///     Should this item be spilled when thrown?
     /// </summary>

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -25,6 +25,7 @@
       collection: MetalThud
   - type: Spillable
     solution: absorbed
+    spillWhenThrown: false #imp edit
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -57,6 +58,8 @@
       types:
         Blunt: 6
     staminaCost: 8
+  - type: DrainableSolution #imp edit, lets mop splash contents on melee attack
+    solution: absorbed
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -88,6 +88,7 @@
          collection: MetalThud
     - type: Spillable
       solution: absorbed
+      spillWhenThrown: false #imp edit
     - type: Wieldable
     - type: IncreaseDamageOnWield
       damage:
@@ -126,6 +127,8 @@
         types:
           Blunt: 6
       staminaCost: 8
+    - type: DrainableSolution #imp edit, lets mop splash contents on melee attack
+      solution: absorbed
 
 - type: entity
   name: wet floor sign

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -25,6 +25,7 @@
       collection: MetalThud
   - type: Spillable
     solution: absorbed
+    allowMeleeDamage: true #imp edit
     spillWhenThrown: false #imp edit
   - type: Wieldable
   - type: IncreaseDamageOnWield
@@ -88,6 +89,7 @@
          collection: MetalThud
     - type: Spillable
       solution: absorbed
+      allowMeleeDamage: true #imp edit
       spillWhenThrown: false #imp edit
     - type: Wieldable
     - type: IncreaseDamageOnWield


### PR DESCRIPTION
This adds the DrainableSolution component to the mop and advanced mop, letting them splash their contents on mobs when hit with a melee attack (up to 20 units at a time, spread evenly across all mobs hit when used in wide swing). I opted to make this only work on melee and not thrown, otherwise the entire contents of the mop would spill on the floor if it were enabled, which I don't really think the mop should do.  This additionally modifies the SpillableComponent and PuddleSystem.Spillable to allow spillable items to also deal melee damage if AllowMeleeDamage is set to true.

A fringe behavior that I found that adding this component caused was that it lets you use liquid containers like beakers on mops to drain their contents, but you can already do this by using the mop itself on containers, so I don't think it's a real issue.

![a9GfiRj](https://github.com/user-attachments/assets/28ba78e7-2c5c-4d34-bef5-6c32d55ccf73)

**Changelog**

:cl:
- add: Using a mop as a melee weapon now splashes some of its contents when it hits a mob.