### PR TITLE
Allow cultists to use the monument while the tier up delay is active

### DIFF
--- a/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
+++ b/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
@@ -78,8 +78,7 @@ public sealed partial class MonumentMenu : FancyWindow
     {
         var percentComplete = ((float) state.CurrentProgress / (float) state.TargetProgress) * 100f; //too many parenthesis & probably unnecessary float casts but I'm not taking any chances
 
-        if (percentComplete > 100)
-           percentComplete -= 100; //mini hack to force things to behave
+        percentComplete = Math.Min(percentComplete, 100);
 
         CultProgressBar.Value = percentComplete;
 
@@ -95,7 +94,7 @@ public sealed partial class MonumentMenu : FancyWindow
             availableEntropy = cultComp.EntropyBudget.ToString();
         }
 
-        var entropyToNextStage = state.TargetProgress - state.CurrentProgress;
+        var entropyToNextStage = Math.Max(state.TargetProgress - state.CurrentProgress, 0);
         var min = entropyToNextStage == 0 ? 0 : 1; //I have no idea what to call this. makes it so that it shows 0 crew for the final stage but at least one at all other times
         var crewToNextStage = (int) Math.Max(Math.Round((double) entropyToNextStage / _config.GetCVar(ImpCCVars.CosmicCultistEntropyValue), MidpointRounding.ToPositiveInfinity), min); //force it to be at least one
 

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
@@ -16,7 +16,6 @@ using Content.Shared.Coordinates;
 using Content.Shared.Parallax;
 using Robust.Shared.Map.Components;
 using Content.Shared.Temperature.Components;
-using Content.Server.Body.Components;
 using Content.Server.Atmos.Components;
 using Content.Server.Objectives.Components;
 using Robust.Server.Player;
@@ -24,7 +23,6 @@ using Content.Shared.GameTicking.Components;
 using Content.Server.GameTicking.Events;
 using Content.Shared.Stunnable;
 using Content.Shared.Mind;
-using Content.Shared.Administration.Logs;
 using Content.Server.Actions;
 using Robust.Server.GameObjects;
 using Robust.Shared.Timing;
@@ -89,6 +87,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly ILogManager _logman = default!;
+    [Dependency] private readonly CosmicCultSystem _cult = default!;
 
     public readonly SoundSpecifier BriefingSound = new SoundPathSpecifier("/Audio/_Impstation/CosmicCult/antag_cosmic_briefing.ogg");
     public readonly SoundSpecifier DeconvertSound = new SoundPathSpecifier("/Audio/_Impstation/CosmicCult/antag_cosmic_deconvert.ogg");
@@ -100,109 +99,15 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     public double PercentConverted; // percentage of connected players that are cultists
     public int EntropySiphoned; // the total entropy siphoned by the cult.
 
