### PR TITLE
Pain Insensitive people shouldn't notice painful radiation effects

### DIFF
--- a/Content.Server/_Impstation/Radiation/Systems/RadiationNoticingSystem.cs
+++ b/Content.Server/_Impstation/Radiation/Systems/RadiationNoticingSystem.cs
@@ -29,10 +29,6 @@ public sealed class RadiationNoticingSystem : EntitySystem
         if (!TryComp<DamageableComponent>(uid, out var damageable))
             return; // If you aren't taking damage from radiation then what the messages say make no sense
 
-        // Pain insensitive people don't notice pain
-        if (HasComp<PainNumbnessComponent>(uid))
-            return;
-
         var trueTotalRads = args.TotalRads;
 
         DamageSpecifier damage = new();
@@ -77,10 +73,10 @@ public sealed class RadiationNoticingSystem : EntitySystem
                 "radiation-noticing-message-1",
                 "radiation-noticing-message-2",
                 "radiation-noticing-message-3",
-                "radiation-noticing-message-4",
-                "radiation-noticing-message-5",
-                "radiation-noticing-message-6",
-                "radiation-noticing-message-7"
+                "radiation-noticing-message-pain-0",
+                "radiation-noticing-message-pain-1",
+                "radiation-noticing-message-pain-2",
+                "radiation-noticing-message-pain-3"
             ];
 
         // Todo: detect possessing specific types of organs/blood/etc and conditionally add related messages to the list
@@ -88,6 +84,9 @@ public sealed class RadiationNoticingSystem : EntitySystem
         // pick a random message
         var msgId = _random.Pick(msgArr);
         var msg = Loc.GetString(msgId);
+
+        if (HasComp<PainNumbnessComponent>(uid) && msgId.Contains("-pain-"))
+            return; // Do not show pain messages if the person has pain numbness
 
         // show it as a popup
         _popupSystem.PopupEntity(msg, uid, uid);

--- a/Content.Server/_Impstation/Radiation/Systems/RadiationNoticingSystem.cs
+++ b/Content.Server/_Impstation/Radiation/Systems/RadiationNoticingSystem.cs
@@ -4,10 +4,9 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
-using Content.Server.Radiation.Components;
+using Content.Shared.Traits.Assorted;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Prototypes;
-
 using System.Linq;
 
 namespace Content.Server.Radiation.Systems;
@@ -29,6 +28,11 @@ public sealed class RadiationNoticingSystem : EntitySystem
         // Convert recieved radiation from event into actual radiation after rad damage reductions
         if (!TryComp<DamageableComponent>(uid, out var damageable))
             return; // If you aren't taking damage from radiation then what the messages say make no sense
+
+        // Pain insensitive people don't notice pain
+        if (HasComp<PainNumbnessComponent>(uid))
+            return;
+
         var trueTotalRads = args.TotalRads;
 
         DamageSpecifier damage = new();

--- a/Resources/Locale/en-US/_Impstation/radiation/radiation-notice-messages.ftl
+++ b/Resources/Locale/en-US/_Impstation/radiation/radiation-notice-messages.ftl
@@ -1,8 +1,9 @@
-radiation-noticing-message-0 = You feel prickling inside you.
-radiation-noticing-message-1 = Something tastes of metal.
-radiation-noticing-message-2 = You feel nauseous.
-radiation-noticing-message-3 = You see a bright dot that immediately disappears.
-radiation-noticing-message-4 = The taste of metal hits the back of your throat.
-radiation-noticing-message-5 = You feel a deep burning.
-radiation-noticing-message-6 = You feel like parts of you are peeling away.
-radiation-noticing-message-7 = ITCHING!
+radiation-noticing-message-0 = Something tastes of metal.
+radiation-noticing-message-1 = You feel nauseous.
+radiation-noticing-message-2 = You see a bright dot that immediately disappears.
+radiation-noticing-message-3 = The taste of metal hits the back of your throat.
+
+radiation-noticing-message-pain-0 = You feel prickling inside you.
+radiation-noticing-message-pain-1 = You feel a deep burning.
+radiation-noticing-message-pain-2 = You feel like parts of you are peeling away.
+radiation-noticing-message-pain-3 = ITCHING!


### PR DESCRIPTION
People with pain insensitivity trait will now no longer be shown the radiation noticing popups if the popup would have been pain related. This will mechanically make radiation harder to notice for them, and prevent dissonance.

:cl:
- tweak: Pain insensitive people will no longer notice painful radioactive effects.