### PR TITLE
direct solar panel upgrading

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
@@ -118,6 +118,26 @@
           steps:
             - tool: Prying
               doAfter: 0.5
+        # imp edits
+        - to: solarpanelplasma
+          conditions:
+          - !type:EntityAnchored
+          steps:
+          - material: Plasma
+            amount: 2
+            doAfter: 0.5
+          completed:
+          - !type:SnapToGrid
+        - to: solarpaneluranium
+          conditions:
+          - !type:EntityAnchored
+          steps:
+          - material: Uranium
+            amount: 2
+            doAfter: 0.5
+          completed:
+          - !type:SnapToGrid
+        # end imp edits
 
     - node: solarpanel_broken
       entity: SolarPanelBroken


### PR DESCRIPTION
adds window upgrading tech to solar panels

**Changelog**
:cl:
- add: Solar panels can be directly upgraded to their plasma/uranium variants, similarly to window upgrading.