### PR TITLE
Hide "Station-Specific" Category

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -152,3 +152,4 @@
   - Psychologist
   primary: false
   manifestHidden: true #imp edit
+  editorHidden: true #imp edit


### PR DESCRIPTION
Despite being called station-specific and having its own editor category, we kinda added all of them to almost every map. You can still choose these jobs in the Service and Medical category but I don't think it needs its own box now.
One line change and doesn't fuck anything up.
:cl:
- tweak: Station-specific category no longer appears on the job selection menu, as the jobs are not station-specific.

