### PR TITLE
Kammerer Parity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -139,7 +139,7 @@
   name: Enforcer
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponShotgunEnforcer
-  description: A premium semi-automatic combat shotgun, featuring a pistol grip and full-length magazine tube for those nasty close-quarters engagements. Uses .50 shotgun shells. #imp
+  description: A premium semi-automatic combat shotgun, featuring a pistol grip and sleek profile for those nasty close-quarters engagements. Uses .50 shotgun shells. #imp
   components: # intend for Enforcer to have wider choke for semi-auto function
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
@@ -161,7 +161,7 @@
   name: Kammerer
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponShotgunKammerer
-  description: Even centuries after his time, the legacy of John Moses Browning lives on. This pump-action shotgun is a favorite of hunters and militia forces throughout many worlds. Uses .50 shotgun shells. #imp
+  description: Even centuries after his time, the legacy of John Moses Browning lives on. This pump-action shotgun is a favorite of hunters and militia forces across many worlds. Uses .50 shotgun shells. #imp
   components: # intend for Kammerer to have tighter choke for slower fire rate and/or manual cycling
   - type: Item
     size: Normal

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -2,7 +2,7 @@
   name: stun Enforcer
   parent: WeaponShotgunEnforcer
   id: WeaponShotgunEnforcerBeanbag
-  description: A premium combat shotgun with an extended magazine and a built-in silencer, modified to only accept .50 stun slugs.
+  description: A premium combat shotgun with a pistol grip and a built-in silencer, modified to only accept .50 stun slugs.
   components:
   - type: Sprite
     sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagenforcer.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -44,7 +44,7 @@
   - type: Clothing
     sprite: _Impstation/Objects/Weapons/Guns/Shotguns/beanbagpump.rsi
   - type: Gun
-    fireRate: 2
+    fireRate: 1
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -56,7 +56,7 @@
     whitelist:
       tags:
       - ShellShotgunBeanbag
-    capacity: 4
+    capacity: 7
     proto: ShellShotgunBeanbag
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg


### PR DESCRIPTION
The Kammerer got this awesome update to fire half as fast but carry equal shells as the Enforcer. Makes the Kammerer feel more useful without making the Enforcer obsolete. Fixed up the descriptions to match the change and gave the update to the Stun Kammerer as well.
:cl:
- tweak: Stun Kammerers should now match their lethal counterparts in terms of fire rate and shells
- tweak: Descriptions on shotguns should now match their qualities a bit better