### PR TITLE
thieving beacon contraband & subfloor anchoring

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/thief.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief.yml
@@ -1,4 +1,5 @@
 - type: entity
+  parent: BaseMinorContraband
   id: ThiefBeacon
   name: thieving beacon
   description: A device that will teleport everything around it to the thief's vault at the end of the shift.
@@ -37,6 +38,15 @@
       layers:
         - state: extraction_point
           map: [ "foldedLayer" ]
+    # imp edit start
+    - type: SubFloorHide
+    - type: Anchorable
+    - type: CollideOnAnchor
+    - type: Transform
+      anchored: false
+    - type: Visibility
+      layer: 1
+    # imp edit end
 
 - type: entity
   id: ToolboxThief


### PR DESCRIPTION
#1731 was made with the intention of stopping every person on the station from picking up beacons in maintenance and turning them in to security, ruining a thief's round for a few lines of examine text. the pendulum has swung the other way though, and thieving beacons are being left out in broad daylight because there are no consequences to leaving your shit out in the open

we're bringing the fear back. minor contraband status returns. to make thieves sneakier, they can now hide their beacon under floor tiles instead. this should stop people from bumbling into a room, seeing the Bad Item and swiping it. they'll show on t-ray scanners, but their contraband status won't be revealed unless the floor tile is removed since they're not considered close enough for detailed examination

![image](https://github.com/user-attachments/assets/42dfc49d-b566-43e3-8ae7-22833a0fca1a)

how does it fit under there? idk man

**Changelog**
:cl:
- tweak: Thieving beacons have been given minor contraband status, and can be anchored under tiles similar to the smuggler's satchel.