### PR TITLE
lathe reorganization

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -131,6 +131,7 @@
     - PowerCellsStatic
     - ElectronicsStatic
     - ImpAutoStatic # Imp
+    - ReportingStatic # DeltaV
     dynamicPacks:
     - ImpAutoDynamic # Imp
   - type: EmagLatheRecipes
@@ -196,6 +197,7 @@
     - ChemistryStatic
     - SurgeryStatic
     - ImpProtoStatic # Imp
+    - ReportingStatic # DeltaV
     dynamicPacks:
     - AdvancedTools
     - ScienceEquipment
@@ -212,6 +214,7 @@
     - Equipment
     - FauxTiles
     - ImpProtoDynamic # Imp
+    - NFService # Frontier
   - type: EmagLatheRecipes
     emagDynamicPacks:
     - SecurityAmmo
@@ -529,6 +532,8 @@
     - Carpets
     - Bedsheets
     - ImpClothesStatic # Imp
+    - BeltsDeltaV # DeltaV
+    - ClothingJustice # DeltaV
   - type: EmagLatheRecipes
     emagStaticPacks:
     - ClothingCentComm

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -137,6 +137,7 @@
   - type: EmagLatheRecipes
     emagStaticPacks:
     - SecurityAmmoStatic
+    - ImpAutoEmagged # imp
   - type: BlueprintReceiver
     whitelist:
       tags:
@@ -274,6 +275,7 @@
     - CameraBoards
     - MechBoards
     - ShuttleBoards
+    - ImpCircuitDynamic # imp
   - type: EmagLatheRecipes
     emagDynamicPacks:
     - SecurityBoards
@@ -405,7 +407,6 @@
     - SecurityPracticeStatic
     - SecurityAmmoStatic
     - SecurityWeaponsStatic
-    - ImpSecStatic # Imp
     dynamicPacks:
     - SecurityEquipment
     - SecurityBoards
@@ -413,7 +414,6 @@
     - SecurityAmmo
     - SecurityWeapons
     - SecurityDisablers
-    - ImpSecDynamic # Imp
   - type: MaterialStorage
     whitelist:
       tags:
@@ -449,7 +449,6 @@
       unlitRunningState: unlit-building
       staticPacks:
       - SecurityAmmoStatic
-      - ImpAmmoStatic # Imp
     - type: MaterialStorage
       whitelist:
         tags:
@@ -531,7 +530,7 @@
     - Scarves
     - Carpets
     - Bedsheets
-    - ImpClothesStatic # Imp
+    - PrideFlags # imp
     - BeltsDeltaV # DeltaV
     - ClothingJustice # DeltaV
   - type: EmagLatheRecipes

--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -10,6 +10,7 @@
 - type: latheRecipePack
   parent:
   - ClothingCargoDeltaV # DeltaV
+  - ClothingCargoImp # imp
   id: ClothingCargo
   recipes:
   - ClothingUniformJumpsuitCargo
@@ -27,6 +28,7 @@
   id: ClothingCommand
   parent:
   - ClothingCommandDeltaV # DeltaV
+  - ClothingCommandImp # imp
   recipes:
   # Captain
   - ClothingHeadHatCapcap
@@ -122,6 +124,7 @@
   - ClothingUniformJumpskirtWarden
 
 - type: latheRecipePack
+  parent: ClothingServiceImp # imp
   id: ClothingService
   recipes:
   - ClothingUniformJumpsuitBartender
@@ -145,6 +148,7 @@
 - type: latheRecipePack
   parent:
   - WinterCoatsDeltaV # DeltaV
+  - WinterCoatsImp # imp
   id: WinterCoats
   recipes:
   - ClothingOuterWinterCap

--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -8,6 +8,8 @@
   - ClothingUniformJumpsuitLoungewear
 
 - type: latheRecipePack
+  parent:
+  - ClothingCargoDeltaV # DeltaV
   id: ClothingCargo
   recipes:
   - ClothingUniformJumpsuitCargo
@@ -23,6 +25,8 @@
 
 - type: latheRecipePack
   id: ClothingCommand
+  parent:
+  - ClothingCommandDeltaV # DeltaV
   recipes:
   # Captain
   - ClothingHeadHatCapcap
@@ -50,6 +54,8 @@
   - ClothingUniformJumpskirtSeniorEngineer
 
 - type: latheRecipePack
+  parent:
+  - ClothingMedicalDeltaV # DeltaV
   id: ClothingMedical
   recipes:
   - ClothingUniformJumpsuitChemistry
@@ -69,6 +75,8 @@
   - ClothingHeadHatParamedicsoft
 
 - type: latheRecipePack
+  parent:
+  - ClothingEpistemics # DeltaV
   id: ClothingScience
   recipes:
   - ClothingHeadHatBeretRND
@@ -80,6 +88,8 @@
   - ClothingUniformJumpskirtSeniorResearcher
 
 - type: latheRecipePack
