### PR TITLE
Let Gray blood trigger radiation nodes

### DIFF
--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -179,7 +179,7 @@
     groups:
       Acidic: [ Touch ]
     reactions:
-    - reagents: [ Uranium, Tritium, Radium, UnstableMutagen, Phalanximine ]
+    - reagents: [ Uranium, Tritium, Radium, UnstableMutagen, Phalanximine, GrayBlood ]
       methods: [ Touch ]
       effects:
       - !type:ActivateArtifact


### PR DESCRIPTION
Allow Gray blood reagent to trigger artifact nodes.


**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- fix: Gray blood now counts as radioactive when splashed on science rocks