### PR TITLE
More small monument UI fixes

### DIFF
--- a/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
+++ b/Content.Client/_Impstation/CosmicCult/UI/Monument/MonumentMenu.xaml.cs
@@ -14,6 +14,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Client._Impstation.CosmicCult.UI.Monument;
 [GenerateTypedNameReferences]
@@ -70,7 +71,7 @@ public sealed partial class MonumentMenu : FancyWindow
         UpdateBar(state);
         UpdateEntropy(state);
         UpdateGlyphs();
-        UpdateInfluences(state);
+        UpdateInfluences();
     }
 
     // Update all the entropy fields
@@ -139,14 +140,14 @@ public sealed partial class MonumentMenu : FancyWindow
     }
 
     // Update all the influence thingies
-    private void UpdateInfluences(MonumentBuiState state)
+    private void UpdateInfluences()
     {
         InfluencesContainer.RemoveAllChildren();
 
         var influenceUIBoxes = new List<InfluenceUIBox>();
         foreach (var influence in _influencePrototypes)
         {
-            var uiBoxState = GetUIBoxStateForInfluence(influence, state);
+            var uiBoxState = GetUIBoxStateForInfluence(influence);
             var influenceBox = new InfluenceUIBox(influence, uiBoxState);
             influenceUIBoxes.Add(influenceBox);
             influenceBox.OnGainButtonPressed += () => OnGainButtonPressed?.Invoke(influence.ID);
@@ -164,7 +165,7 @@ public sealed partial class MonumentMenu : FancyWindow
         }
     }
 
-    private InfluenceUIBox.InfluenceUIBoxState GetUIBoxStateForInfluence(InfluencePrototype influence, MonumentBuiState state)
+    private InfluenceUIBox.InfluenceUIBoxState GetUIBoxStateForInfluence(InfluencePrototype influence)
     {
         if (!_entityManager.TryGetComponent<CosmicCultComponent>(_playerManager.LocalEntity, out var cultComp)) //this feels wrong but seems to be the correct way to do this?
             return InfluenceUIBox.InfluenceUIBoxState.Locked; //early return with locked if there's somehow no cult comp

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
@@ -457,10 +457,19 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         UpdateMonumentAppearance(uid, false);
 
         Dirty(uid);
-        _ui.SetUiState(uid.Owner, MonumentKey.Key, new MonumentBuiState(uid.Comp));
+
+        //janky hacks time - ruddygreat
+        //defer the UI state sending until the next frame
+        //this works but is morally kinda evil, I have no idea how it got broken if this is the fix
+        //todo an actual fix for this? I have no idea if that's possible
+        Timer.Spawn(TimeSpan.FromMilliseconds(1),
+            () =>
+            {
+                _ui.SetUiState(uid.Owner, MonumentKey.Key, new MonumentBuiState(uid.Comp));
+            });
     }
 
-    //note - these ar the thresholds for moving to the next tier
+    //note - these are the thresholds for moving to the next tier
     //so t1 -> 2 needs 20% of the crew
     //t2 -> 3 needs 40%
     //and t3 -> finale needs an extra 20 entropy


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Adds a timer to force a single frame of delay between the CosmicCultRuleSystem.UpdateCultData() being called & the UI state being sent off so that the UI properly updates when the monument goes up a tier.
Draft for now because this fix is evil and I want to make sure it's the only way to fix things before actually putting it in the codebase.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
