### PR TITLE
Fix borgs losing items

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -92,7 +92,7 @@ namespace Content.Server.Destructible
                             var childEnumerator = Transform(uid).ChildEnumerator;
                             while (childEnumerator.MoveNext(out var child))
                             {
-                                if (TryComp<EmbeddableProjectileComponent>(child, out var embeddable))
+                                if (TryComp<EmbeddableProjectileComponent>(child, out var embeddable) && embeddable.EmbeddedIntoUid != null)
                                     ProjectileSystem.RemoveEmbed(child, embeddable);
                             }
                             break;

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -84,12 +84,19 @@ namespace Content.Server.Destructible
                             $"Unknown damage source caused {ToPrettyString(uid):subject} to trigger [{triggeredBehaviors}]");
                     }
 
-                    // Unembed any embedded projectiles
-                    var childEnumerator = Transform(uid).ChildEnumerator;
-                    while (childEnumerator.MoveNext(out var child))
+                    // Unembed any embedded projectiles if the entity is about to be destroyed
+                    foreach (var behavior in threshold.Behaviors)
                     {
-                        if (TryComp<EmbeddableProjectileComponent>(child, out var embeddable))
-                            ProjectileSystem.RemoveEmbed(child, embeddable);
+                        if (behavior is DoActsBehavior actBehavior && actBehavior.HasAct(ThresholdActs.Destruction))
+                        {
+                            var childEnumerator = Transform(uid).ChildEnumerator;
+                            while (childEnumerator.MoveNext(out var child))
+                            {
+                                if (TryComp<EmbeddableProjectileComponent>(child, out var embeddable))
+                                    ProjectileSystem.RemoveEmbed(child, embeddable);
+                            }
+                            break;
+                        }
                     }
 
                     threshold.Execute(uid, this, EntityManager, args.Origin);


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About this PR
Fixes a bug causing borgs to lose certain items from their modules. This was caused by `DestructibleSystem` attempting to unembed all embeddable projectiles from an entity whenever they reached a threshold for a damage trigger (such as the one that borgs use to play a sound at low health.)

This PR adjusts `DestructibleSystem` so that it will only attempt to unembed projectiles if they are actually embedded in an entity AND if the `DamageThreshold` behavior intends to destroy the entity.

### Media

Previous behavior: 

https://github.com/user-attachments/assets/8a268dbe-6e46-480b-95a0-bc26e37b7786

Fixed behavior (+ demonstrating that the intended unembedding behavior still works):

https://github.com/user-attachments/assets/d76b02e2-5d14-47fe-a899-4b3a96b9d7d5




**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed cyborg modules losing certain items at low health.
