### PR TITLE
Allow multiple jobs to be blacklisted from thief objective

### DIFF
--- a/Content.Server/Objectives/Components/NotJobRequirementComponent.cs
+++ b/Content.Server/Objectives/Components/NotJobRequirementComponent.cs
@@ -1,7 +1,7 @@
 using Content.Server.Objectives.Systems;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+// using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype; it got really cranky about using a serializer with an array and idk what to do about that, so I hope that wasn't too important!
 
 /// <summary>
 /// Requires that the player not have a certain job to have this objective.
@@ -12,6 +12,6 @@ public sealed partial class NotJobRequirementComponent : Component
     /// <summary>
     /// ID of the job to ban from having this objective.
     /// </summary>
-    [DataField(required: true, customTypeSerializer: typeof(PrototypeIdSerializer<JobPrototype>))]
-    public string Job = string.Empty;
+    [DataField(required: true)] // imp edit
+    public string[] Job; // imp edit, allows multiple jobs to be blacklisted
 }

--- a/Content.Server/Objectives/Components/NotJobRequirementComponent.cs
+++ b/Content.Server/Objectives/Components/NotJobRequirementComponent.cs
@@ -1,7 +1,7 @@
 using Content.Server.Objectives.Systems;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
-// using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype; it got really cranky about using a serializer with an array and idk what to do about that, so I hope that wasn't too important!
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array; //imp edit
 
 /// <summary>
 /// Requires that the player not have a certain job to have this objective.
@@ -12,6 +12,6 @@ public sealed partial class NotJobRequirementComponent : Component
     /// <summary>
     /// ID of the job to ban from having this objective.
     /// </summary>
-    [DataField(required: true)] // imp edit
+    [DataField(required: true, customTypeSerializer: typeof(PrototypeIdArraySerializer<JobPrototype>))] // imp edit
     public string[] Job; // imp edit, allows multiple jobs to be blacklisted
 }

--- a/Content.Server/Objectives/Systems/NotJobRequirementSystem.cs
+++ b/Content.Server/Objectives/Systems/NotJobRequirementSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Objectives.Components;
 using Content.Shared.Roles.Jobs;
+using System.Linq; // imp edit
 
 namespace Content.Server.Objectives.Systems;
 
@@ -25,7 +26,7 @@ public sealed class NotJobRequirementSystem : EntitySystem
         _jobs.MindTryGetJob(args.MindId, out var proto);
 
         // if player has no job then don't care
-        if (proto is not null && proto.ID == comp.Job)
+        if (proto is not null && comp.Job.Contains(proto.ID)) // imp edit
             args.Cancelled = true;
     }
 }

--- a/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
@@ -34,6 +34,7 @@
 
 - type: entity
   name: HoP Corgi Spawner
+  suffix: HoP's pet, steal target #imp edit
   id: SpawnMobCorgi
   parent: MarkerBase
   components:
@@ -64,6 +65,7 @@
 
 - type: entity
   name: Possum Morty Spawner
+  suffix: Morgue pet, steal target #imp edit
   id: SpawnMobPossumMorty
   parent: MarkerBase
   components:
@@ -90,6 +92,7 @@
 
 - type: entity
   name: Fox Renault Spawner
+  suffix: Captain's pet, steal target #imp edit
   id: SpawnMobFoxRenault
   parent: MarkerBase
   components:
@@ -104,8 +107,7 @@
 - type: entity
   name: Runtime Spawner
   id: SpawnMobCatRuntime
-  #suffix imp edit
-  suffix: CMO's pet, steal target
+  suffix: CMO's pet, steal target #imp edit
   parent: MarkerBase
   components:
   - type: Sprite
@@ -119,8 +121,7 @@
 - type: entity
   name: Exception Spawner
   id: SpawnMobCatException
-  #suffix imp edit
-  suffix: CMO's pet, steal target
+  suffix: CMO's pet, steal target #imp edit
   parent: MarkerBase
   components:
   - type: Sprite
@@ -147,8 +148,7 @@
 - type: entity
   name: Floppa Spawner
   id: SpawnMobCatFloppa
-  #suffix imp edit
-  suffix: CMO's pet, steal target
+  suffix: CMO's pet, steal target #imp edit
   parent: MarkerBase
   components:
   - type: Sprite
@@ -162,8 +162,7 @@
 - type: entity
   name: Bingus Spawner
   id: SpawnMobCatBingus
