### PR TITLE
Thaven Emagging Rebalance

### DIFF
--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Impstation.Thaven.Components; // imp
 using Content.Shared.Administration.Logs;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
@@ -5,6 +6,7 @@ using Content.Shared.Database;
 using Content.Shared.Emag.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
+using Content.Shared.Mobs.Systems; // imp
 using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Content.Shared.Whitelist;
@@ -27,6 +29,7 @@ public sealed class EmagSystem : EntitySystem
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!; // DeltaV - Add a whitelist/blacklist to the Emag
+    [Dependency] private readonly MobStateSystem _mobState = default!; // imp - thaven can only be emagged when crit or dead
     public override void Initialize()
     {
         base.Initialize();
@@ -70,6 +73,14 @@ public sealed class EmagSystem : EntitySystem
             return false;
         }
         // End of DV code
+
+        // imp
+        if (TryComp<ThavenMoodsComponent>(target, out _) && !_mobState.IsIncapacitated(target) && target != user)
+        {
+            _popup.PopupClient(Loc.GetString("emag-thaven-alive", ("emag", ent), ("target", target)), user, user);
+            return false;
+        }
+        // end imp
 
         TryComp<LimitedChargesComponent>(ent, out var charges);
         if (_charges.IsEmpty(ent, charges))

--- a/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
+++ b/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
@@ -21,8 +21,9 @@ public abstract class SharedThavenMoodSystem : EntitySystem
         if (_emag.CheckFlag(ent, EmagType.Interaction))
             return;
 
-        if (ent.Owner == args.UserUid)
-            return;
+        /// yo this is beck. i'm gonna let this ride for a bit to see how it goes. if thaven emagging themselves is bad we can uncomment this
+        //if (ent.Owner == args.UserUid)
+        //    return;
 
         args.Handled = true;
     }

--- a/Resources/Locale/en-US/_Impstation/emag/emag.ftl
+++ b/Resources/Locale/en-US/_Impstation/emag/emag.ftl
@@ -1,0 +1,1 @@
+emag-thaven-alive = {CAPITALIZE(THE($emag))} doesn't seem to work on {THE($target)}. Maybe try it when {SUBJECT($target)} {CONJUGATE-BE($target)} incapacitated.


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
![I569y4D](https://github.com/user-attachments/assets/c331c5c6-f141-4af7-b19d-f80c4f30bdc6)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Thaven can now emag themselves.
- tweak: Thaven can no longer be emagged by others unless they are dead or in critical condition.