+  parent:
+  - ClothingSecurityDeltaV # DeltaV
   id: ClothingSecurity
   recipes:
   - ClothingUniformJumpsuitDetective
@@ -133,6 +143,8 @@
   - ClothingUniformJumpsuitMusician
 
 - type: latheRecipePack
+  parent:
+  - WinterCoatsDeltaV # DeltaV
   id: WinterCoats
   recipes:
   - ClothingOuterWinterCap
@@ -208,6 +220,8 @@
   - ClothingUniformJumpsuitCentcomOfficial
 
 - type: latheRecipePack
+  parent:
+  - ClothingSyndieDeltaV # DeltaV
   id: ClothingSyndie
   recipes:
   - ClothingHeadHatSyndieMAA

--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -9,6 +9,7 @@
   - CyborgEndoskeleton
 
 - type: latheRecipePack
+  parent: BorgModulesStaticImp # imp
   id: BorgModulesStatic
   recipes:
   - BorgModuleCable
@@ -34,6 +35,7 @@
   - ProximitySensor
 
 - type: latheRecipePack
+  parent: BorgModulesImp # imp
   id: BorgModules
   recipes:
   - BorgModuleAdvancedCleaning
@@ -45,7 +47,6 @@
   - BorgModuleHarvesting
   - BorgModuleDefibrillator
   - BorgModuleAdvancedTreatment
-  - BorgModuleMining #imp
 
 - type: latheRecipePack
   id: MechParts

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -68,6 +68,7 @@
 
 # Only contains parts for making basic modular grenades, no actual explosives
 - type: latheRecipePack
+  parent: ScienceExplosivesImp # imp
   id: ScienceExplosives
   recipes:
   - ChemicalPayload

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -15,6 +15,7 @@
 
 # Practice ammo/mags and practice weapons
 - type: latheRecipePack
+  parent: SecurityPracticeStaticImp # imp
   id: SecurityPracticeStatic
   recipes:
   - BoxShotgunPractice
@@ -28,6 +29,7 @@
 
 # Shared between secfab and emagged autolathe
 - type: latheRecipePack
+  parent: SecurityAmmoStaticImp # imp
   id: SecurityAmmoStatic
   recipes:
   - BoxLethalshot
@@ -63,6 +65,7 @@
 ## Dynamic recipes
 
 - type: latheRecipePack
+  parent: SecurityEquipmentImp # imp
   id: SecurityEquipment
   recipes:
   - ClothingBackpackElectropack
@@ -94,6 +97,7 @@
 
 # Shared between secfab and emagged protolathe
 - type: latheRecipePack
+  parent: SecurityAmmoImp # imp
   id: SecurityAmmo
   recipes:
   - BoxBeanbag
@@ -122,6 +126,7 @@
   - SpeedLoaderMagnumUranium
 
 - type: latheRecipePack
+  parent: SecurityWeaponsImp # imp
   id: SecurityWeapons
   recipes:
   - Truncheon
@@ -131,6 +136,7 @@
   - WeaponXrayCannon
 
 - type: latheRecipePack
+  parent: SecurityDisablersImp # imp
   id: SecurityDisablers
   recipes:
   - WeaponDisabler

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -1,6 +1,8 @@
 ## Static recipes
 
 - type: latheRecipePack
+  parent:
+  - SecurityEquipmentStaticDeltaV # DeltaV
   id: SecurityEquipmentStatic
   recipes:
   - ClothingEyesHudSecurity

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -1,6 +1,7 @@
 ## Static
 
 - type: latheRecipePack
+  parent: ImpServiceStatic # imp
   id: ServiceStatic
   recipes:
   - Bucket

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -16,6 +16,7 @@
   - ConveyorBeltAssembly
 
 - type: latheRecipePack
+  parent: ImpLightPack # imp
   id: LightsStatic
   recipes:
   - LightTube

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -44,6 +44,8 @@
 
 # Things you'd expect sci salv and engi to make use of
 - type: latheRecipePack
+  parent:
+  - EquipmentDeltaV # DeltaV
   id: Equipment
   recipes:
   - HandHeldMassScanner

--- a/Resources/Prototypes/Recipes/Lathes/Packs/tiles.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/tiles.yml
@@ -1,6 +1,9 @@
 ## Static
 
 - type: latheRecipePack
+  parent:
+  - FloorTilesStaticImp # imp
+  - FloorTilesStaticCorvax # also imp lol
   id: FloorTilesStatic
   recipes:
   - FloorTileItemDark

