### PR TITLE
do NOT map

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/ghost_roles.yml
@@ -7,7 +7,7 @@
   parent: MarkerBase
   id: SpawnPointPlayerCharacter
   name: ghost role spawn point
-  suffix: player character, DO NOT MAP
+  suffix: player character
   components:
     - type: GhostRole
       name: Roleplay Ghost Role

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/rubber_stamp.yml
@@ -2,7 +2,7 @@
   parent: RubberStampBase
   id: RubberStampAdminAssistant
   name: administrative assistant rubber stamp
-  suffix: DO NOT MAP
+  categories: [ DoNotMap ] # imp
   components:
   - type: Stamp
     stampedName: stamp-component-stamped-name-admin-assistant

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/eldritch_mobs.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/eldritch_mobs.yml
@@ -132,7 +132,7 @@
   id: MobGhoulRustWalker
   name: rust walker
   description: A grinding, clanking construct which leaches life from its surroundings with every armoured step.
-  suffix: DO NOT MAP
+  categories: [ DoNotMap ] # imp
   components:
   - type: Ghoul
     totalHealth: 100

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/polymorph.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/polymorph.yml
@@ -70,7 +70,7 @@
   id: MobHereticFleshAscend
   name: eldritch horror
   description: An incomprehensible mess of limbs and eyes. You can feel it's stare into your soul.
-  suffix: DO NOT MAP
+  categories: [ DoNotMap ] # imp
   components:
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/_Impstation/CosmicCult/Tileset/floors.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Tileset/floors.yml
@@ -147,7 +147,7 @@
 
 - type: entity
   id: FloorCosmicDecayAlt
-  suffix: DO NOT MAP
+  categories: [ HideSpawnMenu ]
   name: "???"
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/_Impstation/CosmicCult/Tileset/monument.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Tileset/monument.yml
@@ -116,7 +116,7 @@
   id: MonumentCosmicCultSpawnIn
   name: The Monument
   parent: BaseStructure
-  suffix: Spawn, DO NOT MAP
+  categories: [ HideSpawnMenu ]
   components:
   - type: Visibility
     layer: 777
@@ -173,7 +173,7 @@
   id: MonumentCosmicCultMoveStart
   name: The Monument
   parent: BaseStructure
-  suffix: Spawn, DO NOT MAP
+  categories: [ HideSpawnMenu ]
   components:
   - type: Visibility
     layer: 777
@@ -227,7 +227,7 @@
   id: MonumentCosmicCultMoveEnd
   name: The Monument
   parent: BaseStructure
-  suffix: Spawn, DO NOT MAP
+  categories: [ HideSpawnMenu ]
   components:
   - type: Visibility
     layer: 777
@@ -282,7 +282,7 @@
 
 - type: entity
   id: MonumentCollider
-  suffix: Debug, DO NOT MAP
+  categories: [ HideSpawnMenu ]
   parent: BaseStructure
   placement:
     mode: AlignTileAny
@@ -304,7 +304,7 @@
 
 - type: entity
   id: MonumentSlowZone
-  suffix: Debug, DO NOT MAP
+  categories: [ HideSpawnMenu ]
   placement:
     mode: SnapgridCenter
     snap:
@@ -340,7 +340,7 @@
 - type: entity
   parent: MonumentCosmicCultBase
   id: MonumentCosmicCult1
-  suffix: Base, DO NOT MAP
+  categories: [ DoNotMap ]
   components:
   - type: Monument # Causes test fail without
     targetProgress: 35
@@ -348,7 +348,6 @@
 
 - type: entity
   id: MonumentCosmicCult2
-  suffix: DO NOT MAP, DO NOT SPAWN
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
@@ -358,7 +357,6 @@
 
 - type: entity
   id: MonumentCosmicCult3
-  suffix: DO NOT MAP, DO NOT SPAWN
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Neck/cloaks.yml
@@ -10,7 +10,8 @@
 - type: entity
   parent: [ClothingNeckCloakStraight, BaseToggleClothing]
   id: ClothingHeadCloakStraightKill
-  suffix: KILL, DO NOT MAP
+  suffix: KILL
+  categories: [ DoNotMap ]
   components:
   - type: ToggleClothing
     action: ActionBecomeValid

--- a/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/dino.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/dino.yml
@@ -2,7 +2,7 @@
   name: random dinosaur spawner
   id: DinosaurSpawnerRandom
   parent: MarkerBase
-  suffix: DO NOT MAP
+  categories: [ DoNotMap ]
   components:
     - type: Sprite
       layers:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/toys.yml
@@ -180,7 +180,7 @@
   parent: BasePlushie
   id: PlushieEvilBug
   name: evil bug plushie
-  suffix: DO NOT MAP
+  categories: [ DoNotMap ]
   description: Heh...
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/rubber_stamp.yml
@@ -2,7 +2,7 @@
   name: hospitality director's rubber stamp
   parent: [RubberStampBase, BaseCommandContraband]
   id: RubberStampHD
-  suffix: DO NOT MAP
+  categories: [ DoNotMap ]
   components:
   - type: Stamp
     stampedName: stamp-component-stamped-name-hd

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
@@ -44,7 +44,7 @@
   id: BorgModuleTckTckGun
   parent: [ BaseBorgModule, BaseProviderBorgModule, DecapoidEmpireContraband ]
   name: tck'tck gun module
-  suffix: DO NOT MAP
+  categories: [ DoNotMap ]
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Melee/mining.yml
@@ -3,7 +3,7 @@
   parent: BaseItem
   id: BorgPickaxe
   description: Notched to perfection, for jamming it into rocks.
-  suffix: DO NOT MAP
+  categories: [ HideSpawnMenu ]
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
added donotmap/hidespawnmenu categories to several non-upstream prototypes that were using suffixes to accomplish the same thing

im not 100% on the c.cult edits but from my understanding spawning the monument from spawn menu in basically any context breaks things badly so i opted to hide it instead of categorizing it dnm

if this fails tests its the mappers fault and not mine ok ❤️ 

**Changelog**

not player facinggggggg
