### PR TITLE
Spider Legs!

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2536,8 +2536,8 @@
   - type: Butcherable
     spawned:
     - id: FoodMeatSpider
-      amount: 1
-    - id: FoodMeatSpiderLeg
+      amount: 1 # imp
+    - id: FoodMeatSpiderLeg # imp
       amount: 2
   - type: CombatMode
   - type: Body

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2536,6 +2536,8 @@
   - type: Butcherable
     spawned:
     - id: FoodMeatSpider
+      amount: 1
+    - id: FoodMeatSpiderLeg
       amount: 2
   - type: CombatMode
   - type: Body

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2537,7 +2537,7 @@
     spawned:
     - id: FoodMeatSpider
       amount: 1 # imp
-    - id: FoodMeatSpiderLeg # imp
+    - id: FoodMeatSpiderLeg
       amount: 2
   - type: CombatMode
   - type: Body

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -223,6 +223,8 @@
     - id: EggSpider
       amount: 1
       prob: 0.5
+    - id: FoodMeatSpiderLeg
+      amount: 1
   - type: Bloodstream
     bloodMaxVolume: 250
     bloodReagent: Cryoxadone

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -223,7 +223,7 @@
     - id: EggSpider
       amount: 1
       prob: 0.5
-    - id: FoodMeatSpiderLeg
+    - id: FoodMeatSpiderLeg # imp
       amount: 1
   - type: Bloodstream
     bloodMaxVolume: 250

--- a/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
@@ -424,3 +424,14 @@
   solids:
     FoodRainbowCannabisButter: 2
     FoodSnackChocolateBar: 2
+
+- type: microwaveMealRecipe
+  id: RecipeBoiledSpiderLeg
+  name: boiled spider leg recipe
+  result: FoodMeatSpiderlegCooked
+  time: 5
+  group: Savory
+  reagents:
+    Water: 10
+  solids:
+    FoodMeatSpiderLeg: 1

--- a/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
@@ -425,7 +425,7 @@
     FoodRainbowCannabisButter: 2
     FoodSnackChocolateBar: 2
 
-- type: microwaveMealRecipe
+- type: microwaveMealRecipe # imp
   id: RecipeBoiledSpiderLeg
   name: boiled spider leg recipe
   result: FoodMeatSpiderlegCooked


### PR DESCRIPTION
Made space spiders and tarantulas drop spider legs on butchering (+1 for space spiders and +2 for tarantulas at the cost of -1 spider meat) and added a microwave recipe for boiled spider legs (10u water + 1 raw spider leg for 5 seconds)

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
add: Space spiders and tarantulas now drop raw spider legs when butchered, and raw spider legs can be cooked.

https://github.com/user-attachments/assets/3ac04623-5af7-4d55-bedb-8ebb18516664

