### PR TITLE
Kodepiia can now use inherent stores & can check moods

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/kodepiia.yml
@@ -36,6 +36,11 @@
         type: HumanoidMarkingModifierBoundUserInterface
       enum.StrippingUiKey.Key:
         type: StrippableBoundUserInterface
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
+      enum.ThavenMoodsUiKey.Key:
+        type: ThavenMoodsBoundUserInterface
+        requireInputValidation: false
   - type: Sprite
     layers:
     - map: [ "enum.HumanoidVisualLayers.Chest" ]


### PR DESCRIPTION
Kodepiia can now use inherent stores (lings & heretic) and check moods

:cl:
- fix: Kodes can now use inherent stores (ling & heretic)
- fix: Kodes can now check their moods, if they have them
