### PR TITLE
Drone Rework

### DIFF
--- a/Content.Client/_Impstation/Illiterate/IlliterateSystem.cs
+++ b/Content.Client/_Impstation/Illiterate/IlliterateSystem.cs
@@ -1,0 +1,9 @@
+using Content.Shared._Impstation.Illiterate;
+
+namespace Content.Client._Impstation.Illiterate;
+
+public sealed class IlliterateSystem : EntitySystem
+{
+
+};
+

--- a/Content.Server/Drone/Components/DroneComponent.cs
+++ b/Content.Server/Drone/Components/DroneComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Whitelist;
-using Robust.Shared.Serialization;
 using Content.Shared.Alert;
 using Robust.Shared.Prototypes;
 
@@ -26,7 +25,7 @@ namespace Content.Server.Drone.Components
         public EntityWhitelist? Blacklist;
 
         [DataField]
-        public ProtoId<AlertPrototype> BatteryAlert = "BorgBattery";
+        public ProtoId<AlertPrototype> BatteryAlert = "DroneBattery";
 
         [DataField]
         public ProtoId<AlertPrototype> NoBatteryAlert = "BorgBatteryNone";

--- a/Content.Server/Drone/Components/DroneComponent.cs
+++ b/Content.Server/Drone/Components/DroneComponent.cs
@@ -1,4 +1,7 @@
 using Content.Shared.Whitelist;
+using Robust.Shared.Serialization;
+using Content.Shared.Alert;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Drone.Components
 {
@@ -21,5 +24,13 @@ namespace Content.Server.Drone.Components
 
         [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
         public EntityWhitelist? Blacklist;
+
+        [DataField]
+        public ProtoId<AlertPrototype> BatteryAlert = "BorgBattery";
+
+        [DataField]
+        public ProtoId<AlertPrototype> NoBatteryAlert = "BorgBatteryNone";
+
+        public short LastChargePercent;
     }
 }

--- a/Content.Server/Drone/DroneSystem.cs
+++ b/Content.Server/Drone/DroneSystem.cs
@@ -3,6 +3,8 @@ using Content.Server.Drone.Components;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Popups;
 using Content.Server.Tools.Innate;
+using Content.Server.PowerCell;
+using Content.Shared.Alert;
 using Content.Shared.UserInterface;
 using Content.Shared.Body.Components;
 using Content.Shared.Drone;
@@ -14,6 +16,8 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -22,7 +26,16 @@ using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Content.Shared.Throwing;
 using Content.Shared.Whitelist;
+using Content.Shared.PowerCell;
+using Content.Shared.PowerCell.Components;
 using Robust.Shared.Timing;
