### PR TITLE
Readded the mining module to the lathe recipes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -45,6 +45,7 @@
   - BorgModuleHarvesting
   - BorgModuleDefibrillator
   - BorgModuleAdvancedTreatment
+  - BorgModuleMining #imp
 
 - type: latheRecipePack
   id: MechParts


### PR DESCRIPTION
Upstream merge killed the mining nerf...
:cl:
- fix: Fixed the mining module not appearing in the exofab after it was researched
