### PR TITLE
0.1% chance of vent reagent slime

### DIFF
--- a/Resources/Prototypes/_Impstation/GameRules/pests.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/pests.yml
@@ -10,11 +10,13 @@
   - type: VentCrittersRule
     entries:
     - id: MobAdultSlimesBlueAngry
-      prob: 0.02
+      prob: 0.01998
     - id: MobAdultSlimesGreenAngry
-      prob: 0.02
+      prob: 0.01998
     - id: MobAdultSlimesYellowAngry
-      prob: 0.02
+      prob: 0.01998
+    - id: ReagentSlimeSpawner
+      prob: 0.00006
 
 - type: entity
   id: SnakeSpawn


### PR DESCRIPTION
Slime event now has a 0.1% chance of reagent slime.

:cl:
- tweak: minuscule chance that the vent slimes discovered how to be made of drugs
