### PR TITLE
The Syndicate is Saved!!

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -85,6 +85,9 @@
     outerClothing: ClothingOuterHardsuitSyndieCommander
   storage:
     back:
+    - DeathAcidifierImplanter
+    - WeaponPistolViper
+    - PinpointerSyndicateNuclear
     - NukieSpectralLocator # Imp special!!
   inhand:
   - NukeOpsDeclarationOfWar
@@ -123,6 +126,4 @@
     - PinpointerSyndicateNuclear
     - DeathAcidifierImplanter
     - NukieSpectralLocator # Imp special!!
-    - DeathAcidifierImplanter
-    - WeaponPistolViper
 


### PR DESCRIPTION
I completely forgot to fix this forever ago. Lone op had double gear and nukie commander had lost most of their starting gear. I don't know how I made this mistake lmao, but it's fixed now!

**Changelog**
:cl:
- fix: The Nukie Commander has gotten their spare gear back, after the Lone Op borrowed it for a while.