### PR TITLE
boxing is fair for all species

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -16,7 +16,7 @@
     attackRate: 1.5
     damage:
       types:
-        Blunt: 0.4
+        Blunt: 0 #imp, to make boxing fully fair for all species since blunt now does a little stamina damage itself
     soundHit:
       collection: BoxingHit
     animation: WeaponArcFist


### PR DESCRIPTION
removes the 0.4 blunt damage on boxing gloves since blunt damage does stun damage now, so species with blunt resistance or vulnerability aren't better or worse at boxing, which should be skill based

red legend is going to LOSE

:cl:
- tweak: Removes blunt damage from boxing gloves so its fair for all species