### PR TITLE
Add ticket pads into SecTech vending machine

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -23,6 +23,7 @@
     RiotShield: 2
     SecurityWhistle: 5
     TearGasGrenade: 4
+    TicketPad: 5 # imp
     Tourniquet: 5
     Zipties: 12
   # security officers need to follow a diet regimen!


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Literally just a one-line change for sensical security doings. Set the number at 5, per other "harmless" sec items (i.e. seclite, whistle) being set at 5.
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Added ticket pads into the SecTech vending machine.