### PR TITLE
minor thief changes

### DIFF
--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -116,7 +116,7 @@
   id: MailStealCollectionObjective
   components:
   - type: NotJobRequirement
-    job: CargoTechnician
+    job: [ CargoTechnician, Courier, SalvageSpecialist ] # imp
   - type: StealCondition
     stealGroup: Mail
     minCollectionSize: 4
@@ -161,7 +161,7 @@
   id: ForensicScannerStealObjective
   components:
   - type: NotJobRequirement
-    job: Detective
+    job: [ SecurityOfficer, Detective, Brigmedic, Warden ] # imp
   - type: StealCondition
     stealGroup: ForensicScanner
   - type: Objective
@@ -218,7 +218,7 @@
   - type: Objective
     difficulty: 1
 
-#- type: entity
+#- type: entity # imp - removed in favor of a broader headset theft objective
   #parent: BaseThiefStealObjective
   #id: ClothingHeadsetAltMedicalStealObjective
   #components:
@@ -450,6 +450,7 @@
     job: [MedicalDoctor, Paramedic, Chemist ] # imp edit
   - type: StealCondition
     stealGroup: AnimalNamedCat
+    verifyMapExistence: true # imp - because sometimes the cat is finfin
   - type: Objective
     difficulty: 1
 
@@ -458,7 +459,7 @@
   id: McGriffStealObjective
   components:
   - type: NotJobRequirement
-    job: Detective
+    job: [ SecurityOfficer, Detective, Brigmedic, Warden ] # imp
   - type: StealCondition
     stealGroup: AnimalMcGriff
   - type: Objective
@@ -502,7 +503,7 @@
   id: ShivaStealObjective
   components:
   - type: NotJobRequirement
-    job: SecurityOfficer
+    job: [ SecurityOfficer, Detective, Brigmedic, Warden ] # imp
   - type: StealCondition
     stealGroup: AnimalShiva
   - type: Objective
@@ -513,7 +514,7 @@
   id: TropicoStealObjective
   components:
   - type: NotJobRequirement
-    job: [ AtmosphericTechnician, StationEngineer] # imp edit
+    job: [ AtmosphericTechnician, StationEngineer ] # imp edit
   - type: StealCondition
     stealGroup: AnimalTropico
   - type: Objective

--- a/Resources/Prototypes/_Impstation/Objectives/thief.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/thief.yml
@@ -126,6 +126,8 @@
   parent: BaseThiefStealObjective
   id: SecPillCanisterStealObjective
   components:
+  - type: NotJobRequirement
+    job: [ SecurityOfficer, Detective, Brigmedic, Warden ] # you never know
   - type: StealCondition
     stealGroup: SecPillCanister
   - type: Objective
@@ -220,7 +222,7 @@
   id: SecTechStealObjective
   components:
   - type: NotJobRequirement
-    job: [ SecurityOfficer, Detective ] #you never know!
+    job: [ SecurityOfficer, Detective, Brigmedic, Warden ] #you never know!
   - type: StealCondition
     stealGroup: SecTech
   - type: Objective
@@ -253,7 +255,7 @@
   id: SecDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: [ SecurityOfficer, Detective ]
+    job: [ SecurityOfficer, Detective, Brigmedic, Warden ]
   - type: StealCondition
     stealGroup: SecDrobe
   - type: Objective
@@ -297,7 +299,7 @@
   id: SalvDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: SalvageSpecialist
+    job: [ CargoTechnician, SalvageSpecialist, Courier ]
   - type: StealCondition
     stealGroup: SalvDrobe
   - type: Objective
@@ -374,7 +376,7 @@
   id: DetDrobeStealObjective
   components:
   - type: NotJobRequirement
-    job: Detective
+    job: [ SecurityOfficer, Detective, Brigmedic, Warden ]
   - type: StealCondition
     stealGroup: DetDrobe
   - type: Objective


### PR DESCRIPTION
bug report that the CMO pet objective is still rolling even when the CMO pet is replaced by fin fin. this shouldn't be happening bc it should have inherited verifyMapExistence from its parent but i added it again to be super super super sure

also altered the mail theft objective so salv and courier can't roll it and a few security objectives in the vanishingly rare case theres a security character that rolls thief

**Changelog**
:cl:
- fix: Couriers no longer feel compelled to steal the mail.