--- a/Resources/Prototypes/_Corvax/Recipes/Lathes/Packs/tiles.yml
+++ b/Resources/Prototypes/_Corvax/Recipes/Lathes/Packs/tiles.yml
@@ -1,0 +1,23 @@
+﻿# Static
+
+- type: latheRecipePack
+  id: FloorTilesStaticCorvax
+  recipes:
+  - FloorTileItemWoodParquet
+  - FloorTileItemWoodBlack
+  - FloorTileItemWoodDark
+  - FloorTileItemWoodLight
+  - FloorTileItemWoodRed
+  - FloorTileItemWoodLargeBlack
+  - FloorTileItemWoodLargeDark
+  - FloorTileItemWoodLargeLight
+  - FloorTileItemWoodLargeRed
+  - FloorTileItemWoodParquetBlack
+  - FloorTileItemWoodParquetDark
+  - FloorTileItemWoodParquetLight
+  - FloorTileItemWoodParquetRed
+  - FloorTileItemWoodChess
+  - FloorTileItemWoodChessBlack
+  - FloorTileItemWoodChessDark
+  - FloorTileItemWoodChessLight
+  - FloorTileItemWoodChessRed

--- a/Resources/Prototypes/_Corvax/Recipes/Lathes/tiles.yml
+++ b/Resources/Prototypes/_Corvax/Recipes/Lathes/tiles.yml
@@ -1,0 +1,89 @@
+﻿- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodParquet
+  result: FloorTileItemWoodParquet
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodBlack
+  result: FloorTileItemWoodBlack
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodDark
+  result: FloorTileItemWoodDark
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodLight
+  result: FloorTileItemWoodLight
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodRed
+  result: FloorTileItemWoodRed
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodLargeBlack
+  result: FloorTileItemWoodLargeBlack
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodLargeDark
+  result: FloorTileItemWoodLargeDark
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodChess
+  result: FloorTileItemWoodChess
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodParquetBlack
+  result: FloorTileItemWoodParquetBlack
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodChessBlack
+  result: FloorTileItemWoodChessBlack
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodParquetDark
+  result: FloorTileItemWoodParquetDark
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodChessDark
+  result: FloorTileItemWoodChessDark
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodLargeLight
+  result: FloorTileItemWoodLargeLight
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodParquetLight
+  result: FloorTileItemWoodParquetLight
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodChessLight
+  result: FloorTileItemWoodChessLight
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodLargeRed
+  result: FloorTileItemWoodLargeRed
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodParquetRed
+  result: FloorTileItemWoodParquetRed
+
+- type: latheRecipe
+  parent: BaseWoodTileRecipe
+  id: FloorTileItemWoodChessRed
+  result: FloorTileItemWoodChessRed

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/clothing.yml
@@ -1,0 +1,82 @@
+﻿## Static
+
+- type: latheRecipePack
+  id: ClothingCargoDeltaV
+  recipes:
+  # Salvage
+  - ClothingUniformJumpskirtSalvageSpecialistDV
+  - ClothingUniformJumpsuitSalvageSpecialistDV
+
+- type: latheRecipePack
+  id: ClothingCommandDeltaV
+  recipes:
+  # Administrative Assistant
+  - ClothingUniformJumpsuitAdminAssistant
+  - ClothingUniformJumpskirtAdminAssistant
+
+- type: latheRecipePack
+  id: ClothingEpistemics
+  recipes:
+  # Mystagogue
+  - ClothingHeadHoodMysta
+  # Scientist
+  - ClothingUniformJumpsuitScientistFormal
+  - ClothingUniformJumpskirtScientistFormal
+
+- type: latheRecipePack
+  id: ClothingMedicalDeltaV
+  recipes:
+  # Chemist
+  - ClothingUniformJumpsuitChemShirt
+
+- type: latheRecipePack
+  id: ClothingJustice
+  recipes:
+  # CJ
+  - ClothingUniformJumpsuitChiefJusticeFormal
+  - ClothingUniformJumpskirtCJFormal
+  - ClothingUniformJumpsuitChiefJusticeWhite
+  # Clerk
+  - ClothingUniformJumpsuitClerk
+  - ClothingUniformJumpskirtClerk
+  - ClothingOuterClerkVest
+  # Prosecutor
+  - ClothingUniformJumpsuitProsecutor
+  - ClothingUniformJumpskirtProsecutor
+
+- type: latheRecipePack
+  id: ClothingSecurityDeltaV
+  recipes:
+  # HoS
+  - ClothingUniformJumpskirtHoSGrey
+  # Security Officer
+  - ClothingUniformJumpsuitSecBlue
+  - ClothingUniformJumpsuitSecGrey
+  - ClothingUniformJumpskirtSecGrey
+
+- type: latheRecipePack
+  id: WinterCoatsDeltaV
+  recipes:
+  # Coats
+  - ClothingOuterStasecSweater
+  # Ponchos
+  - ClothingNeckCWPSec
+  - ClothingNeckCWPArctic
+
+- type: latheRecipePack
+  id: BeltsDeltaV
+  recipes:
+  - ClothingBeltPaperwork
+
+- type: latheRecipePack
+  id: ClothingSyndieDeltaV
+  recipes:
+  - UniformScrubsColorCybersun
+  - ClothingUniformCybersunAttorney
+  - ClothingHeadHatSurgcapCybersun
+  - ClothingOuterCoatCybersunWindbreaker
+  - ClothingMaskInterdyneChemistry
+  - ClothingUniformCybersunHazard
+  - ClothingUniformCybersunCasual
+  - ClothingUniformCybersunRND
+  - ClothingOuterCybersunOvercoat

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/clothing.yml
@@ -21,7 +21,6 @@
   - ClothingHeadHoodMysta
   # Scientist
   - ClothingUniformJumpsuitScientistFormal
