### PR TITLE
Remove roundstart service worker

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -142,7 +142,7 @@
   parent: SpawnPointJobBase
   name: service worker
   components:
-  - type: SpawnPoint #imp
+  - type: SpawnPoint
     job_id: ServiceWorker
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -142,7 +142,7 @@
   parent: SpawnPointJobBase
   name: service worker
   components:
-  - type: SpawnPoint
+  - type: SpawnPoint #imp
     job_id: ServiceWorker
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -28,17 +28,17 @@
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
             # service - 14
-            Bartender: [ 1, 1 ]
+            Bartender: [ 2, 2 ] #imp 1 > 2
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 1, 1 ]
+            Chef: [ 2, 2 ] #imp 1 > 2
             Clown: [ 1, 1 ]
             Janitor: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 5-7
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -25,7 +25,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 11
+            # service - 11 incl. service worker
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -35,7 +35,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            ServiceWorker: [ 1, 1 ]
+            #ServiceWorker: [ 1, 1 ] #imp
             # engineering - 4-7
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 17
+            # service - 17 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -38,7 +38,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 7-11
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 17
+            # service - 17 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chaplain: [ 1, 1 ]
@@ -38,7 +38,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 8-12
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 11
+            # service - 11 incl. service worker
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -37,7 +37,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            ServiceWorker: [ 1, 1 ]
+            #ServiceWorker: [ 1, 1 ] #imp
             # engineering - 5-7
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 23
+            # service - 23 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Boxer: [ 2, 2 ]
@@ -39,7 +39,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 3, 3 ]
+            #ServiceWorker: [ 3, 3 ] #imp
             Zookeeper: [ 1, 1 ]
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -27,7 +27,7 @@
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]
             Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
+            #ServiceWorker: [ 3, 3 ] #imp
             Reporter: [ 1, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -29,19 +29,19 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 19
+            # service - 20 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Boxer: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 1, 1 ]
+            Chef: [ 2, 2 ] #imp 1 > 2
             Clown: [ 1, 1 ]
             Janitor: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 3, 3 ]
+            #ServiceWorker: [ 3, 3 ] #imp
             # engineering - 6-8
             StationEngineer: [ 4, 4 ]
             AtmosphericTechnician: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -30,17 +30,17 @@
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
             # service - 14
-            Bartender: [ 1, 1 ]
+            Bartender: [ 2, 2 ] #imp 1 > 2
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 1, 1 ]
+            Chef: [ 2, 2 ] #imp 1 > 2
             Clown: [ 1, 1 ]
             Janitor: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 5-7
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -26,14 +26,14 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (17)
+            #service (17) incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chef: [ 2, 2 ]
             Janitor: [ 4, 4 ]
             Chaplain: [ 1, 1 ]
             Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             Reporter: [ 2, 2 ]
             #engineering (9)
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -26,7 +26,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 19
+            # service - 19 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chaplain: [ 1, 1 ]
@@ -37,7 +37,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             Zookeeper: [ 1, 1 ]
             # engineering - 7-11
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -25,14 +25,14 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (14)
+            #service (14) incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
             Janitor: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
             Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
+            #ServiceWorker: [ 3, 3 ] #imp
             Reporter: [ 1, 1 ]
             #engineering (8)
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] #imp
             Quartermaster: [ 1, 1 ]
-            # service - 16
+            # service - 16 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -38,7 +38,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 17
+            # service - 17 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -38,7 +38,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 9-15
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 6, 6 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -26,7 +26,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 23
+            # service - 23 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chaplain: [ 1, 1 ]
@@ -37,7 +37,7 @@
             Mime: [ 2, 2 ]
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             Zookeeper: [ 1, 1 ]
             # engineering - 8-12
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 14
+            # service - 14 incl. service worker
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -38,7 +38,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 5-7
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -26,7 +26,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service 28
+            # service 28  incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Boxer: [ 2, 2 ]
@@ -38,7 +38,7 @@
             Mime: [ 2, 2 ]
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 3, 3 ]
+            #ServiceWorker: [ 3, 3 ] #imp
             # engineering 9-12
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 6, 6 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -28,16 +28,16 @@
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
             # service - 13
-            Bartender: [ 1, 1 ]
+            Bartender: [ 2, 2 ] #imp 1 > 2
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 1, 1 ]
+            Chef: [ 2, 2 ] #imp 1 > 2
             Clown: [ 1, 1 ]
             Janitor: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering 6-9
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -29,7 +29,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 19
+            # service - 19  incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -40,7 +40,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 8-12
             AtmosphericTechnician: [ 4, 4 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -27,16 +27,16 @@
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
             # service - 12
-            Bartender: [ 1, 1 ]
+            Bartender: [ 2, 2 ] #imp 1 > 2
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 1, 1 ]
+            Chef: [ 2, 2 ] #imp 1 > 2
             Clown: [ 1, 1 ]
             Janitor: [ 1, 1 ]
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 6-10
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -30,17 +30,17 @@
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
             # service - 14
-            Bartender: [ 1, 1 ]
+            Bartender: [ 2, 2 ] #imp 1 > 2
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 1, 1 ]
+            Chef: [ 2, 2 ] #imp 1 > 2
             Clown: [ 1, 1 ]
             Janitor: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/Maps/xeno.yml
+++ b/Resources/Prototypes/Maps/xeno.yml
@@ -29,7 +29,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 16-18
+            # service - 16-18 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]
             Chaplain: [ 1, 1 ]
