### PR TITLE
Fix Lone Operative appearing on antag selection in the lobby screen

### DIFF
--- a/Resources/Prototypes/_Impstation/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Antags/nukeops.yml
@@ -3,7 +3,6 @@
   name: ghost-role-information-loneop-name
   antagonist: true
   playTimeTracker: AntagLoneOperative
-  setPreference: true
   objective: ghost-role-information-loneop-description
   requirements:
   - !type:OverallPlaytimeRequirement


### PR DESCRIPTION
Missed a line in creating the lone op's antag prototype in #2272. This fixes them appearing in the antag selection in the lobby. There's an interesting suggestion thread to turn loneop into a sub gamemode like wizard, but until anything like that is implemented, this is a bug and needs to be fixed.

**Changelog**

:cl:
- fix: Fixed Lone Operative appearing in the antag selection screen in the lobby.
