### PR TITLE
new trait: echolalia

### DIFF
--- a/Content.Server/_NF/Speech/EntitySystems/ParrotSpeechSystem.cs
+++ b/Content.Server/_NF/Speech/EntitySystems/ParrotSpeechSystem.cs
@@ -31,9 +31,9 @@ public sealed class ParrotSpeechSystem : EntitySystem
             if (component.LearnedPhrases.Count == 0)
                 // This parrot has not learned any phrases, so can't say anything interesting.
                 continue;
-            if (TryComp<MindContainerComponent>(uid, out var mind) && mind.HasMind)
-                // Pause parrot speech when someone is controlling the parrot.
-                continue;
+            // if (TryComp<MindContainerComponent>(uid, out var mind) && mind.HasMind)
+                // Imp edit - need to skip this check for echolalia trait
+                // continue;
             if (_timing.CurTime < component.NextUtterance)
                 continue;
 

--- a/Resources/Locale/en-US/_Impstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Impstation/traits/traits.ftl
@@ -58,3 +58,6 @@ trait-propercapitalization-desc = You speak with proper capitalization, somehow.
 
 trait-properpunctuation-name = Proper punctuation
 trait-properpunctuation-desc = Your sentences end with periods or other punctuation, always.
+
+trait-echolalia-name = Echolalia
+trait-echolalia-desc = You can't help yourself from repeating phrases you've heard.

--- a/Resources/Prototypes/_Impstation/Traits/speech.yml
+++ b/Resources/Prototypes/_Impstation/Traits/speech.yml
@@ -101,6 +101,21 @@
   components:
   - type: StiltedSpeech
 
+- type: trait
+  id: Echolalia
+  name: trait-echolalia-name
+  description: trait-echolalia-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ActiveListener
+    range: 5
+  - type: ParrotSpeech
+    maximumPhraseLength: 24 # higher chance of saying a full sentence
+    minimumWait: 300
+    maximumWait: 900 # triggers once every 15 minutes
+    learnChance: 0.1
+
 # 2 cost
 
 - type: trait


### PR DESCRIPTION
![SS14 Loader_ruwRqmPTaA](https://github.com/user-attachments/assets/5cf7f3d2-6b3e-4cc8-8526-05b3ff8bb0ef)

1 point speech trait, causes you to randomly repeat things said in earshot

notes
- literally _everything_ in local chat range has a chance to be repeated, including things the trait holder has said, vending machine advertisements, previous triggers of the trait, etc
- nothing heard via headset will be repeated. spent a few minutes troubleshooting this but decided it wasnt worth the effort
- it applies accents to repeated phrases
![SS14 Loader_kpcl7lnDrX](https://github.com/user-attachments/assets/872a42cb-4595-47fc-bc17-a80d11db2e47)
- echolalia triggers do not show up in the chat window, vending machine style. this would be an easy fix if desired but i think its kinda funnier to go "what the fuck was that"

**Changelog**
:cl:
- add: Added an echolalia trait. Stop repeating yourself. Stop repeating yourself. Stop repeating yourself.
