### PR TITLE
remove brigmed hardsuit from warden locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -25,7 +25,6 @@
       - id: RemoteSignaller
         amount: 2
       - id: ClothingHeadsetWarden
-      - id: ClothingOuterHardsuitBrigmedic
       - id: BoxToken #imp
       - id: BaseSeclinkRadio #imp
 
@@ -54,7 +53,6 @@
         amount: 2
       - id: RemoteSignaller
         amount: 2
-      - id: ClothingOuterHardsuitBrigmedic
       - id: ClothingHeadsetWarden
       - id: TicketPad #imp special
       - id: BoxToken #imp


### PR DESCRIPTION
we have an actual mapped brigmed locker now on afaik every single map with a brigmed slot so this has just been causing confusion/bug reports

**Changelog**
:cl:
- remove: The warden locker no longer has a brigmedic hardsuit.
