### PR TITLE
supply assistant loadout de-swag

### DIFF
--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -9,13 +9,6 @@
 
 ## Supply Assistant
 - type: loadoutGroup
-  id: SupplyAssistantHead
-  name: loadout-group-supply-assistant-head
-  minLimit: 0
-  loadouts:
-  - CargoTechnicianHead
-
-- type: loadoutGroup
   id: SupplyAssistantJumpsuit
   name: loadout-group-supply-assistant-jumpsuit
   loadouts:
@@ -29,20 +22,6 @@
   - CargoTechnicianBackpack
   - CargoTechnicianSatchel
   - CargoTechnicianDuffel
-
-- type: loadoutGroup
-  id: SupplyAssistantOuterClothing
-  name: loadout-group-supply-assistant-outerclothing
-  minLimit: 0
-  loadouts:
-  - CargoTechnicianWintercoat
-
-- type: loadoutGroup
-  id: SupplyAssistantShoes
-  name: loadout-group-supply-assistant-shoes
-  loadouts:
-  - BlackShoes
-  - CargoWinterBoots
 
 # Command
 ## Administrative Assistant

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -3,8 +3,8 @@
   groups:
   - GroupTankHarness
   - SupplyAssistantJumpsuit
-  - Glasses
   - SupplyAssistantBackpack
+  - Glasses
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -3,7 +3,6 @@
   groups:
   - GroupTankHarness
   - SupplyAssistantJumpsuit
-  - SupplyAssistantBackpack
   - Glasses
   - SupplyAssistantBackpack
   - Survival

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -2,11 +2,8 @@
   id: JobSupplyAssistant
   groups:
   - GroupTankHarness
-  - SupplyAssistantHead
   - SupplyAssistantJumpsuit
   - SupplyAssistantBackpack
-  - SupplyAssistantOuterClothing
-  - SupplyAssistantShoes
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
@@ -14,6 +14,7 @@
 - type: startingGear
   id: SupplyAssistantGear
   equipment:
+    shoes: ClothingShoesColorBlack
     id: SupplyAssistantPDA
     ears: ClothingHeadsetCargo
     pocket1: BookLogistics


### PR DESCRIPTION
removes loadout options from the supply assistant to be in-line with other assistant roles. if you want swag, get a promotion
i'm giving exception to admin assistant on this pr since it's more of a service worker-style role with more potential than just learning

![image](https://github.com/user-attachments/assets/2e885752-91bc-4be9-b189-755915859722)

**Changelog**
:cl:
- remove: Supply assistant's loadout options reduced to be in line with other intern roles.