### PR TITLE
Prestige reduction/removal

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/cargo_technician.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Cargo
-      time: 216000 # 60 hrs
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobQuartermaster
-      time: 72000 #20 hrs
+      time: 36000 #10 hrs, ~7 rounds #imp
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobSalvageSpecialist
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Back
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobBartender
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/botanist.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobBotanist
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/chef.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChef
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Head
 - type: loadout
@@ -52,7 +52,7 @@
   id: ChefShoes
   equipment:
     shoes: ClothingShoesChef
-  
+
 # id
 - type: loadout
   id: ChefPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -5,7 +5,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobJanitor
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/musician.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobMusician
-      time: 36000 #10 hours
+      time: 36000 #10 hrs, ~7 rounds #imp
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -6,9 +6,9 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobPassenger
-      time: 36000 #10 hrs, silly reward for people who play passenger a lot
+      time: 36000 #10 hrs, ~7 rounds, silly reward for people who play passenger a lot
 
-# Head of Greytide (for grey mantle)
+# Head of Greytide (for grey mantle) (imp edit: grey mantle unlocked at 10 hours by GreyTider instead since we have the greycloak)
 - type: loadoutEffectGroup
   id: MasterGrey
   effects:
@@ -16,7 +16,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobPassenger
-      time: 72000 #20 hrs, fun mantle for the most experienced greytiders
+      time: 72000 #20 hrs, ~14 rounds, fun mantle for the most experienced greytiders
 
 # Face
 - type: loadout
@@ -64,7 +64,7 @@
     neck: ClothingNeckMantle
   effects:
   - !type:GroupLoadoutEffect
-    proto: MasterGrey
+    proto: GreyTider #imp
 
 - type: startingGear
   id: Mantle

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobCaptain
-      time: 72000 #20 hrs
+      time: 36000 #10 hrs, ~7 rounds #imp
 
 # Jumpsuit
 - type: loadout
@@ -39,14 +39,6 @@
   id: CaptainCap
   equipment:
     head: ClothingHeadHatCapcap
-
-- type: loadout
-  id: CaptainCrusherCap
-  equipment:
-    head: ClothingHeadHatCaptaincrushercap
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCap
 
 # Glasses
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -6,9 +6,9 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfPersonnel
-      time: 54000 #15 hrs, ~10 rounds #imp
+      time: 36000 #10 hrs, ~7 rounds #imp
 
-# Professional HoP Time
+# Professional HoP Time (imp edit: ian backpack unlocked by MasterHoP instead)
 - type: loadoutEffectGroup
   id: ProfessionalHoP
   effects:
@@ -61,7 +61,7 @@
   - !type:GroupLoadoutEffect
     proto: ProfessionalHoP
   equipment:
-    back: ClothingBackpackIan
+    back: MasterHoP
 
 # Outerclothing
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfPersonnel
-      time: 72000 #20 hrs
+      time: 54000 #15 hrs, ~10 rounds #imp
 
 # Professional HoP Time
 - type: loadoutEffectGroup

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -59,9 +59,9 @@
   id: HoPBackpackIan
   effects:
   - !type:GroupLoadoutEffect
-    proto: ProfessionalHoP
+    proto: MasterHoP
   equipment:
-    back: MasterHoP
+    back: ClothingBackpackIan
 
 # Outerclothing
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/atmospheric_technician.yml
@@ -6,7 +6,8 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
+
 # Jumpsuit
 - type: loadout
   id: AtmosphericTechnicianJumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefEngineer
-      time: 72000 #20 hrs
+      time: 36000 #10 hrs, ~7 rounds #imp
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -6,17 +6,17 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 21600 #6 hrs
+      time: 18000 #5 hrs, ~4 rounds #imp
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
       role: JobStationEngineer
-      time: 21600 #6 hrs
+      time: 18000 #5 hrs, ~4 rounds #imp
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Engineering
-      time: 216000 # 60 hrs
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Head
 - type: startingGear

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
@@ -6,7 +6,8 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChemist
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
+
 # Jumpsuit
 - type: loadout
   id: ChemistJumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefMedicalOfficer
-      time: 72000 #20 hrs
+      time: 36000 #10 hrs, ~7 rounds #imp
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -6,17 +6,17 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChemist
-      time: 21600 #6 hrs
+      time: 18000 #5 hrs, ~4 rounds #imp
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 21600 #6 hrs
+      time: 18000 #5 hrs, ~4 rounds #imp
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Medical
-      time: 216000 # 60 hrs
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Other Timers
 