-    private ISawmill? _sawmill = default;
-
     public override void Initialize()
     {
         base.Initialize();
-
-        _sawmill = _logman.GetSawmill("monument");
 
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
         SubscribeLocalEvent<CosmicCultRuleComponent, AfterAntagEntitySelectedEvent>(OnAntagSelect);
         SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
         SubscribeLocalEvent<CosmicCultComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<CosmicMarkGodComponent, ComponentInit>(OnGodSpawn);
-    }
-
-    public override void Update(float frameTime) // This Update() can fit so much functionality in it
-    {
-        base.Update(frameTime);
-
-        var tierQuery = EntityQueryEnumerator<MonumentComponent>();
-        while (tierQuery.MoveNext(out var uid, out var comp))
-        {
-            if (_timing.CurTime >= comp.TierChangeTimer && comp.TierChanging && CurrentTier == 2) // TIER 2 STAGEUP
-            {
-                var sender = Loc.GetString("cosmiccult-announcement-sender");
-                _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier2-progress"), sender, Color.FromHex("#4cabb3"));
-                _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier2-warning"), null, Color.FromHex("#cae8e8"));
-                _audio.PlayGlobal("/Audio/_Impstation/CosmicCult/tier2.ogg", Filter.Broadcast(), false, AudioParams.Default);
-
-                for (var i = 0; i < Convert.ToInt16(TotalCrew / 4); i++) // spawn # malign rifts equal to 25% of the playercount
-                {
-                    if (TryFindRandomTile(out var _, out var _, out var _, out var coords))
-                    {
-                        Spawn("CosmicMalignRift", coords);
-                    }
-                }
-
-                var lights = EntityQueryEnumerator<PoweredLightComponent>();
-                while (lights.MoveNext(out var light, out _))
-                {
-                    if (!_rand.Prob(0.50f))
-                        continue;
-                    _ghost.DoGhostBooEvent(light);
-                }
-                comp.TierChanging = false;
-                comp.Enabled = true;
-                Dirty(uid, comp);
-            }
-
-            if (_timing.CurTime >= comp.TierChangeTimer && comp.TierChanging && CurrentTier == 3) // TIER 3 STAGEUP
-            {
-                var query = EntityQueryEnumerator<CosmicCultComponent>();
-                while (query.MoveNext(out var cultist, out var cultComp))
-                {
-                    EnsureComp<CosmicStarMarkComponent>(cultist);
-                    EnsureComp<PressureImmunityComponent>(cultist);
-                    EnsureComp<TemperatureImmunityComponent>(cultist);
-
-                    _damage.SetDamageContainerID(cultist, "BiologicalMetaphysical");
-
-                    foreach (var influenceProto in _protoMan.EnumeratePrototypes<InfluencePrototype>().Where(influenceProto => influenceProto.Tier == 3))
-                    {
-                        cultComp.UnlockedInfluences.Add(influenceProto.ID);
-                    }
-                    cultComp.Respiration = false;
-                    cultComp.EntropyBudget += Convert.ToInt16(Math.Floor(Math.Round((double)TotalCrew / 100 * 10))); //pity system. 10% of the playercount worth of entropy on tier up
-                    Dirty(cultist, cultComp);
-                }
-
-                var sender = Loc.GetString("cosmiccult-announcement-sender");
-                var mapData = _map.GetMap(_transform.GetMapId(MonumentInGame.Owner.ToCoordinates()));
-                _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier3-progress"), sender, Color.FromHex("#4cabb3"));
-                _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier3-warning"), null, Color.FromHex("#cae8e8"));
-                _audio.PlayGlobal("/Audio/_Impstation/CosmicCult/tier3.ogg", Filter.Broadcast(), false, AudioParams.Default);
-
-                EnsureComp<ParallaxComponent>(mapData, out var parallax);
-                parallax.Parallax = "CosmicFinaleParallax";
-                Dirty(mapData, parallax);
-
-                EnsureComp<MapLightComponent>(mapData, out var mapLight);
-                mapLight.AmbientLightColor = Color.FromHex("#210746");
-
-                Dirty(mapData, mapLight);
-
-                var lights = EntityQueryEnumerator<PoweredLightComponent>();
-                while (lights.MoveNext(out var light, out _))
-                {
-                    if (!_rand.Prob(0.25f))
-                        continue;
-                    _ghost.DoGhostBooEvent(light);
-                }
-                var colideQuery = EntityQueryEnumerator<MonumentCollisionComponent>();
-                while (colideQuery.MoveNext(out var collideEnt, out var collideComp))
-                {
-                    collideComp.HasCollision = true;
-                    Dirty(collideEnt, collideComp);
-                }
-                _visibility.SetLayer(uid, 1, true);
-                comp.TierChanging = false;
-                comp.Enabled = true;
-                Dirty(uid, comp);
-            }
-        }
     }
 
     private void OnRoundStart(RoundStartingEvent ev)
@@ -385,20 +290,47 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         uid.Comp.CurrentProgress = uid.Comp.TotalEntropy + (TotalCult * _config.GetCVar(ImpCCVars.CosmicCultistEntropyValue));
 
         if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 3 && !finaleComp.FinaleActive && !finaleComp.FinaleReady)
-            FinaleReady(uid, finaleComp);
+            ReadyFinale(uid, finaleComp);
         else if (finaleComp.FinaleReady || finaleComp.FinaleActive)
             uid.Comp.TargetProgress = uid.Comp.CurrentProgress;
-        else if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 2)
+        else if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 2 && uid.Comp.CanTierUp)
         {
-            MonumentTier3(uid);
+            uid.Comp.CanTierUp = false;
 
-            UpdateMonumentReqsForTier(uid, CurrentTier);
+            var cultistQuery = EntityQueryEnumerator<CosmicCultComponent>();
+            while (cultistQuery.MoveNext(out var cultist, out var cultistComp))
+            {
+                _antag.SendBriefing(cultist, Loc.GetString("cosmiccult-monument-stage3-briefing"), Color.FromHex("#4cabb3"), StageAlertSound);
+            }
+
+            Timer.Spawn(uid.Comp.TierUpWait,
+                () =>
+                {
+                    MonumentTier3(uid);
+                    UpdateMonumentReqsForTier(uid, CurrentTier);
+                    uid.Comp.CanTierUp = true;
+                    UpdateCultData(uid); //instantly go up a tier if they manage it. this might be too easy.
+                });
         }
