### PR TITLE
Legalize suspicious beacons + Thief toolboxes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
@@ -1,8 +1,8 @@
 - type: entity
-  parent: BaseMinorContraband
+  #parent: BaseMinorContraband # imp edit
   id: ThiefBeacon
   name: suspicious beacon
-  description: A device that will teleport everything around it... elsewhere... at the end of the shift.
+  description: A device that will teleport everything around it... elsewhere... at the end of the shift. # imp
   components:
     - type: ThiefBeacon
     - type: StealArea

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -152,7 +152,7 @@
   id: ToolboxThief
   name: thief undetermined toolbox
   description: This is where your favorite thief's supplies lie. Try to remember which ones.
-  parent: [ BaseItem, BaseMinorContraband ]
+  parent: [ BaseItem ] # imp edit
   components:
   - type: Sprite
     sprite: Objects/Tools/Toolboxes/toolbox_thief.rsi


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
It's no fun for Johnny Passenger to discover your thief hideout full of stolen goods and hone in on the beacon, pick it up, and bring it to security, where you will never ever see it again. It's already widespread in security and server culture to ignore thief beacons because everyone _knows_ it sucks to have it taken. The stolen goods themselves should be the items that are removed from the hideout, not the random doohickey that most people wouldn't reasonably recognize as illegal.
Same goes for the thief toolbox, nobody should have that taken away before they have a chance to choose their loadout. That sucks.
This PR removes the contraband component from both.

![bug](https://github.com/user-attachments/assets/b2cdb9d9-6326-4448-8cc2-ccd1595ff9aa)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Suspicious beacons are no longer contraband.
