### PR TITLE
religious supply crate now has one random holy text instead of the bible

### DIFF
--- a/Resources/Prototypes/_Impstation/CosmicCult/cargocrate.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/cargocrate.yml
@@ -41,8 +41,8 @@
           orGroup: HolyText
         - id: HolyTextHolyTablet
           orGroup: HolyText
-        - id: HolyTextGreyBible
-          orGroup: Holytext
+        - id: HolyTextGreybible
+          orGroup: HolyText
           prob: 0.4
         - id: HolyTextKojiki
           orGroup: HolyText

--- a/Resources/Prototypes/_Impstation/CosmicCult/cargocrate.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/cargocrate.yml
@@ -32,6 +32,37 @@
     - type: StorageFill
       contents:
         - id: Bible
+          orGroup: HolyText
+        - id: HolyTextQuran
+          orGroup: HolyText
+        - id: HolyTextTanakh
+          orGroup: HolyText
+        - id: HolyTextHolyScroll
+          orGroup: HolyText
+        - id: HolyTextHolyTablet
+          orGroup: HolyText
+        - id: HolyTextGreyBible
+          orGroup: Holytext
+          prob: 0.4
+        - id: HolyTextKojiki
+          orGroup: HolyText
+        - id: HolyTextTaoTeachings
+          orGroup: HolyText
+        - id: HolyTextPrincipiaDiscordia
+          orGroup: HolyText
+          prob: 0.4
+        - id: HolyTextChaplainsGrimoire
+          orGroup: HolyText
+          prob: 0.4
+        - id: HolyTextUnitologyTome
+          orGroup: HolyText
+          prob: 0.1
+        - id: HolyTextExtremeTeenBible
+          orGroup: HolyText
+          prob: 0.1
+        - id: HolyTextBibble
+          orGroup: HolyText
+          prob: 0.1
         - id: JugHolywater
           amount: 2
 

--- a/Resources/Prototypes/_Impstation/CosmicCult/cargocrate.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/cargocrate.yml
@@ -27,7 +27,7 @@
   id: CrateServiceReligious
   parent: CrateChaplain
   name: religious supplies crate
-  description: Contains holy water and a spare bible.
+  description: Contains holy water and a spare holy text.
   components:
     - type: StorageFill
       contents:


### PR DESCRIPTION

![SS14 Loader_VixdzmTgUL](https://github.com/user-attachments/assets/d6e03ce1-424b-4daa-ae59-af4e097ee9d3)

we love de-emphasizing christianity from chaplains

**Changelog**
:cl:
- tweak: The religious supplies crate now supplies from a wider variety of religions.