### PR TITLE
Move Echolalia to disabilities and remove its point cost.

### DIFF
--- a/Resources/Prototypes/_Impstation/Traits/speech.yml
+++ b/Resources/Prototypes/_Impstation/Traits/speech.yml
@@ -34,6 +34,20 @@
   components:
   - type: ProperPunctuation
 
+- type: trait
+  id: Echolalia
+  name: trait-echolalia-name
+  description: trait-echolalia-desc
+  category: Disabilities
+  components:
+  - type: ActiveListener
+    range: 5
+  - type: ParrotSpeech
+    maximumPhraseLength: 24 # higher chance of saying a full sentence
+    minimumWait: 300
+    maximumWait: 600 # triggers once every 5-10 minutes
+    learnChance: 0.1
+
 # 1 cost
 
 - type: trait
@@ -118,21 +132,6 @@
   cost: 1
   components:
   - type: RelentlessPositivity
-
-- type: trait
-  id: Echolalia
-  name: trait-echolalia-name
-  description: trait-echolalia-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ActiveListener
-    range: 5
-  - type: ParrotSpeech
-    maximumPhraseLength: 24 # higher chance of saying a full sentence
-    minimumWait: 300
-    maximumWait: 600 # triggers once every 5-10 minutes
-    learnChance: 0.1
 
 # 2 cost
 


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Echolalia has been moved to the Disabilities category and had its point cost removed. You may need to reapply it to your characters.

