### PR TITLE
kill the goliath hardsuit

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -417,3 +417,8 @@
     - id: GrenadeFoamDart
       prob: 0.001
       orGroup: NotUseful
+    # imp stuff
+    - id: ClothingOuterHardsuitGoliath
+      prob: 0.05
+    - id: ClothingOuterHardsuitMaxim # i hit the juckport 1 trillion$
+      prob: 0.001

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -251,6 +251,7 @@
     - id: BlueprintSeismicCharge
     - id: WeaponCrusherGlaive
     - id: ClothingOuterHardsuitSalvage
+    - id: ClothingOuterHardsuitGoliath # imp
     - id: OmnizineChemistryBottle
     - !type:GroupSelector
       children:

--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -280,67 +280,15 @@
     sprite: Objects/Storage/petcarrier.rsi
     state: icon
 
-- type: construction
-  name: goliath hardsuit
-  id: HardsuitGoliath
-  graph: HardsuitGoliath
-  startNode: start
-  targetNode: hardsuitGoliath
-  category: construction-category-clothing
-  objectType: Item
-  description: A lightweight hardsuit, adorned with a patchwork of thick, chitinous goliath hide.
-  icon:
-    sprite: Clothing/OuterClothing/Hardsuits/goliath.rsi
-    state: icon
-
-- type: construction
-  name: yarn noodles
-  id: yarnnoodles
-  graph: YarnNoodles
-  startNode: start
-  targetNode: noodles
-  category: construction-category-misc
-  objectType: Item
-  description: A Mothchelin 3-star meal!
-  icon:
-    sprite: _Impstation/Objects/Fun/toys.rsi
-    state: yarn-noodles
-
-- type: construction
-  name: fabric scrap salad
-  id: fabricscrapsalad
-  graph: FabricScrapSalad
-  startNode: start
-  targetNode: salad
-  category: construction-category-misc
-  objectType: Item
-  description: A home-made recipe involving a pair of scissors and being very sneaky.
-  icon:
-    sprite: _Impstation/Objects/Fun/toys.rsi
-    state: fabric-scrap-salad
-
-- type: construction
-  name: improvised pistol
-  id: improvisedpistol
-  graph: ImprovisedPistolGraph
-  startNode: start
-  targetNode: pistol
-  category: construction-category-weapons
-  objectType: Item
-  description: A pistol kitbashed from whatever can be found. Ammo not included.
-  icon:
-    sprite: _Impstation/Objects/Weapons/Guns/Pistols/improvpistol.rsi
-    state: icon
-
-- type: construction
-  name: bouquet
-  id: Bouquet
-  graph: Bouquet
-  startNode: start
-  targetNode: bouquet
-  category: construction-category-misc
-  objectType: Item
-  description: A thoughtful and inedible gift for your loved one(s).
-  icon:
-    sprite: _Impstation/Objects/Fun/bouquet.rsi
-    state: icon
+# - type: construction
+#   name: goliath hardsuit
+#   id: HardsuitGoliath
+#   graph: HardsuitGoliath
+#   startNode: start
+#   targetNode: hardsuitGoliath
+#   category: construction-category-clothing
+#   objectType: Item
+#   description: A lightweight hardsuit, adorned with a patchwork of thick, chitinous goliath hide.
+#   icon:
+#     sprite: Clothing/OuterClothing/Hardsuits/goliath.rsi
+#     state: icon

--- a/Resources/Prototypes/_Impstation/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Crafting/improvised.yml
@@ -23,3 +23,55 @@
   icon:
     sprite: _Impstation/Objects/Fishing/fishingrod.rsi
     state: base
+
+- type: construction
+  name: yarn noodles
+  id: yarnnoodles
+  graph: YarnNoodles
+  startNode: start
+  targetNode: noodles
+  category: construction-category-misc
+  objectType: Item
+  description: A Mothchelin 3-star meal!
+  icon:
+    sprite: _Impstation/Objects/Fun/toys.rsi
+    state: yarn-noodles
+
+- type: construction
+  name: fabric scrap salad
+  id: fabricscrapsalad
+  graph: FabricScrapSalad
+  startNode: start
+  targetNode: salad
+  category: construction-category-misc
+  objectType: Item
+  description: A home-made recipe involving a pair of scissors and being very sneaky.
+  icon:
+    sprite: _Impstation/Objects/Fun/toys.rsi
+    state: fabric-scrap-salad
+
+- type: construction
+  name: improvised pistol
+  id: improvisedpistol
+  graph: ImprovisedPistolGraph
+  startNode: start
+  targetNode: pistol
+  category: construction-category-weapons
+  objectType: Item
+  description: A pistol kitbashed from whatever can be found. Ammo not included.
+  icon:
+    sprite: _Impstation/Objects/Weapons/Guns/Pistols/improvpistol.rsi
+    state: icon
+
+- type: construction
+  name: bouquet
+  id: Bouquet
+  graph: Bouquet
+  startNode: start
+  targetNode: bouquet
+  category: construction-category-misc
+  objectType: Item
+  description: A thoughtful and inedible gift for your loved one(s).
+  icon:
+    sprite: _Impstation/Objects/Fun/bouquet.rsi
+    state: icon


### PR DESCRIPTION
removed the goliath hardsuit crafting recipe because i HATE salvage. added it and the maxim hardsuit to the lottery crate for the funny

being for real, we've had complaints about salvagers ignoring the rest of their job to frame 0 rush the asteroid to play toys instead of helping to supply the station. mechanics inform behaviour or whatever. make big $$$ and buy lottery crates to become gamer

**Changelog**
:cl:
- remove: The goliath hardsuit is no longer craftable.
- tweak: The goliath hardsuit can be found rarely on salvage.
- tweak: The goliath and maxim hardsuits can be found rarely in grand lottery crates.