### PR TITLE
catwalks over water

### DIFF
--- a/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
@@ -1,4 +1,6 @@
 using Content.Shared.Movement.Components;
+using Content.Shared.StepTrigger.Components;
+using Content.Shared.StepTrigger.Systems;
 using Robust.Shared.Physics.Events;
 
 namespace Content.Shared.Movement.Systems;
@@ -13,21 +15,18 @@ public abstract class SharedFloorOcclusionSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<FloorOccluderComponent, StartCollideEvent>(OnStartCollide);
         SubscribeLocalEvent<FloorOccluderComponent, EndCollideEvent>(OnEndCollide);
+        SubscribeLocalEvent<FloorOccluderComponent, StepTriggeredOffEvent>(OnStepTriggered); // imp edit
+        SubscribeLocalEvent<FloorOccluderComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt); // imp edit
     }
 
     private void OnStartCollide(Entity<FloorOccluderComponent> entity, ref StartCollideEvent args)
     {
-        var other = args.OtherEntity;
-
-        if (!TryComp<FloorOcclusionComponent>(other, out var occlusion) ||
-            occlusion.Colliding.Contains(entity.Owner))
-        {
+        // imp edit - added StepTrigger check and moved logic to Occlude()
+        if (HasComp<StepTriggerComponent>(entity))
             return;
-        }
 
-        occlusion.Colliding.Add(entity.Owner);
-        Dirty(other, occlusion);
-        SetEnabled((other, occlusion));
+        var other = args.OtherEntity;
+        Occlude(entity, other);
     }
 
     private void OnEndCollide(Entity<FloorOccluderComponent> entity, ref EndCollideEvent args)
@@ -47,5 +46,34 @@ public abstract class SharedFloorOcclusionSystem : EntitySystem
     protected virtual void SetEnabled(Entity<FloorOcclusionComponent> entity)
     {
 
+    }
+
+    /// <summary>
+    /// Imp: Occludes an entity. Moved from OnStartCollide() to allow it to be re-used in OnStepTriggered().
+    /// </summary>
+    private void Occlude(Entity<FloorOccluderComponent> ent, EntityUid other)
+    {
+        if (!TryComp<FloorOcclusionComponent>(other, out var occlusion) ||
+            occlusion.Colliding.Contains(ent.Owner))
+        {
+            return;
+        }
+
+        occlusion.Colliding.Add(ent.Owner);
+        Dirty(other, occlusion);
+        SetEnabled((other, occlusion));
+    }
+
+    // imp edit
+    private void OnStepTriggered(Entity<FloorOccluderComponent> entity, ref StepTriggeredOffEvent args)
+    {
+        var other = args.Tripper;
+        Occlude(entity, other);
+    }
+
+    // imp edit
+    private static void OnStepTriggerAttempt(Entity<FloorOccluderComponent> entity, ref StepTriggerAttemptEvent args)
+    {
+        args.Continue = true;
     }
 }

--- a/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
@@ -1,6 +1,6 @@
 using Content.Shared.Movement.Components;
-using Content.Shared.StepTrigger.Components;
-using Content.Shared.StepTrigger.Systems;
+using Content.Shared.StepTrigger.Components; // imp edit
+using Content.Shared.StepTrigger.Systems; // imp edit
 using Robust.Shared.Physics.Events;
 
 namespace Content.Shared.Movement.Systems;

--- a/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
+++ b/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
@@ -2,6 +2,8 @@ using Content.Shared.Inventory;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Slippery;
+using Content.Shared.StepTrigger.Components;
+using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Whitelist;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
@@ -27,6 +29,8 @@ public sealed class SpeedModifierContactsSystem : EntitySystem
         SubscribeLocalEvent<SpeedModifierContactsComponent, EndCollideEvent>(OnEntityExit);
         SubscribeLocalEvent<SpeedModifiedByContactComponent, RefreshMovementSpeedModifiersEvent>(MovementSpeedCheck);
         SubscribeLocalEvent<SpeedModifierContactsComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<SpeedModifierContactsComponent, StepTriggeredOffEvent>(OnStepTriggered); // imp edit
+        SubscribeLocalEvent<SpeedModifierContactsComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt); // imp edit
 
         UpdatesAfter.Add(typeof(SharedPhysicsSystem));
     }
@@ -148,6 +152,10 @@ public sealed class SpeedModifierContactsSystem : EntitySystem
 
     private void OnEntityEnter(EntityUid uid, SpeedModifierContactsComponent component, ref StartCollideEvent args)
     {
+        // imp edit - added StepTrigger check
+        if (HasComp<StepTriggerComponent>(uid))
+            return;
+
         AddModifiedEntity(args.OtherEntity);
     }
 
@@ -162,5 +170,17 @@ public sealed class SpeedModifierContactsSystem : EntitySystem
 
         EnsureComp<SpeedModifiedByContactComponent>(uid);
         _toUpdate.Add(uid);
+    }
+
+    // imp edit
+    private void OnStepTriggered(Entity<SpeedModifierContactsComponent> ent, ref StepTriggeredOffEvent args)
+    {
+        AddModifiedEntity(args.Tripper);
+    }
+
+    // imp edit
+    private static void OnStepTriggerAttempt(Entity<SpeedModifierContactsComponent> ent, ref StepTriggerAttemptEvent args)
+    {
+        args.Continue = true;
     }
 }

--- a/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
+++ b/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
@@ -2,8 +2,8 @@ using Content.Shared.Inventory;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Slippery;
-using Content.Shared.StepTrigger.Components;
-using Content.Shared.StepTrigger.Systems;
+using Content.Shared.StepTrigger.Components; // imp edit
+using Content.Shared.StepTrigger.Systems; // imp edit
 using Content.Shared.Whitelist;
 using Robust.Shared.Map.Components; // imp edit
 using Robust.Shared.Physics.Components;


### PR DESCRIPTION
adds support for `StepTrigger` blacklists to `SharedFloorOcclusionSystem` and `SpeedModifierContactsSystem`, primarily to allow catwalks over water to function "correctly." this is important for refsdal in particular to prevent the need for special water tiles with those two components removed, but i think there's also a bigger map with a catwalk diving board

known issue: footstep sounds are still prioritising water over catwalks. this is an existing issue and not one i really feel like fixing in this pr

**Changelog**
:cl:
- tweak: Catwalks placed over water tiles keep you above the surface.