### PR TITLE
security jetpacks in suit lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -140,7 +140,8 @@
     contents:
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitSecurity
-        - id: ClothingMaskBreath
+        - id: ClothingMaskGasSecurity
+        - id: JetpackSecurityFilled
   - type: AccessReader
     access: [["Security"]]
 


### PR DESCRIPTION
we don't need bomb collars for salvage we need security jetpacks

![image](https://github.com/user-attachments/assets/ce9a1d7c-e805-4286-a58c-2f3a64353b89)

pinkbat already remade them to be for all of sec instead of just the hos, this is just adding them to sec suit lockers per dinner's recommendation

it will be beautiful

:cl:
- tweak: Security jetpacks are now in security hardsuit lockers (they're coming for you)