@@ -27,7 +27,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 108000 #30 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 # Head
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobParamedic
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 # Head
 - type: loadout
   id: ParamedicHead

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobResearchDirector
-      time: 72000 #20 hrs
+      time: 36000 #10 hrs, ~7 rounds #imp
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Science
-      time: 216000 #60 hrs
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 # Head
 - type: startingGear

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobDetective
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 # Head
 - type: loadout
   id: DetectiveFedora

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfSecurity
-      time: 36000 # Imp, 10 hrs
+      time: 18000 #5 hrs, ~4 rounds, half the standard due to HoS having an extreme unlock requirement #imp
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -6,12 +6,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobWarden
-      time: 21600 #6 hrs
+      time: 18000 #5 hrs, ~4 rounds #imp
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Security
-      time: 216000 # 60 hrs
+      time: 108000 #30 hrs, ~20 rounds #imp
 
 #Security Star
 - type: loadoutEffectGroup
@@ -21,7 +21,7 @@
       requirement:
         !type:DepartmentTimeRequirement
         department: Security
-        time: 360000 #100 hrs
+        time: 324000 #100 hrs, ~60 rounds #imp
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -21,7 +21,7 @@
       requirement:
         !type:DepartmentTimeRequirement
         department: Security
-        time: 324000 #100 hrs, ~60 rounds #imp
+        time: 324000 #90 hrs, ~60 rounds #imp
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobWarden
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 108000 #30 hrs, ~20 rounds #imp
 # Head
 - type: loadout
   id: WardenHead

--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -15,7 +15,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Cargo
-      time: 36000 #10 hours of being a space trucker
+      time: 36000 #10 hours, ~7 rounds, of being a space trucker
 
 # Basic options
 # Glasses

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Back/backpacks.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingBackpack, BaseCommandContraband]
   id: ClothingBackpackCommandveteran
-  name: command veteran backpack
-  description: A sleek backpack, earned through a long career as command.
+  name: command backpack
+  description: A sleek black leather backpack with brass hardware.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Backpacks/commandveteran.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Back/duffel.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingBackpackDuffel, BaseCommandContraband]
   id: ClothingBackpackDuffelCommandveteran
-  name: command veteran duffel bag
-  description: A sleek duffel bag, earned through a long career as command.
+  name: command duffel bag
+  description: A sleek black leather duffel bag with brass hardware.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Duffels/commandveteran.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Back/satchel.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingBackpackSatchel, BaseCommandContraband]
   id: ClothingBackpackSatchelCommandveteran
-  name: command veteran satchel
-  description: A sleek satchel, earned through a long career as command.
+  name: command satchel
+  description: A sleek black leather satchel with brass hardware.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Satchels/commandveteran.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/coats.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseCommandContraband]
   id: ClothingOuterCoatCMO
-  name: chief medical officer's prestige lab coat
+  name: chief medical officer's collared lab coat
   description: A medical lab coat for the Chief Medical Officer. The high collar acts as a splash guard for when a patient's veins are particularly leaky.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobQuartermaster
-      time: 180000 #50 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadout
   id: QuartermasterVeteranHeadset

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -1,14 +1,3 @@
-# Extreme time requirement prestige cape due to how flashy it is
-# They already have a way to show off playing for 52 hours anyway
-- type: loadoutEffectGroup
-  id: DrillerCapeWorthy
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobSalvageSpecialist
-      time: 108000 #30 hrs, ~20 rounds
-
 # Jumpsuit
 - type: loadout
   id: SalvageSpecialistJumpsuit
@@ -26,7 +15,7 @@
   id: DrillerCape
   effects:
   - !type:GroupLoadoutEffect
-    proto: DrillerCapeWorthy
+    proto: SeniorSalvager
   equipment:
     neck: ClothingNeckCloakDriller
 
@@ -35,7 +24,7 @@
   id: GlassesGarGreen
   effects:
   - !type:GroupLoadoutEffect
-    proto: DrillerCapeWorthy
+    proto: SeniorSalvager
   equipment:
     eyes: ClothingEyesGlassesGar
 
@@ -43,7 +32,7 @@
   id: GlassesGarOrange
   effects:
   - !type:GroupLoadoutEffect
