### PR TITLE
Hide manifest hidden departments from crew monitoring console

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -371,7 +371,8 @@ public sealed class SuitSensorSystem : EntitySystem
             userJobIcon = card.Comp.JobIcon;
 
             foreach (var department in card.Comp.JobDepartments)
-                userJobDepartments.Add(Loc.GetString(_proto.Index(department).Name));
+                if (!_proto.Index(department).ManifestHidden) // imp edit
+                    userJobDepartments.Add(Loc.GetString(_proto.Index(department).Name));
         }
 
         // get health mob state


### PR DESCRIPTION
This PR hides departments that are meant to be hidden from the crew manifest from the crew monitoring console as well. This was mostly fixing an oversight from #1870.

Before:

![2mK8URf](https://github.com/user-attachments/assets/c86a9c48-15d0-40f4-861d-c0ec6bec361b)

After:

![TAGB65k](https://github.com/user-attachments/assets/b2c5f21c-b782-43da-aff6-892ccab64e18)

**Changelog**

:cl:
- fix: The Dining Services and Station Specific departments no longer show up on the crew monitoring console.
