### PR TITLE
nutribrick wrapper nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -789,10 +789,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 45
+        maxVol: 10 # imp
         reagents:
         - ReagentId: Fiber
-          Quantity: 40
+          Quantity: 5 # imp - matching the nutribrick nerf
   - type: Tag
     tags:
     - ClothMade


### PR DESCRIPTION
anyway turns out the nutribrick wrapper was the third most nutritious item for moths in the game, behind the web silk dress and post-buff cotton pizza. its now 5 fiber to match the actual brick. ty to moth mains for reporting this

**Changelog**
:cl:
- tweak: The wrapper on a nutribrick is no longer one of the most calorie-dense substances known to mothkind.