### PR TITLE
PowerSwitch component to hotplates and BaseComputer component

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -81,6 +81,7 @@
   - type: Wires
     boardName: wires-board-name-computer
     layoutId: Computer
+  - type: PowerSwitch #imp; idk thought it'd be cute and immersive to turn computers on and off - AvianMaiden
 #
 #     This is overwritten by children, so needs to be defined there
 #  - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
@@ -59,3 +59,4 @@
         enum.SolutionHeaterVisuals.IsOn:
           True: { visible: true }
           False: { visible: false }
+  - type: PowerSwitch #imp; you can turn it on or off ig. Thought it'd be cute and maybe helpful - AvianMaiden


### PR DESCRIPTION
Gives the ability to toggle power for any computer, including TVs! Also hotplates! Switch them on or off as you like. Might be useful in gameplay but mainly for RP/immersion!
:cl:
- add: All computers and TVs and hotplates can now be turned on or off to save power, you heathen.