### PR TITLE
security cadet roundstart sunglasses

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -28,6 +28,7 @@
 - type: startingGear
   id: SecurityCadetGear
   equipment:
+    eyes: ClothingEyesGlassesSunglasses # imp
     shoes: ClothingShoesBootsJackFilled
     outerClothing: ClothingOuterArmorBasic
     id: SecurityCadetPDA


### PR DESCRIPTION
adds regular sunglasses to the security cadet's starting gear to prevent them from getting flashed by portable flashers. they'll still need to learn the importance of picking up security glasses for the hud, but some maps can be dire with their portable flasher placement

i don't know if it's a good idea, but i'm putting a pr up for discussion

![image](https://github.com/user-attachments/assets/685eb2b6-94ba-41be-a071-f21c61ceaaa9)

**Changelog**
:cl:
- add: Security cadets spawn with sunglasses.