### PR TITLE
Replace harmonica trinket with pan flute + make it playable outside of the hand

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
@@ -146,6 +146,12 @@
   - type: Tag
     tags:
     - WoodwindInstrument
+  - type: Clothing #imp
+    quickEquip: false
+    slots:
+    - neck
+  - type: ActivatableUI #imp
+    inHandsOnly: false  
 
 #if you change this to some cringe-ass zelda reference so help me god i will shoot you dead.
 - type: entity

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -44,6 +44,7 @@
   - GoldRingTrinket #imp
   - Hairflower
   - HarmonicaInstrument #imp
+  - PanFluteInstrument #imp
   - Headphones
   - HeartLocket #imp
   - Lighter

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -43,7 +43,6 @@
   - FolderPun #imp
   - GoldRingTrinket #imp
   - Hairflower
-  - HarmonicaInstrument #imp
   - PanFluteInstrument #imp
   - Headphones
   - HeartLocket #imp

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/trinkets.yml
@@ -56,6 +56,15 @@
     proto: MusicallyTalented
 
 - type: loadout
+  id: PanFluteInstrument
+  storage:
+    back:
+    - PanFluteInstrument
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MusicallyTalented
+
+- type: loadout
   id: FlippoLighter
   storage:
     back:


### PR DESCRIPTION
The harmonica is one of the most grating soundfonts in the game to me and right now it is the only option for Thaven music mood; this PR gives an alternative option that is significantly easier on the ears. Like, seriously, half of the reason I have midi turned down is to avoid the 'harmonica' sound..
Honestly, I'd love to remove the harmonica from loadouts until a nicer soundfont is found but I would rather get a read on that from the community, so this first.
_edit: okay, enough people between here, rnd, and the suggestions post have been like "yes please" that i am going for that_

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
:cl:
- tweak: pan flute works the same as harmonica now (including fitting into neck slot)
- tweak: replace harmonica with pan flute in the trinkets list
 
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
