### PR TITLE
no more trash in the roundstart supermatter

### DIFF
--- a/Content.Server/GameTicking/Rules/VariationPass/Components/EntitySpawnVariationPassComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/EntitySpawnVariationPassComponent.cs
@@ -24,4 +24,10 @@ public sealed partial class EntitySpawnVariationPassComponent : Component
     /// </summary>
     [DataField(required: true)]
     public List<EntitySpawnEntry> Entities = default!;
+
+    /// <summary>
+    ///     Imp: Skip spawning an entity if another entity with one of these components exists on the tile.
+    /// </summary>
+    [DataField]
+    public ComponentRegistry? ComponentBlacklist;
 }

--- a/Content.Server/GameTicking/Rules/VariationPass/EntitySpawnVariationPassSystem.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/EntitySpawnVariationPassSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.GameTicking.Rules.VariationPass.Components;
+﻿using System.Linq;
+using Content.Server.GameTicking.Rules.VariationPass.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Random;
 
@@ -7,6 +8,8 @@ namespace Content.Server.GameTicking.Rules.VariationPass;
 /// <inheritdoc cref="EntitySpawnVariationPassComponent"/>
 public sealed class EntitySpawnVariationPassSystem : VariationPassSystem<EntitySpawnVariationPassComponent>
 {
+    [Dependency] private readonly EntityLookupSystem _lookup = default!; // imp edit
+
     protected override void ApplyVariation(Entity<EntitySpawnVariationPassComponent> ent, ref StationVariationPassEvent args)
     {
         var totalTiles = Stations.GetTileCount(args.Station);
@@ -18,6 +21,27 @@ public sealed class EntitySpawnVariationPassSystem : VariationPassSystem<EntityS
         {
             if (!TryFindRandomTileOnStation(args.Station, out _, out _, out var coords))
                 continue;
+
+            // imp edit
+            var valid = true;
+
+            if (ent.Comp.ComponentBlacklist != null)
+            {
+                foreach (var otherEnt in _lookup.GetEntitiesIntersecting(coords))
+                {
+                    foreach (var comp in ent.Comp.ComponentBlacklist.Values.Where(comp => HasComp(otherEnt, comp.Component.GetType())))
+                    {
+                        if (!valid)
+                            continue;
+
+                        valid = false;
+                    }
+                }
+            }
+
+            if (!valid)
+                continue;
+            // end imp edit
 
             var ents = EntitySpawnCollection.GetSpawns(ent.Comp.Entities, Random);
             foreach (var spawn in ents)

--- a/Resources/Prototypes/GameRules/variation.yml
+++ b/Resources/Prototypes/GameRules/variation.yml
@@ -46,6 +46,8 @@
     tilesPerEntityStdDev: 4
     entities:
     - id: RandomSpawner
+    componentBlacklist: # imp
+    - type: Supermatter
 
 - type: weightedRandomFillSolution
   id: RandomFillTrashPuddle


### PR DESCRIPTION
not really a big fan of this implementation but we ball. components can be blacklisted from `EntitySpawnVariationPass` and this is applied to the trash spawn gamerule to exempt things from spawning on tiles intersecting with supermatters

![image](https://github.com/user-attachments/assets/ca0df2d6-06cd-4a3f-9ecc-44aeab4d5138)

^^^^^ here's an extreme example of insane amounts of trash avoiding entities with `PlaceableSurface`

**Changelog**
:cl:
- fix: Trash no longer has a chance to spawn inside the supermatter at roundstart.