### PR TITLE
More laser gun name/description parity. No more grappling melee but laser cannon big melee.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -239,10 +239,10 @@
   - type: Appearance
 
 - type: entity
-  name: practice laser rifle
+  name: TD-95P practice laser carbine #imp
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponLaserCarbinePractice
-  description: This modified laser rifle fires nearly harmless beams in the 40-watt range, for target practice.
+  description: This modified TD-95 laser carbine fires nearly harmless beams at 5-watts for target practice. Best to wear eye protection. #imp
   components:
   - type: Sprite
     sprite: _Impstation/Objects/Weapons/Guns/Battery/laser_gun.rsi #imp
@@ -285,10 +285,10 @@
 #imp edit end
 
 - type: entity
-  name: TD-95 Laser Carbine #imp
+  name: TD-95 laser carbine #imp
   parent: [WeaponLaserCarbinePractice, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponLaserCarbine
-  description: A laser-based energy rifle with familiar ergonomics and controls to its kinetic counterparts. Favored by Nanotrasen for security forces, as they are cheap and easy to use. #imp
+  description: A laser-based energy carbine with familiar ergonomics and controls to its kinetic counterparts. Favored by Nanotrasen for security forces, as they are cheap and easy to use. #imp
   components:
   - type: StaticPrice
     price: 420
@@ -297,7 +297,7 @@
     fireCost: 62.5
 
 - type: entity
-  name: pulse pistol
+  name: PXS-21 pulse pistol #imp
   parent: BaseWeaponBatterySmall
   id: WeaponPulsePistol
   description: A state-of-the-art energy pistol favored as a sidearm by Nanotrasen operatives.
@@ -331,7 +331,7 @@
     startingCharge: 2000
 
 - type: entity
-  name: pulse carbine
+  name: PX-14C pulse carbine #imp
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseCentcommContraband]
   id: WeaponPulseCarbine
   description: A high-tech energy carbine favored by Nanotrasen ERT operatives. #imp
@@ -382,7 +382,7 @@
 #imp edit end
 
 - type: entity
-  name: pulse rifle
+  name: PX-6 pulse rifle #imp
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponPulseRifle
   description: A weapon almost as infamous as its users.
@@ -429,10 +429,10 @@
 #imp edit end
 
 - type: entity
-  name: OL-71 Laser Rifle #imp
+  name: OL-71 laser rifle #imp
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponLaserCannon
-  description: Modern laser technology purpose-built into a military platform-- as deadly as it is precise. #imp
+  description: Modern laser technology purpose-built into a military platform—as deadly as it is precise. #imp
   components:
   - type: Sprite
     sprite: _Impstation/Objects/Weapons/Guns/Battery/laser_cannon.rsi #imp
@@ -528,7 +528,7 @@
 #imp edit end
 
 - type: entity
-  name: x-ray cannon
+  name: EM-40 x-ray cannon #imp
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponXrayCannon
   description: An experimental weapon that uses concentrated x-ray energy against its target.
@@ -758,7 +758,7 @@
     # not putting a BlockMovement component here cause that's funny.
 
 - type: entity
-  name: X-66 Advanced Laser Pistol #imp
+  name: X-66 advanced laser pistol #imp
   parent: [ BaseWeaponBatterySmall, BaseSecurityContraband]
   id: WeaponAdvancedLaser
   description: An experimental high-energy laser pistol with a self-charging nuclear battery.
@@ -882,7 +882,7 @@
     price: 750
 
 - type: entity
-  name: M-1 Energy Shotgun #imp
+  name: M-1 energy shotgun #imp
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseGrandTheftContraband]
   id: WeaponEnergyShotgun
   description: A one-of-a-kind prototype energy weapon that uses various shotgun configurations. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -418,26 +418,6 @@
             True: { state: base-unshaded }
             False: { state: base-unshaded-off }
     - type: PacifismAllowedGun
-#imp edit begin; weapon melee
-    - type: MeleeWeapon
-      range: 0.8
-      attackRate: 0.8
-      damage:
-        types:
-          Blunt: 5
-      soundHit:
-        path: /Audio/Effects/hit_kick.ogg
-      soundSwing:
-        path: /Audio/_Impstation/Weapons/Guns/Melee/shove_folley.ogg
-      resetOnHandSelected: false
-    - type: AltFireMelee
-      attackType: Heavy
-    - type: DamageOtherOnHit #for throwing
-      staminaCost: 6
-      damage:
-        types:
-          Blunt: 5
-#imp edit end
 
 # Admeme
 - type: entity

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/blasters.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/blasters.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: TS-99 Blaster Pistol
+  name: TS-99 blaster pistol
   parent: [ BaseWeaponPowerCellSmall, BaseSecurityContraband ]
   id: WeaponBlasterPistol
   description: A cell-loaded fusion pistol, built on the smallest budget imaginable.
@@ -48,7 +48,7 @@
             - BlasterCell
 
 - type: entity
-  name: TW-07 Blaster Cannon
+  name: TW-07 blaster cannon
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponBlasterCannon
   description: What once started as an overzealous gardening tool was soon picked up by military developers. Packs one hell of a punch!
@@ -82,9 +82,25 @@
   - type: ProjectileBatteryAmmoProvider
     proto: BulletBlasterCannon
     fireCost: 200
+  - type: MeleeWeapon
+    attackRate: 0.4 #slower, but hits harder; bigger object to shove with
+    damage:
+      types:
+        blunt: 8
+  - type: StaminaDamageOnHit
+    damage: 15 #slight stagger, but still like 7 hits to stun completely
+  - type: MeleeRequiresWield
+  - type: MeleeThrowOnHit
+    distance: 0.8
+    speed: 5
+  - type: DamageOtherOnHit #for throwing
+    staminaCost: 15
+    damage:
+      types:
+        Blunt: 12
 
 - type: entity
-  name: TT-10 Blaster Magnum
+  name: TT-10 blaster magnum
   parent: WeaponDisablerPractice
   id: WeaponBlasterMagnum
   description: A culmination of energy weapons research rolled into a single, menacing package.


### PR DESCRIPTION
Added more names to match the new laser guns! Some parity in descriptions too. Also de-capitalized some names to match other items and weapons that aren't proper nouns. Grappling melee seems like it'd conflict, and it's not really a gun so that ability dies. Laser cannon is a cannon so it gets the heavier melee.
:cl:
- add: More laser gun names and descriptions match now!
- tweak: Melee tweaks for a few guns to match the weapons properly.