-  #suffix imp edit
-  suffix: CMO's pet, steal target
+  suffix: CMO's pet, steal target #imp edit
   parent: MarkerBase
   components:
   - type: Sprite
@@ -203,8 +202,7 @@
 - type: entity
   name: Cat Spawner
   id: SpawnMobCat
-  #suffix imp edit
-  suffix: CMO's pet, steal target
+  suffix: CMO's pet, steal target # imp edit
   parent: MarkerBase
   components:
   - type: Sprite
@@ -257,6 +255,7 @@
 
 - type: entity
   name:  McGriff Spawner
+  suffix: Warden's pet, steal target # imp edit
   id: SpawnMobMcGriff
   parent: MarkerBase
   components:
@@ -396,6 +395,7 @@
 - type: entity
   name: Shiva Spawner
   id: SpawnMobShiva
+  suffix: HoS's pet, steal target # imp edit
   parent: MarkerBase
   components:
   - type: Sprite

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -44,7 +44,7 @@
   id: BaseThiefStealAnimalObjective
   components:
   - type: StealCondition
-    verifyMapExistence: false
+    verifyMapExistence: true #imp edit
     checkAlive: true
     objectiveNoOwnerText: objective-condition-steal-title-alive-no-owner
     descriptionText: objective-condition-thief-animal-description
@@ -187,7 +187,7 @@
   id: ClothingOuterHardsuitVoidParamedStealObjective
   components:
   - type: NotJobRequirement
-    job: Paramedic
+    job: [ Paramedic, MedicalDoctor, Chemist ] # imp edit
   - type: StealCondition
     stealGroup: ClothingOuterHardsuitVoidParamed
   - type: Objective
@@ -198,7 +198,7 @@
   id: MedicalTechFabCircuitboardStealObjective
   components:
   - type: NotJobRequirement
-    job: MedicalDoctor
+    job: [ MedicalDoctor, Paramedic, Chemist ] # imp edit
   - type: StealCondition
     stealGroup: MedicalTechFabCircuitboard
   - type: Objective
@@ -220,7 +220,7 @@
   id: FireAxeStealObjective
   components:
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    job: [ AtmosphericTechnician, StationEngineer ] # imp edit
   - type: StealCondition
     stealGroup: FireAxe
   - type: Objective
@@ -231,7 +231,7 @@
   id: AmePartFlatpackStealObjective
   components:
   - type: NotJobRequirement
-    job: StationEngineer
+    job: [ StationEngineer, AtmosphericTechnician ] # imp edit
   - type: StealCondition
     stealGroup: AmePartFlatpack
   - type: Objective
@@ -242,7 +242,7 @@
   id: ExpeditionsCircuitboardStealObjective
   components:
   - type: NotJobRequirement
-    job: SalvageSpecialist
+    job: [ SalvageSpecialist, CargoTechnician, Courier ] # imp edit
   - type: StealCondition
     stealGroup: SalvageExpeditionsComputerCircuitboard
   - type: Objective
@@ -253,7 +253,7 @@
   id: CargoShuttleCircuitboardStealObjective
   components:
   - type: NotJobRequirement
-    job: CargoTechnician
+    job: [ CargoTechnician, SalvageSpecialist, Courier ] # imp edit
   - type: StealCondition
     stealGroup: CargoShuttleConsoleCircuitboard
   - type: Objective
@@ -332,7 +332,7 @@
   id: ChemDispenserStealObjective
   components:
   - type: NotJobRequirement
-    job: Chemist
+    job: [ Chemist, MedicalDoctor, Paramedic ]
   - type: StealCondition
     stealGroup: ChemDispenser
   - type: Objective
@@ -354,7 +354,7 @@
   id: FreezerHeaterStealObjective
   components:
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    job: [ AtmosphericTechnician, StationEngineer, Chef ] # imp edit
   - type: StealCondition
     stealGroup: FreezerHeater
   - type: Objective
@@ -365,7 +365,7 @@
   id: TegStealObjective
   components:
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    job: [ AtmosphericTechnician, StationEngineer ] # imp edit
   - type: StealCondition
     stealGroup: Teg
   - type: Objective
@@ -432,6 +432,8 @@
   parent: BaseThiefStealAnimalObjective
   id: BingusStealObjective
   components:
