### PR TITLE
Three letter changes; Emergency Laser Carbine

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/emergencylaser.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/emergencylaser.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: TD-95C Emergency Laser Carbine
+  name: TD-95C emergency laser carbine
   parent: [WeaponLaserCarbinePractice, BaseGunWieldable, BaseMajorContraband]
   id: EmergencyWeaponLaserCarbine
   description: An emergency laser carbine, for use when getting timely clearance isn't an option. Hand this in to security once the coast is clear.


### PR DESCRIPTION
Missed a single weapon in the previous PR with the laser weapon decapitalization name pass (see #2117) since they aren't proper nouns; keeps parity with other weapons and items and all that.
:cl:
is this notable enough to omit a changelog?