### PR TITLE
ParrotSpeech improvements

### DIFF
--- a/Content.Server/_NF/Speech/EntitySystems/ParrotSpeechSystem.cs
+++ b/Content.Server/_NF/Speech/EntitySystems/ParrotSpeechSystem.cs
@@ -33,12 +33,12 @@ public sealed class ParrotSpeechSystem : EntitySystem
             if (component.LearnedPhrases.Count == 0)
                 // This parrot has not learned any phrases, so can't say anything interesting.
                 continue;
-            // if (TryComp<MindContainerComponent>(uid, out var mind) && mind.HasMind)
-                // Imp edit - need to skip this check for echolalia trait
-                // continue;
             if (_timing.CurTime < component.NextUtterance)
                 continue;
-
+            var humanoid = HasComp<HumanoidAppearanceComponent>(uid);
+            var shouldEcho = TryComp<MindContainerComponent>(uid, out var mind) && (humanoid ? (mind.HasMind) : (!mind.HasMind));
+                // only souled humanoids or non-humanoids without souls, echo (stops a bug with cosmic cult shunting)
+            if (!shouldEcho) continue;
             if (component.NextUtterance != null)
             {
                 var speech = EnsureComp<SpeechComponent>(uid);
@@ -48,7 +48,7 @@ public sealed class ParrotSpeechSystem : EntitySystem
                     uid,
                     _random.Pick(component.LearnedPhrases),
                     InGameICChatType.Speak,
-                    hideChat: !HasComp<HumanoidAppearanceComponent>(uid), // Only humanoids speak in chat with randomly generated messages (imp edit to shut up poly)
+                    hideChat: !humanoid, // Only humanoids can be heard in chat with randomly generated messages (imp edit to shut up poly)
                     hideLog: true, // TODO: Don't spam admin logs either.
                                    // If a parrot learns something inappropriate, admins can search for
                                    // the player that said the inappropriate thing.

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -156,3 +156,8 @@ chat-speech-verb-name-electricity = Electricity
 chat-speech-verb-electricity-1 = crackles
 chat-speech-verb-electricity-2 = buzzes
 chat-speech-verb-electricity-3 = screeches
+
+chat-speech-verb-name-echo = Echo
+chat-speech-verb-echo-1 = echoes
+chat-speech-verb-echo-2 = mimics
+chat-speech-verb-echo-3 = repeats

--- a/Resources/Prototypes/Voice/speech_verbs.yml
+++ b/Resources/Prototypes/Voice/speech_verbs.yml
@@ -162,6 +162,8 @@
   - chat-speech-verb-parrot-1
   - chat-speech-verb-parrot-2
   - chat-speech-verb-parrot-3
+  - chat-speech-verb-echo-2
+  - chat-speech-verb-echo-3
 
 - type: speechVerb
   id: Cluwne
@@ -188,3 +190,11 @@
   - chat-speech-verb-electricity-1
   - chat-speech-verb-electricity-2
   - chat-speech-verb-electricity-3
+
+- type: speechVerb
+  id: Echo
+  name: chat-speech-verb-name-echo
+  speechVerbStrings:
+  - chat-speech-verb-echo-1
+  - chat-speech-verb-echo-2
+  - chat-speech-verb-echo-3


### PR DESCRIPTION
ParrotSpeech is now in chat for players (so that Poly doesn't spam chat, but other people can roleplay while reacting to echolalia), and has a unique speech verb (also to curb spam). I dunno if this is a sound way to change speech verbs without spamming admins, but at least it leaves breadcrumbs. 

Also, NYI, FOR A FUTURE PR - adding a stim action to entities with this trait which allows them to trigger mimic just for fun, per [this](https://discord.com/channels/1327800873660842097/1343238598396219452).

~~Pending a bugfix for [this](https://discord.com/channels/1327800873660842097/1354961707197268009) (which would just require uncommenting a line or something).~~
**Changelog**
:cl:
- tweak: Echolalia will now be sent to chat (for players), and has a unique speech verb!
- fix: Soulless players, and birds *with* souls, no longer echo. (Intentional game design.)