### PR TITLE
Small Disabler Balance Pass

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/disablers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/disablers.yml
@@ -88,9 +88,9 @@
     zeroVisible: true
   - type: Gun
     minAngle: 2
-    maxAngle: 18
+    maxAngle: 15
     angleIncrease: 3
-    angleDecay: 18
+    angleDecay: 15
     fireRate: 3
     selectedMode: FullAuto
     availableModes:
@@ -132,7 +132,7 @@
     steps: 4
     zeroVisible: true
   - type: Gun
-    fireRate: 1.3
+    fireRate: 0.9
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/stunprojector.ogg
   - type: HitscanBatteryAmmoProvider


### PR DESCRIPTION
Small balance pass on the new disablers. Stun Projector is on watch-- going to see how it plays out with the rate of fire change but if that's not considered enough then other options will be considered. Auto Disabler felt maybe a bit too inaccurate, so it got a subtle nudge.

**Changelog**
:cl:
- tweak: Auto Disabler's maximum inaccuracy cone has been narrowed by 3 degrees (18 -> 15)
- tweak: Stun Projector's rate of fire reduced from 1.3 to 0.9 shots per second. Was stunning faster than intended prior.
