### PR TITLE
Storagefill diversity

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
@@ -4,14 +4,38 @@
   suffix: Filled, Captain
   components:
   - type: StorageFill
-    contents:
+    contents: # imp edit - diversifying dressers
       - id: ClothingHeadHatCaptain
+        orGroup: CapHat
       - id: ClothingHeadHatCapcap
-      - id: ClothingUniformJumpsuitCapFormal
-      - id: ClothingUniformJumpskirtCapFormalDress
-      - id: ClothingHandsGlovesCaptain
-      - id: ClothingOuterWinterCap
+        orGroup: CapHat
+      - id: ClothingHeadHatBeretCaptain
+        orGroup: CapHat
+      - id: ClothingHeadHatCaptaincrushercap
+        orGroup: CapHat
       - id: ClothingNeckCloakCap
+        orGroup: CapNeck
+      - id: ClothingNeckCloakCapFormal
+        orGroup: CapNeck
+      - id: ClothingNeckMantleCap
+        orGroup: CapNeck
+      - id: ClothingNeckCloakCaptaingreatcoat
+        orGroup: CapNeck
+      - id: ClothingUniformJumpsuitCaptain
+        orGroup: CapJumpsuit
+      - id: ClothingUniformJumpsuitCapFormal
+        orGroup: CapJumpsuit
+      - id: ClothingUniformJumpsuitCaptaineveningattire
+        orGroup: CapJumpsuit
+      - id: ClothingUniformJumpskirtCaptain
+        orGroup: CapJumpskirt
+      - id: ClothingUniformJumpskirtCapFormalDress
+        orGroup: CapJumpskirt
+      - id: ClothingOuterWinterCap
+      - id: ClothingHandsGlovesCaptain
+        orGroup: CapGloves
+      - id: ClothingHandsGlovesCaptainflightgloves
+        orGroup: CapGloves
 
 - type: entity
   id: DresserChiefEngineerFilled
@@ -19,12 +43,24 @@
   suffix: Filled, Chief Engineer
   components:
   - type: StorageFill
-    contents:
-      - id: ClothingUniformJumpsuitChiefEngineerTurtle
-      - id: ClothingUniformJumpskirtChiefEngineerTurtle
+    contents: # imp edit - diversifying dressers
       - id: ClothingHeadHatBeretEngineering
-      - id: ClothingOuterWinterCE
+        orGroup: CEHat
+      - id: ClothingHeadHatHardhatWhite
+        orGroup: CEHat
       - id: ClothingNeckCloakCe
+        orGroup: CENeck
+      - id: ClothingNeckMantleCE
+        orGroup: CENeck
+      - id: ClothingUniformJumpsuitChiefEngineer
+        orGroup: CEJumpsuit
+      - id: ClothingUniformJumpsuitChiefEngineerTurtle
+        orGroup: CEJumpsuit
+      - id: ClothingUniformJumpskirtChiefEngineer
+        orGroup: CEJumpskirt
+      - id: ClothingUniformJumpskirtChiefEngineerTurtle
+        orGroup: CEJumpskirt
+      - id: ClothingOuterWinterCE
 
 - type: entity
   id: DresserChiefMedicalOfficerFilled
@@ -32,15 +68,32 @@
   suffix: Filled, Chief Medical Officer
   components:
   - type: StorageFill
-    contents:
-      - id: ClothingOuterCoatLabCmo
-      - id: ClothingUniformJumpsuitCMOTurtle
-      - id: ClothingUniformJumpskirtCMOTurtle
+    contents: # imp edit - diversifying dressers
       - id: ClothingHeadHatBeretCmo
+        orGroup: CMOHat
       - id: ClothingHeadMirror
-      - id: ClothingEyesGlasses
-      - id: ClothingOuterWinterCMO
+        orGroup: CMOHat
       - id: ClothingCloakCmo
