### PR TITLE
make ai killable

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -519,6 +519,9 @@
           type: HolopadBoundUserInterface
         enum.HolopadUiKey.AiActionWindow:
           type: HolopadBoundUserInterface
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
 
 # The job-ready version of an AI spawn.
 - type: entity
@@ -833,7 +836,7 @@
   - type: ComplexInteraction
   - type: Body
     prototype: Drone
-    thermalVisibility: false # imp edit. mostly for drones, but i think this is cool and interesting 
+    thermalVisibility: false # imp edit. mostly for drones, but i think this is cool and interesting
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:


### PR DESCRIPTION
[video](https://youtube.com/watch?v=HbR2jDFyLpE)
NOTE: currently, destroying the station AI does not remove the latejoin AI slot. Anyone who latejoins as AI when the AI core is destroyed will just be stuck and incorporeal, and have to /ghost. I dunno how to do that, and upstream will prolly do it themselves eventually. This is just a shitty bandaid fix to enable antag opportunities

:cl:
- add: You can now kill the Station AI.
