### PR TITLE
Printable Tank Harnesses

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
@@ -5,6 +5,7 @@
   recipes:
   - Flare
   - WelderJanitorial
+  - TankHarness
 
 # Dynamic
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
@@ -9,6 +9,7 @@
   - BlindingLens
   - Dropper
   - WalkingCane
+  - TankHarness
 
 # Dynamic
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/misc.yml
@@ -21,3 +21,11 @@
     Steel: 500
     Glass: 500
     Plastic: 500
+
+- type: latheRecipe
+  id: TankHarness
+  result: ClothingOuterVestTank
+  completetime: 2
+  materials:
+    Cloth: 100
+    Steel: 100


### PR DESCRIPTION
a simple addition to let people print tank harnesses! the garment itself is something that's pretty simple, so it's basically the same cost as a utility belt. presently added to both autolathes and med techfabs

**Changelog**
:cl:
- add: Tank harnesses can now be printed at any autolathe or med techfab!
