### PR TITLE
Make the stealth shader actually not crash for real this time

### DIFF
--- a/Resources/Textures/_Impstation/Shaders/accessible_full_stealth.swsl
+++ b/Resources/Textures/_Impstation/Shaders/accessible_full_stealth.swsl
@@ -14,7 +14,7 @@ const highp float light_whitepoint = 1.0;
 void fragment() {
     highp vec4 spriteCol = zTexture(UV);
     highp vec4 outlineCol = getOutlineCol();
-    highp float clampedVis = clamp(visibility, -0.0, 1.0);
+    highp float clampedVis = clamp(visibility, 0.0, 1.0);
 
     if (outlineCol.a > 0.1 && ShowOutline) {
         COLOR.rgb = outlineCol.rgb;

--- a/Resources/Textures/_Impstation/Shaders/accessible_full_stealth.swsl
+++ b/Resources/Textures/_Impstation/Shaders/accessible_full_stealth.swsl
@@ -14,11 +14,11 @@ const highp float light_whitepoint = 1.0;
 void fragment() {
     highp vec4 spriteCol = zTexture(UV);
     highp vec4 outlineCol = getOutlineCol();
-    highp float clampedVis = clamp(visibility, 0, 1);
+    highp float clampedVis = clamp(visibility, -0.0, 1.0);
 
     if (outlineCol.a > 0.1 && ShowOutline) {
         COLOR.rgb = outlineCol.rgb;
-        COLOR.a = outlineCol.a * (1 - clampedVis);
+        COLOR.a = outlineCol.a * (1.0 - clampedVis);
     } else {
         COLOR.rgb = spriteCol.rgb;
         COLOR.a = spriteCol.a * clampedVis;


### PR DESCRIPTION
tiny change that hopefully makes things not explode for people running in compat mode now
no cl

also you can test this in a localhost by changing the default value of the `display.compat` cvar to true (remember to set it back to false when you're done (there's probably a better way to do this but I cba to find it))