### PR TITLE
AI and Cyborg loadout names

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Clothing;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.NameIdentifier;
 using Content.Shared.PDA;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
@@ -135,7 +136,13 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
                 EquipRoleName(jobEntity, loadout, roleProto!);
             }
 
+            if (TryComp<NameIdentifierComponent>(jobEntity, out var identcomp));
+            {
+            _metaSystem.SetEntityName(jobEntity, profile!.Name + " " + identcomp!.FullIdentifier);
+            }
+
             DoJobSpecials(job, jobEntity);
+
             _identity.QueueIdentityUpdate(jobEntity);
             return jobEntity;
         }

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -138,7 +138,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
 
             if (TryComp<NameIdentifierComponent>(jobEntity, out var identcomp));
             {
-            _metaSystem.SetEntityName(jobEntity, profile!.Name + " " + identcomp!.FullIdentifier);
+            _metaSystem.SetEntityName(jobEntity, profile!.Name + " " + identcomp!.FullIdentifier); //imp change
             }
 
             DoJobSpecials(job, jobEntity);


### PR DESCRIPTION
This PR allows players to pick a name for their silicon characters at roundstart, instead of being forced to use a random one.
Notably, this includes the Station AI, who previously couldn't change their name at all, except through admin intervention. 
A side effect of the method used to achieve this means that AI now also have their Positronic Brain Identifier exposed in their entity name. 

![image](https://github.com/user-attachments/assets/60de4fe7-09d7-4bf5-b367-d81dd134432f)


**Changelog**
:cl:
- tweak: Silicon characters can now use character names from the loadout menu.
