### PR TITLE
Allow departments to be hidden from the crew manifest

### DIFF
--- a/Content.Client/CrewManifest/UI/CrewManifestListing.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestListing.cs
@@ -39,7 +39,8 @@ public sealed class CrewManifestListing : BoxContainer
 
         foreach (var (section, listing) in entryDict)
         {
-            entryList.Add((section, listing));
+            if (!section.ManifestHidden) //imp edit: for excluding certain departments from manifest
+                entryList.Add((section, listing));
         }
 
         entryList.Sort((a, b) => DepartmentUIComparer.Instance.Compare(a.section, b.section));

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -47,6 +47,12 @@ public sealed partial class DepartmentPrototype : IPrototype
     /// </summary>
     [DataField]
     public bool EditorHidden;
+
+    /// <summary>
+    /// Toggles the display of the department in the in-round crew manifest. Imp addition.
+    /// </summary>
+    [DataField]
+    public bool ManifestHidden = false;
 }
 
 /// <summary>

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -151,3 +151,4 @@
   - Zookeeper
   - Psychologist
   primary: false
+  manifestHidden: true #imp edit

--- a/Resources/Prototypes/_Impstation/Roles/departments.yml
+++ b/Resources/Prototypes/_Impstation/Roles/departments.yml
@@ -34,3 +34,4 @@
   - ServiceWorker
   primary: false
   editorHidden: true
+  manifestHidden: true


### PR DESCRIPTION
This PR adds the ManifestHidden data field to the Departments prototype, allowing them to be hidden from the PDA crew manifest on a per-department basis. This is implemented to hide the Station Specific (reporter, psychologist, zookeeper, boxer) and Dining Services (chef, bartender, service worker) departments from the crew manifest, as well as any other non-standard departments in the future.

![mz6PiwD](https://github.com/user-attachments/assets/3098c41c-2b42-4bc0-8e60-a19f547fc036)

:cl:
- tweak: The Station Specific and Dining Services departments no longer appear in the crew manifest.

