### PR TITLE
Fix Handheld TV failing integration tests

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -97,6 +97,7 @@
   - ArtifactCrusherMachineCircuitboard
 
 - type: latheRecipePack
+  parent: CameraBoardsImp # imp
   id: CameraBoards
   recipes:
   - SurveillanceCameraRouterCircuitboard

--- a/Resources/Prototypes/_Impstation/Objects/Devices/handheld_tv.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Devices/handheld_tv.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: CameraHandheld
-  parent: [ BaseItem ]
-  suffix: entertainment
+  parent: BaseItem
+  suffix: Entertainment
   name: handheld television
   description: A nifty device that lets you scare yourself from anywhere on the station!
   components:
@@ -10,41 +10,36 @@
     sprite: _Impstation/Objects/Devices/handheld_tv.rsi
     layers:
     - state: handheld_tv
-
   - type: Item
-
   - type: ActivatableUI
     requireActiveHand: false
     inHandsOnly: true
     key: enum.SurveillanceCameraMonitorUiKey.Key
-
   - type: UserInterface
     interfaces:
       enum.SurveillanceCameraMonitorUiKey.Key:
         type: SurveillanceCameraMonitorBoundUserInterface
-
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: SurveillanceCamera
     transmitFrequencyId: SurveillanceCamera
-
+  - type: ContainerContainer
+    containers:
+      cell_slot: !type:ContainerSlot {}
+  - type: PowerCellSlot
+    cellSlotId: cell_slot
   - type: ItemSlots
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-
   - type: DamageOtherOnHit # imp
     damage:
       types:
         Blunt: 5
   - type: WirelessNetworkConnection
     range: 200
-
   - type: DeviceNetworkRequiresPower
-
   - type: Speech
     speechVerb: Robotic
-
   - type: SurveillanceCameraSpeaker
-
   - type: SurveillanceCameraMonitor

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/science.yml
@@ -3,9 +3,7 @@
   recipes:
   - Signaller # idk why this shit got removed everywhere
 
-
 - type: latheRecipePack
-  parent: CameraBoardsImp # imp
-  id: CameraBoards
+  id: CameraBoardsImp
   recipes:
   - CameraHandheld

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/science.yml
@@ -2,3 +2,10 @@
   id: ScienceExplosivesImp
   recipes:
   - Signaller # idk why this shit got removed everywhere
+
+
+- type: latheRecipePack
+  parent: CameraBoardsImp # imp
+  id: CameraBoards
+  recipes:
+  - CameraHandheld


### PR DESCRIPTION
Adds the Container component to the handheld camera so that it should stop failing integration tests.
