### PR TITLE
antag playtime tracking + antag playtime biasing

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -159,6 +159,7 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
     public IEnumerable<KeyValuePair<string, TimeSpan>> FetchPlaytimeByRoles()
     {
         var jobsToMap = _prototypes.EnumeratePrototypes<JobPrototype>();
+        var antagsToMap = _prototypes.EnumeratePrototypes<AntagPrototype>(); // imp
 
         foreach (var job in jobsToMap)
         {
@@ -167,6 +168,14 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
                 yield return new KeyValuePair<string, TimeSpan>(job.Name, locJobName);
             }
         }
+        // imp
+        foreach (var antag in antagsToMap)
+        {
+            if (_roles.TryGetValue(antag.PlayTimeTracker, out var locAntagName))
+            {
+                yield return new KeyValuePair<string, TimeSpan>(antag.Name, locAntagName);
+            }
+        } // end imp
     }
 
     public IReadOnlyDictionary<string, TimeSpan> GetPlayTimes(ICommonSession session)

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -313,7 +313,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         // now we do playtime biasing.
         var probToGuarantee = 0.3f; // the highest chance of getting a guaranteed spot. given to the person queued with the lowest mindrole playtime.
-        var probReduction = probToGuarantee / ((float)playersByRoleTimeAsc.Count() / 2f); // linearly reduces the probability so that it hits zero after going through half of the players.
+        var probReduction = probToGuarantee / ((float)playersByRoleTimeAsc.Count() / 2f); // linearly reduces the probability so that it hits zero after going through half of the players. NOTE: might tweak this to take the desired count instead of total players queued for this antag.
         List<ICommonSession> guaranteed = [];
         foreach (var keyValuePair in playersByRoleTimeAsc) // for each entry, decide whether or not it should override random antag selection based on its weight, and add it to a list if it should.
         {

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -312,7 +312,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         var playersByRoleTimeAsc = from entry in sessionAndRoleTimes orderby entry.Value ascending select entry;
 
         // now we do playtime biasing.
-        var probToGuarantee = 1f; // the highest chance of getting a guaranteed spot. given to the person queued with the lowest mindrole playtime.
+        var probToGuarantee = 0.3f; // the highest chance of getting a guaranteed spot. given to the person queued with the lowest mindrole playtime.
         var probReduction = probToGuarantee / ((float)playersByRoleTimeAsc.Count() / 2f); // linearly reduces the probability so that it hits zero after going through half of the players.
         List<ICommonSession> guaranteed = [];
         foreach (var keyValuePair in playersByRoleTimeAsc) // for each entry, decide whether or not it should override random antag selection based on its weight, and add it to a list if it should.

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -11,6 +11,7 @@ using Content.Server.Preferences.Managers;
 using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
 using Content.Server.Shuttles.Components;
+using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.Antag;
 using Content.Shared.Clothing;
 using Content.Shared.GameTicking;
@@ -31,6 +32,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
 
 namespace Content.Server.Antag;
 
@@ -38,6 +40,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 {
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly PlayTimeTrackingManager _playTime = default!;
     [Dependency] private readonly GhostRoleSystem _ghostRole = default!;
     [Dependency] private readonly JobSystem _jobs = default!;
     [Dependency] private readonly LoadoutSystem _loadout = default!;
@@ -45,6 +48,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IServerPreferencesManager _pref = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly RoleSystem _role = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
@@ -281,11 +285,77 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             picking = false;
         }
 
+        // imp begin. this is our playtime biasing solution.
+        // create a dictionary of player sessions paired with the total antag playtime that player has across mindroles in this rule.
+        Dictionary<ICommonSession, TimeSpan> sessionAndRoleTimes = [];
+        foreach (var session in playerPool.GetPoolSessions())
+        {
+            // if we've picked a valid session from the pool and there are mindroles to assign in the def,
+            if (session != null && def.PrefRoles != null)
+            {
+                var ruleTimeTotal = TimeSpan.Zero;
+                // grab this session's playtimes for each role,
+                foreach (var role in def.PrefRoles)
+                {
+                    TimeSpan? time = null;
+                    if (_prototype.TryIndex(role, out var antagRole))
+                    {
+                        _playTime.TryGetTrackerTime(session, antagRole.PlayTimeTracker, out time);
+                    }
+                    ruleTimeTotal += time != null ? time.Value : TimeSpan.Zero;
+                }
+                // add them to our dict,
+                sessionAndRoleTimes.Add(session, ruleTimeTotal);
+            }
+        }
+        // then sort our dict by role time.
+        var playersByRoleTimeAsc = from entry in sessionAndRoleTimes orderby entry.Value ascending select entry;
+
+        // now we do playtime biasing.
+        var probToGuarantee = 1f; // the highest chance of getting a guaranteed spot. given to the person queued with the lowest mindrole playtime.
+        var probReduction = probToGuarantee / ((float)playersByRoleTimeAsc.Count() / 2f); // linearly reduces the probability so that it hits zero after going through half of the players.
+        List<ICommonSession> guaranteed = [];
+        foreach (var keyValuePair in playersByRoleTimeAsc) // for each entry, decide whether or not it should override random antag selection based on its weight, and add it to a list if it should.
+        {
+            if (_random.Prob(probToGuarantee))
+            {
+                guaranteed.Add(keyValuePair.Key);
+            }
+            probToGuarantee -= probReduction; // reduce the probability of the next entry getting a guaranteed slot by (maximum prob / (total queried players / 2))
+            if (probToGuarantee <= 0) // then stop the loop if the next probability is less than or equal to 0.
+                break;
+        } // end imp
+
         for (var i = 0; i < count; i++)
         {
             var session = (ICommonSession?)null;
             if (picking)
             {
+                // imp begin. if the playtime bias system picked any guaranteed antags, 
+                if (guaranteed.Count > 0)
+                {
+                    foreach (var selectedSession in guaranteed) // do antag adding logic
+                    {
+                        if (!midround && ent.Comp.SelectionTime != AntagSelectionTime.PrePlayerSpawn && selectedSession != null)
+                        {
+                            ent.Comp.SelectedSessions.Add(selectedSession);
+                            QueuedAntags[selectedSession.UserId] = (selectedSession, def, ent);
+                        }
+                        else
+                        {
+                            MakeAntag(ent, selectedSession, def);
+                        }
+
+                        i++; // and add 1 to i (so that each of these counts towards the comparison against `count`)
+                        if (i >= count)
+                            break;
+                    }
+                    if (i >= count)
+                        break;
+                    guaranteed.Clear(); // empty the list so this doesn't run again.
+                    continue;
+                } // end imp
+
                 if (!playerPool.TryPickAndTake(RobustRandom, out session) && noSpawner)
                 {
                     Log.Warning($"Couldn't pick a player for {ToPrettyString(ent):rule}, no longer choosing antags for this definition");

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Guidebook;
+using Content.Shared.Players.PlayTimeTracking; // imp
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype; // imp. iirc this is outdated but i dont care
 
 namespace Content.Shared.Roles;
 
@@ -11,6 +13,9 @@ namespace Content.Shared.Roles;
 [Serializable, NetSerializable]
 public sealed partial class AntagPrototype : IPrototype
 {
+    [DataField("playTimeTracker", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<PlayTimeTrackerPrototype>))]
+    public string PlayTimeTracker { get; private set; } = string.Empty; // imp
+
     [ViewVariables]
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -41,6 +41,11 @@ public abstract class SharedJobSystem : EntitySystem
         {
             _inverseTrackerLookup.Add(job.PlayTimeTracker, job.ID);
         }
+        // imp
+        foreach (var antag in _prototypes.EnumeratePrototypes<AntagPrototype>())
+        {
+            _inverseTrackerLookup.Add(antag.PlayTimeTracker, antag.ID);
+        } // end imp
     }
 
     /// <summary>

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -511,6 +511,7 @@ public abstract class SharedRoleSystem : EntitySystem
                 prototype = comp.AntagPrototype;
                 if (_prototypes.TryIndex(comp.AntagPrototype, out var antag))
                 {
+                    playTimeTracker = antag.PlayTimeTracker; // imp
                     name = antag.Name;
                     valid = true;
                 }

--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -53,3 +53,12 @@ JobNinja = Space Ninja
 AntagNinja = Space Ninja
 AntagDragon = Space Dragon
 AntagSubvertedSilicon = Subverted Silicon
+
+# non-upstream role timers
+
+AntagFugitive = Fugitive
+AntagSyndicateRecruiter = Syndicate Recruiter
+AntagListeningPost = Listening Post Operator
+AntagSynthesisSpecialist = Syndicate Synthesis Specialist
+AntagChangeling = Changeling
+AntagHeretic = Heretic

--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -36,3 +36,20 @@ roles-antag-thief-objective = Add some NT property to your personal collection w
 
 roles-antag-dragon-name = Space Dragon
 roles-antag-dragon-objective = Create a carp army to take over this quadrant.
+
+# role timers
+
+AntagNuclearAgent = Nuclear Operative Agent
+AntagNuclearOperative = Nuclear Operative
+AntagNuclearCommander = Nuclear Operative Commander
+AntagSyndicateAgent = Syndicate Agent
+AntagSyndicateSleeperAgent = Syndicate Sleeper Agent
+AntagThief = Thief
+AntagHeadRevolutionary = Head Revolutionary
+AntagRevolutionary = Revolutionary
+AntagZombie = Zombie
+AntagInitialInfected = Initial Infected
+JobNinja = Space Ninja
+AntagNinja = Space Ninja
+AntagDragon = Space Dragon
+AntagSubvertedSilicon = Subverted Silicon

--- a/Resources/Prototypes/Roles/Antags/dragon.yml
+++ b/Resources/Prototypes/Roles/Antags/dragon.yml
@@ -2,4 +2,5 @@
   id: Dragon
   name: roles-antag-dragon-name
   antagonist: true
+  playTimeTracker: AntagDragon # imp
   objective: roles-antag-dragon-objective

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -2,6 +2,7 @@
   id: SpaceNinja
   name: roles-antag-space-ninja-name
   antagonist: true
+  playTimeTracker: AntagNinja # imp
   setPreference: false
   objective: roles-antag-space-ninja-objective
   guides: [ SpaceNinja ]

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -2,6 +2,7 @@
   id: Nukeops
   name: roles-antag-nuclear-operative-name
   antagonist: true
+  playTimeTracker: AntagNuclearOperative # imp
   setPreference: true
   objective: roles-antag-nuclear-operative-objective
   requirements:
@@ -13,6 +14,7 @@
   id: NukeopsMedic
   name: roles-antag-nuclear-operative-agent-name
   antagonist: true
+  playTimeTracker: AntagNuclearAgent # imp
   setPreference: true
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
@@ -27,6 +29,7 @@
   id: NukeopsCommander
   name: roles-antag-nuclear-operative-commander-name
   antagonist: true
+  playTimeTracker: AntagNuclearCommander # imp
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -2,6 +2,7 @@
   id: HeadRev
   name: roles-antag-rev-head-name
   antagonist: true
+  playTimeTracker: AntagHeadRevolutionary # imp
   setPreference: true
   objective: roles-antag-rev-head-objective
   requirements:
@@ -17,6 +18,7 @@
   id: Rev
   name: roles-antag-rev-name
   antagonist: true
+  playTimeTracker: AntagRevolutionary # imp
   setPreference: false
   objective: roles-antag-rev-objective
   guides: [ Revolutionaries ]

--- a/Resources/Prototypes/Roles/Antags/silicon.yml
+++ b/Resources/Prototypes/Roles/Antags/silicon.yml
@@ -2,5 +2,6 @@
   id: SubvertedSilicon
   name: roles-antag-subverted-silicon-name
   antagonist: true
+  playTimeTracker: AntagSubvertedSilicon # imp
   setPreference: false
   objective: roles-antag-subverted-silicon-objective

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -2,6 +2,7 @@
   id: Thief
   name: roles-antag-thief-name
   antagonist: true
+  playTimeTracker: AntagThief # imp
   setPreference: true
   objective: roles-antag-thief-objective
   guides: [ Thieves ]

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -2,6 +2,7 @@
   id: Traitor
   name: roles-antag-syndicate-agent-name
   antagonist: true
+  playTimeTracker: AntagSyndicateAgent # imp
   setPreference: true
   objective: roles-antag-syndicate-agent-objective
   guides: [ Traitors ]
@@ -10,6 +11,7 @@
   id: TraitorSleeper
   name: roles-antag-syndicate-agent-sleeper-name
   antagonist: true
+  playTimeTracker: AntagSyndicateSleeperAgent # imp
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
   guides: [ Traitors ]

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -2,6 +2,7 @@
   id: InitialInfected
   name: roles-antag-initial-infected-name
   antagonist: true
+  playTimeTracker: AntagInitialInfected # imp
   setPreference: true
   objective: roles-antag-initial-infected-objective
   guides: [ Zombies ]
@@ -10,6 +11,7 @@
   id: Zombie
   name: roles-antag-zombie-name
   antagonist: true
+  playTimeTracker: AntagZombie
   setPreference: false
   objective: roles-antag-zombie-objective
   guides: [ Zombies ]

--- a/Resources/Prototypes/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/Roles/play_time_trackers.yml
@@ -159,3 +159,44 @@
 
 - type: playTimeTracker
   id: JobZookeeper
+
+# imp change - Antag trackers
+
+- type: playTimeTracker
+  id: AntagDragon
+
+- type: playTimeTracker
+  id: AntagNinja
+
+- type: playTimeTracker
+  id: AntagNuclearOperative
+
+- type: playTimeTracker
+  id: AntagNuclearAgent
+
+- type: playTimeTracker
+  id: AntagNuclearCommander
+
+- type: playTimeTracker
+  id: AntagHeadRevolutionary
+
+- type: playTimeTracker
+  id: AntagRevolutionary
+
+- type: playTimeTracker
+  id: AntagSubvertedSilicon
+
+- type: playTimeTracker
+  id: AntagThief
+
+- type: playTimeTracker
+  id: AntagSyndicateAgent
+
+- type: playTimeTracker
+  id: AntagSyndicateSleeperAgent
+
+- type: playTimeTracker
+  id: AntagInitialInfected
+
+- type: playTimeTracker
+  id: AntagZombie

--- a/Resources/Prototypes/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/Roles/play_time_trackers.yml
@@ -160,7 +160,7 @@
 - type: playTimeTracker
   id: JobZookeeper
 
-# imp change - Antag trackers
+# imp change - upstream antag trackers
 
 - type: playTimeTracker
   id: AntagDragon
@@ -200,3 +200,23 @@
 
 - type: playTimeTracker
   id: AntagZombie
+
+# non-upstream antagonists:
+
+- type: playTimeTracker
+  id: AntagFugitive
+
+- type: playTimeTracker
+  id: AntagSyndicateRecruiter
+
+- type: playTimeTracker
+  id: AntagListeningPost
+
+- type: playTimeTracker
+  id: AntagSynthesisSpecialist
+
+- type: playTimeTracker
+  id: AntagChangeling
+
+- type: playTimeTracker
+  id: AntagHeretic

--- a/Resources/Prototypes/_DV/Roles/Antags/fugitive.yml
+++ b/Resources/Prototypes/_DV/Roles/Antags/fugitive.yml
@@ -2,6 +2,7 @@
   id: Fugitive
   name: roles-antag-fugitive-name
   antagonist: true
+  playTimeTracker: AntagFugitive
   objective: roles-antag-fugitive-objective
   # keep these in sync with the spawner
   requirements:

--- a/Resources/Prototypes/_DV/Roles/Antags/listening_post.yml
+++ b/Resources/Prototypes/_DV/Roles/Antags/listening_post.yml
@@ -2,6 +2,7 @@
   id: ListeningPost
   name: roles-antag-listening-post-name
   antagonist: true
+  playTimeTracker: AntagListeningPost
   objective: roles-antag-listening-post-objective
   # keep these in sync with the spawner
   requirements: # Worth considering these numbers for the goal of making sure someone willing to MRP takes this.

--- a/Resources/Prototypes/_DV/Roles/Antags/recruiter.yml
+++ b/Resources/Prototypes/_DV/Roles/Antags/recruiter.yml
@@ -3,6 +3,7 @@
   name: roles-antag-syndicate-recruiter-name
   objective: roles-antag-syndicate-recruiter-objective
   antagonist: false # you ask questions and write papers not kill people
+  playTimeTracker: AntagSyndicateRecruiter
 
 - type: startingGear
   id: SyndicateRecruiterGear

--- a/Resources/Prototypes/_DV/Roles/Antags/synthesis_specialist.yml
+++ b/Resources/Prototypes/_DV/Roles/Antags/synthesis_specialist.yml
@@ -3,6 +3,7 @@
   name: roles-antag-syndicate-synthesis-name
   objective: roles-antag-syndicate-synthesis-objective
   antagonist: true # making poisons and shit on demand is evil
+  playTimeTracker: AntagSynthesisSpecialist
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 86400 # 24h so you probably know some general lore or something

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -2,6 +2,7 @@
   id: Changeling
   name: roles-antag-changeling-name
   antagonist: true
+  playTimeTracker: AntagChangeling
   setPreference: true
   objective: roles-antag-changeling-description
   guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -2,6 +2,7 @@
   id: Heretic
   name: roles-antag-heretic-name
   antagonist: true
+  playTimeTracker: AntagHeretic
   setPreference: true
   objective: roles-antag-heretic-description
   guides: [ Heretics ]


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Adds an antag playtime biasing system. Here's how it works:
- Sorts the players queued for a given gamerule, who have the applicable antag enabled, by their total playtime in all roles granted by that rule.
- The bottom half of that list, the half with the least playtime, roll a random probability based on their position in that list, starting at 30% and decreasing to 0%.
- If they win that roll, they're added to a list of "guaranteed spots," and have antag logic performed on them first, before the remaining antags are rolled fully randomly.

Functionally what this means is that the fewer hours you have in a given antag, the more likely you are to be selected as that antag. 

The system has been tested, but the testing has not been (and possibly cannot be) as thorough as I want it to be. I'm marking this as a draft until I can do more testing and have some people who know the language better than me look at it.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: (Most) antag roles now have playtime tracking in the stats menu.
- tweak: Antag rolling is now slightly weighted towards people with lower playtime in a given antag role.

