### PR TITLE
9/11 for vocaloid fans

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -82,7 +82,7 @@
         amount: 12
   - type: Tag
     tags:
-      - DroneUsable        
+      - DroneUsable
 
 - type: entity
   name: mixed lights box
@@ -101,7 +101,7 @@
         amount: 6
   - type: Tag
     tags:
-      - DroneUsable        
+      - DroneUsable
 
 - type: entity
   name: holiday lighttube box
@@ -238,8 +238,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingShoesBootsPerformer
-      - id: ClothingUniformJumpskirtPerformer
+      # - id: ClothingShoesBootsPerformer # imp - death to vocaloid
+      # - id: ClothingUniformJumpskirtPerformer # imp - death to vocaloid
       - id: FoodMealMemoryleek
         amount: 2
 
@@ -281,7 +281,7 @@
       - state: trashbag
   - type: Tag
     tags:
-      - DroneUsable      
+      - DroneUsable
 
 - type: entity
   name: passenger encryption key box

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -87,8 +87,8 @@
   components:
   - type: StorageFill
     contents:
-    - id: ClothingUniformJumpskirtPerformer
-    - id: ClothingShoesBootsPerformer
+    # - id: ClothingUniformJumpskirtPerformer # imp - death to vocaloid
+    # - id: ClothingShoesBootsPerformer # imp - death to vocaloid
     - id: ClothingOuterSuitMonkey
     - id: ClothingHeadHatAnimalMonkey
     - id: ClothingNeckCloakMoth

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -26,6 +26,9 @@
     ClothingHeadHatKippahSimple: 3 #imp
     ClothingHeadHatKippahWhiteAndBlue: 1 #imp
     ClothingHeadHatKippahBlueAndGold: 1 #imp
+    ClothingHeadHatShrineMaidenWig: 2 # imp edit - giving this religious outfit the sanctity it deserves
+    ClothingOuterSuitShrineMaiden: 2
+    Gohei: 2
   contrabandInventory:
     ClothingMaskClownChaplin: 1
     ClothingOuterClownPriest: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -12,23 +12,23 @@
     ClothingOuterHoodieBlack: 1
     ClothingHeadHatHoodNunHood: 1
     ClothingOuterNunRobe: 1
+    ClothingHeadHatKippahSimple: 3 #imp
+    ClothingHeadHatKippahWhiteAndBlue: 1 #imp
+    ClothingHeadHatKippahBlueAndGold: 1 #imp
     ClothingHeadHatFez: 1
     ClothingHeadHatPlaguedoctor: 1
     ClothingHeadHatWitch: 1
     ClothingHeadHatWitch1: 1
     ClothingOuterPlagueSuit: 1
     ClothingMaskPlague: 1
+    ClothingHeadHatShrineMaidenWig: 2 # imp edit - giving this religious outfit the sanctity it deserves
+    ClothingOuterSuitShrineMaiden: 2 # imp
     ClothingHeadsetService: 2
+    Gohei: 2
     Bible: 1
     BoxCandle: 2
     BoxCandleSmall: 2
     Urn: 5
-    ClothingHeadHatKippahSimple: 3 #imp
-    ClothingHeadHatKippahWhiteAndBlue: 1 #imp
-    ClothingHeadHatKippahBlueAndGold: 1 #imp
-    ClothingHeadHatShrineMaidenWig: 2 # imp edit - giving this religious outfit the sanctity it deserves
-    ClothingOuterSuitShrineMaiden: 2
-    Gohei: 2
   contrabandInventory:
     ClothingMaskClownChaplin: 1
     ClothingOuterClownPriest: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -36,9 +36,9 @@
     ClothingHeadHatChickenhead: 2
     ClothingOuterSuitMonkey: 2
     ClothingHeadHatPumpkin: 2
-    ClothingHeadHatShrineMaidenWig: 2
-    ClothingOuterSuitShrineMaiden: 2
-    Gohei: 2
+    # ClothingHeadHatShrineMaidenWig: 2 # imp edit - giving this religious outfit the sanctity it deserves
+    # ClothingOuterSuitShrineMaiden: 2
+    # Gohei: 2
     ClothingOuterSuitWitchRobes: 2
     ClothingHeadHatWitch1: 2
     ClothingHeadHatRedRacoon: 2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
@@ -2,7 +2,7 @@
   name: gohei
   parent: BaseItem
   id: Gohei
-  description: A wooden stick with white streamers at the end. Originally used by shrine maidens to purify things. Now used by the station's weeaboos.
+  description: A wooden stick with white streamers at the end. Originally used by shrine maidens to purify things. # Now used by the station's weeaboos.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/gohei.rsi


### PR DESCRIPTION
removing the miku outfit from being player accessible. this is b/c i would like to bring things more in line with the general discussion in #1492 and #1612 that "outfit from other media" with no other meaningful addition is not a good fit for the server. 

additionally its mostly been in the past but i found that the miku outfit encourages lrp/referential bits that are skirting towards if not directly in violation of our server rules

i have been successfully talked down from removing the reimu and marisa outfits as well. as a compromise, i've moved the shrine maiden set from the autodrobe to the pietyvend as it is a religious garb and not a cosplay

**Changelog**
:cl:
- remove: You have no longer heard of Hatsune Miku.
- tweak: Due to its status as a religious uniform, the shrine maiden outfit has been moved to the PietyVend.
