### PR TITLE
Remove the "this patient is unrevivalbe" text from the health analyzer

### DIFF
--- a/Content.Shared/Traits/Assorted/UnrevivableComponent.cs
+++ b/Content.Shared/Traits/Assorted/UnrevivableComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class UnrevivableComponent : Component
     /// A field to define if we should display the "Genetic incompatibility" warning on health analysers
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool Analyzable = true;
+    public bool Analyzable; //imp edit - change the default to false to make medical waste their topicals like god intended
 
     /// <summary>
     /// Can this player be cloned using a cloning pod?


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Got brought up in the postround chat and I thought we did this ages ago so I did it now.
Does it by making the "analyzable" field of unrevivableComp default to false instead of true. could remove the thing in the BUI that shows it as well, but that's a bigger diff & might still be useful somehow?

**Changelog**
:cl:
- remove: Health analyzers no longer show if someone is unrevivable
