### PR TITLE
move admin assistant's admin hud from role to locker

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/command.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/command.yml
@@ -8,6 +8,7 @@
     - id: ClothingUniformJumpskirtAdminAssistant
     - id: ClothingHeadsetAltAdminAssistant
     - id: AdminAssistantIDCard
+    - id: ClothingEyesHudCommand
 
 - type: entity
   parent: LockerAdministrativeAssistant

--- a/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
@@ -23,7 +23,6 @@
 - type: startingGear
   id: AdminAssistantGear
   equipment:
-    eyes: ClothingEyesHudCommand
     belt: BoxFolderClipboard
     id: AdminAssistantPDA
     pocket1: RubberStampAdminAssistant


### PR DESCRIPTION
attaching it to the role prevents loadout glasses from working as they should, and not even captain/hop have the luxury of spawning with their hud. security does, but they're special

**Changelog**
:cl:
- tweak: Administrative assistant's HUD has been removed from its roundstart equipment, and added to its locker.