+  - type: NotJobRequirement #imp edit
+    job: [MedicalDoctor, Paramedic, Chemist ] # imp edit
   - type: StealCondition
     stealGroup: AnimalNamedCat
   - type: Objective
@@ -453,7 +455,7 @@
   id: WalterStealObjective
   components:
   - type: NotJobRequirement
-    job: Chemist
+    job: [MedicalDoctor, Paramedic, Chemist ] # imp edit
   - type: StealCondition
     stealGroup: AnimalWalter
   - type: Objective
@@ -463,6 +465,8 @@
   parent: BaseThiefStealAnimalObjective
   id: MortyStealObjective
   components:
+  - type: NotJobRequirement #imp edit
+    job: [MedicalDoctor, Paramedic, Chemist, Chaplain ] # imp edit
   - type: StealCondition
     stealGroup: AnimalMorty
   - type: Objective
@@ -495,7 +499,7 @@
   id: TropicoStealObjective
   components:
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    job: [ AtmosphericTechnician, StationEngineer] # imp edit
   - type: StealCondition
     stealGroup: AnimalTropico
   - type: Objective

--- a/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
@@ -171,7 +171,6 @@
 - type: entity
   name: Dog Spawner
   id: SpawnMobChemDog
-  #suffix imp edit
   suffix: Chemistry pet, steal target
   parent: MarkerBase
   components:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: Suppy
   id: PetSuppy
-  suffix: Steal target
+  suffix: Engineering's pet, steal target
   description: Engineering's pet suppermatter chunk. He dreams of causing station-wide destruction some day, but his bark is bigger than his bite.
   components:
   - type: Clickable

--- a/Resources/Prototypes/_Impstation/Objectives/thief.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/thief.yml
@@ -4,8 +4,9 @@
   parent: BaseThiefStealAnimalObjective
   id: FinFinStealObjective
   components:
+  - type: NotJobRequirement
+    job: [ MedicalDoctor, Paramedic, Chemist ]
   - type: StealCondition
-    verifyMapExistence: true
     stealGroup: AnimalFinFin
   - type: Objective
     difficulty: 2
@@ -15,10 +16,9 @@
   id: PolyStealObjective
   components:
   - type: StealCondition
-    verifyMapExistence: true
     stealGroup: AnimalPoly
   - type: NotJobRequirement
-    job: StationEngineer
+    job: [ StationEngineer, AtmosphericTechnician ]
   - type: Objective
     difficulty: 2.5 # this thing will not shut the fuck up
 
@@ -27,7 +27,7 @@
   id: PetSuppyStealObjective #engineering pet by supermatter
   components:
   - type: NotJobRequirement
-    job: StationEngineer
+    job: [ StationEngineer, AtmosphericTechnician ]
   - type: StealCondition
     stealGroup: PetSuppy
     descriptionText: objective-condition-thief-suppy-description
@@ -41,7 +41,6 @@
   - type: NotJobRequirement
     job: HospitalityDirector
   - type: StealCondition
-    verifyMapExistence: true # why tf is this false for stealanimalobjective anyway
     stealGroup: AnimalOswald
   - type: Objective
     difficulty: 1 # shes literally nice
@@ -53,7 +52,7 @@
   id: GeneratorStealObjective #tesla or singulo generator
   components:
   - type: NotJobRequirement
-    job: StationEngineer
+    job: [ StationEngineer, AtmosphericTechnician ]
   - type: StealCondition
     stealGroup: Generator
     descriptionText: objective-condition-thief-generator-description
@@ -89,7 +88,7 @@
   id: ParticleAcceleratorStealObjective #lol
   components:
   - type: NotJobRequirement
-    job: StationEngineer
+    job: [ StationEngineer, AtmosphericTechnician ]
   - type: StealCondition
     stealGroup: ParticleAccelerator
     descriptionText: objective-condition-thief-multiply-structure-description
@@ -104,7 +103,7 @@
   id: ShipyardComputerCircuitboardStealObjective
   components:
   - type: NotJobRequirement
-    job: SalvageSpecialist
+    job: [ CargoTechnician, SalvageSpecialist, Courier ]
   - type: StealCondition
     stealGroup: ShipyardComputerCircuitboard
   - type: Objective
@@ -165,7 +164,7 @@
   id: MedTekCartridgeStealObjective
   components:
   - type: NotJobRequirement
