### PR TITLE
[DRAFT] Add AccessoryMate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 4500 #imp edit to prevent abritrage - was 2440.
+  cost: 1 #imp edit to prevent abritrage - was 2440.
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -1,4 +1,6 @@
 # DO NOT ADD MORE, USE UNIFORM DYING
+# imp: IF YOU ADD MORE, I WILL KILL YOU!!!!!!!!!!!!!!!!
+#      many upstream things have been removed to add to the appareldrobe, please put non-clothes in there instead
 - type: vendingMachineInventory
   id: ClothesMateInventory
   startingInventory:
@@ -11,14 +13,16 @@
     ClothingUniformRandomSimpleTeeSpawner: 6 #imp
     ClothingUniformRandomSimpleTankSpawner: 6 #imp
     ClothingUniformRandomSimplePantsSpawner: 6 #imp
-    ClothingHeadHatBeret: 4
-    ClothingHeadBandBlack: 2
-    ClothingHeadBandBlue: 2
-    ClothingHeadBandGreen: 2
-    ClothingHeadBandRed: 2
-    ClothingHeadBandSkull: 2
-    ClothingHeadHatGreyFlatcap: 3
-    ClothingHeadHatBrownFlatcap: 3
+    # imp edits start
+#    ClothingHeadHatBeret: 4
+#    ClothingHeadBandBlack: 2
+#    ClothingHeadBandBlue: 2
+#    ClothingHeadBandGreen: 2
+#    ClothingHeadBandRed: 2
+#    ClothingHeadBandSkull: 2
+#    ClothingHeadHatGreyFlatcap: 3
+#    ClothingHeadHatBrownFlatcap: 3
+    # imp edits end
     ClothingUniformJumpsuitColorGrey: 8
     ClothingUniformJumpskirtColorGrey: 8
     ClothingUniformJumpsuitColorWhite: 3
@@ -60,47 +64,43 @@
     ClothingUniformJumpsuitCasualGreen: 2
     ClothingUniformJumpskirtCasualGreen: 2
     # DO NOT ADD MORE, USE UNIFORM DYING
