### PR TITLE
block duplicate stripping doafters

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -218,7 +218,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.None
+            DuplicateCondition = stealth ? DuplicateConditions.None : DuplicateConditions.SameTool // block duplicates if using the thieving gloves : don't if not
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -312,7 +312,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.None
+            DuplicateCondition = stealth ? DuplicateConditions.None : DuplicateConditions.SameTool // block duplicates if using the thieving gloves : don't if not
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -414,7 +414,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.None
+            DuplicateCondition = stealth ? DuplicateConditions.None : DuplicateConditions.SameTool // block duplicates if using the thieving gloves : don't if not
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -517,7 +517,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.None
+            DuplicateCondition = stealth ? DuplicateConditions.None : DuplicateConditions.SameTool // block duplicates if using the thieving gloves : don't if not
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -218,7 +218,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.None
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -312,7 +312,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.None
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -414,7 +414,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.None
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -517,7 +517,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.None
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Thieving gloves can now only initiate one stripping doafter at a time.

