### PR TITLE
middle name fix

### DIFF
--- a/Content.Shared/Humanoid/NamingSystem.cs
+++ b/Content.Shared/Humanoid/NamingSystem.cs
@@ -64,7 +64,7 @@ namespace Content.Shared.Humanoid
 
         public string GetMiddleName(SpeciesPrototype speciesProto)
         {
-            return _random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(speciesProto.MiddleNames).Values);
+            return _random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(speciesProto.MiddleNames));
         }
 
         public string GetLastName(SpeciesPrototype speciesProto)


### PR DESCRIPTION
stops dwarves from generating with broken middle names

**Changelog**
:cl:
- fix: Dwarven names no longer generate incorrectly.