### PR TITLE
Drone update (prep for drone factory)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -990,6 +990,8 @@
     tags:
       - CannotSuicide
       - EmagImmune
+      - CanPilot
+      - VimPilot
 
 # onestar is kinda fucked cause the loadout component is broken. sooo they gotta find guns somewhere i guess. /shrug.
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -893,6 +893,10 @@
         requireInputValidation: false
   - type: StationMap #imp
   - type: GhostRole
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 36000 # ten hours
     makeSentient: true
     name: Maintenance Drone
     description: Maintain the station. Ignore other beings except drones.

--- a/Resources/Prototypes/InventoryTemplates/drone_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/drone_inventory_template.yml
@@ -8,3 +8,11 @@
     strippingWindowPos: 0,0
     displayName: Head
     offset: 0, -0.45
+  - name: pocket1
+    slotTexture: pocket
+    fullTextureName: template_small
+    slotFlags: POCKET
+    slotGroup: MainHotbar
+    uiWindowPos: 0,3
+    strippingWindowPos: 0,4
+    displayName: Pocket 1

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
@@ -29,10 +29,23 @@
   components:
   - type: Unremoveable
 
+- type: entity
+  parent: PinpointerStation
+  id: PinpointerStationUnremoveable
+  description: You are the station. Find yourself. Press E to activate.
+  suffix: Unremoveable
+  components:
+  - type: Unremoveable
+  - type: Pinpointer
+    component: ResearchServer
+    targetName: the station
+
 # StartingGear
 
 - type: startingGear
   id: StartingGearDroneTools
+  equipment:
+    pocket1: PinpointerStationUnremoveable
   inhand:
     - DroneSatchelUnremovable
     - trayScannerUnremoveable


### PR DESCRIPTION

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Drones now have a station pinpointer in their pocket, so they don't get lost in space. 
- add: Drones now have a 10-hour Engineering time requirement. Learn the G menu. 
- add: Drones can now pilot shuttles. 