-    ClothingShoesColorBlack: 8
-    ClothingShoesColorBrown: 4
-    ClothingShoesColorWhite: 3
-    ClothingShoesColorBlue: 2
-    ClothingShoesColorYellow: 2
-    ClothingShoesColorGreen: 2
-    ClothingShoesColorOrange: 2
-    ClothingShoesColorRed: 2
-    ClothingShoesColorPurple: 2
-    ClothingShoesHeelsRed: 4 # imp
-    ClothingShoesHeelsBlack: 4 # imp
-    ClothingShoesHeelsBlue: 3 # imp
-    ClothingShoesHeelsGreen: 2 # imp
-    ClothingShoesHeelsBrown: 2 # imp
-    ClothingShoesFlipflopsBlack: 4 #imp
-    ClothingHeadHatGreysoft: 8
-    ClothingHeadHatMimesoft: 3
-    ClothingHeadHatBluesoft: 2
-    ClothingHeadHatYellowsoft: 2
-    ClothingHeadHatGreensoft: 2
-    ClothingHeadHatOrangesoft: 2
-    ClothingHeadHatRedsoft: 2
-    # DO NOT ADD MORE, USE UNIFORM DYING
-    ClothingHeadHatBlacksoft: 2
-    ClothingHeadHatPurplesoft: 2
-    ClothingHeadHatCorpsoft: 2
-    ClothingHeadFishCap: 2
-    ClothingHeadRastaHat: 2
-    ClothingBeltStorageWaistbag: 3
-    ClothingEyesGlasses: 6
-    ClothingHandsGlovesColorBlack: 4
-    ClothingHandsGlovesColorGray: 4
-    ClothingHandsGlovesColorBrown: 2
-    ClothingHandsGlovesColorWhite: 2
-    ClothingHandsGlovesColorRed: 2
-    ClothingHandsGlovesColorBlue: 2
-    ClothingHandsGlovesColorTeal: 2
-    ClothingHandsGlovesColorGreen: 2
-    ClothingHandsGlovesColorOrange: 2
-    ClothingHandsGlovesColorPurple: 2
-    ClothingEyesGlassesCheapSunglasses: 3
+    # imp edits start
+#    ClothingShoesColorBlack: 8
+#    ClothingShoesColorBrown: 4
+#    ClothingShoesColorWhite: 3
+#    ClothingShoesColorBlue: 2
+#    ClothingShoesColorYellow: 2
+#    ClothingShoesColorGreen: 2
+#    ClothingShoesColorOrange: 2
+#    ClothingShoesColorRed: 2
+#    ClothingShoesColorPurple: 2
+#    ClothingHeadHatGreysoft: 8
+#    ClothingHeadHatMimesoft: 3
+#    ClothingHeadHatBluesoft: 2
+#    ClothingHeadHatYellowsoft: 2
+#    ClothingHeadHatGreensoft: 2
+#    ClothingHeadHatOrangesoft: 2
+#    ClothingHeadHatRedsoft: 2
+#    # DO NOT ADD MORE, USE UNIFORM DYING
+#    ClothingHeadHatBlacksoft: 2
+#    ClothingHeadHatPurplesoft: 2
+#    ClothingHeadHatCorpsoft: 2
+#    ClothingHeadFishCap: 2
+#    ClothingHeadRastaHat: 2
+#    ClothingBeltStorageWaistbag: 3
+#    ClothingEyesGlasses: 6
+#    ClothingHandsGlovesColorBlack: 4
+#    ClothingHandsGlovesColorGray: 4
+#    ClothingHandsGlovesColorBrown: 2
+#    ClothingHandsGlovesColorWhite: 2
+#    ClothingHandsGlovesColorRed: 2
+#    ClothingHandsGlovesColorBlue: 2
+#    ClothingHandsGlovesColorTeal: 2
+#    ClothingHandsGlovesColorGreen: 2
+#    ClothingHandsGlovesColorOrange: 2
+#    ClothingHandsGlovesColorPurple: 2
+#    ClothingEyesGlassesCheapSunglasses: 3
+    # imp edits end
     # DO NOT ADD MORE, USE UNIFORM DYING
     # imp -Space Cadet Jumpsuits
     ClothingSpaceCadetJumpsuitColorWhite: 3
@@ -121,12 +121,11 @@
     ClothingUniformSpaceJumpsuitCasualMulti: 3
     ClothingUniformSpaceJumpsuitCasualBlue: 3
   contrabandInventory:
-    ClothingMaskNeckGaiter: 2
+#    ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1
-    ClothingShoesSwat: 2 # imp
-    ClothingMaskGas: 1
+#    ClothingMaskGas: 1
     ToyFigurinePassenger: 1
-    ToyFigurineGreytider: 1
+#    ToyFigurineGreytider: 1
     ClothingBackpackSatchelSmugglerUnanchored: 1
   # DO NOT ADD MORE, USE UNIFORM DYING

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -122,6 +122,7 @@
   - type: VendingMachineRestock
     canRestock:
     - ClothesMateInventory
+    - AccessoryMateInventory #imp
     - AtmosDrobeInventory
     - BarDrobeInventory
     - CargoDrobeInventory
@@ -343,7 +344,7 @@
     - SpaceUpInventory
     - SodaInventory
     - DrGibbInventory
