### PR TITLE
Fix silicon ghost role info

### DIFF
--- a/Resources/Locale/en-US/_Impstation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Impstation/ghost/roles/ghost-role-component.ftl
@@ -88,3 +88,14 @@ ghost-role-information-tutorial-rules = You are a [color=#39f5ab][bold]special T
 
 ghost-role-information-homunculus-name = homunculus
 ghost-role-information-homunculus-description = A homunculi created by someone who does not appreciate life. It lives to serve.
+
+ghost-role-information-onestar-mecha-name = OneStar Mecha
+ghost-role-information-onestar-mecha-description = You are this station's end.
+
+ghost-role-information-drone-name = Maintenance Drone
+ghost-role-information-drone-description = Maintain the station. Ignore other beings except drones.
+ghost-role-information-drone-rules = You are bound by these laws both in-game and out-of-character:
+
+     1. You may not interfere with the affairs of any being except another drone, regardless of intent or circumstance.
+     2. Your goal is to maintain or improve the station to the best of your ability.
+     3. You may not take any action which causes damage or harm to the station or its inhabitants.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -335,7 +335,4 @@ ghost-role-information-gingerbread-name = Gingerbread Man
 ghost-role-information-gingerbread-description = A being of pure holiday spirit.
                                      Spread molassesy goodness and to all good cheer.
 
-ghost-role-information-onestar-mecha-name = OneStar Mecha
-ghost-role-information-onestar-mecha-description = You are this station's end.
-
 

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -906,13 +906,9 @@
       department: Silicon
       time: 18000 # five hours
     makeSentient: true
-    name: Maintenance Drone
-    description: Maintain the station. Ignore other beings except drones.
-    rules: |
-     You are bound by these laws both in-game and out-of-character:
-     1. You may not interfere with the affairs of any being except another drone, regardless of intent or circumstance.
-     2. Your goal is to maintain or improve the station to the best of your ability.
-     3. You may not take any action which causes damage or harm to the station or its inhabitants.
+    name: ghost-role-information-drone-name
+    description: ghost-role-information-drone-description
+    rules: ghost-role-information-drone-rules
     mindRoles: # imp. this whole prototype needs to be pulled out of upstream
     - MindRoleGhostRoleSilicon
   - type: GhostTakeoverAvailable


### PR DESCRIPTION
This PR brings some minor tweaks to silicon ghost role info internally. Oops.

![image](https://github.com/user-attachments/assets/8251bb53-21a1-4f76-ad5b-e265ab8c89c2)

