### PR TITLE
changelog for cult

### DIFF
--- a/Resources/Audio/_Impstation/CosmicCult/attributions.yml
+++ b/Resources/Audio/_Impstation/CosmicCult/attributions.yml
@@ -41,6 +41,6 @@
     - ability_glare.ogg
     - ability_blank.ogg
   license: "Custom"
-  copyright: "By AftrLite(GitHub) for Cosmic Cult
+  copyright: "By AftrLite(GitHub) for Cosmic Cult 
     - originally released on SS14 Impstation. Made using a combination of (Creative Commons 0) samples from freesound.org and personally-recorded foley."
   source: "https://freesound.org/"


### PR DESCRIPTION


**Changelog**
:cl: AftrLite and the team at Impstation
- add: NEW MAJOR ANTAGONIST: THE COSMIC CULT. The Vast Nameless Unknown wants you to uninstall reality. As a treat.
- add: The Silvered Rosary is now available as a Null Rod Transformation for the Chaplain.
- add: The religious supplies crate is now available from cargo.
- add: The Entro-pop lollipop is now craftable.. Somehow.
- tweak: The price of mindshield crates has been increased.
- tweak: Bibles have been removed from mail.