+using Robust.Server.GameObjects;
+using Robust.Shared.Containers;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+using Content.Server.Traits.Assorted;
+using Content.Shared.Item.ItemToggle.Components;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Content.Server.Drone
 {
@@ -37,10 +50,16 @@ namespace Content.Server.Drone
         [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+        [Dependency] private readonly PowerCellSystem _powerCell = default!;
+        [Dependency] private readonly SharedMindSystem _mind = default!;
+        [Dependency] private readonly ItemToggleSystem _toggle = default!;
+        [Dependency] private readonly UserInterfaceSystem _ui = default!;
+        [Dependency] private readonly AlertsSystem _alerts = default!;
 
         public override void Initialize()
         {
             base.Initialize();
+            SubscribeLocalEvent<DroneComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<DroneComponent, UseAttemptEvent>(OnUseAttempt);
             SubscribeLocalEvent<DroneComponent, UserOpenActivatableUIAttemptEvent>(OnActivateUIAttempt);
             SubscribeLocalEvent<DroneComponent, MobStateChangedEvent>(OnMobStateChanged);
@@ -49,6 +68,17 @@ namespace Content.Server.Drone
             SubscribeLocalEvent<DroneComponent, MindRemovedMessage>(OnMindRemoved);
             SubscribeLocalEvent<DroneComponent, EmoteAttemptEvent>(OnEmoteAttempt);
             SubscribeLocalEvent<DroneComponent, ThrowAttemptEvent>(OnThrowAttempt);
+            SubscribeLocalEvent<DroneComponent, PowerCellChangedEvent>(OnPowerCellChanged);
+            SubscribeLocalEvent<DroneComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty);
+        }
+
+        // imp. for the battery system
+        private void OnMapInit(Entity<DroneComponent> ent, ref MapInitEvent args)
+        {
+            UpdateBatteryAlert((ent.Owner, ent.Comp));
+
+            if (!TryComp<MindContainerComponent>(ent.Owner, out var mind) || !mind.HasMind)
+                _powerCell.SetDrawEnabled(ent.Owner, false);
         }
 
         // Imp. this replaces OnInteractionAttempt from the upstream version of DroneSystem.
@@ -56,7 +86,16 @@ namespace Content.Server.Drone
         {
             if (args.Used != null && NonDronesInRange(uid, component))
             {
-                if (_whitelist.IsBlacklistPass(component.Blacklist, args.Used)) // imp special. blacklist. this one *does* prevent actions. it would probably be best if this read from the component or something.
+                if (_whitelist.IsWhitelistPass(component.Whitelist, args.Used)) /// tag whitelist. sends proximity warning popup if the item isn't whitelisted. Doesn't prevent actions. Takes precedent over blacklist.
+				{
+                    if (_gameTiming.CurTime >= component.NextProximityAlert)
+                    {
+                        _popupSystem.PopupEntity(Loc.GetString("drone-too-close", ("being", component.NearestEnt)), uid, uid);
+                        component.NextProximityAlert = _gameTiming.CurTime + component.ProximityDelay;
+                    }
+                }
+
+                else if (_whitelist.IsBlacklistPass(component.Blacklist, args.Used)) // imp special. blacklist. this one *does* prevent actions. it would probably be best if this read from the component or something.
                 {
                     args.Cancel();
                     if (_gameTiming.CurTime >= component.NextProximityAlert)
@@ -65,19 +104,9 @@ namespace Content.Server.Drone
                         component.NextProximityAlert = _gameTiming.CurTime + component.ProximityDelay;
                     }
                 }
-
-                else if (_whitelist.IsWhitelistPass(component.Whitelist, args.Used)) /// tag whitelist. sends proximity warning popup if the item isn't whitelisted. Doesn't prevent actions.
-				{
-                    component.NextProximityAlert = _gameTiming.CurTime + component.ProximityDelay;
-                    if (_gameTiming.CurTime >= component.NextProximityAlert)
-                    {
-                        _popupSystem.PopupEntity(Loc.GetString("drone-too-close", ("being", component.NearestEnt)), uid, uid);
-                        component.NextProximityAlert = _gameTiming.CurTime + component.ProximityDelay;
-                    }
-                }
             }
 
-            else if (args.Used != null && _whitelist.IsBlacklistPass(component.Blacklist, args.Used))
+            else if (args.Used != null && _whitelist.IsWhitelistFail(component.Whitelist, args.Used) && _whitelist.IsBlacklistPass(component.Blacklist, args.Used)) // prevent actions when no one is nearby only if the whitelist fails AND the blacklist passes.
             {
                 args.Cancel();
                 if (_gameTiming.CurTime >= component.NextProximityAlert)
@@ -121,16 +150,36 @@ namespace Content.Server.Drone
             }
         }
 
+        private void OnPowerCellChanged(EntityUid uid, DroneComponent component, PowerCellChangedEvent args)
+        {
+            UpdateBatteryAlert((uid, component));
+
+            // if we run out of charge, kill the drone
+            if (!_powerCell.HasDrawCharge(uid))
+            {
+                _mobStateSystem.ChangeMobState(uid, MobState.Dead);
+            }
+
+            UpdateUI(uid, component);
+        }
+
+        private void OnPowerCellSlotEmpty(EntityUid uid, DroneComponent component, ref PowerCellSlotEmptyEvent args)
+        {
+            _mobStateSystem.ChangeMobState(uid, MobState.Dead);
+        }
+
         private void OnMindAdded(EntityUid uid, DroneComponent drone, MindAddedMessage args)
         {
             UpdateDroneAppearance(uid, DroneStatus.On);
             _popupSystem.PopupEntity(Loc.GetString("drone-activated"), uid, PopupType.Large);
+            _powerCell.SetDrawEnabled(uid, true);
         }
 
         private void OnMindRemoved(EntityUid uid, DroneComponent drone, MindRemovedMessage args)
         {
             UpdateDroneAppearance(uid, DroneStatus.Off);
             EnsureComp<GhostTakeoverAvailableComponent>(uid);
+            _powerCell.SetDrawEnabled(uid, false);
         }
 
         private void OnEmoteAttempt(EntityUid uid, DroneComponent component, EmoteAttemptEvent args)
