### PR TITLE
Reagent slime probability

### DIFF
--- a/Content.Server/_Impstation/Spawners/Components/SpawnEntrySpawnerComponent.cs
+++ b/Content.Server/_Impstation/Spawners/Components/SpawnEntrySpawnerComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Content.Shared.Storage;
+
+namespace Content.Server._Impstation.Spawners.Components
+{
+    [RegisterComponent, EntityCategory("Spawner")]
+    public sealed partial class SpawnEntrySpawnerComponent : Component, ISerializationHooks
+    {
+        /// <summary>
+        /// List of entities that can be spawned by this component. Each entity will be spawned according to the rules of entity spawn entries.
+        /// </summary>
+        [DataField]
+        public List<EntitySpawnEntry>? Spawns;
+
+        /// <summary>
+        /// Scatter of entity spawn coordinates
+        /// </summary>
+        [DataField]
+        public float Range { get; set; } = 0.2f;
+    }
+}

--- a/Content.Server/_Impstation/Spawners/EntitySystems/SpawnEntrySpawnerSystem.cs
+++ b/Content.Server/_Impstation/Spawners/EntitySystems/SpawnEntrySpawnerSystem.cs
@@ -1,0 +1,48 @@
+using Content.Server.GameTicking;
+using Robust.Shared.Random;
+using System.Numerics;
+using Content.Server._Impstation.Spawners.Components;
+using Content.Shared.Storage;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.Spawners.EntitySystems
+{
+    public sealed class SpawnerEntrySpawnerSystem : EntitySystem
+    {
+
+        [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly TransformSystem _transform = default!;
+
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<SpawnEntrySpawnerComponent, ComponentInit>(OnSpawnEntrySpawnMapInit);
+        }
+
+        private void OnSpawnEntrySpawnMapInit(EntityUid uid, SpawnEntrySpawnerComponent component, ComponentInit args)
+        {
+            TrySpawn(uid, component);
+        }
+
+        private void TrySpawn(EntityUid uid, SpawnEntrySpawnerComponent component)
+        {
+
+            var coordinates = Transform(uid).Coordinates;
+
+            if (component.Spawns is not {} spawns)
+                return;
+
+            var coord = _transform.GetMapCoordinates(uid);
+            foreach (var spawn in EntitySpawnCollection.GetSpawns(spawns, _random))
+            {
+                var dx = _random.NextFloat(-component.Range, component.Range);
+                var dy = _random.NextFloat(-component.Range, component.Range);
+                var spawnCord = coord.Offset(new Vector2(dx, dy));
+                var ent = Spawn(spawn, spawnCord);
+                _transform.AttachToGridOrMap(ent);
+            }
+        }
+    }
+}

