### PR TITLE
Shader compat mode fixes ... again

### DIFF
--- a/Resources/Textures/_Impstation/Shaders/monument_pulse.swsl
+++ b/Resources/Textures/_Impstation/Shaders/monument_pulse.swsl
@@ -21,9 +21,9 @@ highp vec2 quantiseVecDown(highp vec2 v) {
 }
 
 //hate that I have to do this because we can't just set the loop behaviour on the texture
-highp vec2 loopVec(highp vec2 toLoop) {
-    return abs(mod(toLoop, 1));
-}
+//highp vec2 loopVec(highp vec2 toLoop) {
+//    return abs(mod(toLoop, 1));
+//}
 
 highp vec3 rgb2hsv(highp vec3 c) {
     highp vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);

--- a/Resources/Textures/_Impstation/Shaders/monument_stars.swsl
+++ b/Resources/Textures/_Impstation/Shaders/monument_stars.swsl
@@ -51,9 +51,9 @@ highp vec2 quantiseVecDown(highp vec2 v, highp vec2 divisions) {
 }
 
 //hate that I have to do this because we can't just set the loop behaviour on the texture
-highp vec2 loopVec(highp vec2 toLoop) {
-    return abs(mod(toLoop, 1));
-}
+//highp vec2 loopVec(highp vec2 toLoop) {
+//   return abs(mod(toLoop, 1));
+//}
 
 highp vec3 rgb2hsv(highp vec3 c) {
     highp vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);

--- a/Resources/Textures/_Impstation/Shaders/saturation_shuffle.swsl
+++ b/Resources/Textures/_Impstation/Shaders/saturation_shuffle.swsl
@@ -15,9 +15,9 @@ highp vec2 quantiseVecDown(highp vec2 v, highp vec2 divisions) {
 }
 
 //hate that I have to do this because we can't just set the loop behaviour on the texture
-highp vec2 loopVec(highp vec2 toLoop) {
-    return abs(mod(toLoop, 1));
-}
+//highp vec2 loopVec(highp vec2 toLoop) {
+//    return abs(mod(toLoop, 1));
+//}
 
 highp vec3 rgb2hsv(highp vec3 c) {
     highp vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

You'd think I'd remember to test this after the third time.
Fixes #1995,  though the monument preview does now look a little wierd in compat mode for reasons that are beyond mortal ken.

no cl; not player facing.
