### PR TITLE
Fix the monument preview's "pulse" effect

### DIFF
--- a/Content.Client/_Impstation/CosmicCult/Visuals/MonumentPlacementPreviewOverlay.cs
+++ b/Content.Client/_Impstation/CosmicCult/Visuals/MonumentPlacementPreviewOverlay.cs
@@ -116,7 +116,7 @@ public sealed class MonumentPlacementPreviewOverlay : Overlay
         }
 
         //have the outline's alpha slightly "breathe"
-        var outlineAlphaModulate = 0.65f + (0.35f * (float) Math.Sin(_timing.CurTime.TotalSeconds));
+        var outlineAlphaModulate = 0.75f + (0.25f * (float) Math.Sin(_timing.CurTime.TotalSeconds));
 
         //stuff to make the monument preview stick in place once the ability is confirmed
         Color color;
@@ -144,7 +144,7 @@ public sealed class MonumentPlacementPreviewOverlay : Overlay
 
         //some fancy schmancy things for the inside of the monument
         worldHandle.UseShader(_starsShader);
-        worldHandle.DrawTexture(_spriteSystem.Frame0(starTex), _lastPos.Position - new Vector2(1.5f, 0.5f), color.WithAlpha(alpha)); //don't inherit the alpha mult on the inside bit
+        worldHandle.DrawTexture(_spriteSystem.Frame0(starTex), _lastPos.Position - new Vector2(1.5f, 0.5f), color);
         worldHandle.UseShader(null);
     }
 }

--- a/Resources/Textures/_Impstation/Shaders/monument_pulse.swsl
+++ b/Resources/Textures/_Impstation/Shaders/monument_pulse.swsl
@@ -1,20 +1,15 @@
 light_mode unshaded;
 
 uniform highp vec2 tileSize; //this can probably just be TEXTURE_PIXEL_SIZE instead?
-
-const highp float pulseTime = 4;
+const highp float pulseTime = 4.0;
 
 void fragment() {
-    highp vec2 crunched = quantiseVecDown(UV);
-    highp float aMultPulse = sin(TIME);
-    highp vec4 baseCol = vec4(texture(TEXTURE, UV).rgb, texture(TEXTURE, UV).a * (0.6 + (0.4 * aMultPulse)));
-
     highp float pulseProgress = mod(TIME, pulseTime) / pulseTime;
-    highp float distA = pulseProgress - crunched.y;
-    highp float distB = crunched.y - pulseProgress;
+    highp float distA = pulseProgress - UV2.y;
+    highp float distB = UV2.y - pulseProgress;
     highp float distReal = min(abs(distA), 1.0 - abs(distB));
 
-    COLOR = vec4(baseCol.rgb, 1.0 * (distReal * distReal * distReal * distReal));
+    COLOR = vec4(texture(TEXTURE, UV).rgb,  distReal * distReal);
 }
 
 //something might have become fucked with this between copying it over?

--- a/Resources/Textures/_Impstation/Shaders/monument_pulse.swsl
+++ b/Resources/Textures/_Impstation/Shaders/monument_pulse.swsl
@@ -9,7 +9,7 @@ void fragment() {
     highp float distB = UV2.y - pulseProgress;
     highp float distReal = min(abs(distA), 1.0 - abs(distB));
 
-    COLOR = vec4(texture(TEXTURE, UV).rgb,  distReal * distReal);
+    COLOR = vec4(texture(TEXTURE, UV).rgb,  distReal * distReal * distReal);
 }
 
 //something might have become fucked with this between copying it over?


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Incredibly stupid solution to this one, shaders delanda est.

fixed effects for summon & relocate.

https://github.com/user-attachments/assets/218bcf51-6178-4138-8236-8e3c65090c0b

https://github.com/user-attachments/assets/0cc845f2-4092-4d63-a1cd-eef7cc03f9bf

no cl; not player-facing