@@ -152,6 +201,65 @@ namespace Content.Server.Drone
             }
         }
 
+        public void UpdateUI(EntityUid uid, DroneComponent? component = null)
+        {
+            if (!Resolve(uid, ref component))
+                return;
+
+            var chargePercent = 0f;
+            var hasBattery = false;
+            if (_powerCell.TryGetBatteryFromSlot(uid, out var battery))
+            {
+                hasBattery = true;
+                chargePercent = battery.CurrentCharge / battery.MaxCharge;
+            }
+
+            var state = new DroneBuiState(chargePercent, hasBattery);
+            _ui.SetUiState(uid, DroneUiKey.Key, state);
+        }
+
+        private void UpdateBatteryAlert(Entity<DroneComponent> ent, PowerCellSlotComponent? slotComponent = null)
+        {
+            if (!_powerCell.TryGetBatteryFromSlot(ent, out var battery, slotComponent))
+            {
+                _alerts.ClearAlert(ent, ent.Comp.BatteryAlert);
+                _alerts.ShowAlert(ent, ent.Comp.NoBatteryAlert);
+                return;
+            }
+
+            var chargePercent = (short) MathF.Round(battery.CurrentCharge / battery.MaxCharge * 10f);
+
+            if (chargePercent == 5 && chargePercent < ent.Comp.LastChargePercent)
+            {
+                if (_gameTiming.CurTime >= ent.Comp.NextProximityAlert)
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("drone-med-battery"), ent.Owner, ent.Owner, PopupType.MediumCaution);
+                    ent.Comp.NextProximityAlert = _gameTiming.CurTime + ent.Comp.ProximityDelay;
+                }
+            }
+
+            if (chargePercent == 2 && chargePercent < ent.Comp.LastChargePercent)
+            {
+                if (_gameTiming.CurTime >= ent.Comp.NextProximityAlert)
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("drone-low-battery"), ent.Owner, ent.Owner, PopupType.LargeCaution);
+                    ent.Comp.NextProximityAlert = _gameTiming.CurTime + ent.Comp.ProximityDelay;
+                }
+            }
+
+            // we make sure 0 only shows if they have absolutely no battery.
+            // also account for floating point imprecision
+            if (chargePercent == 0 && _powerCell.HasDrawCharge(ent, cell: slotComponent))
+            {
+                chargePercent = 1;
+            }
+
+            ent.Comp.LastChargePercent = chargePercent;
+
+            _alerts.ClearAlert(ent, ent.Comp.NoBatteryAlert);
+            _alerts.ShowAlert(ent, ent.Comp.BatteryAlert, chargePercent);
+        }
+
         private bool NonDronesInRange(EntityUid uid, DroneComponent component)
         {
             var xform = Comp<TransformComponent>(uid);
@@ -161,7 +269,7 @@ namespace Content.Server.Drone
                 if (HasComp<MindContainerComponent>(entity) && !HasComp<DroneComponent>(entity) && !HasComp<GhostComponent>(entity))
                 {
                     // imp change. this filters out all dead entities.
-                    if ((TryComp<MobStateComponent>(entity, out var entityMobState) && _mobStateSystem.IsDead(entity, entityMobState)))
+                    if (TryComp<MobStateComponent>(entity, out var entityMobState) && _mobStateSystem.IsDead(entity, entityMobState))
                         continue;
                     if (_gameTiming.IsFirstTimePredicted)
                     {

--- a/Content.Server/Drone/DroneSystem.cs
+++ b/Content.Server/Drone/DroneSystem.cs
@@ -12,10 +12,7 @@ using Content.Shared.Emoting;
 using Content.Shared.Examine;
 using Content.Shared.Ghost;
 using Content.Shared.IdentityManagement;
-using Content.Shared.Interaction;
-using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
-using Content.Shared.Item;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -30,12 +27,6 @@ using Content.Shared.PowerCell;
 using Content.Shared.PowerCell.Components;
 using Robust.Shared.Timing;
 using Robust.Server.GameObjects;
-using Robust.Shared.Containers;
-using Robust.Shared.Player;
-using Robust.Shared.Random;
-using Content.Server.Traits.Assorted;
-using Content.Shared.Item.ItemToggle.Components;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Content.Server.Drone
 {

--- a/Content.Shared/Drone/SharedDroneSystem.cs
+++ b/Content.Shared/Drone/SharedDroneSystem.cs
@@ -17,4 +17,24 @@ namespace Content.Shared.Drone
             On
         }
     }
+
+    [Serializable, NetSerializable]
+    public sealed class DroneBuiState : BoundUserInterfaceState
+    {
+        public float ChargePercent;
+
+        public bool HasBattery;
+
+        public DroneBuiState(float chargePercent, bool hasBattery)
+        {
+            ChargePercent = chargePercent;
+            HasBattery = hasBattery;
+        }
+    }
+
+    [Serializable, NetSerializable]
+    public enum DroneUiKey : byte
+    {
+        Key
+    }
 }

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Tag;
 using Robust.Shared.Player;
 using Robust.Shared.Audio.Systems;
 using static Content.Shared.Paper.PaperComponent;
+using Content.Shared._Impstation.Illiterate;
 
 namespace Content.Shared.Paper;
 
@@ -114,7 +115,7 @@ public sealed class PaperSystem : EntitySystem
                     return;
                 }
 
