### PR TITLE
Crayons take 3 seconds to eat now, compared to their 1 second.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -23,6 +23,7 @@
   - type: Crayon
     capacity: 100
   - type: Food
+    delay: 3 # imp i am so piskun mad at eating my CRAYONS
   - type: FlavorProfile
     flavors:
     - chewy


### PR DESCRIPTION
Changed the crayon's eating doafter from 1 second to 3 seconds... sucks hardcore when you're drawing and you accidentally click yourself and eat your own crayon. Especially if it's a rainbow crayon.

:cl:
- tweak: It's now harder for you to accidentally eat your crayons as you're drawing.