### PR TITLE
Reverted upstream fix for borgs having a scream button

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -155,7 +155,6 @@
   - type: Vocal
     sounds:
       Unsexed: UnisexSilicon
-    screamAction: null
   - type: UnblockableSpeech
   - type: FootstepModifier
     footstepSoundCollection:


### PR DESCRIPTION
Upstream removed the scream button for borgs, but we have screams for borgs now, so reverting this change.

:cl:
- fix: Readded the scream button for cyborgs.
-->
