### PR TITLE
perform a sacrifice to see job icons

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -236,6 +236,7 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+    - AdministrationGlasses # imp, for crafting
   - type: IdentityBlocker
     coverage: EYES
   - type: ShowJobIcons

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/eyepatch.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/eyepatch.yml
@@ -14,4 +14,20 @@
     tags:
     - WhitelistChameleon
     - Eyepatch
+    - CaptainsEyepatch
+
+- type: entity
+  parent: [ClothingEyesGlassesCaptaineyepatch]
+  id: ClothingEyesGlassesCaptainEyepatchAdministrativeHud
+  name: captain's eyepatch
+  suffix: AdministrativeHUD
+  categories: [ DoNotMap ]
+  components:
   - type: ShowJobIcons
+  - type: Construction
+    graph: AdminHudCaptainsEyepatch
+    node: adminhudcaptainseyepatch
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+    - Eyepatch

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/glasses.yml
@@ -2,7 +2,7 @@
   parent: [ClothingEyesBase, BaseCommandContraband]
   id: ClothingEyesGlassesCaptainvisor
   name: captain's visor
-  description: "A sleek visor that provides flash immunity and shows ID card status. Secured on your face with futuristic microgravity devices."
+  description: "A sleek visor, secured on your face with futuristic microgravity devices."
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Eyes/Glasses/captainvisor.rsi
@@ -14,9 +14,24 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+    - CaptainsVisor
   - type: IdentityBlocker
     coverage: EYES
+
+- type: entity
+  parent: [ClothingEyesGlassesCaptainvisor]
+  id: ClothingEyesGlassesCaptainVisorAdministrativeHud
+  name: captain's visor
+  suffix: AdministrativeHUD
+  categories: [ DoNotMap ]
+  components:
   - type: ShowJobIcons
+  - type: Construction
+    graph: AdminHudCaptainsVisor
+    node: adminhudcaptainsvisor
+  - type: Tag
+    tags:
+    - WhitelistChameleon
 
 - type: entity
   parent: [ ClothingEyesBase, BaseLensSlot ]

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Shoes/boots.yml
@@ -355,7 +355,7 @@
       - state: winterbits-equipped-FEET
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesBase
   id: ClothingShoesCaptainHighheelBoots
   name: captain's high-heeled boots
   description: Snazzy boots for when you want to be stylish, yet official.

--- a/Resources/Prototypes/_Impstation/Recipes/Construction/Graphs/clothing/prestige_captains_glasses.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Construction/Graphs/clothing/prestige_captains_glasses.yml
@@ -1,0 +1,45 @@
+﻿- type: constructionGraph
+  id: AdminHudCaptainsVisor
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: adminhudcaptainsvisor
+      steps:
+      - tag: CaptainsVisor
+        name: the captain's visor
+        icon:
+          sprite: _Impstation/Clothing/Eyes/Glasses/captainvisor.rsi
+          state: icon
+        doAfter: 1
+      - tag: AdministrationGlasses
+        name: administration glasses
+        icon:
+          sprite: Clothing/Eyes/Glasses/commandglasses.rsi
+          state: icon
+        doAfter: 1
+  - node: adminhudcaptainsvisor
+    entity: ClothingEyesGlassesCaptainVisorAdministrativeHud
+
+- type: constructionGraph
+  id: AdminHudCaptainsEyepatch
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: adminhudcaptainseyepatch
+      steps:
+      - tag: CaptainsEyepatch
+        name: the captain's eyepatch
+        icon:
+          sprite: _Impstation/Clothing/Eyes/Misc/capeyepatch.rsi
+          state: icon
+        doAfter: 1
+      - tag: AdministrationGlasses
+        name: administration glasses
+        icon:
+          sprite: Clothing/Eyes/Glasses/commandglasses.rsi
+          state: icon
+        doAfter: 1
+  - node: adminhudcaptainseyepatch
+    entity: ClothingEyesGlassesCaptainEyepatchAdministrativeHud

--- a/Resources/Prototypes/_Impstation/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Construction/clothing.yml
@@ -21,3 +21,27 @@
   description: A haphazard solution, but at least it'll match...
   icon: { sprite: _Impstation/Clothing/Belt/utility_black.rsi, state: icon }
   objectType: Item
+
+# adding ahud to prestige glasses
+
+- type: construction
+  name: upgraded captain's visor
+  id: ClothingEyesGlassesCaptainVisorAdministrativeHud
+  graph: AdminHudCaptainsVisor
+  startNode: start
+  targetNode: adminhudcaptainsvisor
+  category: construction-category-clothing
+  description: Remove the administrative chip from your standard-issue glasses and place it in your visor. Destroys the original glasses for the sake of fashion.
+  icon: { sprite: _Impstation/Clothing/Eyes/Glasses/captainvisor.rsi, state: icon }
+  objectType: Item
+
+- type: construction
+  name: upgraded captain's eyepatch
+  id: ClothingEyesGlassesCaptainEyepatchAdministrativeHud
+  graph: AdminHudCaptainsEyepatch
+  startNode: start
+  targetNode: adminhudcaptainseyepatch
+  category: construction-category-clothing
+  description: Remove the administrative chip from your standard-issue glasses and place it in your eyepatch. Which works, for some reason.
+  icon: { sprite: _Impstation/Clothing/Eyes/Misc/capeyepatch.rsi, state: icon }
+  objectType: Item

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -1,4 +1,8 @@
 # PUT YOUR TAGS IN ALPHABETICAL ORDER
+
+- type: Tag
+  id: AdministrationGlasses
+
 - type: Tag
   id: BeltUtility
 
@@ -10,6 +14,12 @@
 
 - type: Tag
   id: Cablecuffs
+
+- type: Tag
+  id: CaptainsEyepatch
+
+- type: Tag
+  id: CaptainsVisor
 
 - type: Tag
   id: CartridgeLPistol


### PR DESCRIPTION
its been general consensus for a while that prestige items should _only_ be cosmetic, and there should be no tangible gameplay advantage to having played a role for 30+ hours. the captain's visor, eyepatch, and high-heeled boots violated this by being a playtime unlock with unique utility compared to the rest of their loadout — the visor and eyepatch having ShowJobIcons and the high-heeled boots having the survival knife slot. 

in this PR i've removed that aspect entirely from the high-heeled boots (this looks to have been a parenting mistake), and removed ShowJobIcons from the visor and eyepatch. instead, i have added a crafting recipe that uses up the administration glasses in the captain's locker to give that ability to the prestige glasses.

![Discord_At6a5mJHdJ](https://github.com/user-attachments/assets/5001309a-fed1-40da-8d37-6cfe10bf969d)
![Discord_vHyr1XxHh3](https://github.com/user-attachments/assets/16b3ba92-c8be-42bb-932e-754f95036d2d)


**Changelog**
:cl:
- remove: The captain's visor and eyepatch no longer have administrative hud abilities.
- remove: The captain's high-heeled boots can no longer hide a knife or pistol.
- add: Sacrifice administation glasses to add that ability to your prestige glasses.