-  - ClothingUniformJumpskirtScientistFormal
 
 - type: latheRecipePack
   id: ClothingMedicalDeltaV

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
@@ -1,0 +1,7 @@
+﻿## Static
+
+- type: latheRecipePack
+  id: SecurityEquipmentStaticDeltaV
+  recipes:
+  - ClothingOuterArmorPlateCarrier # plate carrier body armour
+  - ClothingOuterArmorDuraVest # stabproof vest body armour

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/service.yml
@@ -1,0 +1,7 @@
+﻿## Static
+
+- type: latheRecipePack
+  id: ReportingStatic
+  recipes:
+  - CassetteTape
+  - TapeRecorder

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
@@ -1,0 +1,6 @@
+﻿## Dynamic
+
+- type: latheRecipePack
+  id: EquipmentDeltaV
+  recipes:
+  - SignallerDeadMans

--- a/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
@@ -184,11 +184,6 @@
   id: ClothingUniformJumpsuitScientistFormal
   result: ClothingUniformJumpsuitScientistFormal
 
-- type: latheRecipe
-  parent: BaseJumpsuitRecipe
-  id: ClothingUniformJumpskirtScientistFormal
-  result: ClothingUniformJumpskirtScientistFormal
-
 # Utility
 
 - type: latheRecipe

--- a/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
@@ -1,4 +1,28 @@
-﻿# Security Sweater
+﻿# Jumpsuits - Security
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitSecBlue
+  result: ClothingUniformJumpsuitSecBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitSecGrey
+  result: ClothingUniformJumpsuitSecGrey
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtHoSGrey
+  result: ClothingUniformJumpskirtHoSGrey
+
+# Jumpskirts - Security
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtSecGrey
+  result: ClothingUniformJumpskirtSecGrey
+
+# Security Sweater
 - type: latheRecipe
   parent: BaseCoatRecipe
   id: ClothingOuterStasecSweater
@@ -67,6 +91,7 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpskirtProsecutor
   result: ClothingUniformJumpskirtProsecutor
+
 # Salvage Specialist
 - type: latheRecipe
   parent: BaseJumpsuitRecipe
@@ -77,6 +102,18 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpsuitSalvageSpecialistDV
   result: ClothingUniformJumpsuitSalvageSpecialistDV
+
+# Administrative Assistant
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpsuitAdminAssistant
+  result: ClothingUniformJumpsuitAdminAssistant
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpskirtAdminAssistant
+  result: ClothingUniformJumpskirtAdminAssistant
 
 # Command Hats
 
@@ -129,6 +166,28 @@
   parent: BaseHatRecipe
   id: ClothingHeadHatSurgcapCybersun
   result: ClothingHeadHatSurgcapCybersun
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingMaskInterdyneChemistry
+  result: ClothingMaskInterdyneChemistry
+
+# Formal Outfits
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitChemShirt
+  result: ClothingUniformJumpsuitChemShirt
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitScientistFormal
+  result: ClothingUniformJumpsuitScientistFormal
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtScientistFormal
+  result: ClothingUniformJumpskirtScientistFormal
 
 # Utility
 

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -25,11 +25,13 @@
     unlitIdleState: unlit
     unlitRunningState: unlit-building
     staticPacks:
-      - LightPack
+      - LightsStatic
+      - ServiceStatic
       - CleanPack
       - BotanyPack
       - BarPack
       - KitchenPack
+      - BasicChemistryStatic
       - ServiceMiscPack
       - RecordingStatic # DeltaV
     dynamicPacks:

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -31,10 +31,12 @@
       - BarPack
       - KitchenPack
       - ServiceMiscPack
+      - RecordingStatic # DeltaV
     dynamicPacks:
       - CleanPackDynamic
       - ServiceMiscPackDynamic
-      - TilePackDynamic
+      - FauxTiles
+      - NFService # Frontier
   - type: EmagLatheRecipes
     emagStaticPacks:
       - ServiceEmagged

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -33,7 +33,7 @@
       - KitchenPack
       - BasicChemistryStatic
       - ServiceMiscPack
