### PR TITLE
more heretic fixes

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
@@ -3,6 +3,7 @@ using Content.Shared.Dataset;
 using Content.Shared.Heretic;
 using Content.Shared.Heretic.Prototypes;
 using Content.Shared.Tag;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Text;
@@ -19,6 +20,8 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
     private IRobustRandom _rand = default!;
     private EntityLookupSystem _lookup = default!;
     private HereticSystem _heretic = default!;
+    private SharedContainerSystem _container = default!;
+
 
     [ValidatePrototypeId<DatasetPrototype>]
     public const string EligibleTagsDataset = "EligibleTags";
@@ -30,6 +33,7 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
         _rand = IoCManager.Resolve<IRobustRandom>();
         _lookup = args.EntityManager.System<EntityLookupSystem>();
         _heretic = args.EntityManager.System<HereticSystem>();
+
 
         outstr = null;
 
@@ -45,7 +49,9 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
         {
             foreach (var tag in requiredTags)
             {
-                if (!args.EntityManager.TryGetComponent<TagComponent>(look, out var tags))
+                //WHY DID THEY JUST COPY-PASTE THE NORMAL RITUAL CODE. JUST USE THE NORMAL RITUAL CODE I AM BEGGING
+                if (!args.EntityManager.TryGetComponent<TagComponent>(look, out var tags)
+                    || _container.IsEntityInContainer(look))
                     continue;
                 var ltags = tags.Tags;
 

--- a/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-side.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-side.ftl
@@ -8,8 +8,8 @@ knowledge-path-side-s3-armor-desc =
 
 knowledge-path-side-s3-flask-name = Priest's Ritual
 knowledge-path-side-s3-flask-desc =
-    Transmute a tank of water into a Flask of Eldritch Water.
-    When consumed, the water will heal a bit of everything for Heretics, and hurt a bit of everything for Heathens.
+    Transmute a tank of water and a glass shard into a Flask of Eldritch Water.
+    The flask contains a mixture of potent medicines.
 
 ## stage 5
 knowledge-path-side-s5-name = Ritual of Knowledge

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -54,10 +54,11 @@
       drink:
         # it's a cryostasis flash filled with healing goodies what could possibly go wrong?
         # i will certainly not abuse it as a heretic chemist
-        maxVol: 100
-        canReact: false
+        # imp edit: ^^^^this guy no longer has his free 100u cryostasis beaker to pwn noobs with. jesus christ
+        maxVol: 75
+        canReact: true
         reagents:
         - ReagentId: Omnizine
-          Quantity: 80
+          Quantity: 60
         - ReagentId: TranexamicAcid
-          Quantity: 20
+          Quantity: 15

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/HereticsSide.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/HereticsSide.xml
@@ -9,6 +9,14 @@
 
   Eldritch Armor provides great protection while also acting as a focus when hooded.
 
+  ## Priest’s Ritual
+  <Box>
+    <GuideEntityEmbed Entity="HereticEldritchFlask" Caption=""/>
+  </Box>
+  Allows you to transmute a water tank and a shard of glass into an Eldritch Flask.
+
+  This flask contains Omnizine as well as anti-bleeding chemicals.
+ 
   ## Ritual of Knowledge
   You learn a special, one-time-only ritual that requires 4 different items, from various organs to candles and stun batons.
 


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

the Heretic Freak awakens from their slumber once more

:cl:
- tweak: the guidebook page for the eldritch flask now exists.
- tweak: the eldritch flask no longer works as a cryostasis container, and its size has been reduced.
- tweak: the eldritch flask's catalog entry now shows the correct items needed to create it.
- fix: the ritual of knowledge no longer has a chance to eat its user's organs.