### PR TITLE
FIXING THE GUN SHOOT COOLDOWN

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -25,6 +25,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -36,6 +36,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -90,6 +91,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -31,6 +31,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -80,6 +81,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -75,6 +75,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -63,6 +63,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -121,6 +122,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -181,6 +183,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -238,6 +241,7 @@
         path: /Audio/Effects/hit_kick.ogg
       soundSwing:
         path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+      resetOnHandSelected: false
     - type: AltFireMelee
       attackType: Heavy
     - type: DamageOtherOnHit #for throwing
@@ -305,6 +309,7 @@
         path: /Audio/Effects/hit_kick.ogg
       soundSwing:
         path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+      resetOnHandSelected: false
     - type: AltFireMelee
       attackType: Heavy
     - type: DamageOtherOnHit #for throwing
@@ -372,6 +377,7 @@
         path: /Audio/Effects/hit_kick.ogg
       soundSwing:
         path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+      resetOnHandSelected: false
     - type: AltFireMelee
       attackType: Heavy
     - type: DamageOtherOnHit #for throwing
@@ -423,6 +429,7 @@
         path: /Audio/Effects/hit_kick.ogg
       soundSwing:
         path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+      resetOnHandSelected: false
     - type: AltFireMelee
       attackType: Heavy
     - type: DamageOtherOnHit #for throwing
@@ -482,6 +489,7 @@
         path: /Audio/Effects/hit_kick.ogg
       soundSwing:
         path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+      resetOnHandSelected: false
     - type: AltFireMelee
       attackType: Heavy
     - type: DamageOtherOnHit #for throwing
@@ -546,6 +554,7 @@
         path: /Audio/Effects/hit_kick.ogg
       soundSwing:
         path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+      resetOnHandSelected: false
     - type: AltFireMelee
       attackType: Heavy
     - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -78,6 +78,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -60,6 +60,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -61,6 +61,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -266,6 +267,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -68,6 +68,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -55,6 +55,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -132,6 +133,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -253,7 +255,7 @@
   - type: Gun
     fireRate: 1
     soundGunshot:
-      path: /Audio/_Impstation/Weapons/Guns/Gunshots/kammerer.ogg
+      path: /Audio/_Impstation/Weapons/Guns/Gunshots/kammerer.ogg #imp
   - type: Tag
     tags:
     - WeaponShotgunKammerer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -65,6 +65,7 @@
     animation: WeaponArcThrust
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+    resetOnHandSelected: false
   - type: EmbeddableProjectile
     offset: -0.15,0.0
     sound: /Audio/Weapons/star_hit.ogg
@@ -126,6 +127,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -184,6 +186,7 @@
     animation: WeaponArcThrust
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+    resetOnHandSelected: false
   - type: EmbeddableProjectile
     offset: -0.15,0.0
     sound: /Audio/Weapons/star_hit.ogg
@@ -241,6 +244,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -44,6 +44,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/dmr.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/dmr.yml
@@ -68,6 +68,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing
@@ -154,6 +155,7 @@
       path: /Audio/Effects/hit_kick.ogg
     soundSwing:
       path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
   - type: AltFireMelee
     attackType: Heavy
   - type: DamageOtherOnHit #for throwing

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/survival-rifle.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/survival-rifle.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: survival rifle
+  name: survival rifle-pistol
   parent: [BaseWeaponRifle, BaseMajorContraband]
   id: WeaponRifleSurvivalPistol
-  description: A surprisingly robust improvised rifle for survival environments. Only uses .35 pistol rounds, but can be customized.
+  description: A robust improvised rifle for suriving harsh environments. Uses .35 auto ammo and only accepts pistol magazines, but can be modified.
   components:
   - type: Sprite
     sprite: _Impstation/Prospectors/Weapons/survival_rifle.rsi
@@ -48,13 +48,36 @@
     graph: UpgradeWeaponSurvivalRifle
     node: start
   - type: Appearance
-
+  - type: MeleeWeapon
+    range: 0.8
+    attackRate: 0.6
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      path: /Audio/Effects/hit_kick.ogg
+    soundSwing:
+      path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
+    resetOnHandSelected: false
+  - type: AltFireMelee
+    attackType: Heavy
+  - type: DamageOtherOnHit #for throwing
+    staminaCost: 10
+    damage:
+      types:
+        Blunt: 8
+  - type: StaminaDamageOnHit
+    damage: 10 #slight stagger, but still like 10 hits to stun completely
+  - type: MeleeRequiresWield
+  - type: MeleeThrowOnHit
+    distance: 0.8
+    speed: 5
 
 - type: entity
-  name: survival rifle
+  name: survival rifle dual-caliber
   parent: WeaponRifleSurvivalPistol
   id: WeaponRifleSurvivalRifle
-  description: A surprisingly robust improvised rifle for survival environments. It accepts .20 rifle rounds and .35 pistol rounds.
+  description: A robust improvised rifle for suriving harsh environments. Accepts both .20 rifle and .35 auto ammo in either pistol or rifle magazines.
   components:
   - type: Gun
     fireRate: 4
@@ -81,10 +104,10 @@
             - CartridgeRifle
 
 - type: entity
-  name: survival rifle
+  name: survival rifle-SMG
   parent: WeaponRifleSurvivalPistol
   id: WeaponRifleSurvivalSMG
-  description: A surprisingly robust improvised rifle for survival environments. It accepts .35 SMG rounds and .35 pistol rounds.
+  description: A robust improvised rifle for suriving harsh environments. Uses .35 auto ammo in either pistol or SMG magazines.
   components:
   - type: Gun
     fireRate: 4


### PR DESCRIPTION
Goddddd. I thought it was lag but nope! The game forces the melee cooldown when you wield the gun, which means you can't shoot for 1-2 seconds! It feels awful and sucks so I fixed it!
Also I have no clue if anyone uses the survival rifle or if you can even get it but I made it better; descriptions are a little clearer and the names are different-ish. They can also melee now.
:cl:
- fix: You no longer have to contemplate the idea of using state-sanctioned violence to end another's life when wielding a gun. You can now shoot for free with no thoughts!!