-    job: MedicalDoctor
+    job: [ MedicalDoctor, Paramedic, Chemist ]
   - type: StealCondition
     stealGroup: MedTekCartridge
   - type: Objective
@@ -187,7 +186,7 @@
   id: AstroNavCartridgeStealObjective
   components:
   - type: NotJobRequirement
-    job: SalvageSpecialist
+    job: [ SalvageSpecialist, CargoTechnician, Courier ]
   - type: StealCondition
     stealGroup: AstroNavCartridge
   - type: Objective
@@ -197,6 +196,8 @@
   parent: BaseThiefStealObjective
   id: StockTradingCartridgeStealObjective
   components:
+  - type: NotJobRequirement
+    job: [ SalvageSpecialist, CargoTechnician, Courier ]
   - type: StealCondition
     stealGroup: StockTradingCartridge
   - type: Objective
@@ -219,7 +220,7 @@
   id: SecTechStealObjective
   components:
   - type: NotJobRequirement
-    job: SecurityOfficer #you never know!
+    job: [ SecurityOfficer, Detective ] #you never know!
   - type: StealCondition
     stealGroup: SecTech
   - type: Objective
@@ -252,7 +253,7 @@
   id: SecDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: SecurityOfficer
+    job: [ SecurityOfficer, Detective ]
   - type: StealCondition
     stealGroup: SecDrobe
   - type: Objective
@@ -285,7 +286,7 @@
   id: CargoDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: CargoTechnician
+    job: [ CargoTechnician, SalvageSpecialist, Courier ]
   - type: StealCondition
     stealGroup: CargoDrobe
   - type: Objective
@@ -296,7 +297,7 @@
   id: MediDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: MedicalDoctor
+    job: [ MedicalDoctor, Paramedic, Chemist ]
   - type: StealCondition
     stealGroup: MediDrobe
   - type: Objective
@@ -307,7 +308,7 @@
   id: ChemDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: Chemist
+    job: [ MedicalDoctor, Paramedic, Chemist ]
   - type: StealCondition
     stealGroup: ChemDrobe
   - type: Objective
@@ -329,7 +330,7 @@
   id: AtmosDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    job: [ StationEngineer, AtmosphericTechnician ]
   - type: StealCondition
     stealGroup: AtmosDrobe
   - type: Objective
@@ -340,7 +341,7 @@
   id: EngiDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: StationEngineer
+    job: [ StationEngineer, AtmosphericTechnician ]
   - type: StealCondition
     stealGroup: EngiDrobe
   - type: Objective
@@ -406,7 +407,7 @@
   id: GeneDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: MedicalDoctor
+    job: [ MedicalDoctor, Paramedic, Chemist ]
   - type: StealCondition
     stealGroup: GeneDrobe
   - type: Objective
@@ -417,7 +418,7 @@
   id: ViroDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: MedicalDoctor
+    job: [ MedicalDoctor, Paramedic, Chemist ]
   - type: StealCondition
     stealGroup: ViroDrobe
   - type: Objective
@@ -427,6 +428,8 @@
   parent: BaseThiefStealObjective
   id: ServiceTechFabStealObjective
   components:
+  - type: NotJobRequirement
+    job: [ Bartender, Botanist, Chef, Janitor, Lawyer, Librarian, ServiceWorker ] #everyone with service access
   - type: StealCondition
     stealGroup: ServiceTechFab
   - type: Objective
@@ -477,7 +480,7 @@
     - Diona
     - Decapoid
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    job: [ StationEngineer, AtmosphericTechnician ]
   - type: StealCondition
     stealGroup: FireSuit
   - type: Objective


### PR DESCRIPTION
This PR modifies NotJobRequirement to allow multiple jobs to be blacklisted from thief objectives, or any other antag that may use it in the future. I opted to use an array of strings for the Job datafield in NotJobRequirement, as changing it to a hash set or list or job prototypes would require formatting changes to every instance where NotJobRequirement is used and would make it incompatible with any new objectives received from upstream or elsewhere.

With this, I have made more station jobs blacklisted on thief objectives where appropriate. I also took the opportunity to make BaseThiefStealAnimalObjective verify map existence by default (because why the hell would it not?), and add suffixes on more pet spawners to clarify they are a steal target and to whom they belong.

**Changelog**

:cl:
- tweak: Thieves will no longer receive steal objectives for steal targets that they may have easy access to through their departments.
