### PR TITLE
Don't allow changelings to be sacrifice targets

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.Roles.Jobs;
 using Robust.Shared.Prototypes;
 using Content.Shared.Roles;
+using Content.Shared.Changeling;
 
 namespace Content.Server.Heretic.EntitySystems;
 
@@ -54,7 +55,7 @@ public sealed partial class HereticSystem : EntitySystem
         SubscribeLocalEvent<HereticComponent, BeforeDamageChangedEvent>(OnBeforeDamage);
         SubscribeLocalEvent<HereticComponent, DamageModifyEvent>(OnDamage);
 
-        
+
     }
 
     public override void Update(float frameTime)
@@ -123,7 +124,7 @@ public sealed partial class HereticSystem : EntitySystem
             eligibleTargets.Add(target.AttachedEntity!.Value); // it can't be null because see .Where(HasValue)
 
         // no heretics or other baboons
-        eligibleTargets = eligibleTargets.Where(t => !HasComp<GhoulComponent>(t) && !HasComp<HereticComponent>(t)).ToList();
+        eligibleTargets = eligibleTargets.Where(t => !HasComp<GhoulComponent>(t) && !HasComp<HereticComponent>(t) && !HasComp<ChangelingComponent>(t)).ToList();
 
         var pickedTargets = new List<EntityUid?>();
 


### PR DESCRIPTION
This doesn't stop targets from later becoming changelings, e.g from rolling after the heretic, but is an improvement over what already exists.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

:cl:
- fix: Heretics can no longer have changelings appear on the sacrifice heartbeat, because changelings cannot be sacrificed.
