### PR TITLE
Add Brig access maints airlock prototype

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Doors/Airlocks/access.yml
@@ -205,6 +205,16 @@
   - type: Wires
     layoutId: AirlockSecurity
 
+# Security
+- type: entity
+  parent: AirlockMaintSecLocked
+  id: AirlockMaintBrigLocked
+  suffix: Brig, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBrig ]
+
 # Service
 - type: entity
   parent: AirlockMaintServiceLocked


### PR DESCRIPTION
Adds a maints airlock prototype with Brig access. It didn't exist before, so security departments either had to use regular Brig airlocks or use Sec maints airlocks.