### PR TITLE
More internal cult logic changes

### DIFF
--- a/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
+++ b/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
@@ -96,7 +96,8 @@ public sealed partial class MonumentMenu : FancyWindow
         }
 
         var entropyToNextStage = state.TargetProgress - state.CurrentProgress;
-        var crewToNextStage = (int) Math.Round((double) entropyToNextStage / _config.GetCVar(ImpCCVars.CosmicCultistEntropyValue), MidpointRounding.AwayFromZero); //one crew member is "worth" 7 entropy, this needs to be gotten from a cvar - ruddygreat
+        var min = entropyToNextStage == 0 ? 0 : 1; //I have no idea what to call this. makes it so that it shows 0 crew for the final stage but at least one at all other times
+        var crewToNextStage = (int) Math.Max(Math.Round((double) entropyToNextStage / _config.GetCVar(ImpCCVars.CosmicCultistEntropyValue), MidpointRounding.ToPositiveInfinity), min); //force it to be at least one
 
         AvailableEntropy.Text = Loc.GetString("monument-interface-entropy-value", ("infused", availableEntropy));
         EntropyUntilNextStage.Text = Loc.GetString("monument-interface-entropy-value", ("infused", entropyToNextStage.ToString()));

--- a/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
+++ b/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Numerics;
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
+using Content.Shared._Impstation.CCVar;
 using Content.Shared._Impstation.Cosmiccult;
 using Content.Shared._Impstation.CosmicCult.Components;
 using Content.Shared._Impstation.CosmicCult.Prototypes;
@@ -11,6 +12,7 @@ using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client._Impstation.CosmicCult.UI.Monument;
@@ -20,6 +22,7 @@ public sealed partial class MonumentMenu : FancyWindow
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     private readonly SpriteSystem _sprite;
 
@@ -73,7 +76,10 @@ public sealed partial class MonumentMenu : FancyWindow
     // Update all the entropy fields
     private void UpdateBar(MonumentBuiState state)
     {
-        var percentComplete = (state.CurrentProgress - state.ProgressOffset) / (state.TargetProgress - state.ProgressOffset) * 100; //too many parenthesis but I'm not taking any chances
+        var percentComplete = ((float) state.CurrentProgress / (float) state.TargetProgress) * 100f; //too many parenthesis & probably unnecessary float casts but I'm not taking any chances
+
+        if (percentComplete > 100)
+           percentComplete -= 100; //mini hack to force things to behave
 
         CultProgressBar.Value = percentComplete;
 
@@ -90,7 +96,7 @@ public sealed partial class MonumentMenu : FancyWindow
         }
 
         var entropyToNextStage = state.TargetProgress - state.CurrentProgress;
-        var crewToNextStage = (int) Math.Round((double) entropyToNextStage / 7, MidpointRounding.AwayFromZero); //one crew member is "worth" 7 entropy, this needs to be gotten from a cvar - ruddygreat
+        var crewToNextStage = (int) Math.Round((double) entropyToNextStage / _config.GetCVar(ImpCCVars.CosmicCultistEntropyValue), MidpointRounding.AwayFromZero); //one crew member is "worth" 7 entropy, this needs to be gotten from a cvar - ruddygreat
 
         AvailableEntropy.Text = Loc.GetString("monument-interface-entropy-value", ("infused", availableEntropy));
         EntropyUntilNextStage.Text = Loc.GetString("monument-interface-entropy-value", ("infused", entropyToNextStage.ToString()));

--- a/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
+++ b/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
@@ -73,8 +73,11 @@ public sealed partial class MonumentMenu : FancyWindow
     // Update all the entropy fields
     private void UpdateBar(MonumentBuiState state)
     {
-        CultProgressBar.Value = state.PercentageComplete;
-        ProgressBarPercentage.Text = Loc.GetString("monument-interface-progress-bar", ("percentage", state.PercentageComplete.ToString("0")));
+        var percentComplete = (state.CurrentProgress - state.ProgressOffset) / (state.TargetProgress - state.ProgressOffset) * 100; //too many parenthesis but I'm not taking any chances
+
+        CultProgressBar.Value = percentComplete;
+
+        ProgressBarPercentage.Text = Loc.GetString("monument-interface-progress-bar", ("percentage", percentComplete.ToString("0")));
     }
 
     // Update all the entropy fields
