### PR TITLE
Add skin tone category for grays

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1091,7 +1091,7 @@ namespace Content.Client.Lobby.UI
                     var color = SkinColor.HumanSkinTone((int) Skin.Value);
 
                     Markings.CurrentSkinColor = color;
-                    Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));//
+                    Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
                     break;
                 }
                 case HumanoidSkinColor.Hues:
@@ -1134,6 +1134,22 @@ namespace Content.Client.Lobby.UI
                     Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
                     break;
                 }
+                // Imp edit start
+                case HumanoidSkinColor.GrayToned:
+                {
+                    if (!RgbSkinColorContainer.Visible)
+                    {
+                        Skin.Visible = false;
+                        RgbSkinColorContainer.Visible = true;
+                    }
+
+                    var color = SkinColor.GraySkinTone(_rgbSkinColorSelector.Color);
+
+                    Markings.CurrentSkinColor = color;
+                    Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
+                    break;
+                }
+                // Imp edit end
             }
 
             ReloadProfilePreview();

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -99,6 +99,7 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
             HumanoidSkinColor.Hues => speciesPrototype.DefaultSkinTone,
             HumanoidSkinColor.TintedHues => Humanoid.SkinColor.TintedHues(speciesPrototype.DefaultSkinTone),
             HumanoidSkinColor.VoxFeathers => Humanoid.SkinColor.ClosestVoxColor(speciesPrototype.DefaultSkinTone),
+            HumanoidSkinColor.GrayToned => Humanoid.SkinColor.GraySkinTone(speciesPrototype.DefaultSkinTone), //imp
             _ => Humanoid.SkinColor.ValidHumanSkinTone,
         };
 
@@ -198,6 +199,11 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
             // if the species is VoxFeathers toned: confine the skin color to vox limits. Bright colors are otherwise fine, so leave the marking colors alone.
             case HumanoidSkinColor.VoxFeathers:
                 newSkinColor = Humanoid.SkinColor.ProportionalVoxColor(newSkinColor);
+                break;
+
+            // if the species is Gray toned: desaturate. (IMP CHANGE (yes, i know all of this is an imp change (grays are a unique species though (thats why im commenting this (thanks again beck)))))
+            case HumanoidSkinColor.GrayToned:
+                newSkinColor = Humanoid.SkinColor.GraySkinTone(newSkinColor);
                 break;
         }
 

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -17,6 +17,11 @@ public static class SkinColor
     public const float MinFeathersValue = 36f / 100;
     public const float MaxFeathersValue = 55f / 100;
 
+    // Imp edit start
+    public const float GraySaturation = 5f / 100;
+    public const float GrayValue = 1f; //this would be 71f / 100, but because of the way grays are sprited, we're leaving it at 1f
+    // Imp edit end
+
     public static Color ValidHumanSkinTone => Color.FromHsv(new Vector4(0.07f, 0.2f, 1f, 1f));
 
     /// <summary>
@@ -124,6 +129,35 @@ public static class SkinColor
 
         return true;
     }
+
+    // imp edit start
+
+    /// <summary>
+    ///     Convert a color to the graytoned type.
+    /// </summary>
+    /// <param name="color">Color to convert</param>
+    /// <returns>graytoned color in RGB</returns>
+    public static Color GraySkinTone(Color color)
+    {
+        var newColor = Color.ToHsv(color);
+        newColor.Y *= GraySaturation;
+        newColor.Z = GrayValue;
+
+        return Color.FromHsv(newColor);
+    }
+
+    /// <summary>
+    ///     Verify if a color is in the gray skin tone range.
+    /// </summary>
+    /// <param name="color">The color to verify</param>
+    /// <returns>True if valid, false otherwise.</returns>
+    public static bool VerifyGraySkinTone(Color color)
+    {
+        // graytoned just ensures saturation is always .05, or 5% saturation at all times, and value is 71
+        return Color.ToHsv(color).Y <= GraySaturation && Color.ToHsv(color).Z >= GrayValue;
+    }
+
+    // imp edit end
 
     /// <summary>
     ///     Convert a color to the 'tinted hues' skin tone type.
@@ -234,6 +268,7 @@ public static class SkinColor
             HumanoidSkinColor.TintedHues => VerifyTintedHues(color),
             HumanoidSkinColor.Hues => VerifyHues(color),
             HumanoidSkinColor.VoxFeathers => VerifyVoxFeathers(color),
+            HumanoidSkinColor.GrayToned => VerifyGraySkinTone(color), //imp
             _ => false,
         };
     }
@@ -246,6 +281,7 @@ public static class SkinColor
             HumanoidSkinColor.TintedHues => ValidTintedHuesSkinTone(color),
             HumanoidSkinColor.Hues => MakeHueValid(color),
             HumanoidSkinColor.VoxFeathers => ClosestVoxColor(color),
+            HumanoidSkinColor.GrayToned => GraySkinTone(color), //imp
             _ => color
         };
     }
@@ -257,4 +293,5 @@ public enum HumanoidSkinColor : byte
     Hues,
     VoxFeathers, // Vox feathers are limited to a specific color range
     TintedHues, //This gives a color tint to a humanoid's skin (10% saturation with full hue range).
+    GrayToned, //imp special, 5% saturation & 71 value/lightness
 }

--- a/Resources/Prototypes/_Impstation/Species/gray.yml
+++ b/Resources/Prototypes/_Impstation/Species/gray.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#b8b8b8"
   markingLimits: MobGrayMarkingLimits
   dollPrototype: MobGrayDummy
-  skinColoration: TintedHues
+  skinColoration: GrayToned
   maleFirstNames: NamesGrayFirst
   femaleFirstNames: NamesGrayFirst
   lastNames: NamesGrayLast


### PR DESCRIPTION
PROJECT ZERO TEST FAILS

this should hopefully fix the recurring github test fails regarding character creation. given that this was honestly pretty easy, i could def expand the scope of this to put a limit on colors for other species we've got. the math isnt too hard to implement, thankfully

technical details:
- added new category, GrayToned
- GrayToned locks value of skin tone at 100%, and allows saturation to range between 0% to 5%
- adds a validation rule to convert existing skin tones to GrayToned
- changed default gray skin tone to play nice with all of the above

setting as draft for now bc it still doesnt save properly and if i can scope creep this pr to fix that i'll feel like a god
