### PR TITLE
Make Space Mobs/Vent Adders Stunnable

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -67,6 +67,21 @@
   - type: MobPrice
     price: 1000 # Living critters are valuable in space.
   - type: Perishable
+  - type: StatusEffects #imp edit to make space mobs stunnable
+    allowed:
+    - Stun
+    - KnockedDown
+    - SlowedDown
+    - Stutter
+    - Electrocution
+    - ForcedSleep
+    - TemporaryBlindness
+    - Pacified
+    - StaminaModifier
+    - Flashed
+    - RadiationProtection
+    - Drowsiness
+    - Adrenaline
 
 - type: entity
   parent:
@@ -93,21 +108,7 @@
       Parched: 50
       Dead: 0
     baseDecayRate: 0.04
-  - type: StatusEffects
-    allowed:
-    - Stun
-    - KnockedDown
-    - SlowedDown
-    - Stutter
-    - Electrocution
-    - ForcedSleep
-    - TemporaryBlindness
-    - Pacified
-    - StaminaModifier
-    - Flashed
-    - RadiationProtection
-    - Drowsiness
-    - Adrenaline
+# imp; moved status effects to space mob parent
   - type: Bloodstream
     bloodMaxVolume: 150
   - type: MobPrice

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -109,6 +109,21 @@
       Dead: 0
     baseDecayRate: 0.04
 # imp; moved status effects to space mob parent
+#  - type: StatusEffects
+#    allowed:
+#    - Stun
+#    - KnockedDown
+#    - SlowedDown
+#    - Stutter
+#    - Electrocution
+#    - ForcedSleep
+#    - TemporaryBlindness
+#    - Pacified
+#    - StaminaModifier
+#    - Flashed
+#    - RadiationProtection
+#    - Drowsiness
+#    - Adrenaline
   - type: Bloodstream
     bloodMaxVolume: 150
   - type: MobPrice


### PR DESCRIPTION
Like every other mob, space adders are now able to be flashed and baton-d a disabler-d.
Also makes this possible to other space mobs, like space bears and space tarantulas. This also makes them able to bleed to death I and be epi'd think. Basically act like any other hostile mob.
Don't worry I checked and dragons are unchanged; they still can't be flashed and fully stunned.
:cl:
- tweak: Space mobs and snakes can now be like every other creature; if it bleeds, you can flash it.