### PR TITLE
making cargo tech unlock and supass lockout more reasonable

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Cargo
-    time: 21600 # 6 hrs ~3 shifts.
+    time: 7200 # 2 hrs ~2 shifts.
   # End DeltaV modifications
   startingGear: CargoTechGear
   icon: "JobIconCargoTechnician"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Cargo
-    time: 7200 # 2 hrs ~2 shifts.
+    time: 7200 # IMP 2 hrs ~2 shifts, down from 6h
   # End DeltaV modifications
   startingGear: CargoTechGear
   icon: "JobIconCargoTechnician"

--- a/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Cargo
-    time: 18000 #5 hrs
+    time: 18000 #IMP 5 hrs, down from 15h
     inverted: true # stop playing intern if you're good at cargo!
   icon: "JobIconSupplyAssistant"
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Cargo
-    time: 54000 #15 hrs
+    time: 18000 #5 hrs
     inverted: true # stop playing intern if you're good at cargo!
   icon: "JobIconSupplyAssistant"
   supervisors: job-supervisors-qm


### PR DESCRIPTION
supply assistant's now unlock cargo technician at 2 hrs instead of 6 hrs, and lockout of supass at 5 hrs instead of 15 hrs 

:cl:
- tweak: Supply Assistant's may or may not have been randomly promoted! 

