### PR TITLE
delta v midround ghost roles use the correct name datasets

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -50,7 +50,7 @@
       components:
       - type: RandomMetadata
         nameSegments:
-        - names_death_commando
+        - NamesDeathCommando
       - type: AutoImplant
         implants:
         - DeathAcidifierImplant
@@ -91,8 +91,8 @@
       components:
       - type: RandomMetadata
         nameSegments:
-        - fake_human_first
-        - fake_human_last
+        - FakeHumanFirst
+        - FakeHumanLast
       - type: RandomHumanoidAppearance
         randomizeName: false
       - type: EmitSoundOnSpawn # fell out of the ceiling

--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -38,8 +38,8 @@
       components:
       - type: RandomMetadata
         nameSegments:
-        - fake_human_first
-        - fake_human_last
+        - FakeHumanFirst
+        - FakeHumanLast
       - type: RandomHumanoidAppearance
         randomizeName: false
       - type: NpcFactionMember
@@ -82,8 +82,8 @@
       components:
       - type: RandomMetadata
         nameSegments:
-        - fake_human_first
-        - fake_human_last
+        - FakeHumanFirst
+        - FakeHumanLast
       - type: RandomHumanoidAppearance
         randomizeName: false
       - type: NpcFactionMember


### PR DESCRIPTION
#whoops

idk whats going on with dwarf middle names. that shits above my paygrade

**Changelog**
:cl:
- fix: Fake_Human_First Fake_Human_Last has been finally brought to justice.
