### PR TITLE
Seclink purchases should now all fit in sec belts + Pribar tweak

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -485,6 +485,9 @@
         - CombatKnife
         - Truncheon
         - SecTicket
+        - Pribar #imp
+        - SpaceBladeSec #imp
+        - HandheldCriminalRecords #imp
       components:
         - Stunbaton
         - FlashOnTrigger

--- a/Resources/Prototypes/_Impstation/Catalog/seclink_catalog.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/seclink_catalog.yml
@@ -90,6 +90,7 @@
   categories:
     - SeclinkDisabler
 
+#Utility Options
 - type: listing
   id: SeclinkSpaceBladeSec
   name: seclink-spaceblade-name
@@ -98,9 +99,8 @@
   cost:
     DisablerToken: 1
   categories:
-    - SeclinkDisabler
+    - SeclinkUtility
 
-#Utility Options
 - type: listing
   id: SeclinkCrowbar
   name: seclink-crowbar-name

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/security.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/security.yml
@@ -12,6 +12,9 @@
       - state: portable_criminal
       - state: screen-criminal
         shader: unshaded
+  - type: Tag
+    tags:
+    - HandheldCriminalRecords
   - type: ActivatableUI
     key: enum.CriminalRecordsConsoleKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/crowbars.yml
@@ -14,7 +14,10 @@
       sprite: _Impstation/Objects/Tools/pribar.rsi
       state: storage
   - type: Prying
-    speedModifier: 1.25
+    speedModifier: 1.35
+  - type: Tag
+    tags:
+    - Pribar
   - type: MeleeWeapon
     wideAnimationRotation: -135
     damage:

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -94,3 +94,9 @@
 
 - type: Tag
   id: EvidenceMarker
+
+- type: Tag
+  id: Pribar
+
+- type: Tag
+  id: HandheldCriminalRecords

--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/spaceblade.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/spaceblade.yml
@@ -142,6 +142,9 @@
     damage: 8
   - type: DisarmMalus
     malus: 0.225
+  - type: Tag # imp adding this so it fits in a sec belt
+    tags:
+    - SpaceBladeSec
   - type: ItemToggle # imp edit - it deserves to weewoo
     predictable: false
     onUse: false

--- a/Resources/Prototypes/_NF/tags.yml
+++ b/Resources/Prototypes/_NF/tags.yml
@@ -12,3 +12,6 @@
 
 - type: Tag
   id: MailCapsule
+
+- type: Tag #imp
+  id: SpaceBladeSec


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

![Screenshot (1569)](https://github.com/user-attachments/assets/20c852d1-1957-4bf7-bf4f-eeae72677a96)

:cl:
- tweak: Sec Space Blade, Portable Criminal Records Computer, and the Pribar now fit in the security belt
- tweak: Pribar now prys 10% faster
- tweak: moved spaceblade to the utility tab instead of the disabler tab