### PR TITLE
Intrinsic mass scanner for ghosts. 

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -77,6 +77,31 @@
   - type: Tag
     tags:
     - AllowGhostShownByEvent
+  - type: UserInterface # imp - add mass scanner console. might need to remove this if it becomes a performance issue.
+    interfaces:
+      enum.RadarConsoleUiKey.Key:
+        type: RadarConsoleBoundUserInterface
+  - type: IntrinsicUI # imp. ditto
+    uis:
+      enum.RadarConsoleUiKey.Key:
+        toggleAction: ActionGhostShowRadar
+  - type: RadarConsole # imp. ditto
+    followEntity: true
+  - type: IgnoreUIRange # imp. pretty much all this does is make it so that ghosts can see IDs and health info at any range, since ghosts don't have hands or complexinteract
+
+# imp - ActionAghostShowRadar except with CheckCanInteract set to false, and a UseDelay 
+- type: entity
+  id: ActionGhostShowRadar
+  name: Mass Scanner Interface
+  description: View a Mass Scanner Interface.
+  components:
+  - type: InstantAction
+    checkCanInteract: false
+    icon: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
+    iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -6
+    event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
 
 - type: entity
   id: ActionGhostBoo

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -102,6 +102,7 @@
     keywords: [ "AI", "console", "interface" ]
     priority: -6
     event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
+    useDelay: 60 # to discourage everyone from opening it at once and causing potential perf issues.
 
 - type: entity
   id: ActionGhostBoo


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

If the mass scanner thing causes performance issues, feel free to kill it. I just reckon it'd be a nice quality of life thing for observers. It has a substantial UseDelay to discourage people from using it all the time. 

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Player ghosts can now view a mass scanner interface.
- tweak: Player ghosts can now view detailed inspect information on living players from any distance.