@@ -86,9 +89,12 @@ public sealed partial class MonumentMenu : FancyWindow
             availableEntropy = cultComp.EntropyBudget.ToString();
         }
 
+        var entropyToNextStage = state.TargetProgress - state.CurrentProgress;
+        var crewToNextStage = (int) Math.Round((double) entropyToNextStage / 7, MidpointRounding.AwayFromZero); //one crew member is "worth" 7 entropy, this needs to be gotten from a cvar - ruddygreat
+
         AvailableEntropy.Text = Loc.GetString("monument-interface-entropy-value", ("infused", availableEntropy));
-        EntropyUntilNextStage.Text = Loc.GetString("monument-interface-entropy-value", ("infused", state.EntropyUntilNextStage.ToString()));
-        CrewToConvertUntilNextStage.Text = state.CrewToConvertUntilNextStage.ToString();
+        EntropyUntilNextStage.Text = Loc.GetString("monument-interface-entropy-value", ("infused", entropyToNextStage.ToString()));
+        CrewToConvertUntilNextStage.Text = crewToNextStage.ToString();
     }
 
     // Update all the glyph buttons

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
@@ -296,7 +296,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 3 && !finaleComp.FinaleActive && !finaleComp.FinaleReady)
             FinaleReady(uid, finaleComp);
         else if (finaleComp.FinaleReady || finaleComp.FinaleActive)
-            uid.Comp.CurrentProgress = uid.Comp.TargetProgress;
+            uid.Comp.TargetProgress = uid.Comp.CurrentProgress;
         else if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 2)
         {
             MonumentTier3(uid);
@@ -506,6 +506,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
 
         finaleComp.FinaleReady = true;
         uid.Comp.Enabled = false;
+        uid.Comp.TargetProgress = uid.Comp.CurrentProgress;
 
         _popup.PopupCoordinates(Loc.GetString("cosmiccult-finale-ready"), Transform(uid).Coordinates, PopupType.Large);
     }

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.Finale.cs
@@ -46,18 +46,18 @@ public sealed partial class CosmicCultSystem : EntitySystem
             _doAfter.TryStartDoAfter(doargs);
             args.Handled = true;
         }
-        else
-            return;
     }
 
     private void OnFinaleStartDoAfter(Entity<CosmicFinaleComponent> uid, ref StartFinaleDoAfterEvent args)
     {
         var comp = uid.Comp;
+
         if (args.Args.Target == null || args.Cancelled || args.Handled || !TryComp<MonumentComponent>(args.Args.Target, out var monument) || !TryComp<CosmicCorruptingComponent>(uid, out var corruptingComp))
         {
             uid.Comp.Occupied = false;
             return;
         }
+
         _popup.PopupEntity(Loc.GetString("cosmiccult-finale-beckon-success"), args.Args.User, args.Args.User);
         if (!comp.BufferComplete)
         {
@@ -76,15 +76,22 @@ public sealed partial class CosmicCultSystem : EntitySystem
             comp.FinaleSongLength = TimeSpan.FromSeconds(_audio.GetAudioLength(comp.SelectedFinaleSong).TotalSeconds);
             _sound.DispatchStationEventMusic(uid, comp.SelectedFinaleSong, StationEventMusicType.CosmicCult);
         }
+
         var stationUid = _station.GetStationInMap(Transform(uid).MapID);
         if (stationUid != null)
         {
             _alert.SetLevel(stationUid.Value, "octarine", true, true, true, true);
         }
-        if (TryComp<ActivatableUIComponent>(uid, out var uiComp)) uiComp.Key = MonumentKey.Key; // wow! This is the laziest way to enable a UI ever!
+
+        if (TryComp<ActivatableUIComponent>(uid, out var uiComp))
+            uiComp.Key = MonumentKey.Key; // wow! This is the laziest way to enable a UI ever!
+
         comp.FinaleReady = false;
         comp.FinaleActive = true;
         monument.Enabled = true;
+
+        Dirty(args.Args.Target!.Value, monument);
+        _ui.SetUiState(uid.Owner, MonumentKey.Key, new MonumentBuiState(monument));
     }
 
     private void OnFinaleCancelDoAfter(Entity<CosmicFinaleComponent> uid, ref CancelFinaleDoAfterEvent args)
