### PR TITLE
Add LeaderHighlightComponent and add it to Revs

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -16,6 +16,7 @@ using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Screens;
 using Content.Client.UserInterface.Systems.Chat.Widgets;
 using Content.Client.UserInterface.Systems.Gameplay;
+using Content.Client._Impstation.LeaderHighlight; // imp
 using Content.Shared.CollectiveMind;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
@@ -25,6 +26,8 @@ using Content.Shared.Decals;
 using Content.Shared.Input;
 using Content.Shared.Radio;
 using Content.Shared.Roles.RoleCodeword;
+using Content.Shared.Whitelist; // imp. actually not sure this is used
+using Content.Shared._Impstation.LeaderHighlight; // imp
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -73,6 +76,8 @@ public sealed class ChatUIController : UIController, IOnSystemChanged<CharacterI
     [UISystemDependency] private readonly MindSystem? _mindSystem = default!;
     [UISystemDependency] private readonly RoleCodewordSystem? _roleCodewordSystem = default!;
     [UISystemDependency] private readonly CharacterInfoSystem _characterInfo = default!;
+    [UISystemDependency] private readonly LeaderHighlightSystem? _leaderHighlightSystem = default!; // imp
+    [UISystemDependency] private readonly EntityWhitelistSystem _whitelist = default!; // imp
 
     [ValidatePrototypeId<ColorPalettePrototype>]
     private const string ChatNamePalette = "ChatNames";
@@ -977,6 +982,18 @@ public sealed class ChatUIController : UIController, IOnSystemChanged<CharacterI
                 {
                     foreach (string codeword in codewordData.Codewords)
                         msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, codeword, "color", codewordData.Color.ToHex());
+                }
+            }
+        }
+
+        // imp special. Color *all* text sent by your leader. Currently only works for Revolutionaries.
+        if (_player.LocalUser != null && _mindSystem != null && _leaderHighlightSystem != null)
+        {
+            if (_mindSystem.TryGetMind(_player.LocalUser.Value, out var mindId) && _ent.TryGetComponent(mindId, out LeaderHighlightComponent? leaderHighlight))
+            {
+                if (_mindSystem.GetMind(_ent.GetEntity(msg.SenderEntity)) == leaderHighlight.Leader)
+                {
+                    msg.MessageColorOverride = leaderHighlight.HighlightColor;
                 }
             }
         }

--- a/Content.Client/_Impstation/LeaderHighlight/LeaderHighlightSystem.cs
+++ b/Content.Client/_Impstation/LeaderHighlight/LeaderHighlightSystem.cs
@@ -1,0 +1,8 @@
+using Content.Shared._Impstation.LeaderHighlight;
+
+namespace Content.Client._Impstation.LeaderHighlight;
+
+public sealed class LeaderHighlightSystem : SharedLeaderHighlightSystem
+{
+
+}

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -28,6 +28,7 @@ using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.Cuffs.Components;
+using Content.Shared._Impstation.LeaderHighlight; // imp special
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -167,6 +168,11 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
         if (mind?.Session != null)
             _antag.SendBriefing(mind.Session, Loc.GetString("rev-role-greeting"), Color.Red, revComp.RevStartSound);
+
+        // imp special. this grants LeaderHighlightComponent to the mind of the newly-created Rev and assigns their HeadRev as their leader
+        LeaderHighlightComponent leaderHighlight = EnsureComp<LeaderHighlightComponent>(mindId);
+        if (ev.User != null)
+            leaderHighlight.Leader = _mind.GetMind(ev.User.Value);
     }
 
     //TODO: Enemies of the revolution

--- a/Content.Server/_Impstation/LeaderHighlight/LeaderHighlightSystem.cs
+++ b/Content.Server/_Impstation/LeaderHighlight/LeaderHighlightSystem.cs
@@ -1,0 +1,8 @@
+using Content.Shared._Impstation.LeaderHighlight;
+
+namespace Content.Server._Impstation.LeaderHighlight;
+
+public sealed class LeaderHighlightSystem : SharedLeaderHighlightSystem
+{
+
+}

--- a/Content.Shared/_Impstation/LeaderHighlight/LeaderHighlightComponent.cs
+++ b/Content.Shared/_Impstation/LeaderHighlight/LeaderHighlightComponent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Impstation.LeaderHighlight;
+
+[RegisterComponent, AutoGenerateComponentState, NetworkedComponent]
+public sealed partial class LeaderHighlightComponent : Component
+{
+    /// <summary>
+    /// The mind of your current Leader. As this is only implemented in Revs right now, this marks the HeadRev who converted you.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? Leader = null;
+
+    /// <summary>
+    /// The color the text will be highlighted in.
+    /// </summary>
+    [DataField]
+    public Color HighlightColor = Color.Red;
+}

--- a/Content.Shared/_Impstation/LeaderHighlight/LeaderHighlightSystem.cs
+++ b/Content.Shared/_Impstation/LeaderHighlight/LeaderHighlightSystem.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Mind;
+using Robust.Shared.GameStates;
+using Robust.Shared.Player;
+
+namespace Content.Shared._Impstation.LeaderHighlight;
+
+public abstract class SharedLeaderHighlightSystem : EntitySystem
+{
+    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<LeaderHighlightComponent, ComponentGetStateAttemptEvent>(OnCompGetStateAttempt);
+    }
+
+    /// <summary>
+    /// Determines if LeaderHighlightComponent should be sent to the client.
+    /// </summary>
+    /// <param name="ent"></param>
+    /// <param name="args"></param>
+    private void OnCompGetStateAttempt(Entity<LeaderHighlightComponent> ent, ref ComponentGetStateAttemptEvent args)
+    {
+        args.Cancelled = !CanGetState(args.Player, ent.Comp);
+    }
+
+    /// <summary>
+    /// Only sends the component if its owner is the player mind. Else returns false.
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="comp"></param>
+    /// <returns></returns>
+    private bool CanGetState(ICommonSession? player, LeaderHighlightComponent comp)
+    {
+        if (!_mindSystem.TryGetMind(player, out EntityUid mindId, out var _))
+            return false;
+
+        if (!TryComp(mindId, out LeaderHighlightComponent? playerComp) && comp != playerComp)
+            return false;
+
+        return true;
+    }
+}


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Techsplanation:
this adds a new component which basically just stores a mind and a color, and ensures that it's only sending itself to the client if its owner is the player mind.
it adds a check to ChatUIController to check if the message sender's mind is the same as the stored Leader mind, and if it is, overrides that message's base color. 
it also adds a bit in RevolutionaryRuleSystem that adds that component to the mind of newly-converted Revs and sets its Leader value to the mind of the entity that converted them.

![5Hfc11F](https://github.com/user-attachments/assets/6924ec53-fc3a-4d35-9896-2abd90729c49)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Revolutionaries now see messages from the HeadRev who converted them highlighted in red.

