### PR TITLE
heretic madness mask fix

### DIFF
--- a/Content.Server/_Goobstation/Clothing/MadnessMaskSystem.cs
+++ b/Content.Server/_Goobstation/Clothing/MadnessMaskSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.EntityEffects.Effects;
+using Content.Shared.Clothing;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
@@ -20,12 +21,22 @@ public sealed partial class MadnessMaskSystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _statusEffect = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MadnessMaskComponent, ClothingGotEquippedEvent>(OnEquip);
+        SubscribeLocalEvent<MadnessMaskComponent, ClothingGotUnequippedEvent>(OnUnequip);
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
         foreach (var mask in EntityQuery<MadnessMaskComponent>())
         {
+            if (!mask.Equipped)
+                continue;
             mask.UpdateAccumulator += frameTime;
             if (mask.UpdateAccumulator < mask.UpdateTimer)
                 continue;
@@ -50,5 +61,15 @@ public sealed partial class MadnessMaskSystem : EntitySystem
                     _statusEffect.TryAddStatusEffect<SeeingRainbowsComponent>(look, "SeeingRainbows", TimeSpan.FromSeconds(10f), false);
             }
         }
+    }
+
+    private void OnEquip(Entity<MadnessMaskComponent> mask, ref ClothingGotEquippedEvent args)
+    {
+        mask.Comp.Equipped = true;
+    }
+
+    private void OnUnequip(Entity<MadnessMaskComponent> mask, ref ClothingGotUnequippedEvent args)
+    {
+        mask.Comp.Equipped = false;
     }
 }

--- a/Content.Shared/_Goobstation/Clothing/Components/MadnessMaskComponent.cs
+++ b/Content.Shared/_Goobstation/Clothing/Components/MadnessMaskComponent.cs
@@ -4,5 +4,9 @@ namespace Content.Shared.Clothing.Components;
 public sealed partial class MadnessMaskComponent : Component
 {
     public float UpdateAccumulator = 0f;
-    [DataField] public float UpdateTimer = 1f;
+    [DataField]
+    public float UpdateTimer = 1f;
+
+    [DataField]
+    public bool Equipped;
 }

--- a/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-ash.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-ash.ftl
@@ -39,7 +39,7 @@ knowledge-path-ash-s6-desc =
 
     Allows you to transmute any mask, four candles, a stun baton, and a liver to create a Mask of Madness.
     The mask instills fear into heathens who witness it, causing stamina damage, hallucinations, and insanity.
-    It can also be forced onto a heathen, to make them unable to take it off...
+    It cannot be taken off without outside help, no matter if the wearer is a heretic or a heathen.
 
 knowledge-path-ash-s7-name = Fiery Blade
 knowledge-path-ash-s7-desc =

--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -68,6 +68,7 @@
     - id: BookTenebraeConspiracy
     - id: BookKeelBay
     - id: BookKeelBayWorn
+    - id: BookMansus
     - id: BookTEGtorial
     - id: BookSMForDummies
 

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/HereticsAsh.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/HereticsAsh.xml
@@ -44,7 +44,7 @@
 
   The mask instills fear into heathens who witness it, causing stamina damage, hallucinations, and insanity.
 
-  It can also be forced onto a heathen, to make them unable to take it off...
+  It cannot be taken off without outside help, no matter if the wearer is a heretic or a heathen.
 
   ## Fiery Blade
   <Box>


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

my girlfriend taught me how to use git correctly but i'm off my meds so i will be forgetting :)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: the Mask of Madness will now only work if it is worn.
- fix: the heretic lore book will now spawn in the library again.