### PR TITLE
A number of Suppy changes

### DIFF
--- a/Resources/Maps/_Impstation/box.yml
+++ b/Resources/Maps/_Impstation/box.yml
@@ -130219,7 +130219,6 @@ entities:
   - uid: 14349
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-81.5
       parent: 8364
 - proto: PhoneInstrument

--- a/Resources/Maps/_Impstation/union.yml
+++ b/Resources/Maps/_Impstation/union.yml
@@ -103910,7 +103910,6 @@ entities:
   - uid: 2735
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -45.5,-60.5
       parent: 2
 - proto: PhoneInstrument

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -39,6 +39,7 @@
     whitelist:
       tags:
         - VimPilot # If it can fit in a Vim it can fit in a pet carrier.
+        - Suppy # imp edit
   - type: Weldable
   - type: ResistLocker
   - type: PlaceableSurface

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -14,7 +14,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 300
+        density: 1000
         mask:
         - MobMask
         layer:
@@ -60,6 +60,8 @@
       Male: Suppy
       Female: Suppy
       Unsexed: Suppy
+  - type: Actions
+  - type: Alerts
   - type: AnimatedEmotes
   - type: MobState #for deathgasp
   - type: InputMover
@@ -75,6 +77,9 @@
   - type: Eye
   - type: ContentEye
   - type: CameraRecoil
+  - type: Reactive
+    groups:
+      Extinguish: [ Touch ]
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -95,6 +95,12 @@
   - type: Inventory
     speciesId: suppy
     templateId: suppy
+  - type: ContainerContainer
+    containers:
+      body_root_part: !type:ContainerSlot
+      mask: !type:ContainerSlot
+      eyes: !type:ContainerSlot
+      head: !type:ContainerSlot
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -95,7 +95,6 @@
   - type: Inventory
     speciesId: suppy
     templateId: suppy
-  - type: ContainerContainer
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -95,6 +95,7 @@
   - type: Inventory
     speciesId: suppy
     templateId: suppy
+  - type: ContainerContainer
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -106,9 +106,7 @@
       collection: SupermatterAccentNormal
   - type: StealTarget
     stealGroup: PetSuppy
-  - type: ContainerContainer
-    containers:
-      body_root_part: !type:ContainerSlot
   - type: Tag
     tags:
     - DoorBumpOpener
+    - Suppy

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -5,6 +5,12 @@
   suffix: Engineering's pet, steal target
   description: Engineering's pet suppermatter chunk. He dreams of causing station-wide destruction some day, but his bark is bigger than his bite.
   components:
+  - type: ContainerContainer
+    containers:
+      body_root_part: !type:ContainerSlot
+      mask: !type:ContainerSlot
+      eyes: !type:ContainerSlot
+      head: !type:ContainerSlot
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
@@ -95,12 +101,6 @@
   - type: Inventory
     speciesId: suppy
     templateId: suppy
-  - type: ContainerContainer
-    containers:
-      body_root_part: !type:ContainerSlot
-      mask: !type:ContainerSlot
-      eyes: !type:ContainerSlot
-      head: !type:ContainerSlot
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -5,12 +5,6 @@
   suffix: Engineering's pet, steal target
   description: Engineering's pet suppermatter chunk. He dreams of causing station-wide destruction some day, but his bark is bigger than his bite.
   components:
-  - type: ContainerContainer
-    containers:
-      body_root_part: !type:ContainerSlot
-      mask: !type:ContainerSlot
-      eyes: !type:ContainerSlot
-      head: !type:ContainerSlot
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
@@ -101,6 +95,24 @@
   - type: Inventory
     speciesId: suppy
     templateId: suppy
+  - type: ContainerContainer
+    containers:
+      body_root_part: !type:ContainerSlot
+        showEnts: False
+        occludes: True
+        ent: null
+      mask: !type:ContainerSlot
+        showEnts: False
+        occludes: False
+        ent: null
+      eyes: !type:ContainerSlot
+        showEnts: False
+        occludes: False
+        ent: null
+      head: !type:ContainerSlot
+        showEnts: False
+        occludes: False
+        ent: null
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -24,8 +24,22 @@
     state: suppermatter
     noRot: true
     drawdepth: Mobs
+  - type: IntrinsicRadioReceiver
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Common
+    - Engineering
+  - type: ActiveRadio
+    channels:
+    - Common
+    - Engineering
+  - type: Access
+    tags:
+    - Maintenance
+    - Engineering
   - type: Appearance
   - type: Body # for letting someone use the pet carrier on it
+  - type: Buckle
   - type: Climbing
   - type: Pullable
   - type: Damageable
@@ -51,11 +65,16 @@
   - type: InputMover
   - type: Input
     context: "human"
-  - type: Examiner
+  - type: LagCompensation
   - type: MobMover
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.1
     baseSprintSpeed: 0.2
