### PR TITLE
Remove endless flickering tubes (misophonia fix)

### DIFF
--- a/Content.Server/GameTicking/Rules/VariationPass/Components/PoweredLightVariationPassComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/PoweredLightVariationPassComponent.cs
@@ -22,7 +22,8 @@ public sealed partial class PoweredLightVariationPassComponent : Component
     public float LightAgingChance = 0.05f;
 
     [DataField]
-    public float AgedLightTubeFlickerChance = 0.03f;
+    public float AgedLightTubeFlickerChance = 0.00f; //imp edit; was 0.03f / 3%
+    //note this doesn't remove Aged Light Tube spawning from the game, it just removes the chance that they endlessly flicker!
 
     [DataField]
     public EntProtoId BrokenLightBulbPrototype = "LightBulbBroken";

--- a/Content.Server/GameTicking/Rules/VariationPass/PoweredLightVariationPassSystem.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/PoweredLightVariationPassSystem.cs
@@ -38,6 +38,7 @@ public sealed class PoweredLightVariationPassSystem : VariationPassSystem<Powere
             {
                 // some aging fluorescents (tubes) start to flicker
                 // its also way too annoying right now so we wrap it in another prob lol
+                // imp edit: yuuuup
                 if (Random.Prob(ent.Comp.AgedLightTubeFlickerChance))
                     _poweredLight.ToggleBlinkingLight(uid, comp, true);
                 _poweredLight.ReplaceSpawnedPrototype((uid, comp), ent.Comp.AgedLightTubePrototype);


### PR DESCRIPTION
Changes the parameter that determines if an aging light tube spawns endlessly flickering from 3% to 0%, citing misophonia complaints, especially when these types of tubes spawn in substation cubby-holes. It would be ideal if it could be changed to a different behavior (perhaps buzzing between two warmths and volumes?) rather than nixed but for now this is what we got. At least it was a harmless edit.

Also it's really funny that the comments for the original also said it's really fucking annoying. LOL

Change suggested by [rosysaturniidae](https://discord.com/channels/1327800873660842097/1356805832691679333).

**Changelog**
:cl:
- remove: Removed the chance for aged light tubes to flicker endlessly.