### PR TITLE
supermatter signal ports

### DIFF
--- a/Content.Server/_EinsteinEngines/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EinsteinEngines/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -8,6 +8,7 @@ using Content.Shared._EinsteinEngines.Supermatter.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Audio;
 using Content.Shared.Chat;
+using Content.Shared.DeviceLinking;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -799,6 +800,23 @@ public sealed partial class SupermatterSystem
     private void HandleStatus(EntityUid uid, SupermatterComponent sm)
     {
         var currentStatus = GetStatus(uid, sm);
+
+        // Send port updates out for any linked devices
+        if (sm.Status != currentStatus && HasComp<DeviceLinkSourceComponent>(uid))
+        {
+            var port = currentStatus switch
+            {
+                SupermatterStatusType.Normal => sm.PortNormal,
+                SupermatterStatusType.Caution => sm.PortCaution,
+                SupermatterStatusType.Warning => sm.PortWarning,
+                SupermatterStatusType.Danger => sm.PortDanger,
+                SupermatterStatusType.Emergency => sm.PortEmergency,
+                SupermatterStatusType.Delaminating => sm.PortDelaminating,
+                _ => sm.PortInactive
+            };
+
+            _link.InvokePort(uid, port);
+        }
 
         sm.Status = currentStatus;
 

--- a/Content.Server/_EinsteinEngines/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/_EinsteinEngines/Supermatter/Systems/SupermatterSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Audio;
 using Content.Shared.Damage.Components;
 using Content.Shared.Database;
+using Content.Shared.DeviceLinking;
 using Content.Shared.Examine;
 using Content.Shared.Ghost;
 using Content.Shared.Interaction;
@@ -57,6 +58,7 @@ public sealed partial class SupermatterSystem : EntitySystem
     [Dependency] private readonly SharedAmbientSoundSystem _ambient = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedDeviceLinkSystem _link = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly IAdminLogManager _adminLog = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
@@ -101,6 +103,10 @@ public sealed partial class SupermatterSystem : EntitySystem
         var mix = _atmosphere.GetContainingMixture(uid, true, true);
         mix?.AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesStandard - mix.GetMoles(Gas.Oxygen));
         mix?.AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesStandard - mix.GetMoles(Gas.Nitrogen));
+
+        // Send the inactive port for any linked devices
+        if (HasComp<DeviceLinkSourceComponent>(uid))
+            _link.InvokePort(uid, sm.PortInactive);
     }
 
     public void OnSupermatterUpdated(EntityUid uid, SupermatterComponent sm, AtmosDeviceUpdateEvent args)
@@ -170,10 +176,10 @@ public sealed partial class SupermatterSystem : EntitySystem
         var item = args.Used;
         var othersFilter = Filter.Pvs(uid).RemovePlayerByAttachedEntity(target);
 
-        if (args.Handled)
-            return;
-
-        if (HasComp<SupermatterImmuneComponent>(item) || HasComp<GodmodeComponent>(item))
+        if (args.Handled ||
+            HasComp<GhostComponent>(target) ||
+            HasComp<SupermatterImmuneComponent>(item) ||
+            HasComp<GodmodeComponent>(item))
             return;
 
         // TODO: supermatter scalpel

--- a/Content.Shared/_EinsteinEngines/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Supermatter/Components/SupermatterComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Atmos;
+using Content.Shared.DeviceLinking;
 using Content.Shared.DoAfter;
 using Content.Shared.Radio;
 using Content.Shared.Speech;
@@ -373,6 +374,31 @@ public sealed partial class SupermatterComponent : Component
     /// </summary>
     [DataField]
     public bool HasBeenPowered;