-      - RecordingStatic # DeltaV
+      - ReportingStatic # DeltaV
     dynamicPacks:
       - CleanPackDynamic
       - ServiceMiscPackDynamic

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
@@ -4,8 +4,6 @@
   id: ImpAutoStatic
   recipes:
   - Flare
-  - DeskBell
-  - UvLightTube
 
 # Dynamic
 
@@ -16,6 +14,8 @@
 
 # Emagged
 
-# - type: latheRecipePack - for the future
-#   id: ImpProtoEmagged
-#   recipes:
+- type: latheRecipePack
+  id: ImpAutoEmagged
+  recipes:
+  - CombatKnife
+  - RiotShield

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
@@ -6,8 +6,6 @@
   - Flare
   - DeskBell
   - UvLightTube
-  - TapeRecorder # DV
-  - CassetteTape # DV
 
 # Dynamic
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/circuitimprinter.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/circuitimprinter.yml
@@ -4,15 +4,22 @@
   id: ImpCircuitStatic
   recipes:
   - ServiceTechFabCircuitboard
+  - ShipyardComputerCircuitboard # dv doesnt have this craftable but we did so whatever
   - SupermatterComputerCircuitboard
   - ImpCoffeeMachineCircuitboard
-  - MiniGyroscopeMachineCircuitboard
 
 # Dynamic
 
-# - type: latheRecipePack
-#   id: ImpCircuitDynamic
-#   recipes:
+- type: latheRecipePack
+  id: ImpCircuitDynamic
+  recipes:
+  - MiniGyroscopeMachineCircuitboard
+  # below were removed from upstream circuit imprinter. i dont actually think theyre accessible... cloning when...
+  - CloningConsoleComputerCircuitboard
+  - CloningPodMachineCircuitboard
+  - DiagnoserMachineCircuitboard
+  - MedicalScannerMachineCircuitboard
+  - VaccinatorMachineCircuitboard
 
 # Emagged
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/clothing.yml
@@ -3,26 +3,11 @@
 - type: latheRecipePack
   id: ImpClothesStatic
   recipes:
-  - ClothingBeltPaperwork # DeltaV
   - ClothingHeadHatBeretCaptain
   - ClothingHeadHatCouriersoft
-  - ClothingHeadHoodMysta # DeltaV
-  - ClothingOuterClerkVest # DeltaV
-  - ClothingUniformJumpskirtCJFormal # DeltaV
   - ClothingUniformJumpskirtCourier
   - ClothingUniformJumpskirtSalvageSpecialist
-  - ClothingUniformJumpskirtSalvageSpecialistDV # DeltaV
-  - ClothingUniformJumpsuitChiefJusticeFormal # DeltaV
-  - ClothingUniformJumpsuitChiefJusticeWhite # DeltaV
-  - ClothingUniformJumpsuitClerk # DeltaV
   - ClothingUniformJumpsuitCourier
-  - ClothingUniformJumpsuitProsecutor # DeltaV
-  - ClothingUniformJumpsuitSalvageSpecialistDV # DeltaV
-
-  # Winter outfits
-  - ClothingNeckCWPArctic # DeltaV
-  - ClothingNeckCWPSec # DeltaV
-  - ClothingOuterStasecSweater # DeltaV
   - ClothingOuterWinterCourier
 
 # Dynamic
@@ -36,12 +21,4 @@
 - type: latheRecipePack
   id: ImpClothesEmagged
   recipes:
-  - ClothingHeadHatSurgcapCybersun # DeltaV
   - ClothingNeckCloakStraight
-  - ClothingOuterCybersunOvercoat # DeltaV
-  - ClothingOuterCoatCybersunWindbreaker # DeltaV
-  - ClothingUniformCybersunAttorney # DeltaV
-  - ClothingUniformCybersunCasual # DeltaV
-  - ClothingUniformCybersunHazard # DeltaV
-  - ClothingUniformCybersunRND # DeltaV
-  - UniformScrubsColorCybersun # DeltaV

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/clothing.yml
@@ -1,14 +1,53 @@
 # Static
 
 - type: latheRecipePack
-  id: ImpClothesStatic
+  id: ClothingCargoImp
   recipes:
-  - ClothingHeadHatBeretCaptain
   - ClothingHeadHatCouriersoft
   - ClothingUniformJumpskirtCourier
   - ClothingUniformJumpskirtSalvageSpecialist
   - ClothingUniformJumpsuitCourier
+
+- type: latheRecipePack
+  id: ClothingCommandImp
+  recipes:
+  - ClothingHeadHatBeretCaptain
+
+- type: latheRecipePAck
+  id: ClothingServiceImp
+  recipes:
+  - ClothingUniformJumpsuitHD
+  - ClothingUniformJumpskirtHD
+  - ClothingUniformJumpsuitHDTurtle
+  - ClothingUniformJumpskirtHDTurtle
+  - ClothingUniformJumpsuitHospitalityDirectorJanitor
+  - ClothingUniformJumpskirtHospitalityDirectorJanitor
+  - ClothingUniformJumpsuitHospitalityDirectorBartender
+  - ClothingUniformJumpskirtHospitalityDirectorBartender
+  - ClothingUniformJumpsuitHospitalityDirectorBotany
+  - ClothingHeadHatHDsoft
+  - ClothingHeadBandHD
+  - ClothingHeadHatBeretHD
+
+- type: latheRecipePack
+  id: WinterCoatsImp
+  recipes:
+  - ClothingOuterWinterBrigmedic
   - ClothingOuterWinterCourier