@@ -97,22 +104,34 @@ public sealed partial class CosmicCultSystem : EntitySystem
         }
 
         var stationUid = _station.GetOwningStation(uid);
+
         if (stationUid != null)
             _alert.SetLevel(stationUid.Value, "green", true, true, true);
 
         _sound.PlayGlobalOnStation(uid, _audio.GetSound(comp.CancelEventSound));
         _sound.StopStationEventMusic(uid, StationEventMusicType.CosmicCult);
+
         if (!comp.BufferComplete)
             comp.BufferRemainingTime = comp.BufferTimer - _timing.CurTime + TimeSpan.FromSeconds(15);
         else
             comp.FinaleRemainingTime = comp.FinaleTimer - _timing.CurTime;
+
         comp.PlayedFinaleSong = false;
         comp.PlayedBufferSong = false;
         comp.FinaleActive = false;
         comp.FinaleReady = true;
+
         if (TryComp<CosmicCorruptingComponent>(uid, out var corruptingComp)) corruptingComp.CorruptionSpeed = TimeSpan.FromSeconds(6);
+
         if (TryComp<ActivatableUIComponent>(uid, out var uiComp)) uiComp.Key = null; // wow! This is the laziest way to disable a UI ever!
+
         _appearance.SetData(uid, MonumentVisuals.FinaleReached, 1);
+
+        if (!TryComp<MonumentComponent>(args.Args.Target, out var monument))
+            return;
+
+        Dirty(args.Args.Target!.Value, monument);
+        _ui.SetUiState(uid.Owner, MonumentKey.Key, new MonumentBuiState(monument));
     }
 }
 

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.cs
@@ -288,10 +288,6 @@ public sealed partial class CosmicCultSystem : EntitySystem
         monument.Comp.TotalEntropy += quant;
         _cultRule.UpdateCultData(monument);
 
-        //I have no idea if these are doing anything tbh
-        Dirty(monument);
-        _ui.SetUiState(monument.Owner, MonumentKey.Key, new MonumentBuiState(monument.Comp)); //this can't be predicted (afaik) as it relies on the cultRuleSystem, which is serverside
-
         _popup.PopupEntity(Loc.GetString("cosmiccult-entropy-inserted", ("count", quant)), cultist, cultist);
         _audio.PlayEntity("/Audio/_Impstation/CosmicCult/insert_entropy.ogg", cultist, monument);
         QueueDel(entropy);

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.cs
@@ -285,10 +285,11 @@ public sealed partial class CosmicCultSystem : EntitySystem
             Dirty(cultist, cultComp);
         }
 
-        _cultRule.TotalEntropy += quant;
-        monument.Comp.TotalEntropy = _cultRule.TotalEntropy;
+        monument.Comp.TotalEntropy += quant;
         _cultRule.UpdateCultData(monument);
 
+        //I have no idea if these are doing anything tbh
+        Dirty(monument);
         _ui.SetUiState(monument.Owner, MonumentKey.Key, new MonumentBuiState(monument.Comp)); //this can't be predicted (afaik) as it relies on the cultRuleSystem, which is serverside
 
         _popup.PopupEntity(Loc.GetString("cosmiccult-entropy-inserted", ("count", quant)), cultist, cultist);

