### PR TITLE
Hemophilia trait

### DIFF
--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.EntityEffects.Effects;
 using Content.Server.Fluids.EntitySystems;
 using Content.Server.Forensics;
 using Content.Server.Popups;
+using Content.Shared._Impstation.Traits.Assorted;
 using Content.Shared.Alert;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -407,6 +408,9 @@ public sealed class BloodstreamSystem : EntitySystem
         if (!Resolve(uid, ref component, logMissing: false))
             return false;
 
+        // imp edit - applies the multiplier from the trait if bleeding is being reduced
+        if (amount < 0 && TryComp<HemophiliaComponent>(uid, out var trait))
+            amount *= trait.BleedReductionMultiplier;
         component.BleedAmount += amount;
         component.BleedAmount = Math.Clamp(component.BleedAmount, 0, component.MaxBleedAmount);
 

--- a/Content.Shared/_Impstation/Traits/Assorted/HemophiliaComponent.cs
+++ b/Content.Shared/_Impstation/Traits/Assorted/HemophiliaComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._Impstation.Traits.Assorted;
+
+/// <summary>
+/// Used for the Hemophilia trait. BloodstreamSystem will check for this component and modify bleed reduction accordingly. 
+/// </summary>
+[RegisterComponent]
+public sealed partial class HemophiliaComponent : Component
+{
+    [DataField("bleedReductionMultiplier"), ViewVariables(VVAccess.ReadWrite)]
+    public float BleedReductionMultiplier = 0.33f;
+}

--- a/Resources/Locale/en-US/_Impstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Impstation/traits/traits.ftl
@@ -1,3 +1,6 @@
+trait-hemophilia-name = Hemophilia
+trait-hemophilia-desc = Your blood does not clot properly, and it is harder to stop bleeding.
+
 trait-pain-insensitivity-name = Pain Insensitivity
 trait-pain-insensitivity-desc = You are unaware of the status of your health at all times.
 

--- a/Resources/Prototypes/_Impstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Impstation/Traits/disabilities.yml
@@ -1,4 +1,12 @@
 - type: trait
+  id: Hemophilia
+  name: trait-hemophilia-name
+  description: trait-hemophilia-desc
+  category: Disabilities
+  components:
+    - type: Hemophilia
+
+- type: trait
   id: RandomUnrevivable
   name: trait-random-unrevivable-name
   description: trait-random-unrevivable-desc


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About this PR
Adds a new disability trait to character customization that was suggested on the discord: Hemophilia. Drastically reduces the rate at which bleed stacks naturally decay, and makes other methods of reducing bleeding such as gauze and cauterization less effective as well.

Specifically it reduces the effectiveness of these methods to 1/3 of their standard. For smaller cuts this is irrelevant as a single roll of gauze normally heals for the max amount of bleed stacks, but it should make more severe wounds harder to treat without proper medical attention.


**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the Hemophilia trait to character customization.
