### PR TITLE
supermatter console fix-ups

### DIFF
--- a/Content.Client/_EinsteinEngines/Supermatter/Consoles/SupermatterEntryContainer.xaml
+++ b/Content.Client/_EinsteinEngines/Supermatter/Consoles/SupermatterEntryContainer.xaml
@@ -23,7 +23,7 @@
             <gfx:StyleBoxFlat BackgroundColor="#25252a"/>
         </PanelContainer.PanelOverride>
         <BoxContainer Orientation="Horizontal" Margin="6 3">
-            
+
             <!-- Engine details -->
             <BoxContainer HorizontalExpand="True" Orientation="Vertical" Margin="0 0 6 0">
                 <!-- Integrity display -->
@@ -36,7 +36,7 @@
                                     <Label Name="IntegrityBarLabel" HorizontalAlignment="Right" Margin="0 0 4 0" />
                                 </ProgressBar>
                             </PanelContainer>
-                            <Button Name="IntegrityButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1">
+                            <Button Name="IntegrityButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1 -1 -2 -1">
                                 <TextureRect Name="IntegrityButtonArrow" TexturePath="/Textures/_EinsteinEngines/Interface/Supermatter/arrow_down.png" VerticalAlignment="Center" Margin="-8 -2 0 0" />
                             </Button>
                         </BoxContainer>
@@ -59,7 +59,7 @@
                                     <Label Name="PowerBarLabel" HorizontalAlignment="Right" Margin="0 0 4 0" />
                                 </ProgressBar>
                             </PanelContainer>
-                            <Button Name="PowerButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1">
+                            <Button Name="PowerButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1 -1 -2 -1">
                                 <TextureRect Name="PowerButtonArrow" TexturePath="/Textures/_EinsteinEngines/Interface/Supermatter/arrow_down.png" VerticalAlignment="Center" Margin="-8 -2 0 0" />
                             </Button>
                         </BoxContainer>
@@ -82,7 +82,7 @@
                                     <Label Name="RadiationBarLabel" HorizontalAlignment="Right" Margin="0 0 4 0" />
                                 </ProgressBar>
                             </PanelContainer>
-                            <Button Name="RadiationButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1">
+                            <Button Name="RadiationButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1 -1 -2 -1">
                                 <TextureRect Name="RadiationButtonArrow" TexturePath="/Textures/_EinsteinEngines/Interface/Supermatter/arrow_down.png" VerticalAlignment="Center" Margin="-8 -2 0 0" />
                             </Button>
                         </BoxContainer>
@@ -101,9 +101,9 @@
 
                 <!-- Absorbed moles display -->
                 <BoxContainer Orientation="Horizontal" Margin="0 1">
-                    <Label Name="MolesLabel" Text="{Loc 'supermatter-console-window-label-power'}" HorizontalExpand="True" HorizontalAlignment="Left" />
+                    <Label Name="MolesLabel" Text="{Loc 'supermatter-console-window-label-moles'}" HorizontalExpand="True" HorizontalAlignment="Left" />
                     <BoxContainer SetWidth="180" SetHeight="24" Orientation="Horizontal">
-                        <PanelContainer Name="MolesBarBorder" HorizontalExpand="True" Margin="0 0 4 0">
+                        <PanelContainer Name="MolesBarBorder" HorizontalExpand="True" Margin="0">
                             <ProgressBar Name="MolesBar" MinValue="0" MaxValue="100" Margin="1">
                                 <Label Name="MolesBarLabel" HorizontalAlignment="Right" Margin="0 0 4 0" />
                             </ProgressBar>
@@ -115,7 +115,7 @@
                 <BoxContainer Orientation="Horizontal" Margin="0 1">
                     <Label Name="TemperatureLabel" Text="{Loc 'supermatter-console-window-label-temperature'}" HorizontalExpand="True" HorizontalAlignment="Left" />
                     <BoxContainer SetWidth="180" SetHeight="24" Orientation="Horizontal">
-                        <PanelContainer Name="TemperatureBarBorder" HorizontalExpand="True" Margin="0 0 4 0">
+                        <PanelContainer Name="TemperatureBarBorder" HorizontalExpand="True" Margin="0">
                             <ProgressBar Name="TemperatureBar" MinValue="0" MaxValue="1000" Margin="1">
                                 <Label Name="TemperatureBarLabel" HorizontalAlignment="Right" Margin="0 0 4 0" />
                             </ProgressBar>