-        else if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 1)
+        else if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 1 && uid.Comp.CanTierUp)
         {
-            MonumentTier2(uid);
+            uid.Comp.CanTierUp = false;
 
-            UpdateMonumentReqsForTier(uid, CurrentTier);
+            var cultistQuery = EntityQueryEnumerator<CosmicCultComponent>();
+            while (cultistQuery.MoveNext(out var cultist, out var cultistComp))
+            {
+                _antag.SendBriefing(cultist, Loc.GetString("cosmiccult-monument-stage2-briefing"), Color.FromHex("#4cabb3"), StageAlertSound);
+            }
+
+            Timer.Spawn(uid.Comp.TierUpWait,
+                () =>
+                {
+                    MonumentTier2(uid);
+                    UpdateMonumentReqsForTier(uid, CurrentTier);
+                    uid.Comp.CanTierUp = true;
+                    UpdateCultData(uid); //instantly go up a tier if they manage it
+                });
+
         }
 
         UpdateMonumentAppearance(uid, false);
@@ -467,20 +399,20 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     private void MonumentTier2(Entity<MonumentComponent> uid)
     {
         CurrentTier = 2;
-        uid.Comp.TierChangeTimer = _timing.CurTime + uid.Comp.TierWait;
-        uid.Comp.TierChanging = true;
-        uid.Comp.Enabled = false;
+
         UpdateMonumentAppearance(uid, true);
 
         foreach (var glyphProto in _protoMan.EnumeratePrototypes<GlyphPrototype>().Where(proto => proto.Tier == 2))
         {
             uid.Comp.UnlockedGlyphs.Add(glyphProto.ID);
         }
+
         var objectiveQuery = EntityQueryEnumerator<CosmicTierConditionComponent>();
         while (objectiveQuery.MoveNext(out _, out var objectiveComp))
         {
             objectiveComp.Tier = 2;
         }
+
         var query = EntityQueryEnumerator<CosmicCultComponent>();
         while (query.MoveNext(out var cultist, out var cultComp))
         {
@@ -488,19 +420,39 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             {
                 cultComp.UnlockedInfluences.Add(influenceProto.ID);
             }
-            _antag.SendBriefing(cultist, Loc.GetString("cosmiccult-monument-stage2-briefing"), Color.FromHex("#4cabb3"), StageAlertSound);
+
             cultComp.EntropyBudget += (int) Math.Floor(Math.Round((double)TotalCrew / 100 * 10)); // pity system. 10% of the playercount worth of entropy on tier up
+
             Dirty(cultist, cultComp);
         }
 
+        var sender = Loc.GetString("cosmiccult-announcement-sender");
+        _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier2-progress"), sender, Color.FromHex("#4cabb3"));
+        _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier2-warning"), null, Color.FromHex("#cae8e8"));
+        _audio.PlayGlobal("/Audio/_Impstation/CosmicCult/tier2.ogg", Filter.Broadcast(), false, AudioParams.Default);
+
+        for (var i = 0; i < Convert.ToInt16(TotalCrew / 4); i++) // spawn # malign rifts equal to 25% of the playercount
+        {
+            if (TryFindRandomTile(out var _, out var _, out var _, out var coords))
+            {
+                Spawn("CosmicMalignRift", coords);
+            }
+        }
+
+        var lights = EntityQueryEnumerator<PoweredLightComponent>();
+        while (lights.MoveNext(out var light, out _))
+        {
+            if (!_rand.Prob(0.50f))
+                continue;
+            _ghost.DoGhostBooEvent(light);
+        }
+
+        Dirty(uid);
     }
 
     private void MonumentTier3(Entity<MonumentComponent> uid)
     {
         CurrentTier = 3;
-        uid.Comp.TierChangeTimer = _timing.CurTime + uid.Comp.TierWait;
-        uid.Comp.TierChanging = true;
-        uid.Comp.Enabled = false;
 
         foreach (var glyphProto in _protoMan.EnumeratePrototypes<GlyphPrototype>().Where(proto => proto.Tier == 3))
         {
@@ -514,14 +466,63 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         {
             objectiveComp.Tier = 3;
         }
-        var cultQuery = EntityQueryEnumerator<CosmicCultComponent>();
-        while (cultQuery.MoveNext(out var cultist, out var cultComp))
+
+        var query = EntityQueryEnumerator<CosmicCultComponent>();
+        while (query.MoveNext(out var cultist, out var cultComp))
         {
-            _antag.SendBriefing(cultist, Loc.GetString("cosmiccult-monument-stage3-briefing"), Color.FromHex("#4cabb3"), StageAlertSound);
+            EnsureComp<CosmicStarMarkComponent>(cultist);
+            EnsureComp<PressureImmunityComponent>(cultist);
+            EnsureComp<TemperatureImmunityComponent>(cultist);
+
+            _damage.SetDamageContainerID(cultist, "BiologicalMetaphysical");
+
+            foreach (var influenceProto in _protoMan.EnumeratePrototypes<InfluencePrototype>().Where(influenceProto => influenceProto.Tier == 3))
+            {
+                cultComp.UnlockedInfluences.Add(influenceProto.ID);
+            }
+
+            cultComp.Respiration = false;
+            cultComp.EntropyBudget += Convert.ToInt16(Math.Floor(Math.Round((double)TotalCrew / 100 * 10))); //pity system. 10% of the playercount worth of entropy on tier up
+            Dirty(cultist, cultComp);
         }
+
+        var sender = Loc.GetString("cosmiccult-announcement-sender");
+        var mapData = _map.GetMap(_transform.GetMapId(MonumentInGame.Owner.ToCoordinates()));
+        _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier3-progress"), sender, Color.FromHex("#4cabb3"));
+        _announce.SendAnnouncementMessage(_announce.GetAnnouncementId("SpawnAnnounceCaptain"), Loc.GetString("cosmiccult-announce-tier3-warning"), null, Color.FromHex("#cae8e8"));
+        _audio.PlayGlobal("/Audio/_Impstation/CosmicCult/tier3.ogg", Filter.Broadcast(), false, AudioParams.Default);
+
+        EnsureComp<ParallaxComponent>(mapData, out var parallax);
+        parallax.Parallax = "CosmicFinaleParallax";
+        Dirty(mapData, parallax);
+
+        EnsureComp<MapLightComponent>(mapData, out var mapLight);
+        mapLight.AmbientLightColor = Color.FromHex("#210746");
+
+        Dirty(mapData, mapLight);
+
+        var lights = EntityQueryEnumerator<PoweredLightComponent>();
+        while (lights.MoveNext(out var light, out _))
+        {
+            if (!_rand.Prob(0.25f))
+                continue;
+            _ghost.DoGhostBooEvent(light);
+        }
+
+        var collideQuery = EntityQueryEnumerator<MonumentCollisionComponent>();
+        while (collideQuery.MoveNext(out var collideEnt, out var collideComp))
+        {
+            collideComp.HasCollision = true;
+            Dirty(collideEnt, collideComp);
+        }
+
+        if (TryComp<VisibilityComponent>(uid, out var visComp))
+            _visibility.SetLayer((uid, visComp), 1);
+
+        Dirty(uid);
     }
 
-    private void FinaleReady(Entity<MonumentComponent> uid, CosmicFinaleComponent finaleComp)
+    private void ReadyFinale(Entity<MonumentComponent> uid, CosmicFinaleComponent finaleComp)
     {
         if (TryComp<CosmicCorruptingComponent>(uid, out var comp))
             comp.Enabled = true;
@@ -702,3 +703,5 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     }
     #endregion
 }
