### PR TITLE
Salvage Magnet announces what got pulled 

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -394,7 +394,7 @@ public sealed partial class SalvageSystem
 
                 break;
             case SalvageOffering wreck:
-                Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("offeringType", (Loc.GetString($"salvage-map-wreck").ToLower())), ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
+                Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("offeringType", (Loc.GetString($"salvage-map-wreck")).ToLower()), ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
 
                 break;
             default:

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -382,8 +382,25 @@ public sealed partial class SalvageSystem
                 salvMob.LinkedEntity = mapChild;
             }
         }
+        // IMP Change | currently doesn't say the size of the wrecks when pulling due to the markup on the size strings
+        switch (offering)
+        {
+            case AsteroidOffering asteroid:
+                Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("offeringType", (Loc.GetString($"dungeon-config-proto-{asteroid.Id}")).ToLower()), ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
 
-        Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
+                break;
+            case DebrisOffering debris:
+                Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("offeringType", (Loc.GetString($"salvage-magnet-debris-{debris.Id}")).ToLower()), ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
+
+                break;
+            case SalvageOffering wreck:
+                Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("offeringType", (Loc.GetString($"salvage-map-wreck").ToLower())), ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
         _mapManager.DeleteMap(salvMapXform.MapID);
 
         data.Comp.Announced = false;

--- a/Resources/Locale/en-US/salvage/salvage-magnet.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-magnet.ftl
@@ -1,7 +1,8 @@
 salvage-system-announcement-losing = The magnet is no longer able to hold the salvagable debris. Estimated time until loss: {$timeLeft} seconds.
 salvage-system-announcement-spawn-debris-disintegrated = Debris disintegrated during orbital transfer.
 salvage-system-announcement-spawn-no-debris-available = No debris could be recovered by the salvage magnet.
-salvage-system-announcement-arrived = A piece of salvagable debris has been pulled in. Estimated hold time: {$timeLeft} seconds.
+#IMP Change
+salvage-system-announcement-arrived = A piece of salvagable debris of type {$offeringType} has been pulled in. Estimated hold time: {$timeLeft} seconds.
 salvage-asteroid-name = Asteroid
 
 salvage-magnet-window-title = Salvage magnet


### PR DESCRIPTION
Does what the title says. Currently it doesn't tell you what size of wreck got pulled because those strings have markup and I don't feel like doing substring shenanigans to get the actual size. The announcement message was also changed to fit this so let me know if you want the wording changed. 

**Changelog**


:cl:
- tweak: The salvage magnet now tells you what got pulled.