+        orGroup: CMONeck
+      - id: ClothingNeckMantleCMO
+        orGroup: CMONeck
+      - id: ClothingNeckCloakCmosGreatcloak
+        orGroup: CMONeck
+      - id: ClothingUniformJumpsuitCMOTurtle
+        orGroup: CMOJumpsuit
+      - id: ClothingUniformJumpsuitCMO
+        orGroup: CMOJumpsuit
+      - id: ClothingUniformJumpskirtCMOTurtle
+        orGroup: CMOJumpskirt
+      - id: ClothingUniformJumpskirtCMO
+        orGroup: CMOJumpskirt
+      - id: ClothingOuterCoatLabCmo
+        orGroup: CMOOuter
+      - id: ClothingOuterWinterCMO
+        orGroup: CMOOuter
+      - id: ClothingOuterCoatCMO
+        orGroup: CMOOuter
+      - id: ClothingEyesGlasses
 
 - type: entity
   id: DresserHeadOfPersonnelFilled
@@ -48,11 +101,20 @@
   suffix: Filled, Head Of Personnel
   components:
   - type: StorageFill
-    contents:
+    contents: # imp edit - diversifying dressers. also hop didnt have jumpsuits in here for some reason
       - id: ClothingHeadHatHopcap
+      - id: ClothingNeckCloakHop
+        orGroup: HoPNeck
+      - id: ClothingNeckMantleHOP
+        orGroup: HoPNeck
+      - id: ClothingUniformJumpsuitHoP
+        orGroup: HoPJumpsuit
+      - id: ClothingUniformJumpsuitBoatswain
+        orGroup: HoPJumpsuit
+      - id: ClothingUniformJumpskirtHoP
+        orGroup: HoPJumpskirt
       - id: ClothingOuterWinterHoP
       - id: ClothingEyesGlasses
-      - id: ClothingNeckCloakHop
 
 - type: entity
   id: DresserHeadOfSecurityFilled
@@ -60,15 +122,42 @@
   suffix: Filled, Head Of Security
   components:
   - type: StorageFill
-    contents:
+    contents: # imp edit - diversifying dressers
       - id: ClothingHeadHatBeretHoS
+        orGroup: HoSHat
       - id: ClothingHeadHatHoshat
-      - id: ClothingUniformJumpskirtHoSAlt
-      - id: ClothingUniformJumpsuitHoSAlt
-      - id: ClothingUniformJumpskirtHosFormal
-      - id: ClothingUniformJumpsuitHosFormal
-      - id: ClothingOuterWinterHoS
+        orGroup: HoSHat
+      - id: ClothingHeadHatHoshatDV
+        orGroup: HoSHat
+      - id: ClothingHeadHatHOSsoft
+        orGroup: HoSHat
       - id: ClothingNeckCloakHos
+        orGroup: HoSCloak
+      - id: ClothingNeckMantleHOS
+        orGroup: HoSCloak
+      - id: ClothingNeckCloakHosgreatcoat
+        orGroup: HoSCloak
+      - id: ClothingUniformJumpsuitHoS
+        orGroup: HoSJumpsuit
+      - id: ClothingUniformJumpsuitHoSAlt
+        orGroup: HoSJumpsuit
+      - id: ClothingUniformJumpsuitHoSGrey
+        orGroup: HoSJumpsuit
+      - id: ClothingUniformJumpsuitHosFormal
+        orGroup: HoSJumpsuit
+      - id: ClothingUniformJumpsuitHoSPro
+        orGroup: HoSJumpsuit
+      - id: ClothingUniformJumpskirtHoS
+        orGroup: HoSJumpskirt
+      - id: ClothingUniformJumpskirtHoSAlt
+        orGroup: HoSJumpskirt
+      - id: ClothingUniformJumpskirtHoSGrey
+        orGroup: HoSJumpskirt
+      - id: ClothingUniformJumpskirtHosFormal
+        orGroup: HoSJumpskirt
+      - id: ClothingUniformJumpskirtHoSPro
+        orGroup: HosJumpskirt
+      - id: ClothingOuterWinterHoSUnarmored
 
 - type: entity
   id: DresserQuarterMasterFilled
@@ -76,14 +165,32 @@
   suffix: Filled, Quarter Master
   components:
   - type: StorageFill
-    contents:
+    contents: # imp edit - diversifying dressers
       - id: ClothingHeadHatBeretQM