--- a/Content.Shared/_Impstation/CCVar/ImpCCVars.cs
+++ b/Content.Shared/_Impstation/CCVar/ImpCCVars.cs
@@ -44,4 +44,13 @@ public sealed class ImpCCVars : CVars
     /// </summary>
     public static readonly CVarDef<string> ChatHighlightsColor =
         CVarDef.Create("chat.highlights_color", "#17FFC1FF", CVar.CLIENTONLY | CVar.ARCHIVE, "The color in which the highlights will be displayed.");
+
+    public static readonly CVarDef<int> CosmicCultistEntropyValue =
+        CVarDef.Create("cosmiccult.cultist_entropy_value", 7, CVar.SERVER, "How much entropy a convert is worth towards the next monument tier");
+
+    public static readonly CVarDef<int> CosmicCultTargetConversionPercent =
+        CVarDef.Create("cosmiccult.target_conversion_percent", 40, CVar.SERVER, "How much of the crew the cult is aiming to convert for a tier 3 monument");
+
+    public static readonly CVarDef<int> CosmicCultExtraEntropyForFinale =
+        CVarDef.Create<int>("cosmiccult.extra_entropy_for_finale", 20, CVar.SERVER, "How much additional entropy is required to initiate the finale from a tier 3 monument");
 }

--- a/Content.Shared/_Impstation/CosmicCult/Components/MonumentComponent.cs
+++ b/Content.Shared/_Impstation/CosmicCult/Components/MonumentComponent.cs
@@ -48,7 +48,7 @@ public sealed partial class MonumentComponent : Component
     /// offset used to make the progress bar reset to 0 every time
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float ProgressOffset;
+    public int ProgressOffset;
 
     /// <summary>
     /// A bool we use to set whether The Monument's UI is available or not.