+
+- type: latheRecipePack
+  id: PrideFlags
+  recipes:
+  - ClothingNeckCloakAce
+  - ClothingNeckCloakAro
+  - ClothingNeckCloakBear
+  - ClothingNeckCloakBi
+  - ClothingNeckCloakEnby
+  - ClothingNeckCloakGay
+  - ClothingNeckCloakIntersex
+  - ClothingNeckCloakLesbian
+  - ClothingNeckCloakPan
+  - ClothingNeckCloakTrans
 
 # Dynamic
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/clothing.yml
@@ -13,7 +13,7 @@
   recipes:
   - ClothingHeadHatBeretCaptain
 
-- type: latheRecipePAck
+- type: latheRecipePack
   id: ClothingServiceImp
   recipes:
   - ClothingUniformJumpsuitHD

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
@@ -7,6 +7,7 @@
   - PrescriptionLens
   - PrescriptionLensStrong
   - BlindingLens
+  - Dropper
 
 # Dynamic
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
@@ -4,10 +4,6 @@
   id: ImpProtoStatic
   recipes:
   - SGDRecipe
-  - DeskBell
-  - UvLightTube
-  - TapeRecorder # DV
-  - CassetteTape # DV
 
 # Dynamic
 
@@ -19,7 +15,6 @@
   - CleanerGrenade
   - PlantAnalyzer #NF
   - FishingRod
-  - SignallerDeadMans # DeltaV
 
 # Emagged
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
@@ -4,6 +4,9 @@
   id: ImpProtoStatic
   recipes:
   - SGDRecipe
+  - Dropper
+  - Igniter
+  - Implanter
 
 # Dynamic
 
@@ -13,7 +16,6 @@
   - BaseChemistryEmptyVial
   - Drone
   - CleanerGrenade
-  - PlantAnalyzer #NF
   - FishingRod
 
 # Emagged

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/robotics.yml
@@ -1,0 +1,13 @@
+﻿# Static
+
+- type: latheRecipePack
+  id: BorgModulesStaticImp
+  recipes:
+  - BorgModuleArtistic
+
+# Dynamic
+
+- type: latheRecipePack
+  id: BorgModulesImp
+  recipes:
+  - BorgModuleMining

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/science.yml
@@ -1,0 +1,4 @@
+﻿- type: latheRecipePack
+  id: ScienceExplosivesImp
+  recipes:
+  - Signaller # idk why this shit got removed everywhere

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/security.yml
@@ -3,8 +3,6 @@
 - type: latheRecipePack
   id: ImpSecStatic
   recipes:
-  - ClothingOuterArmorDuraVest # DeltaV - stabproof vest body armour
-  - ClothingOuterArmorPlateCarrier # DeltaV - plate carrier body armour
   - MagazineBoxLPistol
   - MagazineBoxLPistolPractice
   - MagazineDMR

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/security.yml
@@ -1,48 +1,45 @@
 # Static
 
 - type: latheRecipePack
-  id: ImpSecStatic
+  id: SecurityPracticeStaticImp
   recipes:
-  - MagazineBoxLPistol
   - MagazineBoxLPistolPractice
-  - MagazineDMR
-  - MagazineDMREmpty
-  - MagazineLPistol
-  - MagazineLPistolEmpty
   - MagazineLPistolPractice
 
 - type: latheRecipePack
-  id: ImpAmmoStatic
+  id: SecurityAmmoStaticImp
   recipes:
   - MagazineBoxLPistol
   - MagazineDMR
   - MagazineDMREmpty
   - MagazineLPistol
   - MagazineLPistolEmpty
-  - MagazinePistolSubMachineGun
-  - MagazinePistolSubMachineGunEmpty
-  - MagazinePistolSubMachineGunTopMounted
-  - MagazinePistolSubMachineGunTopMountedEmpty
 
 # Dynamic
 
 - type: latheRecipePack
-  id: ImpSecDynamic
+  id: SecurityEquipmentImp
   recipes:
-  - FullAutoConversionKit
-  - HyperBurstConversionKit
+  - PRIbarPlusConversionKit
+
+- type: latheRecipePack
+  id: SecurityAmmoImp
+  recipes:
   - MagazineBoxLPistolIncendiary
   - MagazineBoxLPistolUranium
   - MagazineDMRIncendiary
   - MagazineDMRUranium
   - MagazineLPistolIncendiary
   - MagazineLPistolUranium
