### PR TITLE
Add support for antagonist group playtime requirements, modify Nukeops Commander playtime requirements

### DIFF
--- a/Content.Shared/_Impstation/Roles/AntagGroupPrototype.cs
+++ b/Content.Shared/_Impstation/Roles/AntagGroupPrototype.cs
@@ -1,0 +1,32 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Roles;
+
+/// <summary>
+/// Groups antags together for playtime requirements, similar to department prototype.
+/// This can be expanded to be more similar to department prototypes if more uses can be found for it.
+/// </summary>
+[Prototype]
+public sealed partial class AntagGroupPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// The name LocId of the antag group that will be displayed in the playtime requirement popup.
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Name = string.Empty;
+
+    /// <summary>
+    /// A color representing this antag group to use for text.
+    /// </summary>
+    [DataField(required: true)]
+    public Color Color;
+
+    /// <summary>
+    /// Antags to be included in the antag group.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public List<ProtoId<AntagPrototype>> Roles = new();
+}

--- a/Content.Shared/_Impstation/Roles/JobRequirement/AntagGroupTimeRequirement.cs
+++ b/Content.Shared/_Impstation/Roles/JobRequirement/AntagGroupTimeRequirement.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Localizations;
+using Content.Shared.Preferences;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Roles;
+
+/// <summary>
+/// Calculates antag group playtime requirements. Mostly copies DepartmentTimeRequirement.
+/// </summary>
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class AntagGroupTimeRequirement : JobRequirement
+{
+    /// <summary>
+    /// Which antag group needs the required amount of time.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<AntagGroupPrototype> AntagGroup;
+
+    /// <summary>
+    /// How long (in seconds) this requirement is.
+    /// </summary>
+    [DataField(required: true)]
+    public TimeSpan Time;
+
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = new FormattedMessage();
+        var playtime = TimeSpan.Zero;
+
+        // Check all antags' antag groups.
+        var group = protoManager.Index(AntagGroup);
+        var antags = group.Roles;
+        string proto;
+
+        // Check all jobs' playtime
+        foreach (var other in antags)
+        {
+            // The schema is stored on the Job role but we want to explode if the timer isn't found anyway.
+            proto = protoManager.Index(other).PlayTimeTracker;
+
+            playTimes.TryGetValue(proto, out var otherTime);
+            playtime += otherTime;
+        }
+
+        var groupDiffSpan = Time - playtime;
+        var groupDiff = groupDiffSpan.TotalMinutes;
+        var formattedGroupDiff = ContentLocalizationManager.FormatPlaytime(groupDiffSpan);
+        var nameGroup = "role-timer-antag-group-unknown";
+
+        if (protoManager.TryIndex(AntagGroup, out var groupIndexed))
+        {
+            nameGroup = groupIndexed.Name;
+        }
+
+        if (!Inverted)
+        {
+            if (groupDiff <= 0)
+                return true;
+
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                "role-timer-antag-group-insufficient",
+                ("time", formattedGroupDiff),
+                ("group", Loc.GetString(nameGroup)),
+                ("groupColor", group.Color.ToHex())));
+            return false;
+        }
+
+        if (groupDiff <= 0)
+        {
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                "role-timer-antag-group-insufficient",
+                ("time", formattedGroupDiff),
+                ("group", Loc.GetString(nameGroup)),
+                ("groupColor", group.Color.ToHex())));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/_Impstation/Roles/JobRequirement/AntagGroupTimeRequirement.cs
+++ b/Content.Shared/_Impstation/Roles/JobRequirement/AntagGroupTimeRequirement.cs
@@ -41,10 +41,10 @@ public sealed partial class AntagGroupTimeRequirement : JobRequirement
         var antags = group.Roles;
         string proto;
 
