### PR TITLE
Ammofab additions

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -871,6 +871,7 @@
         - MagazineBoxLightRifle
         - MagazineBoxMagnum
         - MagazineBoxPistol
+        - MagazineBoxLPistol #imp
         - MagazineBoxRifle
         - MagazineDMR #imp
         - MagazineDMREmpty #imp
@@ -887,6 +888,10 @@
         - MagazineShotgunSlug
         - SpeedLoaderMagnum
         - SpeedLoaderMagnumEmpty
+        - MagazinePistolSubMachineGun #imp
+        - MagazinePistolSubMachineGunEmpty #imp
+        - MagazinePistolSubMachineGunTopMounted #imp
+        - MagazinePistolSubMachineGunTopMountedEmpty #imp
     - type: MaterialStorage
       whitelist:
         tags:


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
This is mainly for the .22 auto ammo boxes which are currently missing from the ammofab but I added in the magazines too just for some extra flavor. Also I wasn't sure if I needed to add the "#imp" comment for the magazines or not so let me know if I need to get rid of them.

**Changelog**
:cl:
- add: .22 auto ammo boxes, SMG magazines, and WT magazines to the ammo techfab.