-      - id: ClothingUniformJumpsuitQMFormal
-      - id: ClothingUniformJumpsuitQMTurtleneck
-      - id: ClothingUniformJumpskirtQMTurtleneck
-      - id: ClothingHandsGlovesColorBrown
-      - id: ClothingOuterWinterQM
+        orGroup: QMHat
+      - id: ClothingHeadHatQMsoft
+        orGroup: QMHat
       - id: ClothingNeckCloakQm
+        orGroup: QMNeck
+      - id: ClothingNeckMantleQM
+        orGroup: QMNeck
+      - id: ClothingNeckCloakQmgreatcoat
+        orGroup: QMNeck
+      - id: ClothingUniformJumpsuitQM
+        orGroup: QMJumpsuit
+      - id: ClothingUniformJumpsuitQMFormal
+        orGroup: QMJumpsuit
+      - id: ClothingUniformJumpsuitQMTurtleneck
+        orGroup: QMJumpsuit
+      - id: ClothingUniformJumpskirtQM
+        orGroup: QMJumpskirt
+      - id: ClothingUniformJumpskirtQMTurtleneck
+        orGroup: QMJumpskirt
+      - id: ClothingOuterWinterQM
+        orGroup: QMOuter
+      - id: ClothingOuterCoatQmHuge
+        orGroup: QMOuter
+      - id: ClothingHandsGlovesColorBrown # idk why this is in here since it isnt part of the qm loadouts but whatever
 
 - type: entity
   id: DresserResearchDirectorFilled
@@ -91,21 +198,27 @@
   suffix: Filled, Research Director
   components:
   - type: StorageFill
-    contents:
+    contents: # imp edit - diversifying dressers. RD didnt have jumpsuits either for some reason
       - id: ClothingHeadHatBeretRND
-      - id: ClothingHandsGlovesColorPurple
-      - id: ClothingEyesGlasses
-      - id: ClothingOuterWinterRD
-      - id: ClothingOuterCoatRD
-        orGroup: RdCoat
-        prob: 0.5
-      - id: ClothingOuterCoatRndMysta # DeltaV
-        orGroup: RdCoat
+        orGroup: RDHat
+      - id: ClothingHeadHoodMysta
+        orGroup: RDHat
       - id: ClothingNeckCloakRd
-        orGroup: RdCloak
-        prob: 0.5
-      - id: ClothingNeckCloakMystagogue # DeltaV
-        orGroup: RdCloak
+        orGroup: RDNeck
+      - id: ClothingNeckCloakMystagogue
+        orGroup: RDNeck
+      - id: ClothingNeckMantleRD
+        orGroup: RDNeck
+      - id: ClothingUniformJumpsuitResearchDirector
+      - id: ClothingUniformJumpskirtResearchDirector
+      - id: ClothingOuterWinterRD
+        orGroup: RDOuter
+      - id: ClothingOuterCoatRD
+        orGroup: RDOuter
+      - id: ClothingOuterCoatRndMysta
+        orGroup: RDOuter
+      - id: ClothingHandsGlovesColorPurple # not part of the rd loadout but okay
+      - id: ClothingEyesGlasses
 
 - type: entity
   id: DresserWardenFilled
@@ -113,6 +226,25 @@
   suffix: Filled, Warden
   components:
   - type: StorageFill
-    contents:
+    contents: # imp edit - diversifying dressers
       - id: ClothingHeadHatWarden
+        orGroup: WardenHead
       - id: ClothingHeadHatBeretWarden
+        orGroup: WardenHead
+      - id: ClothingUniformJumpsuitWarden
+        orGroup: WardenJumpsuit
+      - id: ClothingUniformJumpsuitWardenTurtle
+        orGroup: WardenJumpsuit
+      - id: ClothingUniformJumpsuitSecBlue
+        orGroup: WardenJumpsuit
+      - id: ClothingUniformJumpsuitChiefJusticeFormal
+        orGroup: WardenJumpsuit
+      - id: ClothingUniformJumpsuitChiefJusticeWhite
+        orGroup: WardenJumpsuit
+      - id: ClothingUniformJumpskirtWarden
+        orGroup: WardenJumpskirt
+      - id: ClothingUniformJumpskirtWardenTurtle
+        orGroup: WardenJumpskirt
+      - id: ClothingUniformJumpskirtCJFormal
+        orGroup: WardenJumpskirt
+      - id: ClothingOuterWinterWardenUnarmored