-        // Check all jobs' playtime
+        // Check all antags' playtime
         foreach (var other in antags)
         {
-            // The schema is stored on the Job role but we want to explode if the timer isn't found anyway.
+            // The schema is stored on the Antag role but we want to explode if the timer isn't found anyway.
             proto = protoManager.Index(other).PlayTimeTracker;
 
             playTimes.TryGetValue(proto, out var otherTime);

--- a/Resources/Locale/en-US/_Impstation/job/role-requirements.ftl
+++ b/Resources/Locale/en-US/_Impstation/job/role-requirements.ftl
@@ -1,0 +1,3 @@
+﻿role-timer-antag-group-insufficient = You require [color=yellow]{$time}[/color] more playtime in the [color={$groupColor}]{$group}[/color] antagonist group to unlock this.
+role-timer-antag-group-too-high = You require [color=yellow]{$time}[/color] less playtime in the [color={$groupColor}]{$group}[/color] antagonist group to select this. (Are you trying to play a trainee role?)
+role-timer-antag-group-unknown = Unknown Antagonist Group

--- a/Resources/Locale/en-US/_Impstation/prototypes/roles/antag_groups.ftl
+++ b/Resources/Locale/en-US/_Impstation/prototypes/roles/antag_groups.ftl
@@ -1,0 +1,1 @@
+﻿antag-group-Nukies = Nuclear Operative Team

--- a/Resources/Locale/en-US/_Impstation/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/_Impstation/prototypes/roles/antags.ftl
@@ -1,0 +1,29 @@
+﻿# role timers
+
+AntagNuclearAgent = Nuclear Operative Agent
+AntagNuclearOperative = Nuclear Operative
+AntagNuclearCommander = Nuclear Operative Commander
+AntagLoneOperative = Lone Operative
+AntagSyndicateAgent = Syndicate Agent
+AntagSyndicateSleeperAgent = Syndicate Sleeper Agent
+AntagThief = Thief
+AntagHeadRevolutionary = Head Revolutionary
+AntagRevolutionary = Revolutionary
+AntagZombie = Zombie
+AntagInitialInfected = Initial Infected
+JobNinja = Space Ninja
+AntagNinja = Space Ninja
+AntagDragon = Space Dragon
+AntagSubvertedSilicon = Subverted Silicon
+AntagSurvivor = Survivor
+AntagWizard = Wizard
+AntagParadoxClone = Paradox Clone
+
+# non-upstream role timers
+
+AntagFugitive = Fugitive
+AntagSyndicateRecruiter = Syndicate Recruiter
+AntagListeningPost = Listening Post Operator
+AntagSynthesisSpecialist = Syndicate Synthesis Specialist
+AntagChangeling = Changeling
+AntagHeretic = Heretic

--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -47,32 +47,3 @@ roles-antag-thief-objective = Add some NT property to your personal collection w
 
 roles-antag-dragon-name = Space Dragon
 roles-antag-dragon-objective = Create a carp army to take over this quadrant.
-
-# role timers
-
-AntagNuclearAgent = Nuclear Operative Agent
-AntagNuclearOperative = Nuclear Operative
-AntagNuclearCommander = Nuclear Operative Commander
-AntagSyndicateAgent = Syndicate Agent
-AntagSyndicateSleeperAgent = Syndicate Sleeper Agent
-AntagThief = Thief
-AntagHeadRevolutionary = Head Revolutionary
-AntagRevolutionary = Revolutionary
-AntagZombie = Zombie
-AntagInitialInfected = Initial Infected
-JobNinja = Space Ninja
-AntagNinja = Space Ninja
-AntagDragon = Space Dragon
-AntagSubvertedSilicon = Subverted Silicon
-AntagSurvivor = Survivor
-AntagWizard = Wizard
-AntagParadoxClone = Paradox Clone
-
-# non-upstream role timers
-
-AntagFugitive = Fugitive
-AntagSyndicateRecruiter = Syndicate Recruiter
-AntagListeningPost = Listening Post Operator
-AntagSynthesisSpecialist = Syndicate Synthesis Specialist
-AntagChangeling = Changeling
-AntagHeretic = Heretic

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -481,7 +481,7 @@
         factions:
         - Syndicate
       mindRoles:
-      - MindRoleNukeops
+      - MindRoleNukeopsLone #imp edit to separate playtime tracking from regular nukies
 
 - type: entity
   parent: BaseTraitorRule

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -33,20 +33,16 @@
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
-  - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 27000 # 7.5 hours
-  - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 27000 # 7.5 hours
-  - !type:DepartmentTimeRequirement
-      department: Security
-      time: 27000 # 7.5 hours
-  - !type:DepartmentTimeRequirement
-      department: Command
-      time: 27000 # 7.5 hours
-  # this is half the requirements to unlock captain, and should be enough for a nuke ops commander to have a basic, broad understanding of the game
-  # should be changed to nukie playtime when thats tracked (wyci)
+  # imp edit start, added general nukie requirment
+  #- !type:OverallPlaytimeRequirement
+  #  time: 18000 # 5h
+  #- !type:DepartmentTimeRequirement
+  #  department: Security
+  #  time: 18000 # 5h
+  - !type:AntagGroupTimeRequirement
+    antagGroup: Nukies
+    time: 14400 # 4h
+  # imp edit end
   guides: [ NuclearOperatives ]
 
 - type: startingGear

--- a/Resources/Prototypes/_Impstation/Roles/Antags/antag_groups.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Antags/antag_groups.yml
@@ -1,0 +1,8 @@
+- type: antagGroup
+  id: Nukies
+  name: antag-group-Nukies
+  color: "#ff0000"
+  roles:
+  - Nukeops
+  - NukeopsMedic
+  - NukeopsCommander

--- a/Resources/Prototypes/_Impstation/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Antags/nukeops.yml
@@ -1,0 +1,11 @@
+- type: antag
+  id: NukeopsLone
+  name: ghost-role-information-loneop-name
+  antagonist: true
+  playTimeTracker: AntagLoneOperative
+  setPreference: true
+  objective: ghost-role-information-loneop-description
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 18000
+  guides: [ NuclearOperatives ]

--- a/Resources/Prototypes/_Impstation/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_Impstation/Roles/MindRoles/mind_roles.yml
@@ -6,3 +6,14 @@
   - type: MindRole
     roleType: FreeAgent
   - type: GhostRoleMarkerRole
+
+#Lone Op
+- type: entity
+  parent: MindRoleNukeops
+  id: MindRoleNukeopsLone
+  name: Lone Operative Role
+  components:
+  - type: MindRole
+    roleType: SoloAntagonist
+    antagPrototype: NukeopsLone
+  - type: NukeopsRole

--- a/Resources/Prototypes/_Impstation/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_Impstation/Roles/play_time_trackers.yml
@@ -37,6 +37,9 @@
   id: AntagNuclearCommander
 
 - type: playTimeTracker
+  id: AntagLoneOperative
+
+- type: playTimeTracker
   id: AntagHeadRevolutionary
 
 - type: playTimeTracker


### PR DESCRIPTION
Adds the AntagGroup prototype which can be used to group different antagonist together for calculating playtime requirements, similar to departmental playtime requirements. This is implemented to add general Nukeops playtime requirements for the Nukeops Commander, but can be expanded on further in the future.

The Nuclear Operative Commander antag now requires 4 hours of Nuclear Operative Team playtime (which includes the Nuclear Operative, Agent, and Commander) in order to play, fulfilling the todo left in the comments for it. I have opted to keep this requirement relatively low, as accumulating playtime as a nukeop generally speaking takes a longer amount of time than regular jobs. and I would prefer to keep the barrier for entry lower to allow for a wider pool of players to learn the role. This also gives Lone Op their own mind role and antagonist prototype with their own playtime tracker so their playtime can be excluded from counting towards commander requirements, as I feel learning how to play in a team should be an important aspect in gaining the requirements for commander. I don't imagine this will apply to any playtime accumulated through loneops retroactively, since that information has already been written to the database.

This also migrates antag playtime tracker locale strings to our namespace, since they were implemented by us.

![ldB01aE](https://github.com/user-attachments/assets/ed86da01-064d-4612-93fd-9066c6918ad9)


**Changelog**

:cl:
- tweak: Nukeops Commander now requires 4 hours of playtime of any team nukeops role in place of its previous requirements.
- tweak: Lone Operative playtime will now be tracked separately from the regular Nuclear Operative role and will not count towards Nukeops Commander playtime requirements.
