### PR TITLE
spider fuzz is colorable now

### DIFF
--- a/Resources/Locale/en-US/_Impstation/markings/arachnid.ftl
+++ b/Resources/Locale/en-US/_Impstation/markings/arachnid.ftl
@@ -53,3 +53,4 @@ marking-ArachnidRLegSegments-leg_r_segments1 = Thigh
 marking-ArachnidRLegSegments-leg_r_segments2 = Shin
 
 marking-ArachnidOverlayFluffy = Fluffy
+marking-ArachnidOverlayFluffy-fluffy = Fluff

--- a/Resources/Locale/en-US/markings/arachnid.ftl
+++ b/Resources/Locale/en-US/markings/arachnid.ftl
@@ -92,3 +92,4 @@ marking-ArachnidLLegStripes = Arachnid Stripes (Left)
 marking-ArachnidLLegStripes-stripes_left = Stripes
 
 marking-ArachnidOverlayFuzzy = Fuzzy
+marking-ArachnidOverlayFuzzy-fuzzy = Fuzz

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/arachnid.yml
@@ -346,7 +346,7 @@
   id: ArachnidOverlayFuzzy
   bodyPart: Chest
   markingCategory: Overlay
-  forcedColoring: true
+  #forcedColoring: true #imp
   speciesRestriction: [Arachnid]
   sprites:
   - sprite: Mobs/Customization/Arachnid/overlay.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/arachnid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/arachnid.yml
@@ -183,7 +183,6 @@
   id: ArachnidOverlayFluffy
   bodyPart: Chest
   markingCategory: Overlay
-  forcedColoring: true
   speciesRestriction: [Arachnid]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Arachnid/overlay.rsi


### PR DESCRIPTION
literally a four-line change, didn't even think about it till i saw screenshots

with this, i think ALL spider markings are freed from the old forced-dark days yay

![image](https://github.com/user-attachments/assets/f671c57c-07a5-4350-9e30-9cd8fe367774)

:cl:
- tweak: Spider Fluffy and Fuzzy overlay markings are now colorable