### PR TITLE
weaker gravity well instant effect for Artifact Supermatter spawn

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Effects/triggers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Effects/triggers.yml
@@ -9,3 +9,28 @@
     state: icon
   - type: TimedDespawn
     lifetime: 0.05
+
+- type: entity
+  id: ArtifactWeakInstantEffectGravityWell
+  suffix: Weak Gravity Well
+  parent: AdminInstantEffectBase
+  components:
+  - type: SoundOnTrigger
+    removeOnTrigger: true
+    sound:
+      path: /Audio/Effects/Grenades/Supermatter/supermatter_start.ogg
+      volume: 5
+  - type: AmbientSound
+    enabled: true
+    volume: -5
+    range: 14
+    sound:
+      path: /Audio/Effects/Grenades/Supermatter/supermatter_loop.ogg
+  - type: GravityWell
+    maxRange: 3
+    baseRadialAcceleration: 2
+    baseTangentialAcceleration: 0
+    gravPulsePeriod: 0.04
+  - type: SingularityDistortion
+    intensity: 10
+    falloffPower: 1.5

--- a/Resources/Prototypes/_Impstation/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/_Impstation/XenoArch/Effects/normal_effects.yml
@@ -555,7 +555,7 @@
     spawns:
     - id: PortalSupermatter
     - id: SupermatterNoAnnouncementSpawner
-    - id: AdminInstantEffectGravityWell
+    - id: ArtifactWeakInstantEffectGravityWell
 
 - type: artifactEffect
   id: EffectMindlessClone


### PR DESCRIPTION
upstream changed how gravity wells work so they are stronger now. this new instant effect brings the gravity pull (when stationwide destruction artifact node spawns a supermatter) back to intended levels

:cl:
- fix: weakened pull when artifact opens a supermatter portal
