### PR TITLE
Fix Hospitality Director mantle requiring CE playtime

### DIFF
--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/hospitality_director.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/hospitality_director.yml
@@ -96,7 +96,7 @@
     neck: ClothingNeckMantleHD
   effects:
   - !type:GroupLoadoutEffect
-    proto: MasterCE
+    proto: MasterHD
 
 - type: startingGear
   id: HospitalityDirectorMantle


### PR DESCRIPTION
Copy-paste moment, fixes the mantle to use the Master HD loudout effect.


:cl:
- fix: Fixed the Hospitality Director's mantle requiring CE playtime instead of HD playtime.