### PR TITLE
Thief Access Breaker Included in Sydie Kit Once More

### DIFF
--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -63,6 +63,7 @@
   - RadioJammer
   - TraitorCodePaper
   - Emag
+  - AccessBreaker
   - Lighter
   - CigPackSyndicate
   - Telecrystal10 #The thief cannot use them, but it may induce communication with traitors


### PR DESCRIPTION
Title.

:cl:
- fix: Thief access breaker is back in the box.

