### PR TITLE
guidebookshelf resorting

### DIFF
--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Books/guidebookshelf.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Books/guidebookshelf.yml
@@ -5,8 +5,10 @@
   components:
   - type: StorageFill
     contents:
-    # ALL GUIDEBOOKS, ONLY GUIDEBOOKS. Imp guidebooks sorted in alphabetically by item name, not including titles that start with an article
+    # ALL GUIDEBOOKS, ONLY GUIDEBOOKS. Guidebooks sorted alphabetically by in-game item name, not item ID
+    # If the title starts with an article (a, an, the), sort it by the next word (e.g., The Book of Control is under B)
     - id: BookBartendersManual #bartender's manual
+    - id: BookTheBookOfControl #the book of control
     - id: BookChemicalCompendium #chempendium
     - id: BookEngineersHandbook #engineer's handbook
     - id: BookTEGtorial #guide ta tha thermo-electric generator (imp)
@@ -14,7 +16,6 @@
     - id: BookHowToKeepStationClean #how to keep station clean
     - id: BookHowToRockAndStone #how to rock and stone
     - id: BookHowToSurvive #how to survive
-    - id: BookJarvisBayCulture # cultural guide to medical (imp)
     - id: BookKeelBay #Keel-Ree's guide to medical (imp)
     - id: BookLeafLoversSecret #leaf lover's secret
     - id: BookMedicalReferenceBook #medical reference book
@@ -27,5 +28,5 @@
     - id: BookSecurity #security 101
     - id: BookSpaceEncyclopedia #space encyclopedia
     - id: BookSpaceLaw #space law
-    - id: BookTheBookOfControl #the book of control
+    - id: BookJarvisBayCulture #suns among the void, a cultural guide to medical (imp)
     - id: BookSMForDummies #the supermatter for dummies


### PR DESCRIPTION
just moving a couple of guidebooks on their shelf so it's properly alphabetical by title (ignoring articles), moved the new medical guidebook and also i realized i had put The Book of Control under T instead of B

keb dewey decimal

![image](https://github.com/user-attachments/assets/81a1e636-2e17-481e-8749-090b79f4a181)

also updated the comments to be more clear

no cl