### PR TITLE
Optimise CosmicCorruptingSystem

### DIFF
--- a/Content.Server/_Impstation/CosmicCult/Components/CosmicCorruptingComponent.cs
+++ b/Content.Server/_Impstation/CosmicCult/Components/CosmicCorruptingComponent.cs
@@ -14,6 +14,12 @@ public sealed partial class CosmicCorruptingComponent : Component
     [AutoPausedField] public TimeSpan CorruptionTimer = default!;
 
     /// <summary>
+    /// the list of tiles that can be corrupted by this corruptor.
+    /// </summary>
+    [DataField]
+    public HashSet<Vector2i> CorruptableTiles = [];
+
+    /// <summary>
     /// The starting radius of the effect.
     /// </summary>
     [DataField] public float CorruptionRadius = 2;


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Replaces the O(n^2) algorithm that tile corruption to run on with an O(n) algorithm by only corrupting neighbouring tiles. yay optimisation!
Draft for now because I want to do this for the wall corruption as well


no cl; not player facing.
