### PR TITLE
Add Service access to all Service jobs. Remove Service access from all Security jobs.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -8,6 +8,7 @@
   supervisors: job-supervisors-hd
   canBeAntag: false #imp CULT HOTFIX. #TODO: ANTAG SELECTION REFACTOR
   access:
+  - Service #imp edit
   - Chapel
   - Maintenance
   special:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -9,7 +9,10 @@
   access:
   - Theatre
   - Maintenance
-  - Clown #Imp
+  # imp edit start
+  - Clown
+  - Service
+  #imp edit end
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -12,7 +12,10 @@
   access:
   - Theatre
   - Maintenance
-  - Mime #Imp
+  #imp edit start
+  - Mime
+  - Service
+  #imp edit end
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -7,9 +7,13 @@
   icon: "JobIconMusician"
   supervisors: job-supervisors-hire
   access:
+
   - Maintenance # TODO Remove maint access for all gimmick jobs once access work is completed
-  - Musician # imp edit
   - Theatre
+  #imp edit start
+  - Musician
+  - Service
+  #imp edit end
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: MikuDay

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -15,7 +15,7 @@
   - Security
   - Brig
   - Maintenance
-  - Service
+  #- Service imp edit
   - Detective
   - Cryogenics
   - External

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -27,7 +27,7 @@
   - Security
   - Armory
   - Maintenance
-  - Service
+  #- Service imp edit
   - External
   - Detective
   - Cryogenics

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -18,7 +18,7 @@
   - Security
   - Brig
   - Maintenance
-  - Service
+  #- Service imp edit
   - External
   - Cryogenics
   special:

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -15,7 +15,7 @@
   - Security
   - Brig
   - Maintenance
-  - Service
+  #- Service imp edit
   - External
   - Cryogenics
   special:

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -16,7 +16,7 @@
   - Brig
   - Armory
   - Maintenance
-  - Service
+  #- Service imp edit
   - External
   - Detective
   - Cryogenics


### PR DESCRIPTION
With Service being more real as a department and the addition of more granular Service job access types, it makes sense to have an access type that all members of Service can use. This PR adds Service access to Chaplain, Clown, Mime, and Musician. This PR also removes Service access from Security Cadet, Security Officer, Warden, Detective, and Head of Security. It turns out Security just always has had Service access. Not sure what the rationale for it was, but I don't think it suits our purposes.

**Changelog**

:cl:
- add: Chaplain, Clown, Mime, and Musician all now have Service access.
- remove: Security jobs no longer have Service access.
