### PR TITLE
stop bottles & vials from fitting in cigarette packs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -49,8 +49,10 @@
       enum.TransferAmountUiKey.Key:
         type: TransferAmountBoundUserInterface
   - type: Item
-    size: Tiny
+    size: Small #imp
     sprite: Objects/Specific/Chemistry/beaker.rsi
+    shape: #imp
+    - 0,0,0,0
   - type: Spillable
     solution: drink
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -55,7 +55,7 @@
       enum.TransferAmountUiKey.Key:
         type: TransferAmountBoundUserInterface
   - type: Item
-    size: Tiny
+    size: Small #imp
     sprite: Objects/Specific/Chemistry/vial.rsi
     shape:
     - 0,0,0,0


### PR DESCRIPTION
explained rationale behind this one in the relevant suggestion thread, think this is a fair compromise (made items small, not tiny, but retained 1x1 size). basically it just doesnt make sense and feels like an exploit

:cl:
- tweak: Bottles and vials are a bit bigger. They might not fit as easily into small containers.