### PR TITLE
auto highlights for brigmed and courier

### DIFF
--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -12,10 +12,14 @@ highlights-detective = Detective, "Det", Security, "Sec"
 highlights-security-cadet = Security Cadet, Cadet, Security, "Sec"
 highlights-security-officer = Security Officer, Secoff, Officer, Security, "Sec"
 highlights-warden = Warden, "Ward", Security, "Sec"
+# impstation edit - new job
+highlights-brigmedic = Brigmedic, Brigmed, "Medic", Security, "Sec"
 
 # Cargo
 highlights-cargo-technician = Cargo Technician, Cargo Tech, Cargo
 highlights-salvage-specialist = Salvage Specialist, Salvager, Salvage, "Salv", Miner
+# impstation edit - new job
+highlights-courier = Courier, Mail
 
 # Engineering
 highlights-atmospheric-technician = Atmospheric Technician, Atmos tech, Atmospheric, Atmos

--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -19,7 +19,7 @@ highlights-brigmedic = Brigmedic, Brigmed, "Medic", Security, "Sec"
 highlights-cargo-technician = Cargo Technician, Cargo Tech, Cargo
 highlights-salvage-specialist = Salvage Specialist, Salvager, Salvage, "Salv", Miner
 # impstation edit - new job
-highlights-courier = Courier, Mail
+highlights-courier = Courier, Mail, Penalized
 
 # Engineering
 highlights-atmospheric-technician = Atmospheric Technician, Atmos tech, Atmospheric, Atmos


### PR DESCRIPTION
turns out this is super easy to add. huh!

![SS14 Loader_blPPLuzRJf](https://github.com/user-attachments/assets/217595d8-e8bf-4897-93d9-9996ab50adc2) ![SS14 Loader_KLhbbYEnDY](https://github.com/user-attachments/assets/5bb34f41-3cf2-49ea-8977-c4f2e450fb4f)


**Changelog**
:cl:
- add: Courier and Brigmedic now have appropriate text highlighting auto-fills.