### PR TITLE
remove surplus recursion

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1095,12 +1095,10 @@
     blacklist:
       tags:
       - NukeOpsUplink
-  # the impstation special (it's really funny when this happens)
-  # seems to be a roughly 10% chance to hit the juck pot 1 million$ and get a double surplus crate
-  #- !type:BuyerWhitelistCondition
-  #  blacklist:
-  #    components:
-  #    - SurplusBundle
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 - type: listing
   id: UplinkSuperSurplusBundle
@@ -1116,8 +1114,6 @@
     blacklist:
       tags:
       - NukeOpsUplink
-  # not allowed to be recursive because it set off a chain reaction that crashed my localhost
-  # can still contain normal surplus bundles though smile
   - !type:BuyerWhitelistCondition
     blacklist:
       components:


### PR DESCRIPTION
it's "funny", but is it good for the game?

**Changelog**
:cl:
- remove: Surplus crates can no longer contain more surplus crates.