### PR TITLE
sacrifice/ghoul sanity checks

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -63,7 +63,9 @@ public sealed partial class MansusGraspSystem : EntitySystem
                 break;
 
             case "Flesh":
-                if (TryComp<MobStateComponent>(target, out var mobState) && mobState.CurrentState == Shared.Mobs.MobState.Dead)
+                if (TryComp<MobStateComponent>(target, out var mobState)
+                    && mobState.CurrentState == Shared.Mobs.MobState.Dead
+                    && !TryComp<HellVictimComponent>(target, out var _))
                 {
                     var ghoul = EnsureComp<GhoulComponent>(target);
                     ghoul.BoundHeretic = performer;

--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
@@ -95,7 +95,9 @@ namespace Content.Server.Heretic.Ritual;
         foreach (var look in lookup)
         {
             if (!args.EntityManager.TryGetComponent<MobStateComponent>(look, out var mobstate) // only mobs
-            || !args.EntityManager.HasComponent<HumanoidAppearanceComponent>(look)) // only humans
+            || !args.EntityManager.HasComponent<HumanoidAppearanceComponent>(look) //player races only
+            || args.EntityManager.HasComponent<HellVictimComponent>(look) //no reusing corpses
+            || args.EntityManager.HasComponent<GhoulComponent>(look)) //shouldn't happen because they gib on death but. sanity check
                 continue;
 
             if (mobstate.CurrentState == Shared.Mobs.MobState.Dead)


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

i could have fucking SWORN there was a check for re-using sacrifice victims but i guess not

this also adds a check to make sure you can't sacrifice ghouls, but that's technically not player facing since they gib on crit anyway

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Sacrifice victims can no longer be ghouled.
- fix: Sacrifice victims can no longer be reused.