### PR TITLE
Derotate Convex

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -10,7 +10,7 @@
   - Box
   - Cluster
   - Cog
-  - Convex
+  #- Convex
   - Core
   - Elkridge
   #- Fland


### PR DESCRIPTION
Convex is a huge map that'll likely need some time in the oven. Currently the only Impstation additions it supports are Supply Assistant and Administrative Assistant. No current map maintainers are interested in maintaining it, so I am derotating for the time being.

:cl:
- remove: Convex has been derotated to reduce map maintenance load.