--- a/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
@@ -8,6 +8,8 @@
     sprite: Clothing/Neck/mantles/capmantle.rsi
   - type: Clothing
     sprite: Clothing/Neck/mantles/capmantle.rsi
+  - type: StealTarget # imp
+    stealGroup: HeadCloak
 
 - type: entity
   parent: [ClothingNeckBase, BaseCommandContraband]
@@ -19,6 +21,8 @@
     sprite: Clothing/Neck/mantles/cemantle.rsi
   - type: Clothing
     sprite: Clothing/Neck/mantles/cemantle.rsi
+  - type: StealTarget # imp
+    stealGroup: HeadCloak
 
 - type: entity
   parent: [ClothingNeckBase, BaseCommandContraband]
@@ -30,6 +34,8 @@
     sprite: Clothing/Neck/mantles/cmomantle.rsi
   - type: Clothing
     sprite: Clothing/Neck/mantles/cmomantle.rsi
+  - type: StealTarget # imp
+    stealGroup: HeadCloak
 
 - type: entity
   parent: [ClothingNeckBase, BaseCommandContraband]
@@ -41,6 +47,8 @@
     sprite: Clothing/Neck/mantles/hopmantle.rsi
   - type: Clothing
     sprite: Clothing/Neck/mantles/hopmantle.rsi
+  - type: StealTarget # imp
+    stealGroup: HeadCloak
 
 - type: entity
   parent: [ClothingNeckBase, BaseCommandContraband]
@@ -52,6 +60,8 @@
     sprite: Clothing/Neck/mantles/hosmantle.rsi
   - type: Clothing
     sprite: Clothing/Neck/mantles/hosmantle.rsi
+  - type: StealTarget # imp
+    stealGroup: HeadCloak
 
 - type: entity
   parent: [ClothingNeckBase, BaseCommandContraband]
@@ -63,6 +73,8 @@
     sprite: Clothing/Neck/mantles/rdmantle.rsi
   - type: Clothing
     sprite: Clothing/Neck/mantles/rdmantle.rsi
+  - type: StealTarget # imp
+    stealGroup: HeadCloak
 
 - type: entity
   parent: [ClothingNeckBase, BaseCommandContraband]
@@ -74,6 +86,8 @@
     sprite: Clothing/Neck/mantles/qmmantle.rsi
   - type: Clothing
     sprite: Clothing/Neck/mantles/qmmantle.rsi
+  - type: StealTarget # imp
+    stealGroup: HeadCloak
 
 - type: entity
   parent: ClothingNeckBase
@@ -84,7 +98,7 @@
   - type: Sprite
     sprite: Clothing/Neck/mantles/mantle.rsi
   - type: Clothing
-    sprite: Clothing/Neck/mantles/mantle.rsi 
+    sprite: Clothing/Neck/mantles/mantle.rsi
 
 - type: entity
   parent: ClothingNeckBase

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1074,7 +1074,7 @@
   minLimit: 0
   loadouts:
   - HeadofSecurityHead
-  - HeadofSecurityHeadDV
+  - HeadofSecurityHeadDV # DeltaV
   - HeadofSecurityBeret
   - HeadofSecurityPatrolCap # imp
 


### PR DESCRIPTION
minor treat just for me i guess. i halfassed this in the dv clothing port and i decided to full ass it now

every filled command dresser now picks from a randomized selection of clothing from the associated job's loadouts. this includes prestige clothing. it does NOT include any clothing with armor values (i even changed the hos winter coat to its imp exclusive unarmored variant for consistency's sake). additionally hop, rd, and warden didn't have jumpsuits/skirts in their dressers so i added those. warden was just two hats this whole time?? do they hate them

additionally i made it so mantles count as valid targets for the head cloak steal objective. im a little surprised this isnt the case upstream and i opted to do it now because the only meaningful gameplay impact randomized dresser contents has is that there are less cloaks in a round for a thief to steal. now there is no gameplay impact outside of more accessible drip :)

**Changelog**
:cl:
- tweak: Command dressers now have a much larger variety of clothing!
- tweak: Command mantles count for a thief's objective to steal Command cloaks.
