### PR TITLE
remove oxygen foam from artifacts

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -205,7 +205,7 @@
   components:
   - type: FoamArtifact
     reagents:
-    - Plasma
+    - Plasma #IMP: REMOVE OXYGEN
     - Blood
     - SpaceCleaner
     - Nutriment

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -205,7 +205,6 @@
   components:
   - type: FoamArtifact
     reagents:
-    - Oxygen
     - Plasma
     - Blood
     - SpaceCleaner

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -205,7 +205,8 @@
   components:
   - type: FoamArtifact
     reagents:
-    - Plasma #IMP: REMOVE OXYGEN
+    #- Oxygen #IMP REMOVED
+    - Plasma
     - Blood
     - SpaceCleaner
     - Nutriment


### PR DESCRIPTION
Oxygen doesn't metabolise in liquid form, so if it gets in you it just stays there clogging up your chemical solution storage and reducing how much can be in you.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- remove: Oxygen foam from artifacts.
