### PR TITLE
BROS no longer take damage from BrosochloricBROS

### DIFF
--- a/Resources/Prototypes/_Impstation/Reagents/fun.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/fun.yml
@@ -30,6 +30,10 @@
           types:
             Poison: 2
             Blunt: 1
+        conditions:
+        - !type:HasTag
+          invert: true
+          tag: BROS
 
 - type: reagent
   id: GroundBros


### PR DESCRIPTION
This is a major buff to BROS foam, because now it no longer kills 95% of the BROS it spawns. NOTE that the BROSnade spawns BROS in a different manner, so this doesn't effect BROSnades.

:cl:
- fix: BROS are no longer poisoned by BROSochloricBROS