@@ -129,7 +129,7 @@
                         <Label Name="TemperatureLimitLabel" Text="{Loc 'supermatter-console-window-label-temperature-limit'}" HorizontalExpand="True" HorizontalAlignment="Left" />
                         <BoxContainer SetWidth="180" SetHeight="24" Orientation="Horizontal">
                             <Label Name="TemperatureLimitBarLabel" HorizontalExpand="True" HorizontalAlignment="Left" Margin="0 0 4 0" />
-                            <Button Name="TemperatureLimitButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1">
+                            <Button Name="TemperatureLimitButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1 -1 -2 -1">
                                 <TextureRect Name="TemperatureLimitButtonArrow" TexturePath="/Textures/_EinsteinEngines/Interface/Supermatter/arrow_down.png" VerticalAlignment="Center" Margin="-8 -2 0 0" />
                             </Button>
                         </BoxContainer>
@@ -182,8 +182,16 @@
                 </BoxContainer>
             </BoxContainer>
 
-            <!-- Gas details (entries added by C# code) -->
-            <BoxContainer Name="GasTable" HorizontalExpand="True" VerticalExpand="True" Orientation="Vertical" Margin="6 0 0 0" />
+            <!-- Gas details -->
+            <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Margin="6 0 0 0">
+                <!-- Show all gases -->
+                <Button Name="ShowAllGasButton" StyleClasses="OpenLeft" SetHeight="26" HorizontalAlignment="Right">
+                    <Label Name="ShowAllGasLabel" Text="{Loc 'supermatter-console-window-label-show-all-gas'}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="4 0 0 0" />
+                </Button>
+
+                <!-- Gas table (entries added by C# code) -->
+                <BoxContainer Name="GasTable" Orientation="Vertical" />
+            </BoxContainer>
         </BoxContainer>
     </PanelContainer>
 

--- a/Content.Client/_EinsteinEngines/Supermatter/Consoles/SupermatterEntryContainer.xaml.cs
+++ b/Content.Client/_EinsteinEngines/Supermatter/Consoles/SupermatterEntryContainer.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
     private readonly Color _colorRed = StyleNano.DangerousRedFore;
     private readonly Color _colorOrange = StyleNano.ConcerningOrangeFore;
     private readonly Color _colorGreen = StyleNano.GoodGreenFore;
-    private readonly Color _colorTurqoise = Color.FromHex("#00fff7");
+    private readonly Color _colorTurquoise = Color.FromHex("#00fff7");
 
     // Arrow icons
     private readonly string _arrowUp = "/Textures/_EinsteinEngines/Interface/Supermatter/arrow_up.png";
@@ -44,6 +44,9 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
 
     // Save focus data values so we don't update too often
     private SupermatterFocusData _focusData;
+
+    // Other saved variables
+    private bool _showAllGases;
 
     public SupermatterEntryContainer(NetEntity uid)
     {
@@ -60,12 +63,12 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
         // Set the engine dictionary
         _engineDictionary = new()
         {
-            { "integrity",   ( IntegrityBarLabel,   IntegrityBar,   IntegrityBarBorder,   0.9f, 0.1f, _colorRed,      _colorOrange, _colorGreen ) },
-            { "power",       ( PowerBarLabel,       PowerBar,       PowerBarBorder,       0.9f, 0.1f, _colorGreen,    _colorOrange, _colorRed   ) },
-            { "radiation",   ( RadiationBarLabel,   RadiationBar,   RadiationBarBorder,   0.1f, 0.9f, _colorGreen,    _colorOrange, _colorRed   ) },
-            { "moles",       ( MolesBarLabel,       MolesBar,       MolesBarBorder,       0.5f, 0.5f, _colorGreen,    _colorOrange, _colorRed   ) },
-            { "temperature", ( TemperatureBarLabel, TemperatureBar, TemperatureBarBorder, 0.9f, 0.1f, _colorTurqoise, _colorGreen,  _colorRed   ) },
-            { "waste",       ( WasteBarLabel,       WasteBar,       WasteBarBorder,       0.5f, 0.5f, _colorGreen,    _colorOrange, _colorRed   ) }
+            { "integrity",   ( IntegrityBarLabel,   IntegrityBar,   IntegrityBarBorder,   0.9f, 0.1f, _colorRed,       _colorOrange, _colorGreen ) },
+            { "power",       ( PowerBarLabel,       PowerBar,       PowerBarBorder,       0.9f, 0.1f, _colorGreen,     _colorOrange, _colorRed   ) },
+            { "radiation",   ( RadiationBarLabel,   RadiationBar,   RadiationBarBorder,   0.1f, 0.9f, _colorGreen,     _colorOrange, _colorRed   ) },
+            { "moles",       ( MolesBarLabel,       MolesBar,       MolesBarBorder,       0.5f, 0.5f, _colorGreen,     _colorOrange, _colorRed   ) },
+            { "temperature", ( TemperatureBarLabel, TemperatureBar, TemperatureBarBorder, 0.9f, 0.1f, _colorTurquoise, _colorGreen,  _colorRed   ) },
+            { "waste",       ( WasteBarLabel,       WasteBar,       WasteBarBorder,       0.5f, 0.5f, _colorGreen,     _colorOrange, _colorRed   ) }
         };
 
         // Set the gas bar data
@@ -151,6 +154,7 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
         // Set fonts and font colors
         SupermatterNameLabel.FontOverride = headerFont;
         SupermatterStatusLabel.FontOverride = normalFont;
+        ShowAllGasLabel.FontOverride = normalFont;
 
         IntegrityHealingInfoLabel.FontColorOverride = _colorGreen;
         RadiationBaseInfoLabel.FontColorOverride = _colorGreen;
@@ -174,6 +178,9 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
             label.FontColorOverride = _colorSlate;
         }
 
+        // Set other variables
+        _showAllGases = false;
+
         // On click
         foreach (var detail in _expandDetails)
         {
@@ -183,6 +190,11 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
                 detail.Arrow.TexturePath = detail.Container.Visible ? _arrowUp : _arrowDown;
             };
         }
+
+        ShowAllGasButton.OnButtonUp += args =>
+        {
+            _showAllGases = !_showAllGases;
+        };
     }
 
     public void UpdateEntry(SupermatterConsoleEntry entry, bool isFocus, SupermatterFocusData? focusData = null)
