### PR TITLE
Artifact trigger: Expressions now work on all emotes instead of just quick wheel emotes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -676,8 +676,10 @@ public sealed partial class ChatSystem : SharedChatSystem
             TryEmoteChatInput(source, action);
         SendInVoiceRange(ChatChannel.Emotes, action, wrappedMessage, source, range, author);
 
+        // #IMP Send event to alert that generic emote has happened
         var ev = new EntityEmotedEvent(source, wrappedMessage);
         RaiseLocalEvent(source, ev);
+
         if (!hideLog)
             if (name != Name(source))
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {ToPrettyString(source):user} as {name}: {action}");
@@ -1044,6 +1046,10 @@ public sealed class EntitySpokeEvent : EntityEventArgs
     }
 }
 
+/// <summary>
+///     #IMP
+///     Raised on an entity when it emotes, whether through emote wheel, hotkeys, /me, @ or * in textbox, etc.
+/// </summary>
 public sealed class EntityEmotedEvent : EntityEventArgs
 {
     public readonly EntityUid Source;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -675,6 +675,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (checkEmote)
             TryEmoteChatInput(source, action);
         SendInVoiceRange(ChatChannel.Emotes, action, wrappedMessage, source, range, author);
+
+        var ev = new EntityEmotedEvent(source, wrappedMessage);
+        RaiseLocalEvent(source, ev);
         if (!hideLog)
             if (name != Name(source))
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {ToPrettyString(source):user} as {name}: {action}");
@@ -1038,6 +1041,18 @@ public sealed class EntitySpokeEvent : EntityEventArgs
         Message = message;
         Channel = channel;
         ObfuscatedMessage = obfuscatedMessage;
+    }
+}
+
+public sealed class EntityEmotedEvent : EntityEventArgs
+{
+    public readonly EntityUid Source;
+    public readonly string Message;
+
+    public EntityEmotedEvent(EntityUid source, string message)
+    {
+        Source = source;
+        Message = message;
     }
 }
 

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactExpressionTriggerSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactExpressionTriggerSystem.cs
@@ -9,10 +9,10 @@ public sealed class ArtifacExpressionTriggerSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<TransformComponent, EmoteEvent>(OnEmote);
+        SubscribeLocalEvent<TransformComponent, EntityEmotedEvent>(OnEmote);
     }
 
-    private void OnEmote(EntityUid emoter, TransformComponent component, EmoteEvent args)
+    private void OnEmote(EntityUid emoter, TransformComponent component, EntityEmotedEvent args)
     {
         var emoterXform = Transform(emoter);
 


### PR DESCRIPTION
Entity Emote event created which will send for all emotes, then ArtifactExpressionTriggerSystem will listen for it.

:cl:
- tweak: artifacts now listen for all types of @ emotes instead of only the special ones on the quick wheel
