### PR TITLE
Remove damage resistance bypass and bonus damage on left-click for Entropic Blade

### DIFF
--- a/Resources/Prototypes/_Impstation/CosmicCult/Objects/cosmicweapons.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Objects/cosmicweapons.yml
@@ -12,7 +12,6 @@
       - state: icon-overlay
         shader: unshaded
   - type: MeleeWeapon
-    resistanceBypass: true
     angle: 90
     animation: WeaponArcCosmic
     attackRate: 0.62

--- a/Resources/Prototypes/_Impstation/CosmicCult/Objects/cosmicweapons.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Objects/cosmicweapons.yml
@@ -16,7 +16,6 @@
     angle: 90
     animation: WeaponArcCosmic
     attackRate: 0.62
-    clickDamageModifier: 1.1
     damage:
       types:
         Slash: 11


### PR DESCRIPTION
The entropic blade currently bypasses damage resistances, which feels a bit overkill on a weapon that already deals three different damage types. This also causes inconsistent issues, as resistanceBypass does not seem to apply to wide swings on melee weapons, causing scenarios where decapoids took cold damage on left-click, but not on right-click. This PR removes the resistanceBypass on the entropic blade, as well as the 10% damage bonus on precise attack. Letting weapons deal bonus on damage on precise attacks creates scenarios where those with better connection to the server are at a numeric advantage in combat in addition to their intrinsic advantage of having the game be more responsive, and I feel should be avoided on weapons that are a part of regular gameplay.

**Changelog**

:cl:
- tweak: The Entropic Blade no longer ignores damage resistances and no longer deals bonus damage on left-click.
