### PR TITLE
punctuation accent hotfix

### DIFF
--- a/Content.Server/_Impstation/Speech/EntitySystems/ProperPunctuationSystem.cs
+++ b/Content.Server/_Impstation/Speech/EntitySystems/ProperPunctuationSystem.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Speech.EntitySystems;
 public sealed class ProperPunctuationSystem : EntitySystem
 {
     // @formatter:off
-    private static readonly Regex RegexEndsWithAnyPunctuation = new(@"[!?\.]+$");
+    private static readonly Regex RegexEndsWithAnyPunctuation = new(@"[!?\.-]+$");
     // @formatter:on
 
     public override void Initialize()


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
i forgot to add dashes to the list of punctuation that the punctuation accent acknowledges, so you couldn't roleplay cutting yourself off mid-sentence. "oh shi-" would become "oh shi-." yuck
i fixa it
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
