### PR TITLE
Add a star mark offset component

### DIFF
--- a/Content.Client/_Impstation/CosmicCult/ClientCosmicCultSystem.cs
+++ b/Content.Client/_Impstation/CosmicCult/ClientCosmicCultSystem.cs
@@ -84,10 +84,14 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
             return;
 
         var layer = sprite.AddLayer(new SpriteSpecifier.Rsi(uid.Comp.RsiPath, uid.Comp.States));
-        //todo StarMarkOffsetComp for doop's anomalocarids
-        //would also let like, monkeys & such get the mark as well maybe
         sprite.LayerMapSet(CosmicRevealedKey.Key, layer);
         sprite.LayerSetShader(layer, "unshaded");
+
+        //offset the mark if the mob has an offset comp
+        if (TryComp<CosmicStarMarkOffsetComponent>(uid, out var offset))
+        {
+            sprite.LayerSetOffset(CosmicRevealedKey.Key, offset.Offset);
+        }
     }
     private void OnCosmicImpositionAdded(Entity<CosmicImposingComponent> uid, ref ComponentStartup args)
     {

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.Abilities.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultSystem.Abilities.cs
@@ -398,7 +398,7 @@ public sealed partial class CosmicCultSystem : EntitySystem
                 }
 
                 //retrieve the monument from cheese world
-                Timer.Spawn(TimeSpan.FromSeconds(0.8), //relative to the last timer
+                Timer.Spawn(TimeSpan.FromSeconds(0.75), //relative to the last timer
                     () =>
                     {
                         var colliderQuery = EntityQueryEnumerator<MonumentCollisionComponent>();

--- a/Content.Shared/_Impstation/CosmicCult/Components/CosmicStarMarkOffsetComponent.cs
+++ b/Content.Shared/_Impstation/CosmicCult/Components/CosmicStarMarkOffsetComponent.cs
@@ -1,0 +1,14 @@
+using System.Numerics;
+
+namespace Content.Shared._Impstation.CosmicCult.Components;
+
+/// <summary>
+/// This is used to apply an offset to the star mark that shows up at cult tier 3.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CosmicStarMarkOffsetComponent : Component
+{
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public Vector2 Offset = Vector2.Zero;
+}

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
@@ -115,6 +115,8 @@
           32:
             sprite: _Impstation/Mobs/Species/Thaven/displacement.rsi
             state: hands
+  - type: CosmicStarMarkOffset
+    offset: 0, 0.0625 #2 px up. doesn't quite line up because computers can't actually do maths but it's close enough.
 
 
 - type: entity


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Adds a star mark offset comp that can be used to shift the t3 cult star mark around & applies it to thaven as an example implementation.
Also makes the monument TP in .05s earlier on in the relocation animation, sneaking that in here because it's tiny.

![markdemo](https://github.com/user-attachments/assets/c44c9daa-bc21-439e-8129-f18c93599142)
no cl; not player-facing
