### PR TITLE
supermatter safety moth parity

### DIFF
--- a/Content.Server/_EinsteinEngines/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EinsteinEngines/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -2,9 +2,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using Content.Server.Chat.Systems;
-using Content.Server.Explosion.EntitySystems;
 using Content.Server.Singularity.Components;
-using Content.Server.Sound.Components;
 using Content.Shared._EinsteinEngines.CCVar;
 using Content.Shared._EinsteinEngines.Supermatter.Components;
 using Content.Shared.Atmos;
@@ -17,6 +15,7 @@ using Content.Shared.Physics;
 using Content.Shared.Radiation.Components;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Speech;
+using Content.Shared.Storage.Components;
 using Content.Shared.Traits.Assorted;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -671,10 +670,11 @@ public sealed partial class SupermatterSystem
         // Play the reality distortion sound for every player on the map
         _audio.PlayGlobal(sm.DistortSound, mapFilter, true);
 
-        // Add hallucinations to every player on the map
+        // Add hallucinations to every mob on the map, except those in EntityStorage (lockers, etc)
         // TODO: change this from paracusia to actual hallucinations whenever those are real
         var mobLookup = new HashSet<Entity<MobStateComponent>>();
         _entityLookup.GetEntitiesOnMap<MobStateComponent>(mapId, mobLookup);
+        mobLookup.RemoveWhere(x => HasComp<InsideEntityStorageComponent>(x));
 
         // These values match the paracusia disability, since we can't double up on paracusia
         var paracusiaSounds = new SoundCollectionSpecifier("Paracusia");
@@ -741,7 +741,7 @@ public sealed partial class SupermatterSystem
     }
 
     /// <summary>
-    /// Checks for 
+    /// Checks whether a mob can see the supermatter, then applies hallucinations and psychologist coefficient
     /// </summary>
     private void HandleVision(EntityUid uid, SupermatterComponent sm)
     {


### PR DESCRIPTION
adds exceptions to the map-wide paracusia for mobs inside EntityStorage like lockers to achieve parity with the safety moth poster. very important

![image](https://github.com/user-attachments/assets/12754c59-bc14-4c52-a1b2-86a41ad8de44)

also removed some unused usings and fixed up a comment

**Changelog**
:cl:
- add: Hiding inside a locker will prevent supermatter delamination hallucinations.
