### PR TITLE
valentines is over

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -64,9 +64,11 @@
     - id: PlushieImp
       weight: 0.1
     - id: PlushieHeadofPersonnel
-    - id: PlushieCaptain
-    - id: PlushieGiantBear
       weight: 0.1
+    - id: PlushieCaptain
+      weight: 0.1
+    - id: PlushieGiantBear
+      weight: 0.5
     # imp edit end
 
 - type: entity

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/snack.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/snack.yml
@@ -7,8 +7,6 @@
     FoodSnackPistachios: 3
     FoodSnackSus: 3
     FoodSnackSemki: 3
-    BoxChocolateHearts: 3 # imp
-    BoxConversationHeart: 3 # imp
   emaggedInventory:
     FoodSnackSyndi: 3
 

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -99,6 +99,7 @@
     - GunpetInstrument
     - BirdToyInstrument
     - MysteryFigureBox
+    - PlushieGiantBear # imp
     - PlushieHampter
     - PlushieLizard
     - PlushieRainbowLizard

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Mail/mail.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Mail/mail.yml
@@ -674,11 +674,13 @@
       prob: 0.1
       orGroup: Plushie
     - id: PlushieHeadofPersonnel
+      prob: 0.1
       orGroup: Plushie
     - id: PlushieCaptain
+      prob: 0.1
       orGroup: Plushie
     - id: PlushieGiantBear
-      prob: 0.1
+      prob: 0.5
       orGroup: Plushie
     # imp edit end
 

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_service.yml
@@ -28,13 +28,13 @@
   category: cargoproduct-category-name-service
   group: market
 
-- type: cargoProduct
-  name: romantic crate
-  id: CrateValentines
-  icon:
-    sprite: _Impstation/Objects/Fun/bouquet.rsi
-    state: icon
-  product: CrateValentinesFilled
-  cost: 750
-  category: cargoproduct-category-name-fun
-  group: market
+#- type: cargoProduct # come back next february
+#  name: romantic crate
+#  id: CrateValentines
+#  icon:
+#    sprite: _Impstation/Objects/Fun/bouquet.rsi
+#    state: icon
+#  product: CrateValentinesFilled
+#  cost: 750
+#  category: cargoproduct-category-name-fun
+#  group: market


### PR DESCRIPTION
romantic crate no longer a cargo order, valentines candy out of the getmore chocolate vend. i increased the chance to see ursa massive in the two venues it was already available and added it to the space villain prize pool

**Changelog**
:cl:
- remove: Workplace relationships are unethical and all romance has been removed from the game.
