### PR TITLE
Three Epic Accents

### DIFF
--- a/Content.Server/_Impstation/Speech/Components/ProperCapitalizationComponent.cs
+++ b/Content.Server/_Impstation/Speech/Components/ProperCapitalizationComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class ProperCapitalizationComponent : Component
+{
+
+}

--- a/Content.Server/_Impstation/Speech/Components/ProperPunctuationComponent.cs
+++ b/Content.Server/_Impstation/Speech/Components/ProperPunctuationComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class ProperPunctuationComponent : Component
+{
+
+}

--- a/Content.Server/_Impstation/Speech/Components/StiltedSpeechComponent.cs
+++ b/Content.Server/_Impstation/Speech/Components/StiltedSpeechComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class StiltedSpeechComponent : Component
+{
+
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/ProperCapitalizationSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/ProperCapitalizationSystem.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class ProperCapitalizationSystem : EntitySystem
+{
+    // @formatter:off
+    private static readonly Regex RegexPunctuationThenWord = new(@"([.!?])\s+([a-z])");
+    // @formatter:on
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ProperCapitalizationComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, ProperCapitalizationComponent component, AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        // When a word follows punctuation, capitalize the first letter
+        message = RegexPunctuationThenWord.Replace(message, match => match.Groups[1].Value + " " + match.Groups[2].Value.ToUpper());
+
+        args.Message = message;
+
+    }
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/ProperPunctuationSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/ProperPunctuationSystem.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class ProperPunctuationSystem : EntitySystem
+{
+    // @formatter:off
+    private static readonly Regex RegexEndsWithAnyPunctuation = new(@"[!?\.]+$");
+    // @formatter:on
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ProperPunctuationComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, ProperPunctuationComponent component, AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        // If the message doesn't end with any punctuation, we add a period
+        if (!RegexEndsWithAnyPunctuation.IsMatch(message))
+        {
+            message += ".";
+        }
+
+        args.Message = message;
+
+    }
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/StiltedSpeechSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/StiltedSpeechSystem.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class StiltedSpeechSystem : EntitySystem
+{
+    // @formatter:off
+    private static readonly Regex RegexStartOfWord = new(@"(?:^|\s)([a-z])");
+    // @formatter:on
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<StiltedSpeechComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, StiltedSpeechComponent component, AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        // Capitalize the first letter of each word
+        message = RegexStartOfWord.Replace(message, match => match.Value.ToUpper());
+
+        args.Message = message;
+    }
+}

