### PR TITLE
decapoids breathing water vapor are hydrated

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -460,6 +460,11 @@
         ratios:
           Ammonia: 1.0
           WaterVapor: -1.0
+      - !type:SatiateThirst # decapoids breathing water vapor don't get thirsty
+        conditions:
+        - !type:OrganType
+          type: Decapoid
+        factor: 2
       - !type:Oxygenate # thaven can breathe all gases safely
         conditions:
         - !type:OrganType


### PR DESCRIPTION
this was originally in the thaven biology pr but kip recommended i make it its own thing

i'll inform beck, but also the thing to argue here is whether or not they get thirsty AT ALL when breathing

right now in this pr the SatiateThirst factor is set to 2, which means they'll never need to drink water, but i think that's fine because those dudes have to go to the sink to refill their vaporizer anyway, so in my mind they're already doing the "get water to live" work due to their special lungs

if we want them to also have to drink in addition to this, i can set the factor to 0.1 so that they only get thirsty slower than normal rather than having stable thirst or increasing thirst

i could see the argument either way.  on the one hand they're constantly sucking water vapor.  on the other, they're fully aquatic creatures and may need _more_ hydration than just breathing water vapor provides.  so either way it makes sense - which means it's arguably just a question of balancing game mechanics 

and just for logging purposes, in my testing i found that a factor of 0.2 BARELY decreases thirst, 0.22 BASICALLY stabilizes it, and 0.25 BARELY increases it.  so the threshold for thirst is around there, if anyone ever needs to know that


:cl:
- tweak: Decapoids are now hydrated by breathing water vapor
