### PR TITLE
I forgot to do something in that last PR

### DIFF
--- a/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
@@ -424,6 +424,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         }
         TotalCult++;
         cultComp.StoredDamageContainer = Comp<DamageableComponent>(uid).DamageContainerID!.Value; //todo: nullable
+        Dirty(uid, cultComp);
+
         rule.Comp.Cultists.Add(uid);
     }
 
@@ -467,6 +469,9 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                 cultComp.UnlockedInfluences.Add("InfluenceForceIngress");
                 cultComp.UnlockedInfluences.Add("InfluenceUnboundStep");
             }
+
+            Dirty(uid, cultComp);
+
             var transmitter = EnsureComp<IntrinsicRadioTransmitterComponent>(uid);
             var radio = EnsureComp<ActiveRadioComponent>(uid);
             radio.Channels = new() { "CosmicRadio" };


### PR DESCRIPTION
Was supposed to be part of #1807 but I forgor :skull:
specifically this makes it so that converts at t2 / 3 get their pity balance properly predicted in the monument before they insert any entropy. also dirties the comp for roundstart cultists to make sure that everything is 100% good.

no Cl; not player facing.