### PR TITLE
fix the finale countdown not having a CanTierUp check

### DIFF
--- a/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
@@ -312,11 +312,12 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
 
         uid.Comp.CurrentProgress = uid.Comp.TotalEntropy + (TotalCult * _config.GetCVar(ImpCCVars.CosmicCultistEntropyValue));
 
-        if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 3 && !finaleComp.FinaleActive && !finaleComp.FinaleReady)
+        if (uid.Comp.CurrentProgress >= uid.Comp.TargetProgress && CurrentTier == 3 && !finaleComp.FinaleActive && !finaleComp.FinaleReady && uid.Comp.CanTierUp)
         {
             if (!finaleComp.FinaleDelayStarted) //check if we've not already started the finale delay
             {
                 finaleComp.FinaleDelayStarted = true; //set that we've started it
+                uid.Comp.CanTierUp = false; //keep it false, we don't want to take this code path after running it once
                 //do everything else
 
                 var timer = TimeSpan.FromSeconds(_config.GetCVar(ImpCCVars.CosmicCultFinaleDelaySeconds));
@@ -335,6 +336,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                 Timer.Spawn(timer,
                     () =>
                     {
+                        uid.Comp.CanTierUp = false; //keep it false, we don't want to take this code path after running it once
                         ReadyFinale(uid, finaleComp);
                         UpdateCultData(uid); //duplicated work but it looks nicer than calling updateAppearance on it's own
                     });


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Accidentally committed this to my master branch, fuck.
Adds a check for CanTierUp to the 2:30 finale warning, before now it would trigger on the next entropy insertion / conversion . deconversion.
Could maybe do with a change to the loc strings to clarify that they're a countdown to the cult being revealed / the cult forcing to start the finale, but I'm not good at words like that.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
