### PR TITLE
Muzzles mute emote sounds

### DIFF
--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -23,6 +23,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnEmote(EntityUid uid, MutedComponent component, ref EmoteEvent args)
         {
+            // imp change
             if (args.Handled || !component.MutedEmotes)
                 return;
 
@@ -33,6 +34,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnScreamAction(EntityUid uid, MutedComponent component, ScreamActionEvent args)
         {
+            // imp change
             if (args.Handled || !component.MutedScream)
                 return;
 
@@ -47,6 +49,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnSpeakAttempt(EntityUid uid, MutedComponent component, SpeakAttemptEvent args)
         {
+            // imp change
             if (!component.MutedSpeech)
                 return;
 

--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnEmote(EntityUid uid, MutedComponent component, ref EmoteEvent args)
         {
-            if (args.Handled)
+            if (args.Handled || !component.MutedEmotes)
                 return;
 
             //still leaves the text so it looks like they are pantomiming a laugh
@@ -33,7 +33,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnScreamAction(EntityUid uid, MutedComponent component, ScreamActionEvent args)
         {
-            if (args.Handled)
+            if (args.Handled || !component.MutedScream)
                 return;
 
             if (HasComp<MimePowersComponent>(uid))
@@ -47,6 +47,9 @@ namespace Content.Server.Speech.Muting
 
         private void OnSpeakAttempt(EntityUid uid, MutedComponent component, SpeakAttemptEvent args)
         {
+            if (!component.MutedSpeech)
+                return;
+
             // TODO something better than this.
 
             if (HasComp<MimePowersComponent>(uid))

--- a/Content.Shared/Speech/Muting/MutedComponent.cs
+++ b/Content.Shared/Speech/Muting/MutedComponent.cs
@@ -5,6 +5,22 @@ namespace Content.Shared.Speech.Muting
     [RegisterComponent, NetworkedComponent]
     public sealed partial class MutedComponent : Component
     {
+        /// <summary>
+        /// Whether or not the affected entity can speak.
+        /// </summary>
+        [DataField(serverOnly: true)]
+        public bool MutedSpeech = true;
 
+        /// <summary>
+        /// Whether or not the affected entity emotes will have sound.
+        /// </summary>
+        [DataField(serverOnly: true)]
+        public bool MutedEmotes = true;
+
+        /// <summary>
+        /// Whether or not the affected entity will be able to scream.
+        /// </summary>
+        [DataField(serverOnly: true)]
+        public bool MutedScream = true;
     }
 }

--- a/Content.Shared/Speech/Muting/MutedComponent.cs
+++ b/Content.Shared/Speech/Muting/MutedComponent.cs
@@ -5,18 +5,21 @@ namespace Content.Shared.Speech.Muting
     [RegisterComponent, NetworkedComponent]
     public sealed partial class MutedComponent : Component
     {
+        // imp change
         /// <summary>
         /// Whether or not the affected entity can speak.
         /// </summary>
         [DataField(serverOnly: true)]
         public bool MutedSpeech = true;
 
+        // imp change
         /// <summary>
         /// Whether or not the affected entity emotes will have sound.
         /// </summary>
         [DataField(serverOnly: true)]
         public bool MutedEmotes = true;
 
+        // imp change
         /// <summary>
         /// Whether or not the affected entity will be able to scream.
         /// </summary>

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -437,6 +437,12 @@
   - type: Construction
     graph: Muzzle
     node: muzzle
+  - type: ClothingGrantComponent
+    component:
+    - type: Muted
+      mutedEmotes: true
+      mutedScream: false
+      mutedSpeech: false
 
 - type: entity
   parent: ClothingMaskPullableBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -437,7 +437,7 @@
   - type: Construction
     graph: Muzzle
     node: muzzle
-  - type: ClothingGrantComponent
+  - type: ClothingGrantComponent #imp change
     component:
     - type: Muted
       mutedEmotes: true


### PR DESCRIPTION
Made adjustments to the muted component to allow you to set what specific things you want to be muted. The default is true for all of them so it shouldn't affect anything else (I did test mimes and mute sting to be sure). This is mainly to make kidnappings slightly easier based on pinkbat5's suggestion.
:cl:
- tweak: Muzzles now mute sounds from emotes like screams or gasping for air.

