### PR TITLE
Echolalia improvements 2

### DIFF
--- a/Content.Server/_NF/Speech/Components/ParrotSpeechComponent.cs
+++ b/Content.Server/_NF/Speech/Components/ParrotSpeechComponent.cs
@@ -44,6 +44,20 @@ public sealed partial class ParrotSpeechComponent : Component
     [DataField] // imp
     public bool RequiresMind = true;
 
+    /// <summary>
+    /// Preserves capitalization in memorized messages and appends a "..." to the start and end of sentence fragments.
+    /// For signifying the context recalled by smarter entities who aren't just repeating sounds (knowingly repeating words).
+    /// </summary>
+    [DataField] // imp
+    public bool PreserveContext = false;
+
+    /// <summary>
+    /// Percentage chance the echo will be a whisper instead of normal speech. Nervous stimming getting mistaken as syndicate clues. Y'know.
+    /// 1.0 = Always whispering. 0.0 = Doesn't whisper.
+    /// </summary>
+    [DataField] // imp
+    public float WhisperChance = 0.0f;
+
     [DataField] // imp
     public bool FakeTypingIndicator = true;
 

--- a/Resources/Prototypes/_Impstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Impstation/Traits/disabilities.yml
@@ -44,3 +44,19 @@
   category: Disabilities
   components:
     - type: Illiterate
+
+- type: trait
+  id: Echolalia
+  name: trait-echolalia-name
+  description: trait-echolalia-desc
+  category: Disabilities
+  components:
+  - type: ActiveListener
+    range: 5
+  - type: ParrotSpeech
+    maximumPhraseLength: 24 # higher chance of saying a full sentence
+    hideMessagesInChat: false # so that people react to it with roleplay
+    minimumWait: 300
+    maximumWait: 600 # triggers once every 5-10 minutes
+    learnChance: 0.1
+# doesn't belong in the speech traits because it's a disability the player cannot control, not something that happens when the player sends a message to chat

--- a/Resources/Prototypes/_Impstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Impstation/Traits/disabilities.yml
@@ -49,7 +49,7 @@
   id: Echolalia
   name: trait-echolalia-name
   description: trait-echolalia-desc
-  category: Disabilities
+  category: Disabilities # doesn't belong in the speech traits because it's something the player cannot control, not something that happens when the player sends a message to chat
   components:
   - type: ActiveListener
     range: 5
@@ -61,4 +61,3 @@
     minimumWait: 300
     maximumWait: 600 # triggers once every 5-10 minutes
     learnChance: 0.1
-# doesn't belong in the speech traits because it's something the player cannot control, not something that happens when the player sends a message to chat

--- a/Resources/Prototypes/_Impstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Impstation/Traits/disabilities.yml
@@ -56,7 +56,7 @@
   - type: ParrotSpeech
     maximumPhraseLength: 24 # higher chance of saying a full sentence
     hideMessagesInChat: false # so that people react to it with roleplay
-    whisperChance: 0.25 # partly so it's not always interjecting into conversations, and partly so that
+    whisperChance: 0.25 # partly so it's not always interjecting into conversations
     preserveContext: true # to both creatively obfuscate and clarify the nature of a player's chat messages (the ellipses might tell you an echo is an excerpt, but the caps preservation might make you think otherwise)
     minimumWait: 300
     maximumWait: 600 # triggers once every 5-10 minutes

--- a/Resources/Prototypes/_Impstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Impstation/Traits/disabilities.yml
@@ -58,7 +58,7 @@
     hideMessagesInChat: false # so that people react to it with roleplay
     whisperChance: 0.25 # partly so it's not always interjecting into conversations, and partly so that
     preserveContext: true # to both creatively obfuscate and clarify the nature of a player's chat messages (the ellipses might tell you an echo is an excerpt, but the caps preservation might make you think otherwise)
-    minimumWait: 30
-    maximumWait: 60 # triggers once every 5-10 minutes
-    learnChance: 1.0
+    minimumWait: 300
+    maximumWait: 600 # triggers once every 5-10 minutes
+    learnChance: 0.1
 # doesn't belong in the speech traits because it's something the player cannot control, not something that happens when the player sends a message to chat

