### PR TITLE
Hide manifest hidden departments from the latejoin menu

### DIFF
--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -170,6 +170,9 @@ namespace Content.Client.LateJoin
 
                 foreach (var department in departments)
                 {
+                    // Skip adding departments that are manifest hidden. Imp addition.
+                    if (department.ManifestHidden)
+                        continue;
                     var departmentName = Loc.GetString(department.Name);
                     _jobCategories[id] = new Dictionary<string, BoxContainer>();
                     var stationAvailable = _gameTicker.JobsAvailable[id];


### PR DESCRIPTION
Extension of #1870, hides the Dining Services and Station Specific departments from the latejoin menu.

**Changelog**

:cl:
- tweak: Station Specific and Dining Services departments no longer appear in the late-join menu.
