### PR TITLE
Lathe qol

### DIFF
--- a/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
@@ -71,7 +71,7 @@ public sealed partial class MaterialDisplay : PanelContainer
         if (!_canEject)
             return;
 
-        int[] sheetsToEjectArray = { 1, 5, 10 };
+        int[] sheetsToEjectArray = { 1, 5, 10, 30 }; //imp, added 30
 
         for (var i = 0; i < sheetsToEjectArray.Length; i++)
         {

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -617,7 +617,7 @@
     - type: Lathe
       idleState: icon
       runningState: building
-      defaultProductionAmount: 30
+      defaultProductionAmount: 30 #Imp, changed from 10 to 30
       staticPacks:
       - OreSmelting
       - RGlassSmelting

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -617,7 +617,7 @@
     - type: Lathe
       idleState: icon
       runningState: building
-      defaultProductionAmount: 10
+      defaultProductionAmount: 30
       staticPacks:
       - OreSmelting
       - RGlassSmelting


### PR DESCRIPTION
Just a small quality of life change for lathes. There's now an additional option in returning mats to give a full stack, makes cargo's and especially borgs (who cannot stack items together without a mats module) life a lot easier.

Also changed the default processing amount for the ore processors to 30 over 10. When salvage does mine, you're normally able to make a LOT, So a default of 10 is a tad small for this case, thought it is simple as changing it in UI, not everyone does.

Please note that the ore processor change won't work until Dark's fix is merged in!

:cl:
- tweak: Lathes now have an option to return 30 of a material.
- tweak: The ore processor now defaults to 30, instead of 10.

