### PR TITLE
Add shader support to decals

### DIFF
--- a/Content.Client/Decals/Overlays/DecalOverlay.cs
+++ b/Content.Client/Decals/Overlays/DecalOverlay.cs
@@ -106,9 +106,11 @@ namespace Content.Client.Decals.Overlays
                     cardinal = worldAngle.GetCardinalDir().ToAngle();
                 }
 
-                //imp edit - use the shader if one is present
-                if (!string.IsNullOrEmpty(decal.ShaderID))
-                    handle.UseShader(_prototypeManager.Index<ShaderPrototype>(decal.ShaderID).Instance());
+                //imp edit - use the shader if one is present, else set it to null
+                handle.UseShader(!string.IsNullOrEmpty(decal.ShaderID)
+                    ? _prototypeManager.Index<ShaderPrototype>(decal.ShaderID).Instance()
+                    : null);
+
 
                 var angle = decal.Angle - cardinal;
 
@@ -116,9 +118,7 @@ namespace Content.Client.Decals.Overlays
                     handle.DrawTexture(cache.Texture, decal.Coordinates, decal.Color);
                 else
                     handle.DrawTexture(cache.Texture, decal.Coordinates, angle, decal.Color);
-
-                //imp edit - reset the shader back to normal
-                handle.UseShader(null);
+                
             }
 
             handle.SetTransform(Matrix3x2.Identity);

--- a/Content.Client/Decals/Overlays/DecalOverlay.cs
+++ b/Content.Client/Decals/Overlays/DecalOverlay.cs
@@ -106,12 +106,19 @@ namespace Content.Client.Decals.Overlays
                     cardinal = worldAngle.GetCardinalDir().ToAngle();
                 }
 
+                //imp edit - use the shader if one is present
+                if (!string.IsNullOrEmpty(decal.ShaderID))
+                    handle.UseShader(_prototypeManager.Index<ShaderPrototype>(decal.ShaderID).Instance());
+
                 var angle = decal.Angle - cardinal;
 
                 if (angle.Equals(Angle.Zero))
                     handle.DrawTexture(cache.Texture, decal.Coordinates, decal.Color);
                 else
                     handle.DrawTexture(cache.Texture, decal.Coordinates, angle, decal.Color);
+
+                //imp edit - reset the shader back to normal
+                handle.UseShader(null);
             }
 
             handle.SetTransform(Matrix3x2.Identity);

--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -306,6 +306,9 @@ namespace Content.Server.Decals
             if (!TryComp(gridId, out DecalGridComponent? comp))
                 return false;
 
+            //imp edit - set the decal's shader
+            decal.ShaderID = PrototypeManager.Index<DecalPrototype>(decal.Id).ShaderID;
+
             decalId = comp.ChunkCollection.NextDecalId++;
             var chunkIndices = GetChunkIndices(decal.Coordinates);
             var chunk = comp.ChunkCollection.ChunkCollection.GetOrNew(chunkIndices);

--- a/Content.Shared/Decals/Decal.cs
+++ b/Content.Shared/Decals/Decal.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Decals
@@ -14,6 +15,9 @@ namespace Content.Shared.Decals
         [DataField("angle")] public  Angle Angle = Angle.Zero;
         [DataField("zIndex")] public  int ZIndex;
         [DataField("cleanable")] public  bool Cleanable;
+
+        // imp edit - shaders for decals
+        [DataField] public string ShaderID = string.Empty;
 
         public Decal() {}
 

--- a/Content.Shared/Decals/DecalPrototype.cs
+++ b/Content.Shared/Decals/DecalPrototype.cs
@@ -13,6 +13,11 @@ namespace Content.Shared.Decals
         [DataField("showMenu")] public bool ShowMenu = true;
 
         /// <summary>
+        /// imp edit - shaders for decals. not a ShaderPrototype protoID because for some reason they're not in shared
+        /// </summary>
+        [DataField] public string ShaderID = string.Empty;
+
+        /// <summary>
         /// If the decal is rotated compared to our eye should we snap it to south.
         /// </summary>
         [DataField("snapCardinals")] public bool SnapCardinals = false;

--- a/Resources/Prototypes/_Impstation/Shaders/shaders.yml
+++ b/Resources/Prototypes/_Impstation/Shaders/shaders.yml
@@ -13,3 +13,8 @@
     func: NotEqual
   params:
     displacementSize: 127
+
+- type: shader
+  id: RedSquare
+  kind: source
+  path: "/Textures/_Impstation/Shaders/red_square.swsl"

--- a/Resources/Textures/_Impstation/Shaders/red_square.swsl
+++ b/Resources/Textures/_Impstation/Shaders/red_square.swsl
@@ -1,0 +1,5 @@
+light_mode unshaded;
+
+void fragment() {
+    COLOR.rgba = vec4(1.0, 0.0, 0.0, 1.0);
+}


### PR DESCRIPTION
Adds a "ShaderID" field to DecalPrototype and Decal + the relevant logic in DecalOverlay to make it actually get used. Unfortunately the shader doesn't show up on the decal in the picker menu because TextureButton is in the engine and can't take a shader.
(example of the "rainbowsign" decals w/ an unshaded colour inversion shader)

![decals](https://github.com/user-attachments/assets/8fa22530-8dc1-4e49-818c-cbb6ad9149c4)

also adds the "RedSquare" shader proto for easier debugging so I don't need to re-create it every time I want to triple check if a shader is actually getting used