-                var ev = new PaperWriteAttemptEvent(entity.Owner);
+                var ev = TryComp<IlliterateComponent>(args.User, out var illiterate) ? new PaperWriteAttemptEvent(entity.Owner, illiterate.FailMsg, true) : new PaperWriteAttemptEvent(entity.Owner);
                 RaiseLocalEvent(args.User, ref ev);
                 if (ev.Cancelled)
                 {

--- a/Content.Shared/_Impstation/Illiterate/IlliterateComponent.cs
+++ b/Content.Shared/_Impstation/Illiterate/IlliterateComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._Impstation.Illiterate;
+
+/// <summary>
+///     Causes the owner of this component to be unable to read or write on paper.
+/// </summary>
+[RegisterComponent]
+public sealed partial class IlliterateComponent : Component
+{
+    [DataField]
+    public LocId FailMsg = "illiterate-default-msg";
+};

--- a/Content.Shared/_Impstation/Illiterate/IlliterateSystem.cs
+++ b/Content.Shared/_Impstation/Illiterate/IlliterateSystem.cs
@@ -1,0 +1,28 @@
+using Content.Shared.Paper;
+using Content.Shared.UserInterface;
+using Content.Shared._Impstation.Illiterate;
+using Content.Shared.Popups;
+using Robust.Shared.Network;
+
+public sealed class IlliterateSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<IlliterateComponent, UserOpenActivatableUIAttemptEvent>(OnActivateUIAttempt);
+    }
+
+    private void OnActivateUIAttempt(Entity<IlliterateComponent> ent, ref UserOpenActivatableUIAttemptEvent args)
+    {
+        if (HasComp<PaperComponent>(args.Target))
+        {
+            args.Cancel();
+            _popupSystem.PopupClient(Loc.GetString(ent.Comp.FailMsg), ent.Owner, ent.Owner);
+        }
+    }
+};
+

--- a/Content.Shared/_Impstation/Illiterate/IlliterateSystem.cs
+++ b/Content.Shared/_Impstation/Illiterate/IlliterateSystem.cs
@@ -1,8 +1,9 @@
 using Content.Shared.Paper;
 using Content.Shared.UserInterface;
-using Content.Shared._Impstation.Illiterate;
 using Content.Shared.Popups;
 using Robust.Shared.Network;
