### PR TITLE
Cardboard RCD update

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -57,6 +57,21 @@
           Quantity: 6
   - type: Item
     heldPrefix: cardboard
+  - type: UserInterface
+    interfaces:
+      enum.ShortConstructionUiKey.Key:
+        type: ShortConstructionMenuBUI
+  - type: ActivatableUI
+    key: enum.ShortConstructionUiKey.Key
+  - type: ShortConstruction
+    prototypes:
+    - WallCardboard
+    - WindowCardboard
+    - WindowDirectionalCardboard
+    - ChairCardboard
+    - TileCardboard
+    - DoorCardboard
+
 
 - type: entity
   parent: MaterialCardboard

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/silicon.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/silicon.yml
@@ -156,10 +156,10 @@
   - type: UnpoweredFlashlight
   - type: PointLight
     enabled: false
-    radius: 3.5
-    softness: 1
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
+    radius: 4
+    energy: 0.8
+    softness: 10
+    color: "#bfe9ff"
   - type: ProtectedFromStepTriggers
   - type: InputMover
   - type: MobMover

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
@@ -103,26 +103,26 @@
   parent: BaseItem
   name: cardboard RCD
   description: A nanomass-compressor fueled Rapid Construction Device designed for speedy, but temporary, repairs. Produces temporary structures made from fiberboard.
-  categories: [ HideSpawnMenu ]
+  suffix: Safe To Spawn
   components:
   - type: Sprite
     sprite: _Impstation/Objects/Tools/dronercd.rsi
     state: icon
   - type: LimitedCharges
-    maxCharges: 8
-    charges: 10
+    maxCharges: 20
+    charges: 20
   - type: AutoRecharge
-    rechargeDuration: 5 # originally 10. buffing it to 5 until we get cardboard RCD
+    rechargeDuration: 5
   - type: RCD
-    availablePrototypes: # significantly pared down - just the essentials for quick patch-jobs. If they want to do more permanent fixes, they start with the materials to do so.
+    availablePrototypes: # significantly pared down - just the essentials for quick patch-jobs. custom-repriced lights and deconstruct.
     - CardboardWall
     - FloorCardboard
     - CardboardWindow
     - WindowCardboardDirectional
     - ChairCardboard
     - DoorCardboard
-    - TubeLight
-    - BulbLight
+    - TubeLightDrone
+    - BulbLightDrone
     - LVCable
     - MVCable
     - HVCable
@@ -138,6 +138,19 @@
   - type: Tag
     tags:
     - DroneUsable
+
+- type: entity
+  id: RCDRechargingCardboardAdmin
+  parent: RCDRechargingCardboard
+  name: experimental cardboard RCD
+  suffix: Admeme
+  components:
+  - type: LimitedCharges
+    maxCharges: 50
+    charges: 50
+  - type: AutoRecharge
+    rechargeDuration: 0.1
+
 
 - type: entity
   id: RCDRechargingCardboardUnremoveable

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools_rcd.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools_rcd.yml
@@ -12,13 +12,39 @@
   delay: 4
 
 - type: rcd
+  id: TubeLightDrone
+  category: Lighting
+  sprite: /Textures/Interface/Radial/RCD/tube_light.png
+  mode: ConstructObject
+  prototype: Poweredlight
+  cost: 8
+  delay: 1
+  collisionMask: TabletopMachineMask
+  collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rotation: User
+  fx: EffectRCDConstruct1
+
+- type: rcd
+  id: BulbLightDrone
+  category: Lighting
+  sprite: /Textures/Interface/Radial/RCD/bulb_light.png
+  mode: ConstructObject
+  prototype: PoweredSmallLight
+  cost: 6
+  delay: 1
+  collisionMask: TabletopMachineMask
+  collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rotation: User
+  fx: EffectRCDConstruct1
+
+- type: rcd
   id: CardboardWall
   name: cardboard wall
   category: WallsAndFlooring
   sprite: /Textures/_Impstation/Structures/Cardboard/CardboardRCDIcons/wall.png
   mode: ConstructObject
   prototype: WallCardboard
-  cost: 2
+  cost: 4
   delay: 2
   collisionMask: FullTileMask
   rotation: Fixed


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a radial quick-build menu to Cardboard.
- add: Added a crew-usable cardboard RCD prototype. Currently not accessible outside of admin intervention.
- tweak: Changed the values of the Cardboard RCD to adjust balance.
- tweak: Drones now have a different flashlight. 
