### PR TITLE
Fix reflective vests reflecting lasers while held

### DIFF
--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -27,6 +27,12 @@ public sealed partial class ReflectComponent : Component
 
     [DataField("soundOnReflect")]
     public SoundSpecifier? SoundOnReflect = new SoundPathSpecifier("/Audio/Weapons/Guns/Hits/laser_sear_wall.ogg");
+
+    /// <summary>
+    /// imp edit - should this item allow reflections while it's held? should be false for clothes specifically
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool ReflectWhileHeld = true;
 }
 
 [Flags]

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -205,7 +205,7 @@ public sealed class ReflectSystem : EntitySystem
 
     private void OnReflectHandEquipped(EntityUid uid, ReflectComponent component, GotEquippedHandEvent args)
     {
-        if (_gameTiming.ApplyingState)
+        if (_gameTiming.ApplyingState || !component.ReflectWhileHeld) //imp edit - add held reflect check
             return;
 
         EnsureComp<ReflectUserComponent>(args.User);

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -104,6 +104,7 @@
     reflectProb: 1
     reflects:
       - Energy
+    reflectWhileHeld: false #imp edit - don't allow this to reflect things while you're holding it
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, Tier3Contraband ]


### PR DESCRIPTION
Been a known bug for a while; didn't bother fixing it because nobody had abused it yet.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
:cl:
- fix: Reflective vests no longer provide their reflection while being held.
