### PR TITLE
Fix magnet annoucement

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -408,7 +408,8 @@ public sealed partial class SalvageSystem
                 throw new ArgumentOutOfRangeException();
         }
 
-        Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
+        // IMP Change ^
+        //Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("timeLeft", data.Comp.ActiveTime.TotalSeconds));
         _mapSystem.DeleteMap(salvMapXform.MapID);
 
         data.Comp.Announced = false;


### PR DESCRIPTION
The original report function call got readded in the upstream merge so I commented it out and added a "Imp change" comment. Probably should've done this in the original PR but oh well.

:cl:
- fix: Salvage magnet announcement no longer happens twice. 
