### PR TITLE
emergency heretic fix

### DIFF
--- a/Content.Server/_Goobstation/Store/Conditions/HereticPathCondition.cs
+++ b/Content.Server/_Goobstation/Store/Conditions/HereticPathCondition.cs
@@ -24,10 +24,10 @@ public sealed partial class HereticPathCondition : ListingCondition
 
 
 
-        if (!minds.TryGetMind(args.Buyer, out var mindId, out var mind))
+        if (!ent.TryGetComponent<MindComponent>(args.Buyer, out var mind))
             return false;
 
-        if (!ent.TryGetComponent<HereticComponent>(args.Buyer, out var hereticComp))
+        if (!ent.TryGetComponent<HereticComponent>(mind.OwnedEntity, out var hereticComp))
             return false;
 
         //Stage is the level of the knowledge we're looking at


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

we have been saved by a wandering ronin

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Kandiyaki, Axionyx
- fix: heretics should be able to buy knowledge again.