### PR TITLE
slime storage is openable by pressing use key on yourself

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -16,7 +16,7 @@
   # they like eat it idk lol
   - type: Storage
     clickInsert: false
-    openOnActivate: false
+    openOnActivate: true # imp - surely it isnt this easy
     grid:
     - 0,0,1,2
     maxItemSize: Large


### PR DESCRIPTION
doesnt open other peoples slime storages b/c the strip menu takes priority. there probably was a reason this was set to false but im having trouble discovering it

**Changelog**

:cl: crocodilecarousel
- tweak: Slimes can use hotkeys to open their slime storage.