+
+namespace Content.Shared._Impstation.Illiterate;
 
 public sealed class IlliterateSystem : EntitySystem
 {

--- a/Resources/Locale/en-US/_Impstation/illiterate/illiterate.ftl
+++ b/Resources/Locale/en-US/_Impstation/illiterate/illiterate.ftl
@@ -1,0 +1,4 @@
+illiterate-default-msg = You cannot read or write.
+
+trait-illiterate-name = Illiterate
+trait-illiterate-desc = You are unable to read and write. 

--- a/Resources/Locale/en-US/drone/drone-system.ftl
+++ b/Resources/Locale/en-US/drone/drone-system.ftl
@@ -6,3 +6,6 @@ drone-cant-use-nearby = This act could cause harm to {THE($being)}. Your program
 drone-cant-use = This act could cause harm to the station or its inhabitants. Your programming prevents it.
 drone-med-battery = Be aware that you will cease to function permanently when your battery runs out. 
 drone-low-battery = Seek a charging station immediately. You are in existential danger.
+
+alerts-drone-battery-name = Battery
+alerts-drone-battery-desc = If your battery depletes, you will self-destruct.

--- a/Resources/Locale/en-US/drone/drone-system.ftl
+++ b/Resources/Locale/en-US/drone/drone-system.ftl
@@ -4,3 +4,5 @@ drone-activated = The drone whirrs to life!
 drone-too-close = Be aware of your proximity to {THE($being)}.
 drone-cant-use-nearby = This act could cause harm to {THE($being)}. Your programming prevents it.
 drone-cant-use = This act could cause harm to the station or its inhabitants. Your programming prevents it.
+drone-med-battery = Be aware that you will cease to function permanently when your battery runs out. 
+drone-low-battery = Seek a charging station immediately. You are in existential danger.

--- a/Resources/Prototypes/Body/Prototypes/drone.yml
+++ b/Resources/Prototypes/Body/Prototypes/drone.yml
@@ -10,14 +10,11 @@
       - hand 2
       - hand 3
       - hand 4
-      - hand 5
     hand 1:
       part: LeftArmBorg
     hand 2:
       part: LeftArmBorg
     hand 3:
-      part: LeftArmBorg
-    hand 4:
       part: RightArmBorg
-    hand 5:
+    hand 4:
       part: RightArmBorg

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -856,6 +856,7 @@
       tags:
       - DroneUsable
       - Trash
+      - Crayon
     blacklist:
       tags:
       - Syringe
@@ -863,8 +864,24 @@
       - Sidearm
       - Taser
       components:
+      - Handcuff
       - Gun
       - EnergySword
+  - type: Illiterate # imp special component. Disables reading and writing on paper.
+  - type: ContainerContainer # imp.
+    containers:
+      cell_slot: !type:ContainerSlot { }
+  - type: PowerCellSlot # imp.
+    cellSlotId: cell_slot
+    fitsInCharger: true
+  - type: PowerCellDraw # imp
+    drawRate: 0.6
+  - type: ItemSlots # imp
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellMedium
+        disableEject: true
   - type: PAI # imp; this is added specifically for the internal station map feature but the other aspects are not especially against the identity of drones. and i dont want to put the work into ECS-ifying PAIComponent
     mapActionId: ActionDroneOpenMap # redefining these to reflavor their descriptions.
     midiActionId: ActionDronePlayMidi
@@ -916,6 +933,12 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 5
     baseSprintSpeed : 5
+    minimumFrictionSpeed: 0
+    weightlessAcceleration: 1.2
+    weightlessFriction: 1
+    weightlessFrictionNoInput: 2 
+    offGridFriction: 1.5
+    weightlessModifier: 1
   - type: MobState
     allowedStates:
       - Alive
@@ -923,7 +946,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      60: Dead
+      25: Dead
   - type: Flash
   - type: NoSlip
   - type: StatusEffects
@@ -948,7 +971,7 @@
     - state: shell
       sprite: Mobs/Silicon/drone.rsi
       map: ["base"]
-  - type: MovementIgnoreGravity
+  - type: MovementAlwaysTouching
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -245,6 +245,7 @@
     whitelist:
       components:
       - BorgChassis
+      - Drone
   - type: Construction
     containers:
     - machine_parts

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
@@ -163,6 +163,39 @@
     event: !type:OpenUiActionEvent
       key: enum.InstrumentUiKey.Key
 
+# Battery Indicator
+
+- type: alert
+  id: DroneBattery
+  category: Battery
+  icons:
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery0
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery1
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery2
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery3
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery4
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery5
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery6
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery7
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery8
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery9
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery10
+  name: alerts-drone-battery-name
+  description: alerts-drone-battery-desc
+  minSeverity: 0
+  maxSeverity: 10
+
 # StartingGear
 
 - type: startingGear

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
@@ -9,6 +9,11 @@
   - type: Unremoveable
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Satchels/dronesatchel.rsi
+  - type: Storage
+    grid:
+    - 0,0,1,1
+    - 3,0,4,1
+    - 6,0,7,1
 
 - type: entity
   parent: trayScanner
@@ -43,7 +48,7 @@
     targetName: the station
 
 - type: entity
-  id: RCDRechargingDrone
+  id: RCDRechargingDroneLighting
   parent: BaseItem
   name: lighting RCD
   description: The sleek, pared-down offspring the standard Rapid Construction Device. Only capable of producing standardized lighting solutions. 
@@ -72,6 +77,65 @@
   - type: Tag
     tags:
     - DroneUsable
+
+- type: entity
+  id: RCDRechargingDrone
+  parent: BaseItem
+  name: mini RCD
+  description: The sleek, pared-down offspring the standard Rapid Construction Device. Contains a nanomass compressor which allows it to recharge slowly over time, but severely limits its charge capacity. It also requires full charge to deconstruct.
+  suffix: Unremoveable
+  components:
+  - type: Unremoveable
+  - type: Sprite
+    sprite: _Impstation/Objects/Tools/dronercd.rsi
+    state: icon
+  - type: LimitedCharges
+    maxCharges: 8
+    charges: 10
+  - type: AutoRecharge
+    rechargeDuration: 10
+  - type: RCD
+    availablePrototypes:
+    - WallSolid
+    - FloorSteel
+    - Catwalk
+    - Grille
+    - Window
+    - WindowDirectional
+    - Airlock
+    - AirlockGlass
+    - Firelock
+    - TubeLight
+    - BulbLight
+    - LVCable
+    - MVCable
+    - HVCable
+    - CableTerminal
+    - ClothingHeadHatCone
+    - DeconstructDrone
+  - type: UserInterface
+    interfaces:
+      enum.RcdUiKey.Key:
+        type: RCDMenuBoundUserInterface
+  - type: ActivatableUI
+    inHandsOnly: true
+    key: enum.RcdUiKey.Key
+  - type: Tag
+    tags:
+    - DroneUsable
+
+# RCD functions
+
+- type: rcd
+  id: DeconstructDrone
+  name: rcd-component-deconstruct
+  category: Main
+  sprite: /Textures/Interface/Radial/RCD/deconstruct.png
+  mode: Deconstruct
+  prototype: EffectRCDDeconstructPreview
+  rotation: Camera
+  cost: 8
+  delay: 4
 
 # PAI actions
 
@@ -107,6 +171,12 @@
     pocket1: trayScannerUnremoveable
     pocket2: PinpointerStationUnremoveable
     back: DroneSatchelUnremovable
+  storage:
+    back:
+    - SheetSteel
+    - SheetGlass
+    - PartRodMetal
   inhand:
     - OmnitoolUnremoveable
     - WelderExperimentalUnremoveable
+    - RCDRechargingDrone

--- a/Resources/Prototypes/_Impstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Impstation/Traits/disabilities.yml
@@ -36,3 +36,11 @@
   components:
     - type: Unborgable
   organ: Brain
+
+- type: trait
+  id: Illiterate
+  name: trait-illiterate-name
+  description: trait-illiterate-desc
+  category: Disabilities
+  components:
+    - type: Illiterate


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

- Added the Mini RCD, a drone-exclusive, limited, recharging RCD.
- Drones are now reliant on a battery, and will die if their battery runs out.
- Drones now spawn with a supply of basic materials in their satchels.
- Drones now only have one free hand.
- Drones are now illiterate.
- Changed the way Drones' off-grid and weightless movement works to make it feel better.
- Drone Satchels are now much smaller.
- Drones now have even less health.
- Drones now properly display a proximity warning when performing any task that is not whitelisted near a living player.

Also the illiterate trait is in this PR. 

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Drones have received a major overhaul. Check the PR on Github for more information.
- add: Your characters can now be illiterate. 

