### PR TITLE
removes the protect objective from traitors

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -41,7 +41,7 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupSocial
   weights:
-    RandomTraitorAliveObjective: 1
+    # RandomTraitorAliveObjective: 1 # imp - worse version of RandomTraitorProgressObjective
     RandomTraitorProgressObjective: 1
 
 


### PR DESCRIPTION
this has come up a lot and im finally going to do the one line change to make it real

this PR removes the "Ensure fellow traitor stays alive" objective. it's come up often in feedback that this is a strictly less interactive and less interesting version of "Ensure fellow traitor achieves at least half their objectives." 'protect objective' is not something you have control over for the most part and the only time it comes into conflict is if you happen to roll protect on someone with DAGD

this doesnt affect SVS at all because it handles objectives totally separate from normal traitors, in case anyone was worried

**Changelog**
:cl:
- remove: Removed the 'ensure fellow traitor stays alive' objective outside of Spy vs Spy.
