### PR TITLE
fix fever dream

### DIFF
--- a/Resources/Locale/en-US/_Impstation/reagents/meta/consumable/drink/drinks.ftl
+++ b/Resources/Locale/en-US/_Impstation/reagents/meta/consumable/drink/drinks.ftl
@@ -11,4 +11,4 @@ reagent-name-orangecoffee = orange coffee
 reagent-desc-orangecoffee = Slide me a drink, Barfriend.
 
 reagent-name-feverdream = fever dream
-reagent-desc-feverdream = A creamy, dizzying cocktail of absinthe and champagne, topped with frothed, exotic blood. Traditionally served with a thaven good luck charm. Open your eyes.
+reagent-desc-feverdream = A creamy, hallucinogenic cocktail of exotic blood, absinthe, and champagne, topped with frothed egg whites. Unpalatable if mixed incorrectly, and traditionally served with a thaven good luck charm. Open your eyes.

--- a/Resources/Locale/en-US/_Impstation/reagents/meta/consumable/drink/drinks.ftl
+++ b/Resources/Locale/en-US/_Impstation/reagents/meta/consumable/drink/drinks.ftl
@@ -11,4 +11,4 @@ reagent-name-orangecoffee = orange coffee
 reagent-desc-orangecoffee = Slide me a drink, Barfriend.
 
 reagent-name-feverdream = fever dream
-reagent-desc-feverdream = A creamy, dizzying cocktail of exotic blood, absinthe, and champagne, topped with frothed egg whites. Traditionally served with a thaven good luck charm. Open your eyes.
+reagent-desc-feverdream = A creamy, dizzying cocktail of absinthe and champagne, topped with frothed, exotic blood. Traditionally served with a thaven good luck charm. Open your eyes.

--- a/Resources/Prototypes/_Impstation/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Reactions/drinks.yml
@@ -426,8 +426,6 @@
     Absinthe:
       amount: 2
     Champagne:
-      amount: 1
-    Egg:
-      amount: 1
+      amount: 2
   products:
     FeverDream: 6

--- a/Resources/Prototypes/_Impstation/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Reactions/drinks.yml
@@ -424,8 +424,10 @@
     ShimmeringBlood:
       amount: 2
     Absinthe:
-      amount: 2
+      amount: 1
     Champagne:
-      amount: 2
+      amount: 1
+    Egg:
+      amount: 1
   products:
     FeverDream: 6


### PR DESCRIPTION
originally when i pr'd this, 5u of a 6u egg would go into a 25u-full glass

now the whole goddamn egg goes in and splashes other reagents on the ground to make room for the last unit of raw egg https://github.com/space-wizards/space-station-14/pull/35459 due to this i think

this leaves you with a drink that has raw egg in it and makes you puke.  and it's C# so i can't change it.  fuuuuuuck

frothed egg drinks are so good irl but having to work around this new change sucks so now new recipe

:cl:
- tweak: Fever Dream recipe changed due to upstream changing eggs
