### PR TITLE
RandomHumanoidAppearance changes.

### DIFF
--- a/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
+++ b/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
@@ -53,6 +53,7 @@ public sealed partial class RandomHumanoidAppearanceComponent : Component
     /// Defined in YML as, for example:
     /// markings:
     ///   ArachnidTorsoFiddleback: [ "#daf7da" ]
+    /// If the square brackets are empty (i.e. if the List<Color> has no members,) the color of that marking will be randomized.
     /// </summary>
     [DataField] public Dictionary<string, List<Color>>? Markings = null;
 }

--- a/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
+++ b/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
@@ -52,7 +52,7 @@ public sealed partial class RandomHumanoidAppearanceComponent : Component
     /// Will overwrite all randomized markings, if there are any. 
     /// Defined in YML as, for example:
     /// markings:
-    ///   ArachnidTorsoFiddleback: "#daf7da"
+    ///   ArachnidTorsoFiddleback: [ "#daf7da" ]
     /// </summary>
     [DataField] public Dictionary<string, List<Color>>? Markings = null;
 }

--- a/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
+++ b/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
@@ -1,4 +1,8 @@
+using Content.Shared.Access.Systems;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Markings;
 using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.Enums;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
 namespace Content.Server.CharacterAppearance.Components;
@@ -7,8 +11,48 @@ namespace Content.Server.CharacterAppearance.Components;
 public sealed partial class RandomHumanoidAppearanceComponent : Component
 {
     [DataField("randomizeName")] public bool RandomizeName = true;
+
+    // Overrides //
+
     /// <summary>
-    /// After randomizing, sets the hair style to this, if possible
+    /// After randomizing, sets the character's sex to this, if applicable.
+    /// </summary>
+    [DataField] public Sex? Sex = null;
+    /// <summary>
+    /// After randomizing, sets the character's age to this, if applicable.
+    /// </summary>
+    [DataField] public int? Age = null;
+    /// <summary>
+    /// After randomizing, sets the character's gender to this, if applicable.
+    /// </summary>
+    [DataField] public Gender? Gender = null;
+
+    /// <summary>
+    /// After randomizing, sets the character's hair to this, if applicable.
     /// </summary>
     [DataField] public string? Hair = null;
+    /// <summary>
+    /// After randomizing, sets the character's hair color to this, if applicable.
+    /// </summary>
+    [DataField] public Color? HairColor = null;
+    /// <summary>
+    /// After randomizing, sets the character's facial hair to this, if applicable.
+    /// </summary>
+    [DataField] public string? FacialHair = null;
+    /// <summary>
+    /// After randomizing, sets the character's eye color to this, if applicable.
+    /// </summary>
+    [DataField] public Color? EyeColor = null;
+    /// <summary>
+    /// After randomizing, sets the character's skin color to this, if applicable.
+    /// </summary>
+    [DataField] public Color? SkinColor = null;
+    /// <summary>
+    /// After randomizing, adds the markings from this dict, if applicable.
+    /// Will overwrite all randomized markings, if there are any. 
+    /// Defined in YML as, for example:
+    /// markings:
+    ///   ArachnidTorsoFiddleback: "#daf7da"
+    /// </summary>
+    [DataField] public Dictionary<string, List<Color>>? Markings = null;
 }

--- a/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
@@ -75,7 +75,6 @@ public sealed class RandomHumanoidAppearanceSystem : EntitySystem
         foreach (var keyValuePair in dict)
         {
             List<Color> markingColors = [];
-            var coolVar = keyValuePair.Value;
             // if the list<color> has no members, set it to our random color. otherwise, set it to the color in the list.
             if (keyValuePair.Value.Count <= 0)
             {

--- a/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.CharacterAppearance.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Preferences;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 
 namespace Content.Server.Humanoid.Systems;
 

--- a/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
@@ -1,8 +1,9 @@
+using System.Linq;
 using Content.Server.CharacterAppearance.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Preferences;
-using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
+using Robust.Shared.Random;
 
 namespace Content.Server.Humanoid.Systems;
 
@@ -10,6 +11,7 @@ public sealed class RandomHumanoidAppearanceSystem : EntitySystem
 {
     [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -65,9 +67,29 @@ public sealed class RandomHumanoidAppearanceSystem : EntitySystem
     private List<Marking> MarkingsToAdd(Dictionary<string, List<Color>> dict)
     {
         List<Marking> output = [];
+        var randomizeColor = new Color(
+        _random.NextFloat(1),
+        _random.NextFloat(1),
+        _random.NextFloat(1));
+
         foreach (var keyValuePair in dict)
         {
-            var toAdd = new Marking(keyValuePair.Key, keyValuePair.Value);
+            List<Color> markingColors = [];
+            var coolVar = keyValuePair.Value;
+            // if the list<color> has no members, set it to our random color. otherwise, set it to the color in the list.
+            if (keyValuePair.Value.Count <= 0)
+            {
+                markingColors.Add(randomizeColor);
+            }
+            else
+            {
+                foreach (var colors in keyValuePair.Value)
+                {
+                    markingColors.Add(colors);
+                }
+            }
+
+            var toAdd = new Marking(keyValuePair.Key, markingColors);
             output.Add(toAdd);
         }
         return output;

--- a/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
@@ -60,6 +60,11 @@
   - type: RandomHumanoidAppearance
     randomizeName: false
     hair: GoblinHairA
+    hairColor: "#ffdd56"
+    eyeColor: "#0d4883"
+    age: 35
+    sex: Male
+    skinColor: "#608c76"
 
 - type: entity
   parent: MobGoblin

--- a/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
@@ -108,12 +108,3 @@
       - id: Claymore 
       - id: EnergySword
         weight: 0.2
-
-- type: entity
-  id: RHATest
-  name: this guy should have markings lol
-  parent: MobArachnid
-  components:
-  - type: RandomHumanoidAppearance
-    markings:
-      ArachnidTorsoFiddleback: [ "#daf7da" ]

--- a/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/Player/goblin_player.yml
@@ -108,3 +108,12 @@
       - id: Claymore 
       - id: EnergySword
         weight: 0.2
+
+- type: entity
+  id: RHATest
+  name: this guy should have markings lol
+  parent: MobArachnid
+  components:
+  - type: RandomHumanoidAppearance
+    markings:
+      ArachnidTorsoFiddleback: [ "#daf7da" ]


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

added manual overrides for every aspect of humanoid profile/appearance in RandomHumanoidAppearanceComponent. used those to make Gollylad always look the same and be the same age. 

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Sir Gollylad now has a consistent appearance. He's still genderfluid, but now it's on purpose.