@@ -40,7 +40,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -1,3 +1,4 @@
+# imp: removed service worker. playtime tracker & visitor service worker roles will remain.
 - type: job
   id: ServiceWorker
   name: job-name-serviceworker
@@ -6,6 +7,8 @@
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service
+  setPreference: false #imp
+  overrideConsoleVisibility: true #imp
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/_Harmony/Maps/barratry.yml
+++ b/Resources/Prototypes/_Harmony/Maps/barratry.yml
@@ -29,7 +29,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
-            # service - 16
+            # service - 16 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -40,7 +40,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ] #imp
             # engineering - 8-12
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]

--- a/Resources/Prototypes/_Impstation/Maps/boat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/boat.yml
@@ -30,18 +30,18 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            # service - 21
-            Bartender: [ 1, 1 ]
+            # service - 22
+            Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 2, 2 ]
+            Chef: [ 3, 3 ]
             Clown: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Librarian: [ 1, 1 ]
             Mime: [ 2, 2 ]
             Musician: [ 2, 2 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
+            #ServiceWorker: [ 3, 3 ]
             # engineering - 6-9
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/hash.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hash.yml
@@ -30,16 +30,16 @@
             HospitalityDirector: [ 1, 1 ] # imp
             Quartermaster: [ 1, 1 ]
             # service - 12
-            Bartender: [ 1, 1 ]
+            Bartender: [ 2, 2 ]
             Botanist: [ 1, 1 ]
             Chaplain: [ 1, 1 ]
             Chef: [ 1, 1 ]
-            Clown: [ 1, 1 ]
+            Clown: [ 2, 2 ]
             Janitor: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ]
             # engineering - 6
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            # service - 23
+            # service - 23 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Boxer: [ 2, 2 ]
@@ -39,7 +39,7 @@
             Mime: [ 2, 2 ]
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 3, 3 ]
+            #ServiceWorker: [ 3, 3 ]
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/_Impstation/Maps/lilboat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/lilboat.yml
@@ -30,7 +30,7 @@
             Quartermaster: [ 1, 1 ]
             AdministrativeAssistant: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ]
-            # service - 11
+            # service - 11 incl. service worker
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
             Chaplain: [ 1, 1 ]
@@ -41,7 +41,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            ServiceWorker: [ 1, 1 ]
+            #ServiceWorker: [ 1, 1 ]
             # engineering - 3-4
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 2, 2 ]

--- a/Resources/Prototypes/_Impstation/Maps/luna.yml
+++ b/Resources/Prototypes/_Impstation/Maps/luna.yml
@@ -29,7 +29,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            # service - 18
+            # service - 18 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Boxer: [ 2, 2 ]
@@ -41,7 +41,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ]
             # engineering - 6
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/refsdal.yml
+++ b/Resources/Prototypes/_Impstation/Maps/refsdal.yml
@@ -30,9 +30,9 @@
             HospitalityDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
             # service
-            Bartender: [ 1, 1 ]
+            Bartender: [ 2, 2 ]
             Botanist: [ 1, 1 ]
-            Chef: [ 1, 1 ]
+            Chef: [ 2, 2 ]
             Clown: [ 1, 1 ]
             Janitor: [ 1, 1 ]
             Mime: [ 1, 1 ]
@@ -40,7 +40,7 @@
             Chaplain: [1, 1]
             Librarian: [1, 1]
             Reporter: [1, 1]
-            ServiceWorker: [2, 2]
+            #ServiceWorker: [2, 2]
             # engineering
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/union.yml
+++ b/Resources/Prototypes/_Impstation/Maps/union.yml
@@ -27,7 +27,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            # service - 19
+            # service - 19 incl. service worker
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Boxer: [ 2, 2 ]
@@ -39,7 +39,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
+            #ServiceWorker: [ 2, 2 ]
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/_Impstation/Roles/departments.yml
+++ b/Resources/Prototypes/_Impstation/Roles/departments.yml
@@ -20,7 +20,7 @@
   - Reporter
   - Visitor
   - Zookeeper
-  - ServiceWorker
+  #- ServiceWorker
 
 #Used for HD playtime requirments
 - type: department
@@ -31,7 +31,7 @@
   roles:
   - Bartender
   - Chef
-  - ServiceWorker
+  #- ServiceWorker
   primary: false
   editorHidden: true
   manifestHidden: true

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -610,3 +610,7 @@ LockerCourierFilledHardsuit: LockerCourierFilled
 # 2025-03-25
 # impstation: swap mail systems
 MailTeleporter: CargoMailTeleporter
+
+# 2025-05-08
+# impstation: remove service worker
+SpawnPointServiceWorker: null

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -610,7 +610,3 @@ LockerCourierFilledHardsuit: LockerCourierFilled
 # 2025-03-25
 # impstation: swap mail systems
 MailTeleporter: CargoMailTeleporter
-
-# 2025-05-08
-# impstation: remove service worker
-SpawnPointServiceWorker: null


### PR DESCRIPTION
Removes service worker from roundstart menu, and map ymls. also migrates out the spawner.
JobPrototype is untouched, so you can still get ghost role service workers.

Admins have made a group decision to remove this role because it just does nothing interesting mechanically. Upstream apparently intended it to be an intern role, but its just become bartender+. since most maps already have slots for bartenders and chefs, this means there's a lot of potential for players to pick service worker and just slack off all round, which we dont want to encourage. Hopefully this change means we'll see more players who would otherwise pick service worker jump into bartender/chef/botanist roles proper.

:cl:
- remove: Removed Service Worker. Rest in Peace Laura Klaus