-    - SmiteInventory 
+    - SmiteInventory
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/_Impstation/Catalog/VendingMachines/Inventories/newdrobe.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/VendingMachines/Inventories/newdrobe.yml
@@ -1,0 +1,57 @@
+# items marked #imp are non-upstream
+- type: vendingMachineInventory
+  id: AccessoryMateInventory
+  startingInventory:
+    ClothingHeadHatBeret: 4
+    ClothingHeadBandBlack: 2
+    ClothingHeadBandBlue: 2
+    ClothingHeadBandGreen: 2
+    ClothingHeadBandRed: 2
+    ClothingHeadBandSkull: 2
+    ClothingHeadHatGreyFlatcap: 3
+    ClothingHeadHatBrownFlatcap: 3
+    ClothingShoesColorBlack: 8
+    ClothingShoesColorBrown: 4
+    ClothingShoesColorWhite: 3
+    ClothingShoesColorBlue: 2
+    ClothingShoesColorYellow: 2
+    ClothingShoesColorGreen: 2
+    ClothingShoesColorOrange: 2
+    ClothingShoesColorRed: 2
+    ClothingShoesColorPurple: 2
+    ClothingShoesHeelsRed: 4 # imp
+    ClothingShoesHeelsBlack: 4 # imp
+    ClothingShoesHeelsBlue: 3 # imp
+    ClothingShoesHeelsGreen: 2 # imp
+    ClothingShoesHeelsBrown: 2 # imp
+    ClothingShoesFlipflopsBlack: 4 #imp
+    ClothingHeadHatGreysoft: 8
+    ClothingHeadHatMimesoft: 3
+    ClothingHeadHatBluesoft: 2
+    ClothingHeadHatYellowsoft: 2
+    ClothingHeadHatGreensoft: 2
+    ClothingHeadHatOrangesoft: 2
+    ClothingHeadHatRedsoft: 2
+    ClothingHeadHatBlacksoft: 2
+    ClothingHeadHatPurplesoft: 2
+    ClothingHeadHatCorpsoft: 2
+    ClothingHeadFishCap: 2
+    ClothingHeadRastaHat: 2
+    ClothingBeltStorageWaistbag: 3
+    ClothingEyesGlasses: 6
+    ClothingHandsGlovesColorBlack: 4
+    ClothingHandsGlovesColorGray: 4
+    ClothingHandsGlovesColorBrown: 2
+    ClothingHandsGlovesColorWhite: 2
+    ClothingHandsGlovesColorRed: 2
+    ClothingHandsGlovesColorBlue: 2
+    ClothingHandsGlovesColorTeal: 2
+    ClothingHandsGlovesColorGreen: 2
+    ClothingHandsGlovesColorOrange: 2
+    ClothingHandsGlovesColorPurple: 2
+    ClothingEyesGlassesCheapSunglasses: 3
+  contrabandInventory:
+    ClothingMaskNeckGaiter: 2
+    ClothingShoesSwat: 2 # imp
+    ClothingMaskGas: 1
+    ToyFigurineGreytider: 1

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/vending_machines.yml
@@ -91,3 +91,39 @@
     access: [["Cargo"]]
   - type: StealTarget #imp
     stealGroup: SalvDrobe
+
+- type: entity
+  parent: VendingMachine
+  id: VendingMachineAccessory
+  name: AccessoryMate
+  description: A vending machine for accessories.
+  components:
+  - type: VendingMachine
+    pack: AccessoryMateInventory
+    offState: off
+    brokenState: broken
+    normalState: normal-unshaded
+    denyState: deny-unshaded
+    soundVend: /Audio/_Impstation/Machines/vending_drop.ogg #imp
+  - type: Advertise
+    pack: ClothesMateAds
+  - type: SpeakOnUIClosed
+    pack: GenericVendGoodbyes
+  - type: Speech
+  - type: Tag
+    tags:
+      - DroneUsable
+  - type: Sprite
+    sprite: Structures/Machines/VendingMachines/clothing.rsi #whatever i do this later!
+    layers:
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.Base"]
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+      shader: unshaded
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: PointLight
+    radius: 1.8
+    energy: 1.6
+    color: "#3db83b"


### PR DESCRIPTION
DONT MERGE THIS YET, i just don't know how to run this test locally
also it needs a sprite.

Moving a whooole lotta shit from the clothesmate to a new vending machine, so we can reduce the cost of the vending restock.
Not 100% sold on this solution, possible alternative is making a new vending restock EXPLICITLY for the clothesmate. dunno how people feel abt that, this seems fine

fundamentally this is just a holdover until we get clothes dyeing anyway

Not mapped, will need to be added by mappers when merged. sorry

:cl:
- add: Hats, shoes, and other apparel have moved from the ClothesMate to a brand new vending machine, the AccessoryDrobe! Coming soon to a station near you.
- tweak: Restocking your drobes just got a LOT cheaper.
