### PR TITLE
Fix Hospitality Director missing Brig access

### DIFF
--- a/Resources/Prototypes/_Impstation/Roles/Jobs/Service/hospitality_director.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Jobs/Service/hospitality_director.yml
@@ -27,6 +27,7 @@
   - Service #why don't other heads have their accesses set up this way?
   access:
   - Maintenance
+  - Brig
   - Command
   - Cryogenics
   special:


### PR DESCRIPTION
Didn't notice all heads of staff have brig access while making Hospitality Director, so this PR fixes that.

:cl:
- fix: Fixed Hospitality Director not having Brig access as all other heads do.

