### PR TITLE
Fix Paradox Clone not using mid-round antag spawners

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -264,7 +264,7 @@
     objectives:
     - ParadoxCloneKillObjective
     - ParadoxCloneLivingObjective
-  - type: AntagRandomSpawn # TODO: improve spawning so they only start in maints
+  # - type: AntagRandomSpawn imp edit, uses midround antag spawners
   - type: AntagSelection
     agentName: paradox-clone-round-end-agent-name
     definitions:


### PR DESCRIPTION
The paradox clone event is parented off of the BaseMidRoundAntag spawn event to have it use pre-mapped mid-round antag spawners, however the paradox clone event also has the AntagRandomSpawn, which causes it to spawn on a random point on the station. This PR fixes it so it should follow the same spawn logic as fugitives, spawning off of mid-round antag spawners and using vent spawn locations as a fallback.

**Changelog**

:cl:
- fix: Paradox clones now correctly use the same spawn location as fugitives.