### PR TITLE
Allow departments and jobs to be implicitly cleared on department and job restricted contraband

### DIFF
--- a/Content.Shared/Contraband/ContrabandComponent.cs
+++ b/Content.Shared/Contraband/ContrabandComponent.cs
@@ -33,4 +33,20 @@ public sealed partial class ContrabandComponent : Component
     [DataField]
     [AutoNetworkedField]
     public HashSet<ProtoId<JobPrototype>> AllowedJobs = new();
+
+    /// <summary>
+    ///     Imp addition. Departments allowed through this will not appear in the examine text.
+    ///     Useful for allowing departments like CentComm to be allowed without it needing to be explicilty stated.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public HashSet<ProtoId<DepartmentPrototype>> ImplicitlyAllowedDepartments = new();
+
+    /// <summary>
+    ///     Imp addition. Jobs allowed through this will not appear in the examine text.
+    ///     Useful for allowing jobs like captain or other heads of staff to be allowed without it needing to be explicilty stated.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public HashSet<ProtoId<JobPrototype>> ImplicitlyAllowedJobs = new();
 }

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -39,6 +39,8 @@ public sealed class ContrabandSystem : EntitySystem
         contraband.Severity = other.Severity;
         contraband.AllowedDepartments = other.AllowedDepartments;
         contraband.AllowedJobs = other.AllowedJobs;
+        contraband.ImplicitlyAllowedDepartments = other.ImplicitlyAllowedDepartments; // imp edit
+        contraband.ImplicitlyAllowedJobs = other.ImplicitlyAllowedJobs; // imp edit
         Dirty(uid, contraband);
     }
 
@@ -84,10 +86,13 @@ public sealed class ContrabandSystem : EntitySystem
             }
         }
 
+        var implicitJobs = component.ImplicitlyAllowedJobs.Select(p => _proto.Index(p).LocalizedName).ToArray(); // imp edit
         String carryingMessage;
         // either its fully restricted, you have no departments, or your departments dont intersect with the restricted departments
         if (departments.Intersect(component.AllowedDepartments).Any()
-            || jobs.Contains(jobId))
+            || departments.Intersect(component.ImplicitlyAllowedDepartments).Any() //imp edit
+            || jobs.Contains(jobId)
+            || implicitJobs.Contains(jobId)) //imp edit
         {
             carryingMessage = Loc.GetString("contraband-examine-text-in-the-clear");
         }

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -57,7 +57,7 @@
     - state: nano_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseCentcommCommandContraband ]
+  parent: [ EncryptionKey, BaseCommandContraband ] #imp edit, cenctomm implicitly allowed through this contraband entity. also all centcomm jobs are already part of command, so like...
   id: EncryptionKeyStationMaster
   name: station master encryption key
   description: An encryption key used by station's bosses.

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -39,6 +39,8 @@
     severity: Restricted
     allowedDepartments: [  ]
     allowedJobs: [  ]
+    implicitlyAllowedDepartments: [ CentralCommand ] #imp edit
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel ] #imp edit
 
 # one department restricted contraband
 - type: entity
@@ -48,6 +50,9 @@
   components:
   - type: Contraband
     allowedDepartments: [ CentralCommand ]
+    implicitlyAllowedDepartments: [ ] #imp edit
+    implicitlyAllowedJobs: [ ] #imp edit
+
 
 - type: entity
   id: BaseCommandContraband
@@ -171,6 +176,7 @@
   - type: Contraband
     allowedDepartments: [ Security ]
     allowedJobs: [ Bartender ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel, HospitalityDirector ] #imp edit
 
 - type: entity
   id: BaseSecurityLawyerContraband
@@ -180,6 +186,7 @@
   - type: Contraband
     allowedDepartments: [ Security ]
     allowedJobs: [ Lawyer ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel, HospitalityDirector ] #imp edit
 
 - type: entity
   id: BaseJanitorContraband
@@ -188,6 +195,7 @@
   components:
   - type: Contraband
     allowedJobs: [ Janitor ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel, HospitalityDirector ] #imp edit
 
 - type: entity
   id: BaseBrigmedicContraband
@@ -196,6 +204,7 @@
   components:
   - type: Contraband
     allowedJobs: [ Brigmedic ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel, HeadOfSecurity ] #imp edit
 
 # for ~objective items
 - type: entity

--- a/Resources/Prototypes/_Impstation/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/base_contraband.yml
@@ -5,6 +5,7 @@
   components:
   - type: Contraband
     allowedJobs: [ Lawyer ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel, HospitalityDirector ]
 
 # For non-sanctioned decapoid tech
 - type: entity
@@ -13,8 +14,6 @@
   components:
   - type: Contraband
     severity: DecapoidEmpire
-    # no dept is authorized to have
-    allowedDepartments: [  ]
 
 # tier 1 contraband: syndicate pajamas, flags, duffels, etc
 - type: entity
@@ -23,8 +22,6 @@
   components:
   - type: Contraband
     severity: Tier1Contraband
-    # no dept is authorized to have
-    allowedDepartments: [  ]
 
 # tier 2 contraband: espionage/sabotage items a la emag, cham projector, cybersun pen, etc
 - type: entity
@@ -33,8 +30,6 @@
   components:
   - type: Contraband
     severity: Tier2Contraband
-    # no dept is authorized to have
-    allowedDepartments: [  ]
 
 # tier 3 contraband: military-level equipment a la blood-red hardsuit, china lake, etc
 - type: entity
@@ -43,8 +38,6 @@
   components:
   - type: Contraband
     severity: Tier3Contraband
-    # no dept is authorized to have
-    allowedDepartments: [  ]
 
 # tier X contraband: paranormal/extraordinary equipment, a la heretic blade, changeling armblade, etc
 - type: entity
@@ -53,5 +46,3 @@
   components:
   - type: Contraband
     severity: TierXContraband
-    # no dept is authorized to have
-    allowedDepartments: [  ]


### PR DESCRIPTION
This PR adds two new data fields to the Contraband component, ImplicitlyAllowedDepartments and ImplicitlyAllowedJobs, allowing the Contraband system to give specified jobs and departments the all clear to use department or job restricted contraband without explicitly stating these jobs or departments in the examine text. This implementation makes it so the Captain, Head of Personnel, and CentComm are all cleared to use all departmental and job restricted contraband, while also allowing specific department heads where appropriate. This PR also cleans up some unnecessary yml in our custom contraband entities. 

![PV25HlT](https://github.com/user-attachments/assets/f404cab7-7b93-4f8e-9aea-157b2ab0c40d)

**Changelog**

:cl:
- add: The Captain, HoP, and other appropriate heads of staff will now be cleared to use departmental or job restricted contraband in that contraband's examine text.