+
+    #endregion
+
+    #region Signal Ports
+
+    [DataField]
+    public ProtoId<SourcePortPrototype> PortInactive = "SupermatterInactive";
+
+    [DataField]
+    public ProtoId<SourcePortPrototype> PortNormal = "SupermatterNormal";
+
+    [DataField]
+    public ProtoId<SourcePortPrototype> PortCaution = "SupermatterCaution";
+
+    [DataField]
+    public ProtoId<SourcePortPrototype> PortWarning = "SupermatterWarning";
+
+    [DataField]
+    public ProtoId<SourcePortPrototype> PortDanger = "SupermatterDanger";
+
+    [DataField]
+    public ProtoId<SourcePortPrototype> PortEmergency = "SupermatterEmergency";
+
+    [DataField]
+    public ProtoId<SourcePortPrototype> PortDelaminating = "SupermatterDelaminating";
 
     #endregion
 

--- a/Resources/Locale/en-US/_EinsteinEngines/supermatter/supermatter-ports.ftl
+++ b/Resources/Locale/en-US/_EinsteinEngines/supermatter/supermatter-ports.ftl
@@ -1,0 +1,20 @@
+signal-port-name-supermatter-inactive = Inactive
+signal-port-description-supermatter-inactive = This port is invoked when the supermatter is inactive.
+
+signal-port-name-supermatter-normal = Normal
+signal-port-description-supermatter-normal = This port is invoked when the supermatter is powered and at high integrity.
+
+signal-port-name-supermatter-caution = Caution
+signal-port-description-supermatter-caution = This port is invoked when the supermatter is at high integrity, but reaching dangerous temperatures.
+
+signal-port-name-supermatter-warning = Warning
+signal-port-description-supermatter-warning = This port is invoked when the supermatter has lost a small amount of integrity.
+
+signal-port-name-supermatter-danger = Danger
+signal-port-description-supermatter-danger = This port is invoked when the supermatter has lost a fair amount of integrity.
+
+signal-port-name-supermatter-emergency = Emergency
+signal-port-description-supermatter-emergency = This port is invoked when the supermatter has lost a great deal of integrity.
+
+signal-port-name-supermatter-delaminating = Delaminating
+signal-port-description-supermatter-delaminating = This port is invoked when the supermatter has reached the delamination countdown.

--- a/Resources/Prototypes/_EinsteinEngines/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/_EinsteinEngines/DeviceLinking/source_ports.yml
@@ -1,0 +1,34 @@
+- type: sourcePort
+  id: SupermatterInactive
+  name: signal-port-name-supermatter-inactive
+  description: signal-port-description-supermatter-inactive
+
+- type: sourcePort
+  id: SupermatterNormal
+  name: signal-port-name-supermatter-normal
+  description: signal-port-description-supermatter-normal
+
+- type: sourcePort
+  id: SupermatterCaution
+  name: signal-port-name-supermatter-caution
+  description: signal-port-description-supermatter-caution
+
+- type: sourcePort
+  id: SupermatterWarning
+  name: signal-port-name-supermatter-warning
+  description: signal-port-description-supermatter-warning
+
+- type: sourcePort
+  id: SupermatterDanger
+  name: signal-port-name-supermatter-danger
+  description: signal-port-description-supermatter-danger
+
+- type: sourcePort
+  id: SupermatterEmergency
+  name: signal-port-name-supermatter-emergency
+  description: signal-port-description-supermatter-emergency
+
+- type: sourcePort
+  id: SupermatterDelaminating
+  name: signal-port-name-supermatter-delaminating
+  description: signal-port-description-supermatter-delaminating

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
@@ -103,6 +103,15 @@
     requireAnchored: false
     joinSystem: true
   - type: RadiationSource
+  - type: DeviceLinkSource
+    ports:
+    - SupermatterInactive
+    - SupermatterNormal
+    - SupermatterCaution
+    - SupermatterWarning
+    - SupermatterDanger
+    - SupermatterEmergency
+    - SupermatterDelaminating
 
 - type: entity
   parent: BaseSupermatter


### PR DESCRIPTION
adds signal ports to the supermatter for mapping purposes. players will just shove their multitool straight into the supermatter instead. also prevents aghosts from inserting things into the supermatter directly, so linking will actually work, and so mappers don't accidentally activate the supermatter

**Changelog**
no cl