### PR TITLE
Brigmed Locker Access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -343,7 +343,7 @@
     stateDoorOpen: armory_open
     stateDoorClosed: brigmedic_door
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["Medical"], ["Armory"]]
 
 # Security Officer
 - type: entity


### PR DESCRIPTION
Brigmed lockers can now also be opened by people with armory access lol, not just medical access. Warden and HoS can get in there if needed, like detective or regular officer lockers. No clue why, but it's Sec jurisdiction, so might be good to have the option.
:cl:
- add: Brigmedical lockers can now be accessed by the brigmedic's superiors.