### PR TITLE
command bags for AA

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Back/backpacks.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingBackpack, BaseCommandContraband]
   id: ClothingBackpackCommandveteran
-  name: command veteran backpack
-  description: A sleek backpack, earned through a long career as command.
+  name: command backpack
+  description: A sleek leather backpack with gold fittings.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Backpacks/commandveteran.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Back/duffel.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingBackpackDuffel, BaseCommandContraband]
   id: ClothingBackpackDuffelCommandveteran
-  name: command veteran duffel bag
-  description: A sleek duffel bag, earned through a long career as command.
+  name: command duffel bag
+  description: A sleek leather duffel bag with gold fittings.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Duffels/commandveteran.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Back/satchel.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingBackpackSatchel, BaseCommandContraband]
   id: ClothingBackpackSatchelCommandveteran
-  name: command veteran satchel
-  description: A sleek satchel, earned through a long career as command.
+  name: command satchel
+  description: A sleek leather satchel with gold fittings.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Satchels/commandveteran.rsi

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -260,6 +260,9 @@
   - CommonSatchel
   - CommonDuffel
   - LeatherSatchel #imp
+  - CommandVeteranBackpack #imp
+  - CommandVeteranSatchel #imp
+  - CommandVeteranDuffel #imp
 
 - type: loadoutGroup
   id: BartenderShoes


### PR DESCRIPTION
per the discussion here, there's some disagreement about whether or not admin assistant should have command veteran bag options https://github.com/impstation/imp-station-14/pull/1683#discussion_r1955569839

in a suggestions thread in our discord ("Should Admin Assistant be an intern role? Or also an RP role?") it seems that people are happy for it to be both for rp and for learning, so presumably we won't add a time lockout to it, in which case i personally believe it's fine that they have these bags as options

imo it seems like an appropriate job for experienced command to take as a 'side job' when they're not really on the clock for captain or whatever.  and, frankly, i don't think these bags being an option is going to be the deciding factor as to whether command mains will play AA.  based on the suggestions thread, they'll still do it, just with basic bags

sooo we'll see, but community feedback has me thinking it's fine

:cl:
- add: Admin Assistant can now select command veteran bags