### PR TITLE
Fix the rev deconversion eui

### DIFF
--- a/Content.Client/_Impstation/CosmicCult/UI/DeconvertedCultistEui.cs
+++ b/Content.Client/_Impstation/CosmicCult/UI/DeconvertedCultistEui.cs
@@ -2,11 +2,11 @@
 
 namespace Content.Client._Impstation.CosmicCult.UI;
 
-public sealed class CosmicDeconvertedEui : BaseEui
+public sealed class DeconvertedCultistEui : BaseEui
 {
     private readonly CosmicDeconvertedMenu _menu;
 
-    public CosmicDeconvertedEui()
+    public DeconvertedCultistEui()
     {
         _menu = new CosmicDeconvertedMenu();
     }

--- a/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicCultRuleSystem.cs
@@ -838,7 +838,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             _role.MindTryRemoveRole<RoleBriefingComponent>(mindId);
             if (_mind.TryGetSession(mindId, out var session))
             {
-                _euiMan.OpenEui(new CosmicDeconvertedEui(), session);
+                _euiMan.OpenEui(new DeconvertedCultistEui(), session); //renamed because ReflectionManager.LooseGetType uses a wierd search criteria
             }
             _eye.SetVisibilityMask(uid, 1);
             TotalCult--;

--- a/Content.Server/_Impstation/CosmicCult/CosmicDeconvertedEui.cs
+++ b/Content.Server/_Impstation/CosmicCult/CosmicDeconvertedEui.cs
@@ -2,7 +2,7 @@ using Content.Server.EUI;
 
 namespace Content.Server._Impstation.CosmicCult;
 
-public sealed class CosmicDeconvertedEui : BaseEui
+public sealed class DeconvertedCultistEui : BaseEui
 {
     // serverside it does nothing since its just to inform the player
 }


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Renames some classes because the method that gets a type from a string does some wierd checking, leading to CosmicDeconversionEUI getting returned for DeconversionEUI.

**Changelog**
:cl:
- fix: former Revolutionaries are no longer cosmic cultists!