-    proto: DrillerCapeWorthy
+    proto: SeniorSalvager
   equipment:
     eyes: ClothingEyesGlassesGarOrange
 
@@ -51,7 +40,7 @@
   id: GlassesGarRed
   effects:
   - !type:GroupLoadoutEffect
-    proto: DrillerCapeWorthy
+    proto: SeniorSalvager
   equipment:
     eyes: ClothingEyesGlassesGarGiga
 
@@ -59,6 +48,6 @@
   id: GlassesGarBlack
   effects:
   - !type:GroupLoadoutEffect
-    proto: DrillerCapeWorthy
+    proto: SeniorSalvager
   equipment:
     eyes: ClothingEyesGlassesGarMecha

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -7,7 +7,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobSalvageSpecialist
-      time: 360000 #100 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/passenger.yml
@@ -15,7 +15,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobPassenger
-      time: 360000 # 100 hours. Only a true passenger main will have access to the greycloak.
+      time: 360000 # 100 hours, ~67 rounds. Only a true passenger main will have access to the greycloak.
 
 # Neck
 - type: loadout

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/captain.yml
@@ -8,16 +8,6 @@
       role: JobCaptain
       time: 108000 #30 hrs, ~20 rounds
 
-# For the veteran command cosmetic set, used for all command jobs
-- type: loadoutEffectGroup
-  id: VeteranCommand
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Command
-      time: 108000 #30 hrs, ~20 rounds
-
 # Jumpsuit
 - type: loadout
   id: CaptainEveningAttire
@@ -29,6 +19,11 @@
   id: CaptainBeret
   equipment:
     head: ClothingHeadHatBeretCaptain
+
+- type: loadout
+  id: CaptainCrusherCap
+  equipment:
+    head: ClothingHeadHatCaptaincrushercap
 
 # Glasses
 - type: loadout

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/captain.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobCaptain
-      time: 180000 #50 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 # For the veteran command cosmetic set, used for all command jobs
 - type: loadoutEffectGroup
@@ -16,16 +16,13 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Command
-      time: 180000 # 50 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 # Jumpsuit
 - type: loadout
   id: CaptainEveningAttire
   equipment:
     jumpsuit: ClothingUniformJumpsuitCaptaineveningattire
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCap
 
 # Head
 - type: loadout
@@ -38,9 +35,6 @@
   id: CaptainVisor
   equipment:
     eyes: ClothingEyesGlassesCaptainvisor
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCap
 
 # Neck
 - type: loadout
@@ -56,24 +50,15 @@
   id: CaptainRepeller
   equipment:
     outerClothing: ClothingOuterArmorCaptainRepeller
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCap
 
 # Gloves
 - type: loadout
   id: CaptainFlightGloves
   equipment:
     gloves: ClothingHandsGlovesCaptainflightgloves
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCap
 
 # Shoes
 - type: loadout
   id: CaptainJumpBoots
   equipment:
     shoes: ClothingShoesBootsCaptainjumpboots
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCap

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/generic_command.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/generic_command.yml
@@ -1,52 +1,36 @@
-# Timers
 - type: loadoutEffectGroup
-  id: Command10Hr
+  id: VeteranCommand
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Command
-      time: 36000 # 10 hours
+      time: 108000 #30 hrs, ~20 rounds
 
 # Back
 - type: loadout
   id: CommandVeteranBackpack
   equipment:
     back: ClothingBackpackCommandveteran
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCommand
 
 - type: loadout
   id: CommandVeteranSatchel
   equipment:
     back: ClothingBackpackSatchelCommandveteran
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCommand
 
 - type: loadout
   id: CommandVeteranDuffel
   equipment:
     back: ClothingBackpackDuffelCommandveteran
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCommand
 
 # Shoes
 - type: loadout
   id: BlackCommandHeels
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: Command10Hr
   equipment:
     shoes: ClothingShoesHeelsCommandBlack
 
 - type: loadout
   id: BlueCommandHeels
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: Command10Hr
   equipment:
     shoes: ClothingShoesHeelsCommandBlue
 

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefEngineer
-      time: 180000 #50 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadout
   id: ChiefEngineerVeteranHeadset

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobStationEngineer
-      time: 36000 #10 hrs
+      time: 36000 #10 hrs, ~7 rounds
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/chemist.yml
@@ -5,7 +5,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChemist
-      time: 36000 #10 hrs
+      time: 36000 #10 hrs, ~7 rounds
 
 # Jumpsuit
 

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefMedicalOfficer
-      time: 180000 #50 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadout
   id: ChiefMedicalOfficerVeteranHeadset
