### PR TITLE
Made Willow a roundstart ghost role

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -712,10 +712,12 @@
     - DoorBumpOpener
     - FootstepSound
   - type: GhostRole
-    prob: 1
+    # imp edit start
+    prob: 1 # up from 0.25
     makeSentient: true
     allowSpeech: true
     allowMovement: true
+    # imp edit end
     name: ghost-role-information-willow-name
     description: ghost-role-information-willow-description
     rules: ghost-role-information-nonantagonist-rules

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -712,7 +712,10 @@
     - DoorBumpOpener
     - FootstepSound
   - type: GhostRole
-    prob: 0.25
+    prob: 1
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
     name: ghost-role-information-willow-name
     description: ghost-role-information-willow-description
     rules: ghost-role-information-nonantagonist-rules


### PR DESCRIPTION
Tiny tweak. Ups the probability of Willow the Boxing Kangaroo being a ghostrole to 100%, up from 25%.

Why:
Came up in the suggestions channel, and I agree. Boxing is in a weird space right now where there's a ring on every map that almost never gets used except to be turned into a maints bar, and a Willow to go along with it. So... why not make her consistently inhabitable?

:cl:
- tweak: Willow's brain experiments were a success! You'll be able to inhabit her body every round.