@@ -253,11 +265,8 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
                     gasData.Add((data, moles));
                     data.Bar.UpdateEntry(gas, _focusData);
 
-                    // Hide 0% gases
-                    if (moles == 0f)
-                        data.Bar.Visible = false;
-                    else
-                        data.Bar.Visible = true;
+                    // Only show gases above 0%, unless "show all gases" is enabled
+                    data.Bar.Visible = moles > 0f || _showAllGases;
                 }
 
                 var gasSort = gasData.OrderByDescending(x => x.Moles).ThenBy(x => x.GasBarData.Gas);

--- a/Content.Client/_EinsteinEngines/Supermatter/Consoles/SupermatterGasBarContainer.xaml
+++ b/Content.Client/_EinsteinEngines/Supermatter/Consoles/SupermatterGasBarContainer.xaml
@@ -13,12 +13,12 @@
                         <Label Name="GasBarLabel" HorizontalAlignment="Right" Margin="0 0 4 0" />
                     </ProgressBar>
                 </PanelContainer>
-                <Button Name="GasButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1">
+                <Button Name="GasButton" SetWidth="27" StyleClasses="ButtonSquare" Margin="-1 -1 0 -1">
                     <TextureRect Name="GasButtonArrow" TexturePath="/Textures/_EinsteinEngines/Interface/Supermatter/arrow_down.png" VerticalAlignment="Center" Margin="-8 -2 0 0" />
                 </Button>
             </BoxContainer>
         </BoxContainer>
-        
+
         <BoxContainer Name="DetailsContainer" Orientation="Vertical" Margin="16 2 0 0" Visible="False">
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
                 <Label Name="HeaderLabel" Text="{Loc 'supermatter-console-window-label-details'}" />

--- a/Resources/Locale/en-US/_EinsteinEngines/supermatter/supermatter-console.ftl
+++ b/Resources/Locale/en-US/_EinsteinEngines/supermatter/supermatter-console.ftl
@@ -15,6 +15,8 @@ supermatter-console-window-status-danger = Danger
 supermatter-console-window-status-emergency = Emergency
 supermatter-console-window-status-delaminating = Delaminating
 
+supermatter-console-window-label-show-all-gas = Show All Gases
+
 supermatter-console-window-label-integrity = Integrity:
 supermatter-console-window-label-integrity-bar = {$integrity}%
 supermatter-console-window-label-integrity-healing = Low Temperature Healing (Δ):


### PR DESCRIPTION
added a "show all gases" button to the supermatter console so engineers dont have to keep loading the sm with different gases to see their properties. also fixed up some minor alignment issues, and the "absorbed moles" label being wrong
![image](https://github.com/user-attachments/assets/aa7e4c7a-a0c4-4978-9d79-5b4b267a5f57)

**Changelog**
:cl:
- add: "Show all gases" has been added to the supermatter console.