### PR TITLE
Burstfire Tweaks to WT550 and C-20R

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -105,7 +105,7 @@
     minAngle: 21
     maxAngle: 32
     shotsPerBurst: 2 #imp
-    burstCooldown: 0.35 #imp
+    burstCooldown: 0.15 #imp
     burstFireRate: 20 #imp
     availableModes:
     - Burst

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -113,7 +113,6 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/c-20r.ogg
-    selectedMode: Burst #imp
   - type: ChamberMagazineAmmoProvider
     autoEject: true
     soundAutoEject:
@@ -157,6 +156,7 @@
       - SemiAuto
       shotsPerBurst: 3
       burstCooldown: 0.25
+      selectedMode: Burst #imp
     - type: ItemSlots
       slots:
         gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -104,13 +104,16 @@
   - type: Gun
     minAngle: 21
     maxAngle: 32
-    shotsPerBurst: 5
+    shotsPerBurst: 2 #imp
+    burstCooldown: 0.6 #imp
+    burstFireRate: 20 #imp
     availableModes:
     - Burst
     - FullAuto
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/c-20r.ogg
+    selectedMode: Burst #imp
   - type: ChamberMagazineAmmoProvider
     autoEject: true
     soundAutoEject:
@@ -257,8 +260,8 @@
     angleIncrease: 1.5
     angleDecay: 6
     selectedMode: FullAuto
-    shotsPerBurst: 5
-    burstCooldown: 0.2
+    shotsPerBurst: 3 #imp
+    burstCooldown: 0.7 #imp
     burstFireRate: 7
     availableModes:
     - Burst

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -105,7 +105,7 @@
     minAngle: 21
     maxAngle: 32
     shotsPerBurst: 2 #imp
-    burstCooldown: 0.6 #imp
+    burstCooldown: 0.35 #imp
     burstFireRate: 20 #imp
     availableModes:
     - Burst
@@ -261,8 +261,8 @@
     angleDecay: 6
     selectedMode: FullAuto
     shotsPerBurst: 3 #imp
-    burstCooldown: 0.7 #imp
-    burstFireRate: 7
+    burstCooldown: 0.5 #imp
+    burstFireRate: 12
     availableModes:
     - Burst
     - FullAuto


### PR DESCRIPTION
The slow five-round burst was driving me crazy and is never used; burst-fire should be a mode alongside single-shot and full-auto. All three modes have their uses. Balanced the WT550 with a slower burst due to its accuracy compared to the Drozd and C-20R. C-20R gets a unique two-round burst that strikes a middle ground between single-shot and full-auto. I don't want there to be an objective best, just options for the user for certain use cases.
Also restored the Drozd having the default be burst, since that was pretty unique to the gun!
I'm also really sorry for making FOUR PRs in 24 hours, all gun-related too.

https://github.com/user-attachments/assets/7b21b058-60ed-47e2-9435-053ac7291578

:cl:
- tweak: Burst-fire modes on the WT550 and C-20R SMGs should feel better to use; try them out on your friends and foes!