-  - PRIbarPlusConversionKit
+
+- type: latheRecipePack
+  id: SecurityWeaponsImp
+  recipes:
+  - FullAutoConversionKit
+  - HyperBurstConversionKit
+
+- type: latheRecipePack
+  id: SecurityDisablersImp
+  recipes:
   - WeaponShotgunEnforcerBeanbag
   - WeaponShotgunKammererBeanbag
-
-# Emagged
-
-# - type: latheRecipePack
-#   id: ImpSecEmagged
-#   recipes:

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
@@ -90,8 +90,6 @@
     - ClothingHeadHatCone
     - SprayPainter
     - HandLabeler
-    - TapeRecorder
-    - CassetteTape
 
 # Dynamic
 
@@ -102,22 +100,13 @@
     - AdvMopItem
     - WeaponSprayNozzle
     - ClothingBackpackWaterTank
-    - CleanerGrenade #imp recipe
+    - CleanerGrenade
 
 - type: latheRecipePack
   id: ServiceMiscPackDynamic
   recipes:
     - PlantAnalyzer #NF recipe
     - FishingRod #imp recipe
-
-- type: latheRecipePack
-  id: TilePackDynamic
-  recipes:
-    - FauxTileAstroGrass
-    - FauxTileMowedAstroGrass
-    - FauxTileJungleAstroGrass
-    - FauxTileAstroIce
-    - FauxTileAstroSnow
 
 # Emagged
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
@@ -1,31 +1,23 @@
 # Static
 
 - type: latheRecipePack
-  id: LightPack
+  id: ImpLightPack
   recipes:
-    - FlashlightLantern
-    - LightReplacer
-    - LightTube
-    - LedLightTube
-    - SodiumLightTube
-    - ExteriorLightTube
     - UvLightTube
-    - LightBulb
-    - LedLightBulb
-    - DimLightBulb
+    - DeskBell
+    - LightReplacer
+
+- type: latheRecipePack
+  id: ImpServiceStatic
+  recipes:
+    - Mousetrap
+    - TrashBag
 
 - type: latheRecipePack
   id: CleanPack
   recipes:
-    - Bucket
-    - SprayBottle
     - Plunger
-    - MopItem
     - MopBucket
-    - Holoprojector
-    - TrashBag
-    - Mousetrap
-    - WetFloorSign
     - SoapNT #imp recipe
 
 - type: latheRecipePack
@@ -43,12 +35,6 @@
 - type: latheRecipePack
   id: BarPack
   recipes:
-    - DrinkMug
-    - DrinkMugMetal
-    - DrinkGlass
-    - DrinkShotGlass
-    - DrinkGlassCoupeShaped
-    - CustomDrinkJug
     - DrinkShaker #imp recipe
     - DrinkJigger #imp recipe
     - DrinkFlaskBar #imp recipe
@@ -64,14 +50,6 @@
   id: KitchenPack
   recipes:
     - KitchenKnife
-    - FoodPlate
-    - FoodPlateSmall
-    - FoodPlatePlastic
-    - FoodPlateSmallPlastic
-    - FoodBowlBig
-    - FoodPlateTin
-    - FoodPlateMuffinTin
-    - FoodKebabSkewer
     - RollingPin #imp recipe
     - Fork #imp recipe
     - Spoon #imp recipe
@@ -82,14 +60,10 @@
 - type: latheRecipePack
   id: ServiceMiscPack
   recipes:
-    - Beaker
-    - LargeBeaker
     - Dropper
-    - Syringe
-    - DeskBell
     - ClothingHeadHatCone
     - SprayPainter
-    - HandLabeler
+    - FlashlightLantern
 
 # Dynamic
 
@@ -105,7 +79,6 @@
 - type: latheRecipePack
   id: ServiceMiscPackDynamic
   recipes:
-    - PlantAnalyzer #NF recipe
     - FishingRod #imp recipe
 
 # Emagged

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
@@ -4,7 +4,6 @@
   id: ImpLightPack
   recipes:
     - UvLightTube
-    - DeskBell
     - LightReplacer
 
 - type: latheRecipePack
@@ -12,13 +11,14 @@
   recipes:
     - Mousetrap
     - TrashBag
+    - DeskBell
 
 - type: latheRecipePack
   id: CleanPack
   recipes:
     - Plunger
     - MopBucket
-    - SoapNT #imp recipe
+    - SoapNT
 
 - type: latheRecipePack
   id: BotanyPack
@@ -30,32 +30,32 @@
     - HydroponicsToolSpade
     - HydroponicsToolClippers
     - Shovel
-    - PlantBag #imp recipe
+    - PlantBag
 
 - type: latheRecipePack
   id: BarPack
   recipes:
