### PR TITLE
Security Officers put Reminders in their PDAs

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/goldzipper.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/goldzipper.yml
@@ -29,7 +29,7 @@
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/goldlaser.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserGold
-    fireCost: 100
+    fireCost: 1
   - type: PointLight
     radius: 1.2
     energy: 1.34
@@ -45,4 +45,4 @@
   components:
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserFGold
-    fireCost: 100
+    fireCost: 1

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Security/security_officer.yml
@@ -37,6 +37,11 @@
   equipment:
     pocket1: WeaponBlasterPistol
 
+- type: loadout
+  id: SecurityPistolGunpet
+  equipment:
+    pocket1: GunpetInstrument
+
 # Ammunition
 - type: loadout
   id: SecurityAmmoPistol
@@ -55,3 +60,9 @@
   storage:
     back:
     - PowerCellBlaster
+
+- type: loadout
+  id: SecurityAmmoSnapPop
+  storage:
+    back:
+    - SnapPopBox

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -945,8 +945,6 @@
 - type: loadoutGroup
   id: SecurityCommandFirearm
   name: loadout-group-security-gun-command
-  minLimit: 0
-  maxLimit: 1
   loadouts:
   - SecurityPistolMk58
   - SecurityPistolP2
@@ -955,8 +953,6 @@
 - type: loadoutGroup
   id: SecurityCommandAmmo
   name: loadout-group-security-ammo-command
-  minLimit: 0
-  maxLimit: 1
   loadouts:
   - SecurityAmmoPistol
   - SecurityAmmoP2
@@ -1018,8 +1014,6 @@
 - type: loadoutGroup
   id: DetectiveFirearm
   name: loadout-group-detective-gun
-  minLimit: 0
-  maxLimit: 1
   loadouts:
   - SecurityRevolverInspector
   - SecurityRevolverDerringer
@@ -1028,7 +1022,7 @@
 - type: loadoutGroup
   id: DetectiveAmmo
   name: loadout-group-detective-ammo
-  minLimit: 0
+  minLimit: 1
   maxLimit: 2
   loadouts:
   - SecurityAmmoSpeedloaderLethal
@@ -1105,22 +1099,20 @@
 - type: loadoutGroup
   id: SecurityOfficerFirearm
   name: loadout-group-security-gun
-  minLimit: 0
-  maxLimit: 1
   loadouts:
   - SecurityPistolMk58
   - SecurityPistolP2
   - SecurityPistolBlaster
+  - SecurityPistolGunpet
 
 - type: loadoutGroup
   id: SecurityOfficerAmmo
   name: loadout-group-security-ammo
-  minLimit: 0
-  maxLimit: 1
   loadouts:
   - SecurityAmmoPistol
   - SecurityAmmoP2
   - SecurityAmmoBlaster
+  - SecurityAmmoSnapPop
 
 - type: loadoutGroup
   id: GroupSpeciesBreathToolMedSec


### PR DESCRIPTION
Even if you uncheck your loadout selection you will spawn with a pistol as a secoff. Also included as a loadout option for secoffs that don't want to carry a lethal firearm around.

**Changelog**
:cl:
- add: you can now choose a Gunpet and a box of snap pops as your "pistol" and "ammo" as a secoff.
- tweak: security workers no longer have the opportunity to forget their service weapon.