### PR TITLE
add logistics 101 to guidebookshelf

### DIFF
--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Books/guidebookshelf.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Books/guidebookshelf.yml
@@ -18,6 +18,7 @@
     - id: BookHowToSurvive #how to survive
     - id: BookKeelBay #Keel-Ree's guide to medical (imp)
     - id: BookLeafLoversSecret #leaf lover's secret
+    - id: BookLogistics #logistics 101
     - id: BookMedicalReferenceBook #medical reference book
     - id: BookAtmosAirAlarms #Newton's Guide to Atmos: Air Alarms
     - id: BookAtmosDistro #Newton's Guide to Atmos: The Distro


### PR DESCRIPTION
didn't know this book existed but i guess we got it when we got supply assistant?  it's from DV

guidebookshelf now has 24 books in it, preetty sure that's all of the current informational books

![image](https://github.com/user-attachments/assets/76691d5f-d178-42d8-9b12-75b9832d6386)

:cl:
- add: Logistics 101 is now properly in the Guidebookshelf