### PR TITLE
Fix Cluwne polymorph and other adjustments

### DIFF
--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -51,7 +51,7 @@
     inventory: None
     transferName: true
     transferDamage: true
-    revertOnCrit: false
+    revertOnCrit: true
     revertOnDeath: true
 
 - type: polymorph
@@ -72,7 +72,8 @@
     forced: true
     transferName: true
     transferHumanoidAppearance: true
-    inventory: Transfer
+    inventory: None
+    revertOnCrit: true
     revertOnDeath: true
 
 # this is a test for transferring some visual appearance stuff


### PR DESCRIPTION
Turns out the inventory transfer for the cluwne polymorph caused a error which made you stay as a cluwne despite it being intended that you revert on death. Also makes the monkey and cluwne polymorph revert on crit for RDNR/DNR reasons. I also wanted to make polymorph durations a part of this PR but I will save that for another PR in case there is discussion around it.
:cl:
- tweak: Cluwne and monkey polymorphs now revert on crit.
- fix: Wizards can no longer make you a cluwne beyond death.