--- a/Content.Shared/_Impstation/CosmicCult/Components/MonumentComponent.cs
+++ b/Content.Shared/_Impstation/CosmicCult/Components/MonumentComponent.cs
@@ -9,27 +9,88 @@ namespace Content.Shared._Impstation.CosmicCult.Components;
 [AutoGenerateComponentPause]
 public sealed partial class MonumentComponent : Component
 {
+    /// <summary>
+    /// used to hide the monument from non-cultists
+    /// </summary>
     [NonSerialized] public const int LayerMask = 777;
-    [DataField, AutoNetworkedField] public HashSet<ProtoId<InfluencePrototype>> UnlockedInfluences = [];
-    [DataField, AutoNetworkedField] public HashSet<ProtoId<GlyphPrototype>> UnlockedGlyphs = [];
-    [DataField, AutoNetworkedField] public ProtoId<GlyphPrototype> SelectedGlyph;
-    [DataField, AutoNetworkedField] public int TotalEntropy;
-    [DataField, AutoNetworkedField] public int EntropyUntilNextStage;
-    [DataField, AutoNetworkedField] public int CrewToConvertNextStage;
-    [DataField, AutoNetworkedField] public float PercentageComplete;
+
+    /// <summary>
+    /// the list of glyphs that this monument is allowed to scribe
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<GlyphPrototype>> UnlockedGlyphs = [];
+
+    /// <summary>
+    /// the glyph that will be scribed when the button is pressed
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<GlyphPrototype> SelectedGlyph;
+
+    /// <summary>
+    /// the total amount of entropy that has been inserted into the monument
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int TotalEntropy;
+
+    /// <summary>
+    /// how much progress (entropy and converted crew) the cult has made
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int CurrentProgress;
+
+    /// <summary>
+    /// how much progress the cult need to make to tier up
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int TargetProgress;
+
+    /// <summary>
+    /// offset used to make the progress bar reset to 0 every time
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ProgressOffset;
+
     /// <summary>
     /// A bool we use to set whether The Monument's UI is available or not.
     /// </summary>
-    [DataField, AutoNetworkedField] public bool Enabled = true;
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+
     /// <summary>
     /// A bool that determines whether The Monument is tangible to non-cultists.
     /// </summary>
-    [DataField, AutoNetworkedField] public bool HasCollision = false;
-    [DataField, AutoNetworkedField] public TimeSpan TransformTime = TimeSpan.FromSeconds(2.8);
-    [DataField, AutoNetworkedField] public EntityUid? CurrentGlyph;
-    [AutoPausedField, DataField] public TimeSpan VitalityCheckTimer = default!;
-    [DataField] public TimeSpan CheckWait = TimeSpan.FromSeconds(5);
-    [DataField] public DamageSpecifier MonumentHealing = new()
+    [DataField, AutoNetworkedField]
+    public bool HasCollision = false;
+
+    /// <summary>
+    /// how long the monument takes to transform on a tier up
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan TransformTime = TimeSpan.FromSeconds(2.8);
+
+    /// <summary>
+    /// the entity for the currently scribed glyph
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? CurrentGlyph;
+
+    /// <summary>
+    /// the timer used for ticking healing from vacuous vitality
+    /// </summary>
+    [AutoPausedField, DataField]
+    public TimeSpan VitalityCheckTimer = default!;
+
+    /// <summary>
+    /// the amount of time between the above timer's ticks
+    /// </summary>
+    [DataField]
+    public TimeSpan CheckWait = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// what the monument heals
+    /// </summary>
+    [DataField]
+    public DamageSpecifier MonumentHealing = new()
     {
         DamageDict = new()
         {

--- a/Content.Shared/_Impstation/CosmicCult/MonumentUI.cs
+++ b/Content.Shared/_Impstation/CosmicCult/MonumentUI.cs
@@ -14,26 +14,26 @@ public enum MonumentKey : byte
 [Serializable, NetSerializable]
 public sealed class MonumentBuiState : BoundUserInterfaceState
 {
-    public int EntropyUntilNextStage;
-    public int CrewToConvertUntilNextStage;
-    public float PercentageComplete;
+    public int CurrentProgress;
+    public int TargetProgress;
+    public float ProgressOffset;
     public ProtoId<GlyphPrototype> SelectedGlyph;
     public HashSet<ProtoId<GlyphPrototype>> UnlockedGlyphs;
 
-    public MonumentBuiState(int entropyUntilNextStage, int crewToConvertUntilNextStage, float percentageComplete, ProtoId<GlyphPrototype> selectedGlyph, HashSet<ProtoId<GlyphPrototype>> unlockedGlyphs)
+    public MonumentBuiState(int currentProgress, int targetProgress, float progressOffset, ProtoId<GlyphPrototype> selectedGlyph, HashSet<ProtoId<GlyphPrototype>> unlockedGlyphs)
     {
-        EntropyUntilNextStage = entropyUntilNextStage;
-        CrewToConvertUntilNextStage = crewToConvertUntilNextStage;
-        PercentageComplete = percentageComplete;
+        CurrentProgress = currentProgress;
+        TargetProgress = targetProgress;
+        ProgressOffset = progressOffset;
         SelectedGlyph = selectedGlyph;
         UnlockedGlyphs = unlockedGlyphs;
     }
 
     public MonumentBuiState(MonumentComponent comp)
     {
-        EntropyUntilNextStage = comp.EntropyUntilNextStage;
-        CrewToConvertUntilNextStage = comp.CrewToConvertNextStage;
-        PercentageComplete = comp.PercentageComplete;
+        CurrentProgress = comp.CurrentProgress;
+        TargetProgress = comp.TargetProgress;
+        ProgressOffset = comp.ProgressOffset;
         SelectedGlyph = comp.SelectedGlyph;
         UnlockedGlyphs = comp.UnlockedGlyphs;
     }

--- a/Content.Shared/_Impstation/CosmicCult/MonumentUI.cs
+++ b/Content.Shared/_Impstation/CosmicCult/MonumentUI.cs
@@ -16,24 +16,21 @@ public sealed class MonumentBuiState : BoundUserInterfaceState
 {
     public int CurrentProgress;
     public int TargetProgress;
-    public float ProgressOffset;
     public ProtoId<GlyphPrototype> SelectedGlyph;
     public HashSet<ProtoId<GlyphPrototype>> UnlockedGlyphs;
 
-    public MonumentBuiState(int currentProgress, int targetProgress, float progressOffset, ProtoId<GlyphPrototype> selectedGlyph, HashSet<ProtoId<GlyphPrototype>> unlockedGlyphs)
+    public MonumentBuiState(int currentProgress, int targetProgress, int progressOffset, ProtoId<GlyphPrototype> selectedGlyph, HashSet<ProtoId<GlyphPrototype>> unlockedGlyphs)
     {
-        CurrentProgress = currentProgress;
-        TargetProgress = targetProgress;
-        ProgressOffset = progressOffset;
+        CurrentProgress = currentProgress - progressOffset;
+        TargetProgress = targetProgress - progressOffset;
         SelectedGlyph = selectedGlyph;
         UnlockedGlyphs = unlockedGlyphs;
     }
 
     public MonumentBuiState(MonumentComponent comp)
     {
-        CurrentProgress = comp.CurrentProgress;
-        TargetProgress = comp.TargetProgress;
-        ProgressOffset = comp.ProgressOffset;
+        CurrentProgress = comp.CurrentProgress - comp.ProgressOffset;
+        TargetProgress = comp.TargetProgress - comp.ProgressOffset;
         SelectedGlyph = comp.SelectedGlyph;
         UnlockedGlyphs = comp.UnlockedGlyphs;
     }

--- a/Content.Shared/_Impstation/CosmicCult/SharedMonumentSystem.cs
+++ b/Content.Shared/_Impstation/CosmicCult/SharedMonumentSystem.cs
@@ -60,18 +60,11 @@ public sealed class SharedMonumentSystem : EntitySystem
 
         if (ent.Comp.Enabled && TryComp<CosmicCultComponent>(args.Actor, out var cultComp))
         {
-            var buiState = new MonumentBuiState(
-                ent.Comp.EntropyUntilNextStage,
-                ent.Comp.CrewToConvertNextStage,
-                ent.Comp.PercentageComplete,
-                ent.Comp.SelectedGlyph,
-                ent.Comp.UnlockedGlyphs
-                );
-
-            _ui.SetUiState(ent.Owner, MonumentKey.Key, buiState);
+            _ui.SetUiState(ent.Owner, MonumentKey.Key, new MonumentBuiState(ent.Comp));
         }
         else
-            _ui.CloseUi(ent.Owner, MonumentKey.Key); // based on the prior IF, this effectively cancels the UI if the user is either not a cultist, or the Finale is ready to trigger.
+            _ui.CloseUi(ent.Owner, MonumentKey.Key); //close the UI if the finale is ready to trigger
+        //todo this can probably be done better - have it keep the UI open but replace everything with some kinda "The End Is Coming" text? - ruddygreat
 
     }
 

--- a/Resources/Prototypes/_Impstation/CosmicCult/Tileset/monument.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Tileset/monument.yml
@@ -97,9 +97,6 @@
     - ccGlyphProjection
     selectedGlyph: ccGlyphKnowledge
     totalEntropy: 0
-    entropyUntilNextStage: 777
-    crewToConvertNextStage:  777
-    percentageComplete: 0
   - type: GuideHelp
     guides:
     - CosmicCult


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

fixes the issue where the monument's UI doesn't get properly updated when it goes up a tier, makes the UI's progress bar show the progress to the next tier instead of the wierd not-quite-overall progress it used to be, auto-closes the monument UI when the finale becomes available, CCvar-ifies a few things, cleans up some maths.

[demo of the UI changes](https://youtu.be/Unh_3Rc1jo4)

no CL; not player facing
