### PR TITLE
Fix drones not fitting in borg charger

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -310,7 +310,7 @@
     whitelist:
       components:
       - BorgChassis
-      - Drone
+      - Drone #imp
   - type: Construction
     containers:
     - machine_parts
@@ -354,6 +354,7 @@
     whitelist:
       components:
       - BorgChassis
+      - Drone #imp
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container


### PR DESCRIPTION
Drones were not added to borg rechargers' EntityStorage whitelist when the battery charging requirement was added to them. This PR fixes that.

**Changelog**

:cl:
- fix: Fixed drones not fitting inside cyborg recharging stations. 
