### PR TITLE
fix heretics able to select heretics, ghouls, and lings as targets

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
@@ -124,7 +124,7 @@ public sealed partial class HereticSystem : EntitySystem
             eligibleTargets.Add(target.AttachedEntity!.Value); // it can't be null because see .Where(HasValue)
 
         // no heretics or other baboons
-        eligibleTargets = eligibleTargets.Where(t => !HasComp<GhoulComponent>(t) || !HasComp<HereticComponent>(t) || !HasComp<ChangelingComponent>(t)).ToList();
+        eligibleTargets = eligibleTargets.Where(t => !HasComp<GhoulComponent>(t) && !HasComp<HereticComponent>(t) && !HasComp<ChangelingComponent>(t)).ToList();
 
         var pickedTargets = new List<EntityUid?>();
 


### PR DESCRIPTION
Was set to 'can pick this person if they are NOT heretic OR they are NOT ghoul OR they are not LING' which means that heretics that aren't lings can be picked. OOPS! Should be AND.


:cl:
- fix: Heretics should no longer be able to get themselves (or other heretics) or changelings as targets

