### PR TITLE
Remove gold pAI from loadouts, move to rare mail drop instead

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/permaescape.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/permaescape.yml
@@ -166,6 +166,11 @@
       - id: ClearPDA # change to visitor one day.
         prob: 0.10
       - id: PersonalAI
+        orGroup: pAI
+        prob: 0.99
+      - id: GoldPersonalAI #imp
+        orGroup: pAI
+        prob: 0.01
 
 - type: entity
   id: CratePermaEscapeLights

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -570,6 +570,9 @@
         orGroup: GiftPool
       - id: PersonalAI
         orGroup: GiftPool
+      - id: GoldPersonalAI #imp
+        orGroup: GiftPool
+        prob: 0.01
       - id: CrayonBox
         orGroup: GiftPool
       - id: ToySword
@@ -776,6 +779,9 @@
         orGroup: GiftPool
       - id: PersonalAI
         orGroup: GiftPool
+      - id: GoldPersonalAI #imp
+        orGroup: GiftPool
+        prob: 0.01
       - id: CrayonBox
         orGroup: GiftPool
       - id: ToySword

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -41,7 +41,6 @@
   - FolderHamster #imp
   - FolderMime #imp
   - FolderPun #imp
-  - GoldPersonalAI #imp
   - GoldRingTrinket #imp
   - Hairflower
   - HarmonicaInstrument #imp

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Mail/mail.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Mail/mail.yml
@@ -576,9 +576,12 @@
     contents:
     - id: PersonalAI
       orGroup: PAI
-      prob: 0.99
+      prob: 0.98
       # Ultra rare
     - id: SyndicatePersonalAI
+      orGroup: PAI
+      prob: 0.01
+    - id: GoldPersonalAI
       orGroup: PAI
       prob: 0.01
 

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
@@ -1,17 +1,4 @@
 - type: loadoutEffectGroup
-  id: PrestigeGold
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:OverallPlaytimeRequirement
-      time: 1512000 #420 hours
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Silicon
-      time: 36000 #10 hours
-
-- type: loadoutEffectGroup
   id: Tutorial #imp
   effects:
   - !type:JobRequirementLoadoutEffect
@@ -37,15 +24,6 @@
   storage:
     back:
     - PersonalAI
-
-- type: loadout
-  id: GoldPersonalAI
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: PrestigeGold
-  storage:
-    back:
-    - GoldPersonalAI
 
 - type: loadout
   id: TutorialAI_Newcomer #imp. <15 hours.

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
@@ -20,12 +20,6 @@
     - CigPackSpirits
 
 - type: loadout
-  id: PersonalAI
-  storage:
-    back:
-    - PersonalAI
-
-- type: loadout
   id: TutorialAI_Newcomer #imp. <15 hours.
   effects:
   - !type:GroupLoadoutEffect

--- a/Resources/Prototypes/_Impstation/Mail/mailDeliveries.yml
+++ b/Resources/Prototypes/_Impstation/Mail/mailDeliveries.yml
@@ -69,7 +69,7 @@
     MailNFSmoke: 0.4
     #MailNFEMP: 0.3 # Imp commented cuz error log :(
     MailNFThrongler: 0.01 # DeltaV: 0.1 to 0.01
-    MailImpFuckingGun: 0.01 # Mira requested this. maybe don't turn it on yet without discussion
+    MailImpFuckingGun: 0.01 # Mira requested this.
 
   # Department and job-specific mail can have slightly higher weights,
   # since they'll be merged with the everyone pool.


### PR DESCRIPTION
This probably should've happened a while back, but got lost in the sauce. Sorry to everyone who valued their 420 hour status symbol.

🆑 
- remove: Removed golden pAIs from the trinket loadout menu, per discussion on discord.
- add: Golden pAIs may now be obtained through the mail as a very very rare package!
