### PR TITLE
removes pda and headset from the syndicate clown bundle

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -428,7 +428,7 @@ uplink-costume-pyjama-name = Syndicate Pyjama Duffel Bag
 uplink-costume-pyjama-desc = Contains 3 pairs of syndicate pyjamas and 4 plushies for the ultimate sleepover.
 
 uplink-costume-clown-name = Clown Costume Duffel Bag
-uplink-costume-clown-desc = Contains a complete Clown outfit. Includes PDA and service radio.
+uplink-costume-clown-desc = Contains a complete Clown outfit.
 
 uplink-carp-suit-bundle-name = Carp Suit Duffel Bag
 uplink-carp-suit-bundle-desc = Contains a carp suit and some friends to play with.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -154,8 +154,8 @@
       - id: ClothingShoesClown
       - id: ClothingMaskClown
       - id: BikeHorn
-      - id: ClownPDA
-      - id: ClothingHeadsetService
+      #- id: ClownPDA # imp edit- 2 tc to get maints access and greencomms is causing people to buy this for the wrong reason
+      #- id: ClothingHeadsetService
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle


### PR DESCRIPTION
this should be something you buy for bit ops but getting maints access and a common encryption key for 2 tc makes it unbelievably meta for nukies

**Changelog**
:cl:
- remove: The Clown Costume Duffel Bag no longer contains a headset and PDA.
