### PR TITLE
ling weighting tweakz

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -4,7 +4,7 @@
   components:
   - type: ChangelingRule
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 20
     delay:
       min: 30
       max: 60
@@ -17,8 +17,8 @@
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      max: 6
-      playerRatio: 10
+      max: 5
+      playerRatio: 15
       lateJoinAdditional: true
       blacklist:
         components:

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -4,7 +4,7 @@
   components:
   - type: ChangelingRule
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 20 #imp: up from 15
     delay:
       min: 30
       max: 60
@@ -17,8 +17,8 @@
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      max: 5
-      playerRatio: 15
+      max: 5 #imp: 6>5
+      playerRatio: 15 #imp: up from 10
       lateJoinAdditional: true
       blacklist:
         components:

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -5,7 +5,7 @@
     Nukeops: 0.13
     Traitor: 0.41
     SpyVsSpy: 0.04
-    Changeling: 0.10
+    Changeling: 0.10 #imp: decreased from 0.13 bc we rolled it so often
     Heretics: 0.13
     Zombie: 0.04
     Zombieteors: 0.01

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,14 +4,14 @@
     # regular gamemodes, gamemodes with 20 population requirement or more
     Nukeops: 0.13
     Traitor: 0.41
-    SpyVsSpy: 0.03
-    Changeling: 0.13
+    SpyVsSpy: 0.04
+    Changeling: 0.10
     Heretics: 0.13
-    Zombie: 0.02
+    Zombie: 0.04
     Zombieteors: 0.01
     Survival: 0.10
     KesslerSyndrome: 0.01
-    Revolutionary: 0.03
+    Revolutionary: 0.04
 
     # lowpop gamemodes, gamemodes with 19 population requirement or below
     TraitorLowpop: 0.50


### PR DESCRIPTION
changelings:
- now require 20 players to roll (increased from 15)
- spawn at a rate of 1:15 (upped from 1:10)
- have a max amount of 5 (down from 6)

gamemodes:
- changeling gamemode 13% > 10%
- zombies 3% > 4%
- revolutionaries 3% > 4%
- spyvspy 3% > 4%

:cl:
- tweak: The overall changeling population has been lightly culled.