+
+

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
@@ -309,7 +309,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                     MonumentTier3(uid);
                     UpdateMonumentReqsForTier(uid, CurrentTier);
                     uid.Comp.CanTierUp = true;
-                    UpdateCultData(uid); //instantly go up a tier if they manage it. this might be too easy.
+                    UpdateCultData(uid); //instantly go up a tier if they manage it. todo replace the 20 entropy buffer with a 5 min timer or so? - ruddygreat
+                    _ui.SetUiState(uid.Owner, MonumentKey.Key, new MonumentBuiState(uid.Comp)); //not sure if this is needed but I'll be safe
                 });
         }
         else if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 1 && uid.Comp.CanTierUp)
@@ -329,6 +330,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                     UpdateMonumentReqsForTier(uid, CurrentTier);
                     uid.Comp.CanTierUp = true;
                     UpdateCultData(uid); //instantly go up a tier if they manage it
+                    _ui.SetUiState(uid.Owner, MonumentKey.Key, new MonumentBuiState(uid.Comp)); //not sure if this is needed but I'll be safe
                 });
 
         }

--- a/Content.Shared/_Impstation/CosmicCult/Components/MonumentComponent.cs
+++ b/Content.Shared/_Impstation/CosmicCult/Components/MonumentComponent.cs
@@ -110,13 +110,13 @@ public sealed partial class MonumentComponent : Component
     /// the amount of time to wait for a stage change
     /// </summary>
     [DataField]
-    public TimeSpan TierWait = TimeSpan.FromSeconds(60);
+    public TimeSpan TierUpWait = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// wether or not there's a stage change queued
     /// </summary>
     [DataField]
-    public bool TierChanging = false;
+    public bool CanTierUp = true;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Should've been part of #1830 but I've got no idea how to push something to someone else's branch.
Does what it says on the tin, might also replace the 20 entropy t3 -> finale buffer with a 5 min timer, though from a little tinkering this'll probably be wierd to do.

no cl; not player facing