-    - DrinkShaker #imp recipe
-    - DrinkJigger #imp recipe
-    - DrinkFlaskBar #imp recipe
-    - DrinkVacuumFlask #imp recipe
-    - DrinkTeapotEmpty # imp recipe
-    - DrinkTeacupEmpty #imp recipe
-    - DrinkWaterBottleEmpty #imp recipe
-    - Pitcher #imp recipe
-    - BarSpoon #imp recipe
-    - DrinkDisposableCup #imp recipe
+    - DrinkShaker
+    - DrinkJigger
+    - DrinkFlaskBar
+    - DrinkVacuumFlask
+    - DrinkTeapotEmpty
+    - DrinkTeacupEmpty
+    - DrinkWaterBottleEmpty
+    - Pitcher
+    - BarSpoon
+    - DrinkDisposableCup
 
 - type: latheRecipePack
   id: KitchenPack
   recipes:
     - KitchenKnife
-    - RollingPin #imp recipe
-    - Fork #imp recipe
-    - Spoon #imp recipe
-    - ForkPlastic #imp recipe
-    - SpoonPlastic #imp recipe
-    - PairedChopsticks #imp recipe
+    - RollingPin
+    - Fork
+    - Spoon
+    - ForkPlastic
+    - SpoonPlastic
+    - PairedChopsticks
 
 - type: latheRecipePack
   id: ServiceMiscPack
@@ -79,7 +79,7 @@
 - type: latheRecipePack
   id: ServiceMiscPackDynamic
   recipes:
-    - FishingRod #imp recipe
+    - FishingRod
 
 # Emagged
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/tiles.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/tiles.yml
@@ -1,0 +1,6 @@
+﻿# Static
+
+- type: latheRecipePack
+  id: FloorTilesStaticImp
+  recipes:
+  - FloorTileItemTechmaintDark

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/clothing.yml
@@ -7,6 +7,7 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpskirtSalvageSpecialist
   result: ClothingUniformJumpskirtSalvageSpecialist
+
 # Courier
 - type: latheRecipe
   parent: BaseHatRecipe
@@ -27,3 +28,65 @@
   parent: BaseCoatRecipe
   id: ClothingOuterWinterCourier
   result: ClothingOuterWinterCourier
+
+# Hospitality Director
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpsuitHD
+  result: ClothingUniformJumpsuitHD
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpskirtHD
+  result: ClothingUniformJumpskirtHD
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpsuitHDTurtle
+  result: ClothingUniformJumpsuitHDTurtle
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpskirtHDTurtle
+  result: ClothingUniformJumpskirtHDTurtle
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpsuitHospitalityDirectorJanitor
+  result: ClothingUniformJumpsuitHospitalityDirectorJanitor
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpskirtHospitalityDirectorJanitor
+  result: ClothingUniformJumpskirtHospitalityDirectorJanitor
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpsuitHospitalityDirectorBartender
+  result: ClothingUniformJumpsuitHospitalityDirectorBartender
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpskirtHospitalityDirectorBartender
+  result: ClothingUniformJumpskirtHospitalityDirectorBartender
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpsuitHospitalityDirectorBotany
+  result: ClothingUniformJumpsuitHospitalityDirectorBotany
+
+- type: latheRecipe
+  parent: BaseCommandHatRecipe
+  id: ClothingHeadHatHDsoft
+  result: ClothingHeadHatHDsoft
+
+- type: latheRecipe
+  parent: BaseCommandHatRecipe
+  id: ClothingHeadBandHD
+  result: ClothingHeadBandHD
+
+- type: latheRecipe
+  parent: BaseCommandHatRecipe
+  id: ClothingHeadHatBeretHD
+  result: ClothingHeadHatBeretHD

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/service.yml
@@ -1,0 +1,4 @@
+﻿- type: latheRecipePack
+  id: NFService
+  recipes:
+  - PlantAnalyzer

--- a/Resources/Prototypes/_NF/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/misc.yml
@@ -1,12 +1,4 @@
 - type: latheRecipe
-  id: ClothingShoesBootsMagAdv
-  result: ClothingShoesBootsMagAdv 
-  completetime: 12
-  materials:
-    Silver: 1000
-    Gold: 500
-
-- type: latheRecipe
   id: MailCapsule
   result: MailCapsulePrimed
   completetime: 1


### PR DESCRIPTION
almost entirely back end stuff. cleaning up the lathe packs: splitting out DV and NF recipes into their own packs, splitting up our recipe packs to better integrate into upstream ones. the wood tiles from corvax are now in the tile cutter and all the hospitality director outfits are in the uniform printer. pride flags are back in the uniform printer. i did some big reorganizing to the service techfab in general. also there was an existing but unused lathe recipe for the fucking CE magboots? i removed that lol

**Changelog**
:cl:
- add: Pride flag cloaks are back in the uniform printer! As are the Hospitality Director's outfits.
- add: All the new wood tiles can be printed from a tile cutter.