### PR TITLE
Gray stomachs can now be used in rituals

### DIFF
--- a/Resources/Prototypes/_Impstation/Body/Organs/gray.yml
+++ b/Resources/Prototypes/_Impstation/Body/Organs/gray.yml
@@ -213,6 +213,11 @@
     groups:
     - id: Food
     - id: Drink
+  - type: Tag # goob edit
+    tags:
+    - Meat
+    - Organ
+    - Stomach
 
 - type: entity
   id: OrganGrayLiver


### PR DESCRIPTION
Added tags to Gray stomachs (the 'Fuubu').
- Organ
- Meat
- Stomach

:cl:
- fix: Gray stomachs are now able to be used as ingredients in rituals
