### PR TITLE
Add more tools to admin ghost loadout

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -144,6 +144,14 @@
     - trayScanner
     - AccessConfiguratorUniversal
     - Multitool
+    # imp edit start
+    - PowerDrill
+    - JawsOfLife
+    - WelderExperimental
+    - GeigerCounter
+    - SprayPainter
+    - CrayonRainbowInfinite
+    # imp edit end
 
 #Gladiator with spear
 - type: startingGear


### PR DESCRIPTION
Adds a power drill, jaws of life, experimental welder, geiger counter, spray painter, and infinite rainbow crayon to the admin ghost map for the convenience of admins and mappers.

no cl, admin's will notice it when they aghost and look in their backpack

![jPQ1ARr](https://github.com/user-attachments/assets/7aeae63f-7f19-4a62-a24f-16dbe95d9dd1)