@@ -28,6 +28,3 @@
   id: CMOPrestigeLabcoat
   equipment:
     outerClothing: ClothingOuterCoatCMO
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranCMO

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Science/research_director.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobResearchDirector
-      time: 180000 #50 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadout
   id: ResearchDirectorVeteranHeadset

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/head_of_security.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfSecurity
-      time: 90000 #25 hrs
+      time: 54000 #15 hrs, ~10 rounds, half the standard due to HoS having an extreme unlock requirement
 
 - type: loadout
   id: HeadofSecurityVeteranHeadset
@@ -28,9 +28,6 @@
   id: HeadofSecurityEliteArmor
   equipment:
     outerClothing: ClothingOuterArmorHoSEliteArmor
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: VeteranHOS
 
 - type: loadout
   id: HeadofSecurityJumpsuitGrey

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/clown_prestige.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/clown_prestige.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobClown
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadoutEffectGroup
   id: ClownJanitorTimer
@@ -15,12 +15,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobClown
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
       role: JobJanitor
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadoutEffectGroup
   id: ClownCargoTimer
@@ -29,12 +29,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobClown
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Cargo
-      time: 216000 #60 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadoutEffectGroup
   id: ClownEngineerTimer
@@ -43,12 +43,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobClown
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Engineering
-      time: 216000 #60 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadoutEffectGroup
   id: ClownDoctorTimer
@@ -57,12 +57,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobClown
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Medical
-      time: 216000 #60 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadoutEffectGroup
   id: ClownScientistTimer
@@ -71,12 +71,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobClown
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Science
-      time: 216000 #60 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 - type: loadoutEffectGroup
   id: ClownSecurityTimer
@@ -85,12 +85,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobClown
-      time: 108000 # 30 hrs
+      time: 108000 #30 hrs, ~20 rounds
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Security
-      time: 216000 #60 hrs
+      time: 108000 #30 hrs, ~20 rounds
 
 # Civilian
 - type: loadout

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/glasses.yml
@@ -1,4 +1,4 @@
-﻿# colorful glasses timers - 2h so its like twoish rounds to unlock
+﻿# colorful glasses timers
 - type: loadoutEffectGroup
   id: SecurityGlassesTimer
   effects:
@@ -6,7 +6,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Security
-      time: 7200
+      time: 7200 #2 hrs, ~2 rounds
 
 - type: loadoutEffectGroup
   id: MedicalGlassesTimer
@@ -15,7 +15,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Medical
-      time: 7200
+      time: 7200 #2 hrs, ~2 rounds
 
 - type: loadoutEffectGroup
   id: ScienceGlassesTimer
@@ -24,7 +24,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Science
-      time: 7200
+      time: 7200 #2 hrs, ~2 rounds
 
 - type: loadoutEffectGroup
   id: ServiceGlassesTimer
@@ -33,7 +33,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Civilian
-      time: 7200
+      time: 7200 #2 hrs, ~2 rounds
 
 - type: loadoutEffectGroup
   id: CargoGlassesTimer
@@ -42,7 +42,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Cargo
-      time: 7200
+      time: 7200 #2 hrs, ~2 rounds
 
 - type: loadoutEffectGroup
   id: EngineeringGlassesTimer
@@ -51,7 +51,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Engineering
-      time: 7200
+      time: 7200 #2 hrs, ~2 rounds
 
 # colorful glasses loadouts
 


### PR DESCRIPTION
ok, based on the suggestions thread, i reduced/removed all prestige requirements following these guidelines:

- command prestige should be restricted to neck items and small things like headsets
- 10 hours for mantles, 30 hours for our newer neck items and headsets
- other command clothing items have had their requirements removed altogether
- 5 and 15 hours for HoS respectively since it has extreme unlock requirements
- 10 hours for small things like greytider gear
- 30 hours for senior department cosmetics (sometimes with 5 hours required in other jobs in that department)

30 hours was requested as a hard limit, with the one exception being the greycloak, requested to stay at 100 hours by beck

:cl:
- tweak: Reduced or removed prestige item requirements per feedback