--- a/Content.Server/_Impstation/Speech/EntitySystems/StiltedSpeechSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/StiltedSpeechSystem.cs
@@ -19,7 +19,7 @@ public sealed class StiltedSpeechSystem : EntitySystem
     {
         var message = args.Message;
 
-        // Capitalize the first letter of each word
+        // Capitalize the first letter of every word
         message = RegexStartOfWord.Replace(message, match => match.Value.ToUpper());
 
         args.Message = message;

--- a/Resources/Locale/en-US/_Impstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Impstation/traits/traits.ftl
@@ -10,3 +10,42 @@ sgdrequired-cant-speak = You can't speak without an SGD!
 
 trait-unborgable-name = Unborgable
 trait-unborgable-desc = Your brain is unable to fit into a Man-Machine Interface.
+
+trait-accentless-name = No species accent
+trait-accentless-desc = You don't have the accent that your species would usually have.
+
+trait-accentimmune-name = No accent
+trait-accentimmune-desc = You have no accent whatsoever, somehow. Where are you from?
+
+trait-mobster-name = Mobster accent
+trait-mobster-desc = Reminds you of a certain rat...
+
+trait-ratvarian-name = Ratvarian language
+trait-ratvarian-desc = Gur jbex jvyy o- *ahem* You speak in the language of a certain outdated cult. Cenvfr Ratvar.
+
+trait-slime-name = Slime speech
+trait-slime-desc = Blimpuf? Bluuump... Blabl blump!
+
+trait-snalien-name = Slow talker
+trait-snalien-desc = Yyoouu taallk rreeaallyy... rreeaallyy... sslloowwllyy.
+
+trait-scrambled-name = Scrambled speech
+trait-scrambled-desc = There was an accident with a tesla engine, now others have trouble understanding you.
+
+trait-nocontractions-name = No contractions
+trait-nocontractions-desc = You are (mostly) incapable of using contractions.
+
+trait-sharpinflection-name = Sharp inflection
+trait-sharpinflection-desc = You mumble... When you aren't shouting!!
+
+trait-monotonous-name = Monotonous
+trait-monotonous-desc = You speak in a way that others see as total disinterest. Always.
+
+trait-basicfrench-name = French (Basic)
+trait-basicfrench-desc = You speak with the cadence of someone who has cast off their vow of silence, with much less word replacements.
+
+trait-basicrussian-name = Russian (Basic)
+trait-basicrussian-desc = You speak with a russian accent, with much less word replacements.
+
+trait-stiltedspeech-name = Stilted Speech
+trait-stiltedspeech-desc = You Speak With An Odd Formality To Your Tone.

--- a/Resources/Locale/en-US/_Impstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Impstation/traits/traits.ftl
@@ -47,5 +47,11 @@ trait-basicfrench-desc = You speak with the cadence of someone who has cast off 
 trait-basicrussian-name = Russian (Basic)
 trait-basicrussian-desc = You speak with a russian accent, with much less word replacements.
 
-trait-stiltedspeech-name = Stilted Speech
-trait-stiltedspeech-desc = You Speak With An Odd Formality To Your Tone.
+trait-stiltedspeech-name = Stilted speech
+trait-stiltedspeech-desc = You Speak Very Properly At All Times.
+
+trait-propercapitalization-name = Proper capitalization
+trait-propercapitalization-desc = You speak with proper capitalization, somehow. Whenever you end a sentence with punctuation, the following word always begins with a capital letter.
+
+trait-properpunctuation-name = Proper punctuation
+trait-properpunctuation-desc = Your sentences end with periods or other punctuation, always.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -27,12 +27,6 @@ trait-unrevivable-desc = You are unable to be revived by defibrillators.
 trait-pirate-accent-name = Pirate accent
 trait-pirate-accent-desc = You can't stop speaking like a pirate!
 
-trait-accentless-name = No species accent
-trait-accentless-desc = You don't have the accent that your species would usually have.
-
-trait-accentimmune-name = No accent
-trait-accentimmune-desc = You have no accent whatsoever, somehow. Where are you from?
-
 trait-frontal-lisp-name = Frontal lisp
 trait-frontal-lisp-desc = You thpeak with a lithp.
 
@@ -57,15 +51,6 @@ trait-german-desc = You seem to come from space Germany.
 trait-italian-name = Italian accent
 trait-italian-desc = Mamma mia! You seem to have lived in space Italy!
 
-trait-mobster-name = Mobster accent
-trait-mobster-desc = Reminds you of a certain rat...
-
-trait-ratvarian-name = Ratvarian language
-trait-ratvarian-desc = Gur jbex jvyy o- *ahem* You speak in the language of a certain outdated cult. Cenvfr Ratvar.
-
-trait-slime-name = Slime speech
-trait-slime-desc = Blimpuf? Bluuump... Blabl blump!
-
 trait-russian-name = Russian accent
 trait-russian-desc = Is шoиdeяful daУ oи Space Sтaтioи 14, da?
 
@@ -74,27 +59,6 @@ trait-french-desc = You speak with the cadence of someone who has cast off their
 
 trait-spanish-name = Spanish accent
 trait-spanish-desc = You speak with the accent of someone who grew up in Earth Spain.
-
-trait-snalien-name = Slow talker
-trait-snalien-desc = Yyoouu taallk rreeaallyy... rreeaallyy... sslloowwllyy.
-
-trait-scrambled-name = Scrambled speech
-trait-scrambled-desc = There was an accident with a tesla engine, now others have trouble understanding you.
-
-trait-nocontractions-name = No contractions
-trait-nocontractions-desc = You are (mostly) incapable of using contractions.
-
-trait-sharpinflection-name = Sharp inflection
-trait-sharpinflection-desc = You mumble... When you aren't shouting!!
-
-trait-monotonous-name = Monotonous
-trait-monotonous-desc = You speak in a way that others see as total disinterest. Always.
-
-trait-basicfrench-name = French (Basic)
-trait-basicfrench-desc = You speak with the cadence of someone who has cast off their vow of silence, with much less word replacements.
-
-trait-basicrussian-name = Russian (Basic)
-trait-basicrussian-desc = You speak with a russian accent, with much less word replacements.
 
 trait-painnumbness-name = Numb
 trait-painnumbness-desc = You lack any sense of feeling pain, being unaware of how hurt you may be.

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -1,21 +1,3 @@
-# Free
-
-- type: trait
-  id: Accentless
-  name: trait-accentless-name
-  description: trait-accentless-desc
-  category: SpeechTraits
-  cost: 0
-  components:
-  - type: Accentless
-    removes:
-    - type: LizardAccent
-    - type: MothAccent
-    - type: SnalienAccent
-    - type: GrayAccent
-    - type: DwarfAccent
-    - type: NoContractionsAccent
-
 # 1 Cost
 
 - type: trait
@@ -84,63 +66,7 @@
   - type: ReplacementAccent
     accent: liar
 
-- type: trait
-  id: Scrambled
-  name: trait-scrambled-name
-  description: trait-scrambled-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ScrambledAccent
-
-- type: trait
-  id: NoContractions
-  name: trait-nocontractions-name
-  description: trait-nocontractions-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ReplacementAccent
-    accent: nocontractions
-  - type: NoContractionsAccent
-
-- type: trait
-  id: SharpInflection
-  name: trait-sharpinflection-name
-  description: trait-sharpinflection-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: SharpInflection
-
-- type: trait
-  id: Monotonous
-  name: trait-monotonous-name
-  description: trait-monotonous-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: Monotonous
-
-- type: trait
-  id: BasicFrenchAccent
-  name: trait-basicfrench-name
-  description: trait-basicfrench-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: BasicFrenchAccent
-
 # 2 Cost
-
-- type: trait
-  id: Snalien
-  name: trait-snalien-name
-  description: trait-snalien-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: SnalienAccent
 
 - type: trait
   id: SocialAnxiety
@@ -165,35 +91,6 @@
   - type: FrontalLisp
 
 - type: trait
-  id: Mobster
-  name: trait-mobster-name
-  description: trait-mobster-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: ReplacementAccent
-    accent: mobster
-
-- type: trait
-  id: Ratvarian
-  name: trait-ratvarian-name
-  description: trait-ratvarian-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: RatvarianLanguage
-
-- type: trait
-  id: Slime
-  name: trait-slime-name
-  description: trait-slime-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: ReplacementAccent
-    accent: slimes
-
-- type: trait
   id: Russian
   name: trait-russian-name
   description: trait-russian-desc
@@ -203,15 +100,6 @@
   - type: RussianAccent
 
 - type: trait
-  id: BasicRussian
-  name: trait-basicrussian-name
-  description: trait-basicrussian-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: BasicRussianAccent
-
-- type: trait
   id: FrenchAccent
   name: trait-french-name
   description: trait-french-desc
@@ -219,35 +107,3 @@
   cost: 2
   components:
   - type: FrenchAccent
-
-- type: trait
-  id: AccentImmune
-  name: trait-accentimmune-name
-  description: trait-accentimmune-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: Accentless
-    removes:
-    - type: SouthernAccent
-    - type: PirateAccent
-    - type: GermanAccent
-    - type: SpanishAccent
-    - type: ScrambledAccent
-    - type: NoContractionsAccent
-    - type: SharpInflection
-    - type: Monotonous
-    - type: BasicFrenchAccent
-    - type: SnalienAccent
-    - type: StutteringAccent
-    - type: FrontalLisp
-    - type: RatvarianLanguage
-    - type: RussianAccent
-    - type: BasicRussianAccent
-    - type: FrenchAccent
-    - type: LizardAccent
-    - type: MothAccent
-    - type: GrayAccent
-    - type: DwarfAccent
-      # Imp TODO: add cowboy, italian, liar, mobster, and slimes to this list one day since apparently you can only remove one ReplacementAccent at a time without pissing off the linter, maybe we can figure it out later. For now, adding the dwarf accent since that's an accent you can spawn with under current circumstances.
-      # idk about all this but dwarves have their own accent component now yay!!!!

--- a/Resources/Prototypes/_Impstation/Traits/speech.yml
+++ b/Resources/Prototypes/_Impstation/Traits/speech.yml
@@ -1,0 +1,157 @@
+# Free
+
+- type: trait
+  id: Accentless
+  name: trait-accentless-name
+  description: trait-accentless-desc
+  category: SpeechTraits
+  cost: 0
+  components:
+  - type: Accentless
+    removes:
+    - type: LizardAccent
+    - type: MothAccent
+    - type: SnalienAccent
+    - type: GrayAccent
+    - type: DwarfAccent
+    - type: NoContractionsAccent
+
+# 1 cost
+
+
+- type: trait
+  id: Scrambled
+  name: trait-scrambled-name
+  description: trait-scrambled-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ScrambledAccent
+
+- type: trait
+  id: NoContractions
+  name: trait-nocontractions-name
+  description: trait-nocontractions-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: nocontractions
+  - type: NoContractionsAccent
+
+- type: trait
+  id: SharpInflection
+  name: trait-sharpinflection-name
+  description: trait-sharpinflection-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: SharpInflection
+
+- type: trait
+  id: Monotonous
+  name: trait-monotonous-name
+  description: trait-monotonous-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: Monotonous
+
+- type: trait
+  id: BasicFrenchAccent
+  name: trait-basicfrench-name
+  description: trait-basicfrench-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: BasicFrenchAccent
+
+- type: trait
+  id: BasicRussian
+  name: trait-basicrussian-name
+  description: trait-basicrussian-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: BasicRussianAccent
+
+- type: trait
+  id: StiltedSpeech
+  name: trait-stiltedspeech-name
+  description: trait-stiltedspeech-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: StiltedSpeech
+
+# 2 cost
+
+- type: trait
+  id: Snalien
+  name: trait-snalien-name
+  description: trait-snalien-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: SnalienAccent
+
+- type: trait
+  id: Mobster
+  name: trait-mobster-name
+  description: trait-mobster-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: ReplacementAccent
+    accent: mobster
+
+- type: trait
+  id: Ratvarian
+  name: trait-ratvarian-name
+  description: trait-ratvarian-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: RatvarianLanguage
+
+- type: trait
+  id: Slime
+  name: trait-slime-name
+  description: trait-slime-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: ReplacementAccent
+    accent: slimes
+
+- type: trait
+  id: AccentImmune
+  name: trait-accentimmune-name
+  description: trait-accentimmune-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: Accentless
+    removes:
+    - type: SouthernAccent
+    - type: PirateAccent
+    - type: GermanAccent
+    - type: SpanishAccent
+    - type: ScrambledAccent
+    - type: NoContractionsAccent
+    - type: SharpInflection
+    - type: Monotonous
+    - type: BasicFrenchAccent
+    - type: SnalienAccent
+    - type: StutteringAccent
+    - type: FrontalLisp
+    - type: RatvarianLanguage
+    - type: RussianAccent
+    - type: BasicRussianAccent
+    - type: FrenchAccent
+    - type: LizardAccent
+    - type: MothAccent
+    - type: GrayAccent
+    - type: DwarfAccent
+      # Imp TODO: add cowboy, italian, liar, mobster, and slimes to this list one day since apparently you can only remove one ReplacementAccent at a time without pissing off the linter, maybe we can figure it out later. For now, adding the dwarf accent since that's an accent you can spawn with under current circumstances.
+      # idk about all this but dwarves have their own accent component now yay!!!!

--- a/Resources/Prototypes/_Impstation/Traits/speech.yml
+++ b/Resources/Prototypes/_Impstation/Traits/speech.yml
@@ -16,8 +16,25 @@
     - type: DwarfAccent
     - type: NoContractionsAccent
 
-# 1 cost
+- type: trait
+  id: ProperCapitalization
+  name: trait-propercapitalization-name
+  description: trait-propercapitalization-desc
+  category: SpeechTraits
+  cost: 0
+  components:
+  - type: ProperCapitalization
 
+- type: trait
+  id: ProperPunctuation
+  name: trait-properpunctuation-name
+  description: trait-properpunctuation-desc
+  category: SpeechTraits
+  cost: 0
+  components:
+  - type: ProperPunctuation
+
+# 1 cost
 
 - type: trait
   id: Scrambled


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Adds three accents, two of which are more QOL than actual accents. 
The first is proper capitalization, it makes it so that new sentences also start with a capital letter, i.e. "First sentence. second sentence" becomes "First sentence. Second sentence" ... maybe this should be rolled into regular speech for everyone? Idk

Before and after:
![capitalization_before](https://github.com/user-attachments/assets/fedc201f-3260-476a-bba0-cf953fc8ad5c)
![capitalization](https://github.com/user-attachments/assets/7cacf047-7701-4c6c-8732-a1ada925cea5)

The second is proper punctuation. If you don't end a sentence with punctuation, it adds a period for you.

![punctuation](https://github.com/user-attachments/assets/6483bbe9-8b3b-4fdc-81c1-083fba17460f)

Both are opt-in but cost zero points.
I made these QOL ones separate because some people very deliberately avoid adding punctuation to some dialogue, so I wanted the proper capitalization to still be usable by them.

The third is stilted speech, which just capitalizes the start of every word. It reads as talking like a Complete Weirdo to me and I think that's funny

![Screenshot 2025-02-17 005438](https://github.com/user-attachments/assets/b83bd15b-40f1-43db-b1a7-575c686005d4)


ALSO!! I noticed imp accent ftl and ymls were in the upstream folder so I migrated them.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added two zero-point accents that automatically correct your capitalization and/or punctuation.
- add: Added stilted speech, an accent that Makes You Talk Like This.