### PR TITLE
Move tokens from roundstart sec inventories to seclinks

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -34,7 +34,4 @@
     - Flash
     - ForensicPad
     - ForensicScanner
-    - BatonToken1  #imp
-    - DisablerToken1  #imp
-    - UtilityToken1  #imp
     - CrayonChalk # imp edit

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -49,7 +49,4 @@
     back:
     - Flash
     - MagazinePistol
-    - BatonToken1  #imp
-    - DisablerToken1  #imp
-    - UtilityToken1  #imp
 

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -39,7 +39,4 @@
     back:
     - Flash
     - MagazinePistol
-    - BatonToken1  #imp
-    - DisablerToken1  #imp
-    - UtilityToken1  #imp
     - WeaponPistolMk58

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -32,6 +32,3 @@
     back:
     - Flash
     - MagazinePistol
-    - BatonToken1  #imp
-    - DisablerToken1  #imp
-    - UtilityToken1  #imp

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -34,7 +34,4 @@
     back:
     - Flash
     - MagazinePistol
-    - BatonToken1  #imp
-    - DisablerToken1  #imp
-    - UtilityToken1  #imp
 

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Security/seclink.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Security/seclink.yml
@@ -118,6 +118,6 @@
     key: enum.StoreUiKey.Key
   - type: Store
     balance:
-      BatonToken: 0
-      DisablerToken: 0
-      UtilityToken: 0
+      BatonToken: 1
+      DisablerToken: 1
+      UtilityToken: 1

--- a/Resources/Prototypes/_Impstation/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Jobs/Security/brigmedic.yml
@@ -31,9 +31,3 @@
     ears: ClothingHeadsetBrigmedic
     id: BrigmedicPDA
     belt: ClothingBeltMedicalEMTFilled
-  storage:
-    back:
-    - Flash
-    - BatonToken1  #imp
-    - DisablerToken1  #imp
-    - UtilityToken1  #imp


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Before seclinks were introduced, anybody that broke into a security locker could nab a disabler or stun baton out of it. Newly deputized officers could just walk in and grab their things from the locker room without assistance from a Warden or HoS, and if you're an antag on a map with one of those isolated security outposts with lockers in them, breaking in would net you some valuable loot. This PR lets you do both again.
While it is now possible for anybody in security to loot multiple lockers and buy two disablers or whatever, it was also possible to grab multiple disablers from lockers before seclinks were introduced, and that didn't happen so much. I suspect most people are not going to be a dick and take too much from the lockers. If they do, the Warden still has spare tokens they can give out.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Baton, disabler and utility tokens now start in seclinks instead of roundstart security inventories.
