### PR TITLE
remove command req from command roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -13,9 +13,6 @@
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 72000 #20 hours, imp
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 21600 #6 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -13,9 +13,6 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 72000 #20 hrs, imp
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 21600 #6 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,9 +15,6 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 72000 #20 hrs, imp
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 21600 #6 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -7,9 +7,6 @@
     - !type:DepartmentTimeRequirement
       department: Science
       time: 72000 #20 hrs, imp
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 21600 #6 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -13,9 +13,6 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 324000 # 90 hrs
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 21600 #6 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10


### PR DESCRIPTION
this might end up being temporary but we can just call it a hotfix

:cl:
- tweak: Command playtime is no longer required for most command roles.