### PR TITLE
Decapoids dont need suit storage to wear a vaporizer

### DIFF
--- a/Resources/Prototypes/_Impstation/InventoryTemplates/decapoid_inventory_template.yml
+++ b/Resources/Prototypes/_Impstation/InventoryTemplates/decapoid_inventory_template.yml
@@ -82,10 +82,7 @@
       slotGroup: MainHotbar
       stripTime: 3
       uiWindowPos: 2,0
-      strippingWindowPos: 2,5
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: AllowSuitStorage
+      strippingWindowPos: 2,5 #they dont need suit storage clothing to use this slot
       displayName: Suit Storage
     - name: id
       slotTexture: id


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
me when I delete three lines. please dont make me scope creep this ill cry. beck said they were gonna do this like a few months ago but didnt get around to it and I wanna wear a cool jacket really badly.
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Decapoids can now wear a vaporizer with no clothing requirements.
