### PR TITLE
Tck'tck access fix

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
@@ -306,3 +306,5 @@
     - Engineering
     - External
     - Salvage
+    - Cargo
+    - Maintenance


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Two line change, they didnt have maintenance or cargo access so they got stuck if they spawned in salvage. oopsi
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Tck'tck now has proper access for cargo and maintenance.