--- a/Resources/Prototypes/_Impstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Impstation/Traits/disabilities.yml
@@ -56,7 +56,9 @@
   - type: ParrotSpeech
     maximumPhraseLength: 24 # higher chance of saying a full sentence
     hideMessagesInChat: false # so that people react to it with roleplay
-    minimumWait: 300
-    maximumWait: 600 # triggers once every 5-10 minutes
-    learnChance: 0.1
-# doesn't belong in the speech traits because it's a disability the player cannot control, not something that happens when the player sends a message to chat
+    whisperChance: 0.25 # partly so it's not always interjecting into conversations, and partly so that
+    preserveContext: true # to both creatively obfuscate and clarify the nature of a player's chat messages (the ellipses might tell you an echo is an excerpt, but the caps preservation might make you think otherwise)
+    minimumWait: 30
+    maximumWait: 60 # triggers once every 5-10 minutes
+    learnChance: 1.0
+# doesn't belong in the speech traits because it's something the player cannot control, not something that happens when the player sends a message to chat

--- a/Resources/Prototypes/_Impstation/Traits/speech.yml
+++ b/Resources/Prototypes/_Impstation/Traits/speech.yml
@@ -34,20 +34,6 @@
   components:
   - type: ProperPunctuation
 
-- type: trait
-  id: Echolalia
-  name: trait-echolalia-name
-  description: trait-echolalia-desc
-  category: Disabilities
-  components:
-  - type: ActiveListener
-    range: 5
-  - type: ParrotSpeech
-    maximumPhraseLength: 24 # higher chance of saying a full sentence
-    minimumWait: 300
-    maximumWait: 600 # triggers once every 5-10 minutes
-    learnChance: 0.1
-
 # 1 cost
 
 - type: trait


### PR DESCRIPTION
Adds some features to ParrotSpeech (currently exclusive to echolalia) while re-enabling it being sent to the chatlog for echolalia users. As data fields, I've not added them to other uses of the ParrotSpeech system, but the option is there. 

This adds two extra variables to ParrotSpeechComponent, both in service of making the disability more interesting to roleplay with as a user, and more inviting to roleplay with for non-users:

1. **WhisperChance** is a random chance for the echoed message to be whispered instead of spoken normally. In-universe I envision this as a nervous whisper. Ideally, this serves dual function: it reduces the amount of times that echolalia will be intrusive on conversations, while also making it potentially more intrusive for rounds where secret radio channels (and thus, seemingly random whispers) are in play. (I've set this to 25% of the time for now, with ideally it being tuned as admin and player feedback is received 😄)
2. **PreserveContext** is a most often going to be a skip for the lower-casing of the mimicked message, preserving the case of a parroted message particularly for character names and concepts and the like (i.e. "the AME" rather than "the ame", or "Martin Aguirre" rather than "martin aguirre").\* In the event someone parrots a fragment of a passage, it also prepends/appends ellipses as necessary, as in the example below, with the intent of both obfuscating and clarifying the player's "intent" with their reflexive, unintended messages.

![image](https://github.com/user-attachments/assets/99d35ba6-e596-4310-a0c8-240c3d5d1e8f)

\*According to the [original pull-request](https://github.com/new-frontiers-14/frontier-station-14/pull/1801) for ParrotSpeech, the intent was to have it so parrots (the birds) to not understand underlying context of what they're saying, hence the removal of the casing of mimicked messages. I'd say sapient species definitely have a bit more of a handle on language, so would be somewhat knowingly mimicking the context in what they hear. 

Also, a non-player-facing change: Since Echolalia was moved out of speech traits, I moved it to `disabilities.yml`, where it belongs.

**Changelog**
:cl:
- fix: A player's echoed messages are back to being sent to the chat.
- tweak: Echolalia now might echo a message as a whisper.
- tweak: Players who echo now do so smartly, making it more interesting to determine what is and isn't an unconscious message.

