### PR TITLE
supermatter processing adjustments + console fix

### DIFF
--- a/Content.Client/_EE/Supermatter/Consoles/SupermatterConsoleBoundUserInterface.cs
+++ b/Content.Client/_EE/Supermatter/Consoles/SupermatterConsoleBoundUserInterface.cs
@@ -9,6 +9,8 @@ public sealed class SupermatterConsoleBoundUserInterface(EntityUid owner, Enum u
 
     protected override void Open()
     {
+        base.Open();
+
         _menu = new SupermatterConsoleWindow(this, Owner);
         _menu.OpenCentered();
         _menu.OnClose += Close;
@@ -18,8 +20,10 @@ public sealed class SupermatterConsoleBoundUserInterface(EntityUid owner, Enum u
     {
         base.UpdateState(state);
 
-        var castState = (SupermatterConsoleBoundInterfaceState)state;
-        _menu?.UpdateUI(castState.Supermatters, castState.FocusData);
+        if (_menu == null || state is not SupermatterConsoleBoundInterfaceState msg)
+            return;
+
+        _menu?.UpdateUI(msg.Supermatters, msg.FocusData);
     }
 
     public void SendFocusChangeMessage(NetEntity? netEntity)

--- a/Content.Shared/_EE/CCVar/EECCVars.cs
+++ b/Content.Shared/_EE/CCVar/EECCVars.cs
@@ -146,7 +146,7 @@ public sealed partial class EECCVars : CVars
     ///     Divisor on the amount of gas absorbed by the supermatter during the roundstart grace period.
     /// </summary>
     public static readonly CVarDef<float> SupermatterGasEfficiencyGraceModifier =
-        CVarDef.Create("supermatter.gas_efficiency_grace_modifier", 10f, CVar.SERVER);
+        CVarDef.Create("supermatter.gas_efficiency_grace_modifier", 2.5f, CVar.SERVER);
 
     /// <summary>
     ///     Divisor on the amount of damage that the supermatter takes from absorbing hot gas.
@@ -196,7 +196,7 @@ public sealed partial class EECCVars : CVars
     ///     Base amount of radiation that the supermatter emits.
     /// </summary>
     public static readonly CVarDef<float> SupermatterRadsBase =
-        CVarDef.Create("supermatter.rads_base", 3f, CVar.SERVER);
+        CVarDef.Create("supermatter.rads_base", 4f, CVar.SERVER);
 
     /// <summary>
     ///     Directly multiplies the amount of rads put out by the supermatter. Be VERY conservative with this.

--- a/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
@@ -142,7 +142,7 @@ public sealed partial class SupermatterComponent : Component
     /// The percentage of the gas on the supermatter's tile that is absorbed each atmos tick.
     /// </summary>
     [DataField]
-    public float GasEfficiency = 0.15f;
+    public float GasEfficiency = 0.05f;
 
     /// <summary>
     /// Uses <see cref="PowerlossDynamicScaling"/> and <see cref="GasStorage"/> to lessen the effects of our powerloss functions


### PR DESCRIPTION
upstream changed some stuff that broke the console so i fixed it yay!! also made some changes to supermatter processing based on feedback from our burdened engineers. im pushing cvar edits in a pr because im sick & twisted. this will help our future impstation lrp fork and the pumpstation project

details:
- gas absorption reduced from 15% to 5% to extend the supermatter's lifespan before it needs a gas top-up - this is still 2.5x faster than intended by tg code but we live in a different world
- grace period divisor decreased from 10 (1.5% gas absorption) to 2.5 (2% gas absorption) - the console only showed whole integers so it was already displaying as 2%, and i really dont want to put 3.33 in
- base radiation increased from 3 to 4 - given how plasma collectors slope down over time, the amount of power that a roundstart nitrogen sm produces is really lacking

**Changelog**
:cl:
- tweak: The supermatter's gas absorption has been slowed down to increase the amount of time before it requires gas refilling.
- tweak: The supermatter emits slightly more radiation to increase its base power production.