### PR TITLE
Fix smoking animations

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -121,6 +121,8 @@ public abstract class ClothingSystem : EntitySystem
     {
         if (args.Current is not ClothingComponentState state)
             return;
+
+        SetEquippedPrefix(uid, state.EquippedPrefix, component);
     }
 
     /// imp start


### PR DESCRIPTION
I noticed a line of code that was missing despite it being present in space-wizards#34080 which was included in the upstream merge. Readding this line fixes a issue where the equippedprefix wouldn't get set on the client side for cigarettes which caused the animation to stay hidden.
:cl:
- fix: Smoking will now make smoke again.