+  - type: DoAfter
+  - type: Examiner
+  - type: Eye
+  - type: ContentEye
+  - type: CameraRecoil
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup
@@ -70,3 +89,6 @@
   - type: ContainerContainer
     containers:
       body_root_part: !type:ContainerSlot
+  - type: Tag
+    tags:
+    - DoorBumpOpener

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -1,6 +1,7 @@
 - type: entity
   name: Suppy
   id: PetSuppy
+  parent: StripableInventoryBase
   suffix: Engineering's pet, steal target
   description: Engineering's pet suppermatter chunk. He dreams of causing station-wide destruction some day, but his bark is bigger than his bite.
   components:
@@ -24,6 +25,8 @@
     state: suppermatter
     noRot: true
     drawdepth: Mobs
+  - type: Transform
+    noRot: true
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:
@@ -80,6 +83,18 @@
   - type: Reactive
     groups:
       Extinguish: [ Touch ]
+  - type: SupermatterImmune
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 25
+    soundHit:
+      collection: MetalThud
+  - type: StaminaDamageOnHit #if you launch suppy at someone, it'll bonk them bad and knock them on their ass
+    damage: 100
+  - type: Inventory
+    speciesId: suppy
+    templateId: suppy
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-superdense
   - type: InteractionPopup

--- a/Resources/Prototypes/_Impstation/InventoryTemplates/suppy_inventory_template.yml
+++ b/Resources/Prototypes/_Impstation/InventoryTemplates/suppy_inventory_template.yml
@@ -1,0 +1,20 @@
+- type: inventoryTemplate
+  id: suppy
+  slots:
+  - name: mask
+    slotTexture: mask
+    slotFlags: MASK
+    uiWindowPos: 1,1
+    strippingWindowPos: 1,1
+    displayName: Mask
+    offset: -0.3, -0.2
+    whitelist:
+      tags:
+        - PetWearable
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiWindowPos: 1,2
+    strippingWindowPos: 1,0
+    displayName: Head
+    offset: -0.1, 0.0

--- a/Resources/Prototypes/_Impstation/InventoryTemplates/suppy_inventory_template.yml
+++ b/Resources/Prototypes/_Impstation/InventoryTemplates/suppy_inventory_template.yml
@@ -1,20 +1,34 @@
 - type: inventoryTemplate
   id: suppy
   slots:
+
   - name: mask
     slotTexture: mask
     slotFlags: MASK
+    stripTime: 1
     uiWindowPos: 1,1
-    strippingWindowPos: 1,1
+    strippingWindowPos: 1,2
     displayName: Mask
     offset: -0.3, -0.2
     whitelist:
       tags:
         - PetWearable
+
+  - name: eyes
+    slotTexture: glasses
+    slotFlags: EYES
+    stripTime: 1
+    uiWindowPos: 1,2
+    strippingWindowPos: 1,1
+    displayName: Eyes
+    offset: -0.1, -0.06
+
   - name: head
     slotTexture: head
     slotFlags: HEAD
-    uiWindowPos: 1,2
+    stripTime: 1
+    uiWindowPos: 1,3
     strippingWindowPos: 1,0
     displayName: Head
     offset: -0.1, 0.0
+

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -114,6 +114,9 @@
   id: SprayPainter
 
 - type: Tag
+  id: Suppy
+
+- type: Tag
   id: VapeCart
 
 - type: Tag


### PR DESCRIPTION
Adds some more QoL stuff to Suppy in the event that he becomes sentient, along with some other fun stuff.

- Copied some more components from BaseMob for better functionality, such as being able to zoom their camera and be affected by screen shakes from explosives.
- Fixed Suppy not fitting in pet carriers after they were changed.
- Made him even heavier.
- Can now vault onto surfaces himself (only others could do this for him before).
- Can now be buckled and may unbuckle himself by clicking on the buckled alert.
- Can now open doors by himself and has Engineering and Maintenance access. This does mean that someone could use Suppy to open engineering doors for them but 1. Suppy is already locked behind engineering access, 2. dragging Suppy slows you down considerably, 3. subverting the dragging slowdown by either dragging him by his bed or carrying him a pet carrier is funny.
- Can no longer be destroyed by the supermatter. Having this as an option was funny, but now that he has engineering access, I would rather avoid the scenario of someone joining in as Suppy and immediately killing themselves on the supermatter.
- Can now have reagents spilled on him. This won't do anything directly, but it's nice for RP.
- Can now listen and speak on the Command and Engineering radio channels.
- Will now do a decent chunk of blunt damage and stun someone if launched through disposals.
- And most importantly, can now wear hats, wear glasses, and smoke.

![hHq7ThB](https://github.com/user-attachments/assets/5424f913-f2d3-4de1-90e3-8c59dc2e43b0)

**Changelog**

:cl:
- tweak: A confluence of space magic has caused Suppy to undergo some quality of life changes in the event that he becomes sentient, including the ability to puts hats on him, buckle him, and some other fun stuff.

