### PR TITLE
Readd the ability to fold clothes while equipped

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/FoldableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FoldableClothingSystem.cs
@@ -37,8 +37,9 @@ public sealed class FoldableClothingSystem : EntitySystem
         }
 
         // Setting hidden layers while equipped is not currently supported.
-        if (ent.Comp.FoldedHideLayers != null || ent.Comp.UnfoldedHideLayers != null)
-            args.Cancelled = true;
+        // Imp Change
+        // if (ent.Comp.FoldedHideLayers != null || ent.Comp.UnfoldedHideLayers != null)
+        //     args.Cancelled = true;
     }
 
     private void OnFolded(Entity<FoldableClothingComponent> ent, ref FoldedEvent args)


### PR DESCRIPTION
space-wizards#34080 Made changes to the foldable clothes system which removed the ability to fold clothes that is equipped due to a bug with bandanas. This makes sense for upstream but doesn't really matter here so I commented out the check that prevented folding while equipped.
:cl: Oberonics
- tweak: You can freely tie your jumpsuit around your waist once again.


