### PR TITLE
Refer to Suppy as "superdense" in sentience event announcement

### DIFF
--- a/Resources/Locale/en-US/_Impstation/station-events/events/random-sentience.ftl
+++ b/Resources/Locale/en-US/_Impstation/station-events/events/random-sentience.ftl
@@ -1,1 +1,3 @@
 ﻿station-event-random-sentience-flavor-avian = avian
+
+station-event-random-sentience-flavor-superdense = superdense

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -57,7 +57,7 @@
     baseWalkSpeed: 0.1
     baseSprintSpeed: 0.2
   - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-inanimate
+    flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup
     successChance: .1
     interactSuccessString: petting-success-suppy


### PR DESCRIPTION
Makes Suppy referred to as a superdense being instead of an inanimate being in the random sentience announcement.

:cl:
- tweak: Suppy is now referred to as a "superdense being" by the random sentience random event.