### PR TITLE
CMO belt selection and shoes

### DIFF
--- a/Resources/Locale/en-US/_Impstation/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Impstation/preferences/loadout-groups.ftl
@@ -124,6 +124,7 @@ loadout-group-brigmedic-backpack = Brigmedic backpack
 # medical
 loadout-group-chief-medical-officer-backpack = Chief Medical Officer backpack
 loadout-group-chief-medical-officer-headset = Chief Medical Officer headset
+loadout-group-chief-medical-officer-belt = Chief Medical Officer belt
 
 loadout-group-medical-doctor-neck = Medical Doctor neck
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1306,6 +1306,8 @@
   loadouts:
   - BrownShoes
   - WhiteShoes # imp
+  - LacedShoes #imp
+  - LeatherShoes
   - MedicalWinterBoots
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -531,6 +531,7 @@
   - ChiefMedicalOfficerJumpsuit
   - ChiefMedicalOfficerOuterClothing
   - MedicalGloves
+  - ChiefMedicalOfficerBelt #imp
   - ChiefMedicalOfficerShoes
   - ChiefMedicalOfficerHeadset #imp
   - Glasses

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -42,7 +42,7 @@
   id: CMOGear
   equipment:
     id: CMOPDA
-    belt: ClothingBeltMedicalFilled
+    #belt: ClothingBeltMedicalFilled #imp
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/generic_medical.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/generic_medical.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: BeltMedical
+  equipment:
+    belt: ClothingBeltMedicalFilled
+
+- type: loadout
+  id: BeltMedicalEMT
+  equipment:
+    belt: ClothingBeltMedicalEMTFilled

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -865,6 +865,13 @@
   - CommandVeteranDuffel
 
 - type: loadoutGroup
+  id: ChiefMedicalOfficerBelt
+  name: loadout-group-chief-medical-officer-belt
+  loadouts:
+  - BeltMedical
+  - BeltMedicalEMT
+
+- type: loadoutGroup
   id: MedicalDoctorNeck
   name: loadout-group-medical-doctor-neck
   minLimit: 0


### PR DESCRIPTION
cmos can now select the paramed belt if they want (looks better and they deserve the extra couple of epis)

also they have dress shoes options since doctors irl tend to wear sneakers, clogs, or loafers

we don't got clogs but we got loafers (though someone should give them crocs)

:cl:
- add: CMO can now select standard or paramedic belt from loadout
- add: CMO can now spawn with loafers if they're the dressy type of doctor