### PR TITLE
Remove Cluwne spell and replace with wand 

### DIFF
--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -55,6 +55,10 @@ spellbook-wand-polymorph-door-description = For when you need a get-away route.
 spellbook-wand-polymorph-carp-name = Wand of Carp Polymorph
 spellbook-wand-polymorph-carp-description = For when you need a carp filet quick and the clown is looking juicy.
 
+# Imp Addition
+spellbook-wand-polymorph-cluwne-name = Wand of Cluwning
+spellbook-wand-polymorph-cluwne-description = For when you really hate someone and Smite isn't enough.
+
 spellbook-wand-locker-name = Wand of the Locker
 spellbook-wand-locker-description = Shoot cursed lockers at your enemies and lock em away!
 

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -214,20 +214,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-# imp addition
-- type: listing
-  id: SpellbookWandPolymorphCluwne
-  name: spellbook-wand-polymorph-cluwne-name
-  description: spellbook-wand-polymorph-cluwne-description
-  productEntity: WeaponWandCluwne
-  cost:
-    WizCoin: 3
-  categories:
-  - SpellbookEquipment
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
 - type: listing
   id: SpellbookWandLocker
   name: spellbook-wand-locker-name

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -39,18 +39,19 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- type: listing
-  id: SpellbookCluwne
-  name: spellbook-cluwne-name
-  description: spellbook-cluwne-desc
-  productAction: ActionCluwne
-  cost:
-    WizCoin: 3
-  categories:
-  - SpellbookOffensive
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+# Imp change
+#- type: listing
+#  id: SpellbookCluwne
+#  name: spellbook-cluwne-name
+#  description: spellbook-cluwne-desc
+#  productAction: ActionCluwne
+#  cost:
+#    WizCoin: 3
+#  categories:
+#  - SpellbookOffensive
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
 - type: listing
   id: SpellbookSlip
@@ -205,6 +206,20 @@
   name: spellbook-wand-polymorph-carp-name
   description: spellbook-wand-polymorph-carp-description
   productEntity: WeaponWandPolymorphCarp
+  cost:
+    WizCoin: 3
+  categories:
+  - SpellbookEquipment
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+# imp addition
+- type: listing
+  id: SpellbookWandPolymorphCluwne
+  name: spellbook-wand-polymorph-cluwne-name
+  description: spellbook-wand-polymorph-cluwne-description
+  productEntity: WeaponWandCluwne
   cost:
     WizCoin: 3
   categories:

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -28,31 +28,30 @@
   components:
   - type: Magic
 
-# Imp Change
-#- type: entity
-#  id: ActionCluwne
-#  name: Cluwne's Curse
-#  description: Turns someone into a Cluwne!
-#  components:
-#  - type: EntityTargetAction
-#    useDelay: 120
-#    itemIconStyle: BigAction
-#    whitelist:
-#      components:
-#      - Body
-#    canTargetSelf: false
-#    interactOnMiss: false
-#    sound: !type:SoundPathSpecifier
-#      path: /Audio/Items/brokenbikehorn.ogg
-#    icon:
-#      sprite: Clothing/Mask/cluwne.rsi
-#      state: icon
-#    event: !type:ChangeComponentsSpellEvent
-#      speech: action-speech-spell-cluwne
-#      toAdd:
-#      - type: Cluwne
-#  - type: Magic
-#    requiresClothes: true
+- type: entity
+  id: ActionCluwne
+  name: Cluwne's Curse
+  description: Turns someone into a Cluwne!
+  components:
+  - type: EntityTargetAction
+    useDelay: 120
+    itemIconStyle: BigAction
+    whitelist:
+      components:
+      - Body
+    canTargetSelf: false
+    interactOnMiss: false
+    sound: !type:SoundPathSpecifier
+      path: /Audio/Items/brokenbikehorn.ogg
+    icon:
+      sprite: Clothing/Mask/cluwne.rsi
+      state: icon
+    event: !type:ChangeComponentsSpellEvent
+      speech: action-speech-spell-cluwne
+      toAdd:
+      - type: Cluwne
+  - type: Magic
+    requiresClothes: true
 
 - type: entity
   id: ActionSlippery

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -28,30 +28,31 @@
   components:
   - type: Magic
 
-- type: entity
-  id: ActionCluwne
-  name: Cluwne's Curse
-  description: Turns someone into a Cluwne!
-  components:
-  - type: EntityTargetAction
-    useDelay: 120
-    itemIconStyle: BigAction
-    whitelist:
-      components:
-      - Body
-    canTargetSelf: false
-    interactOnMiss: false
-    sound: !type:SoundPathSpecifier
-      path: /Audio/Items/brokenbikehorn.ogg
-    icon:
-      sprite: Clothing/Mask/cluwne.rsi
-      state: icon
-    event: !type:ChangeComponentsSpellEvent
-      speech: action-speech-spell-cluwne
-      toAdd:
-      - type: Cluwne
-  - type: Magic
-    requiresClothes: true
+# Imp Change
+#- type: entity
+#  id: ActionCluwne
+#  name: Cluwne's Curse
+#  description: Turns someone into a Cluwne!
+#  components:
+#  - type: EntityTargetAction
+#    useDelay: 120
+#    itemIconStyle: BigAction
+#    whitelist:
+#      components:
+#      - Body
+#    canTargetSelf: false
+#    interactOnMiss: false
+#    sound: !type:SoundPathSpecifier
+#      path: /Audio/Items/brokenbikehorn.ogg
+#    icon:
+#      sprite: Clothing/Mask/cluwne.rsi
+#      state: icon
+#    event: !type:ChangeComponentsSpellEvent
+#      speech: action-speech-spell-cluwne
+#      toAdd:
+#      - type: Cluwne
+#  - type: Magic
+#    requiresClothes: true
 
 - type: entity
   id: ActionSlippery

--- a/Resources/Prototypes/_Impstation/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/spellbook_catalog.yml
@@ -10,3 +10,16 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+
+- type: listing
+  id: SpellbookWandPolymorphCluwne
+  name: spellbook-wand-polymorph-cluwne-name
+  description: spellbook-wand-polymorph-cluwne-description
+  productEntity: WeaponWandCluwne
+  cost:
+    WizCoin: 3
+  categories:
+  - SpellbookEquipment
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1


### PR DESCRIPTION
This pr removes the cluwne spell and replaces it with a purchasable cluwne wand. The spell just added the cluwne component to the target which explains why it behaved differently from the cluwne polymorph I adjusted before. I tried to change the way the spell works to use a polymorph instead but it would've been far more complicated then it's worth.
:cl: Oberonics
- remove: Cluwne spells are now banned magic.
- tweak: Wizards can buy a cluwne wand instead.


