### PR TITLE
Walking canes in medfab

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
@@ -8,6 +8,7 @@
   - PrescriptionLensStrong
   - BlindingLens
   - Dropper
+  - WalkingCane
 
 # Dynamic
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/medical.yml
@@ -20,3 +20,11 @@
   materials:
     Glass: 100
     Plasma: 50
+
+- type: latheRecipe
+  id: WalkingCane
+  result: WalkingCane
+  completetime: 2
+  materials:
+    Steel: 100
+    Wood: 100


### PR DESCRIPTION
Added walking canes to the medical techfab.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
:cl:
- add: Walking canes can now be printed from the medical techfab.



https://github.com/user-attachments/assets/04b49019-80cc-4e96-a101-50122285361f


