### PR TITLE
fix goblin tags again

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/Species/goblin.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/Species/goblin.yml
@@ -87,6 +87,10 @@
   - type: Tag
     tags:
     - VimPilot
+    - DoorBumpOpener
+    - CanPilot
+    - FootstepSound
+    - AnomalyHost
   - type: Reactive
     groups:
       Flammable: [ Touch ]


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Goblins can once more open doors, pilot shuttles, and host anomalies. 