--- a/Content.Server/_Impstation/Spawners/EntitySystems/SpawnEntrySpawnerSystem.cs
+++ b/Content.Server/_Impstation/Spawners/EntitySystems/SpawnEntrySpawnerSystem.cs
@@ -28,9 +28,6 @@ namespace Content.Server.Spawners.EntitySystems
 
         private void TrySpawn(EntityUid uid, SpawnEntrySpawnerComponent component)
         {
-
-            var coordinates = Transform(uid).Coordinates;
-
             if (component.Spawns is not {} spawns)
                 return;
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -381,39 +381,101 @@
         - state: red
         - sprite: Mobs/Aliens/elemental.rsi
           state: alive
-    - type: RandomSpawner
-      prototypes:
-        - ReagentSlime
-        - ReagentSlimeBeer
-        - ReagentSlimePax
-        - ReagentSlimeNocturine
-        - ReagentSlimeTHC
-        - ReagentSlimeBicaridine
-        - ReagentSlimeToxin
-        - ReagentSlimeNapalm
-        - ReagentSlimeOmnizine
-        - ReagentSlimeMuteToxin
-        - ReagentSlimeNorepinephricAcid
-        - ReagentSlimeEphedrine
-        - ReagentSlimeRobustHarvest
-        - ReagentSlimeTestosterone
-        - ReagentSlimeEstradiol
-        - ReagentSlimeRomerol
-        - ReagentSlimePhlogiston
-        - ReagentSlimeLicoxide
-        - ReagentSlimeMindbreakerToxin
-        - ReagentSlimeDesoxyephedrine
-        - ReagentSlimeLexorin
-        - ReagentSlimeHorsepussy
-        - ReagentSlimeCogChamp
-        - ReagentSlimeDrGibb
-        - ReagentSlimeBrosochloricBros
-        - ReagentSlimeJuiceThatMakesYouWeh
-        - ReagentSlimeChlorineTrifluoride
-        - ReagentSlimeHonk
-        - ReagentSlimeIpecac
-        - ReagentSlimeJuiceThatMakesYouUngh
-      chance: 1
+    - type: SpawnEntrySpawner #IMP: Change to spawner that uses more complex probabilities
+      spawns:
+      - id: ReagentSlime
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeBeer
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimePax
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeNocturine
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeTHC
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeBicaridine
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeToxin
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeNapalm
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeOmnizine
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeMuteToxin
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeNorepinephricAcid
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeEphedrine
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeRobustHarvest
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeTestosterone
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeEstradiol
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeRomerol
+        prob: 0.5
+        orGroup: ReagentSlimes
+      - id: ReagentSlimePhlogiston
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeLicoxide
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeMindbreakerToxin
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeDesoxyephedrine
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeLexorin
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeHorsepussy
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeCogChamp
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeDrGibb
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeBrosochloricBros
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeJuiceThatMakesYouWeh
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeChlorineTrifluoride
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeHonk
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeIpecac
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeJuiceThatMakesYouUngh
+        prob: 1
+        orGroup: ReagentSlimes
+      - id: ReagentSlimeCoffee
+        prob: 1
+        orGroup: ReagentSlimes
 
 - type: entity
   id: ReagentSlimeBeer
@@ -624,292 +686,3 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
         color: "#3e901c"
-
-- type: entity
-  id: ReagentSlimeTestosterone
-  parent: ReagentSlime
-  suffix: Testosterone
-  components:
-  - type: Bloodstream
-    bloodReagent: Testosterone
-  - type: PointLight
-    color: "#267ef0"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#267ef0"
-
-- type: entity
-  id: ReagentSlimeEstradiol
-  parent: ReagentSlime
-  suffix: Estradiol
-  components:
-  - type: Bloodstream
-    bloodReagent: Estradiol
-  - type: PointLight
-    color: "pink"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "pink"
-
-- type: entity
-  id: ReagentSlimeRomerol
-  parent: ReagentSlime
-  suffix: Romerol
-  components:
-  - type: Bloodstream
-    bloodReagent: Romerol
-  - type: PointLight
-    color: "#7e916e"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#7e916e"
-
-- type: entity
-  id: ReagentSlimePhlogiston
-  parent: ReagentSlime
-  suffix: Phlogiston
-  components:
-  - type: Bloodstream
-    bloodReagent: Phlogiston
-  - type: PointLight
-    color: "#D4872A"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#D4872A"
-
-- type: entity
-  id: ReagentSlimeLicoxide
-  parent: ReagentSlime
-  suffix: Licoxide
-  components:
-  - type: Bloodstream
-    bloodReagent: Licoxide
-  - type: PointLight
-    color: "#FDD023"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#FDD023"
-
-- type: entity
-  id: ReagentSlimeMindbreakerToxin
-  parent: ReagentSlime
-  suffix: MindbreakerToxin
-  components:
-  - type: Bloodstream
-    bloodReagent: MindbreakerToxin
-  - type: PointLight
-    color: "#77b58e"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#77b58e"
-
-- type: entity
-  id: ReagentSlimeDesoxyephedrine
-  parent: ReagentSlime
-  suffix: Desoxyephedrine
-  components:
-  - type: Bloodstream
-    bloodReagent: Desoxyephedrine
-  - type: PointLight
-    color: "#FAFAFA"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#FAFAFA"
-
-- type: entity
-  id: ReagentSlimeCogChamp
-  parent: ReagentSlime
-  suffix: CogChamp
-  components:
-  - type: Bloodstream
-    bloodReagent: CogChamp
-  - type: PointLight
-    color: "#B5A642"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#B5A642"
-
-- type: entity
-  id: ReagentSlimeLexorin
-  parent: ReagentSlime
-  suffix: Lexorin
-  components:
-  - type: Bloodstream
-    bloodReagent: Lexorin
-  - type: PointLight
-    color: "#6b0007"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#6b0007"
-
-- type: entity
-  id: ReagentSlimeHorsepussy
-  parent: ReagentSlime
-  suffix: TheeHorsepussy
-  components:
-  - type: Bloodstream
-    bloodReagent: TheeHorsepussy
-  - type: PointLight
-    color: "#7BD18C"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#7BD18C"
-
-- type: entity
-  id: ReagentSlimeIpecac
-  parent: ReagentSlime
-  suffix: Ipecac
-  components:
-  - type: Bloodstream
-    bloodReagent: Ipecac
-  - type: PointLight
-    color: "#422912"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#422912"
-
-- type: entity
-  id: ReagentSlimeHonk
-  parent: ReagentSlime
-  suffix: Honk
-  components:
-  - type: Bloodstream
-    bloodReagent: Honk
-  - type: PointLight
-    color: "#F2E9D2"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#F2E9D2"
-
-- type: entity
-  id: ReagentSlimeChlorineTrifluoride
-  parent: ReagentSlime
-  suffix: Chlorine Trifluoride
-  components:
-  - type: Bloodstream
-    bloodReagent: ChlorineTrifluoride
-  - type: PointLight
-    color: "#FFC8C8"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#FFC8C8"
-
-- type: entity
-  id: ReagentSlimeJuiceThatMakesYouWeh
-  parent: ReagentSlime
-  suffix: JuiceThatMakesYouWeh
-  components:
-  - type: Bloodstream
-    bloodReagent: JuiceThatMakesYouWeh
-  - type: PointLight
-    color: "#59b23a"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#59b23a"
-
-- type: entity
-  id: ReagentSlimeBrosochloricBros
-  parent: ReagentSlime
-  suffix: BrosochloricBros
-  components:
-  - type: Bloodstream
-    bloodReagent: BrosochloricBros
-  - type: PointLight
-    color: "#47181A"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#47181A"
-
-- type: entity
-  id: ReagentSlimeDrGibb
-  parent: ReagentSlime
-  suffix: DrGibb
-  components:
-  - type: Bloodstream
-    bloodReagent: DrGibb
-  - type: PointLight
-    color: "#102000"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#102000"
-
-- type: entity
-  id: ReagentSlimeJuiceThatMakesYouUngh
-  parent: ReagentSlime
-  suffix: JuiceThatMakesYouUngh
-  components:
-  - type: Bloodstream
-    bloodReagent: JuiceThatMakesYouUngh
-  - type: PointLight
-    color: "#8F3134"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#8F3134"

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/elemental.yml
@@ -1,0 +1,305 @@
+- type: entity
+  id: ReagentSlimeTestosterone
+  parent: ReagentSlime
+  suffix: Testosterone
+  components:
+  - type: Bloodstream
+    bloodReagent: Testosterone
+  - type: PointLight
+    color: "#267ef0"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#267ef0"
+
+- type: entity
+  id: ReagentSlimeEstradiol
+  parent: ReagentSlime
+  suffix: Estradiol
+  components:
+  - type: Bloodstream
+    bloodReagent: Estradiol
+  - type: PointLight
+    color: "pink"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "pink"
+
+- type: entity
+  id: ReagentSlimeRomerol
+  parent: ReagentSlime
+  suffix: Romerol
+  components:
+  - type: Bloodstream
+    bloodReagent: Romerol
+  - type: PointLight
+    color: "#7e916e"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#7e916e"
+
+- type: entity
+  id: ReagentSlimePhlogiston
+  parent: ReagentSlime
+  suffix: Phlogiston
+  components:
+  - type: Bloodstream
+    bloodReagent: Phlogiston
+  - type: PointLight
+    color: "#D4872A"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#D4872A"
+
+- type: entity
+  id: ReagentSlimeLicoxide
+  parent: ReagentSlime
+  suffix: Licoxide
+  components:
+  - type: Bloodstream
+    bloodReagent: Licoxide
+  - type: PointLight
+    color: "#FDD023"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#FDD023"
+
+- type: entity
+  id: ReagentSlimeMindbreakerToxin
+  parent: ReagentSlime
+  suffix: MindbreakerToxin
+  components:
+  - type: Bloodstream
+    bloodReagent: MindbreakerToxin
+  - type: PointLight
+    color: "#77b58e"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#77b58e"
+
+- type: entity
+  id: ReagentSlimeDesoxyephedrine
+  parent: ReagentSlime
+  suffix: Desoxyephedrine
+  components:
+  - type: Bloodstream
+    bloodReagent: Desoxyephedrine
+  - type: PointLight
+    color: "#FAFAFA"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#FAFAFA"
+
+- type: entity
+  id: ReagentSlimeCogChamp
+  parent: ReagentSlime
+  suffix: CogChamp
+  components:
+  - type: Bloodstream
+    bloodReagent: CogChamp
+  - type: PointLight
+    color: "#B5A642"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#B5A642"
+
+- type: entity
+  id: ReagentSlimeLexorin
+  parent: ReagentSlime
+  suffix: Lexorin
+  components:
+  - type: Bloodstream
+    bloodReagent: Lexorin
+  - type: PointLight
+    color: "#6b0007"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#6b0007"
+
+- type: entity
+  id: ReagentSlimeHorsepussy
+  parent: ReagentSlime
+  suffix: TheeHorsepussy
+  components:
+  - type: Bloodstream
+    bloodReagent: TheeHorsepussy
+  - type: PointLight
+    color: "#7BD18C"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#7BD18C"
+
+- type: entity
+  id: ReagentSlimeIpecac
+  parent: ReagentSlime
+  suffix: Ipecac
+  components:
+  - type: Bloodstream
+    bloodReagent: Ipecac
+  - type: PointLight
+    color: "#422912"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#422912"
+
+- type: entity
+  id: ReagentSlimeHonk
+  parent: ReagentSlime
+  suffix: Honk
+  components:
+  - type: Bloodstream
+    bloodReagent: Honk
+  - type: PointLight
+    color: "#F2E9D2"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#F2E9D2"
+
+- type: entity
+  id: ReagentSlimeChlorineTrifluoride
+  parent: ReagentSlime
+  suffix: Chlorine Trifluoride
+  components:
+  - type: Bloodstream
+    bloodReagent: ChlorineTrifluoride
+  - type: PointLight
+    color: "#FFC8C8"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#FFC8C8"
+
+- type: entity
+  id: ReagentSlimeJuiceThatMakesYouWeh
+  parent: ReagentSlime
+  suffix: JuiceThatMakesYouWeh
+  components:
+  - type: Bloodstream
+    bloodReagent: JuiceThatMakesYouWeh
+  - type: PointLight
+    color: "#59b23a"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#59b23a"
+
+- type: entity
+  id: ReagentSlimeBrosochloricBros
+  parent: ReagentSlime
+  suffix: BrosochloricBros
+  components:
+  - type: Bloodstream
+    bloodReagent: BrosochloricBros
+  - type: PointLight
+    color: "#47181A"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#47181A"
+
+- type: entity
+  id: ReagentSlimeDrGibb
+  parent: ReagentSlime
+  suffix: DrGibb
+  components:
+  - type: Bloodstream
+    bloodReagent: DrGibb
+  - type: PointLight
+    color: "#102000"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#102000"
+
+- type: entity
+  id: ReagentSlimeJuiceThatMakesYouUngh
+  parent: ReagentSlime
+  suffix: JuiceThatMakesYouUngh
+  components:
+  - type: Bloodstream
+    bloodReagent: JuiceThatMakesYouUngh
+  - type: PointLight
+    color: "#8F3134"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#8F3134"
+
+- type: entity
+  id: ReagentSlimeCoffee
+  parent: ReagentSlime
+  suffix: Coffee
+  components:
+  - type: Bloodstream
+    bloodReagent: Coffee
+  - type: PointLight
+    color: "#664300"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#664300"


### PR DESCRIPTION
Adds
- new spawner system using EntitySpawnEntry, which allows individual probability per entity
- changed reagent slimes to use this system, so we can control the probabilities
- halved chance of romerol compared to everything else
- added coffee reagent slime
- migrated imp slimes to impstation

:cl:
- tweak: reduced romerol slime probability
- add: coffee slime (it is yum OR poison)
