### PR TITLE
thaven sex selection changes voice

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
@@ -62,8 +62,8 @@
     proto: guardian
   - type: Vocal
     sounds:
-      Male: MaleHuman
-      Female: FemaleHuman
+      Male: MaleThaven
+      Female: FemaleThaven
       Unsexed: UnisexThaven
   - type: Speech
     speechSounds: Alto

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
@@ -62,8 +62,8 @@
     proto: guardian
   - type: Vocal
     sounds:
-      Male: UnisexThaven
-      Female: UnisexThaven
+      Male: MaleHuman
+      Female: FemaleHuman
       Unsexed: UnisexThaven
   - type: Speech
     speechSounds: Alto


### PR DESCRIPTION
see the suggestions thread about it, just a two-line code change but like doop said it's weird to hear an at-times masculine voice come out of your character when you don't think they sound like that

you CAN still get the higher-pitched male voices (what all thaven have right now) by just selecting unisex, and since even the "young captain woman" text you see when you have no ID draws from pronouns rather than selected sex

so unless we introduce actual sexual dimorphism for thaven sprites, then as far as i can tell there are no strings attached and it just lets people choose character voice types

:cl:
- add: Thavens can now select masculine/feminine voices by changing the 'sex' selection, or unisex to keep the current voices