### PR TITLE
officially killing the "survivor/free agent" part of the event spells

### DIFF
--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -26,7 +26,7 @@
       sprite: Objects/Weapons/Guns/Rifles/ak.rsi
       state: base
     event: !type:RandomGlobalSpawnSpellEvent
-      makeSurvivorAntagonist: true
+      makeSurvivorAntagonist: false #imp edit, fuck this free agent shit ^^!
       spawns:
       - id: WeaponPistolViper
         orGroup: Guns
@@ -173,7 +173,7 @@
       sprite: Objects/Magic/magicactions.rsi
       state: magicmissile
     event: !type:RandomGlobalSpawnSpellEvent
-      makeSurvivorAntagonist: true
+      makeSurvivorAntagonist: false #imp
       spawns:
       - id: SpawnSpellbook
         orGroup: Magics

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -1,4 +1,5 @@
-- type: antag
+# I'm leaving survivor here just in case someone reworks it, but it should stop rolling on gun event
+- type: antag 
   id: Survivor
   name: roles-antag-survivor-name
   antagonist: true


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
if you for some reason like this part of the gun and magic event spells, you can fight like animals about how to make it work. however it seems more like folks consider it a moderating nightmare and an LRP blasting fest. 
if no one else wants to put in elbow grease to save this part of the event spells, we're taking her out back.
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Wizard event spells no longer possess you with a desire to hoard guns and kill people.

