### PR TITLE
removing musician time from harmonica

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/musician.yml
@@ -1,13 +1,3 @@
-# To unlock the harmonica trinket on any job
-- type: loadoutEffectGroup
-  id: MusicallyTalented
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobMusician
-      time: 36000 #10 hours
-
 # Jumpsuit
 - type: loadout
   id: MusicianJumpsuit

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
@@ -79,9 +79,6 @@
   storage:
     back:
     - HarmonicaInstrument
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MusicallyTalented
 
 - type: loadout
   id: FlippoLighter


### PR DESCRIPTION
multiple maintainers and players have said now that prestige items kinda suck

if we're gonna be pushing for that eventually, it seems to make sense to remove the requirement from the only trinket (besides the towel recolors that are specifically intended as prestige) that needs you to play a specific job to unlock it

might as well start with that

:cl:
- tweak: Harmonica trinket no longer requires musician time