### PR TITLE
Port: Sink sound fix

### DIFF
--- a/Content.Server/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/DrainSystem.cs
@@ -141,7 +141,7 @@ public sealed class DrainSystem : SharedDrainSystem
             if (!_solutionContainerSystem.ResolveSolution((uid, manager), DrainComponent.SolutionName, ref drain.Solution, out var drainSolution))
                 continue;
 
-            if (drainSolution.AvailableVolume <= 0)
+            if (drainSolution.Volume <= 0 && !drain.AutoDrain) // Upstream: cherry-pick #34173 (add drainSolution.Volume); inspired by FrontierStation #2948 which is identical
             {
                 _ambientSoundSystem.SetAmbience(uid, false);
                 continue;
@@ -158,7 +158,7 @@ public sealed class DrainSystem : SharedDrainSystem
                 _puddles.Clear();
                 _lookup.GetEntitiesInRange(Transform(uid).Coordinates, drain.Range, _puddles);
 
-                if (_puddles.Count == 0)
+                if (_puddles.Count == 0 && drainSolution.Volume <= 0) // Upstream: cherry-pick #34173 (add drainSolution.Volume); inspired by FrontierStation #2948 which is identical
                 {
                     _ambientSoundSystem.SetAmbience(uid, false);
                     continue;


### PR DESCRIPTION
Hi. There's an odd bug where sinks will drain forever and ever when you dump any regent into them. Specifically sinks. Frontier pulled an upstream change, and I'd like to follow suit. Here are links to both of those.
https://github.com/new-frontiers-14/frontier-station-14/pull/2948
https://github.com/space-wizards/space-station-14/pull/34173
Also first time fiddling with actual code so I hope I didn't fuck anything up sorry sorry
:cl:
- fix: Sinks don't drain forever now; thank you, upstream and Frontier!

