### PR TITLE
Artifacts: Only give permanent effect components ONCE

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
@@ -240,14 +240,12 @@ public sealed partial class ArtifactSystem
         {
             var reg = _componentFactory.GetRegistration(name);
 
-            if (node.Discovered && EntityManager.HasComponent(uid, reg.Type))
-            {
-                // Don't re-add permanent components unless this is the first time you've entered this node
-                if (effect.PermanentComponents.ContainsKey(name))
-                    continue;
+            // Don't re-add permanent components, ever
+            if (effect.PermanentComponents.ContainsKey(name) && EntityManager.HasComponent(uid, reg.Type))
+                continue;
 
+            if (node.Discovered && EntityManager.HasComponent(uid, reg.Type))
                 EntityManager.RemoveComponent(uid, reg.Type);
-            }
 
             var comp = (Component)_componentFactory.GetComponent(reg);
 


### PR DESCRIPTION
Artifacts will no longer be able to apply the same permanent effect twice. This will not prevent them from rolling duplicate permanent effects, but the 2nd node onward will do nothing. 

This is primarily so a sentient artifact will not get a 2nd sentience effect node and have the ghost role appear on the role list which cannot be taken as artifact is already controlled by mind. 

May prevent 'reloading' the gun permanent effect when a 2nd one rolls, but that will only happen once and is fairly rare, so the nerf is not a major issue to me.

:cl:
- fix: Sentient artifacts can no longer re-appear in the ghost role list after having been taken, if someone is still inside it.