### PR TITLE
cpr

### DIFF
--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -77,6 +77,24 @@ namespace Content.Server.Body.Components
 
         [ViewVariables]
         public RespiratorStatus Status = RespiratorStatus.Inhaling;
+
+        /// <summary>
+        /// IMP: Amount of times the mob can breathe in crit.
+        /// </summary>
+        [DataField]
+        public int CritBreathCounter;
+
+        /// <summary>
+        /// IMP: The amount of breaths added per successful CPR attempt.
+        /// </summary>
+        [DataField]
+        public int CritBreathIncrease = 5;
+
+        /// <summary>
+        /// IMP: The maximum possible value of <see cref="CritBreathCounter"/>.
+        /// </summary>
+        [DataField]
+        public int CritBreathMax = 8;
     }
 }
 

--- a/Content.Shared/_Impstation/CPR/CprDoAfterEvent.cs
+++ b/Content.Shared/_Impstation/CPR/CprDoAfterEvent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Impstation.CPR;
+
+[Serializable, NetSerializable]
+public sealed partial class CprDoAfterEvent : DoAfterEvent
+{
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/_Impstation/CPR/CprEvents.cs
+++ b/Content.Shared/_Impstation/CPR/CprEvents.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._Impstation.CPR;
+
+[ByRefEvent]
+public record struct PerformCprEvent(EntityUid Target, bool Cancelled = false);
+
+[ByRefEvent]
+public record struct ReceiveCprEvent(EntityUid Performer, bool Cancelled = false);

--- a/Content.Shared/_Impstation/CPR/CprGiverComponent.cs
+++ b/Content.Shared/_Impstation/CPR/CprGiverComponent.cs
@@ -1,0 +1,18 @@
+namespace Content.Shared._Impstation.CPR;
+
+[RegisterComponent]
+public sealed partial class CprGiverComponent : Component
+{
+    /// <summary>
+    /// The amount that the target's UpdateInterval from their RespiratorComponent
+    /// is multiplied by to determine the length of the CPR do-after.
+    /// </summary>
+    [DataField]
+    public float IntervalMultiplier = 2f;
+
+    /// <summary>
+    /// The maximum potential length of a CPR do-after.
+    /// </summary>
+    [DataField]
+    public float IntervalMax = 6f;
+}

--- a/Content.Shared/_Impstation/CPR/CprGiverSystem.cs
+++ b/Content.Shared/_Impstation/CPR/CprGiverSystem.cs
@@ -1,0 +1,98 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.DoAfter;
+using Content.Shared.Inventory;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Robust.Shared.Player;
+
+namespace Content.Shared._Impstation.CPR;
+
+public sealed class CprGiverSystem : EntitySystem
+{
+    [Dependency] private readonly ActionBlockerSystem _blocker = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CprGiverComponent, CprDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnDoAfter(Entity<CprGiverComponent> ent, ref CprDoAfterEvent args)
+    {
+        if (args.Target is not { } target)
+            return;
+
+        RemComp<ReceivingCprComponent>(target);
+
+        if (args.Cancelled || args.Handled)
+            return;
+
+        args.Handled = true;
+
+        var receiveEvent = new ReceiveCprEvent(ent);
+        RaiseLocalEvent(target, ref receiveEvent);
+    }
+
+    public bool TryCpr(EntityUid user, EntityUid target, TimeSpan interval)
+    {
+        if (!TryComp<CprGiverComponent>(user, out var cprComp) || !CanCpr(user, target))
+            return false;
+
+        var performEvent = new PerformCprEvent(target);
+        RaiseLocalEvent(user, ref performEvent);
+
+        if (performEvent.Cancelled)
+            return false;
+
+        var doTime = Math.Min(interval.Seconds * cprComp.IntervalMultiplier, cprComp.IntervalMax);
+        var doAfter = new DoAfterArgs(EntityManager, user, doTime, new CprDoAfterEvent(), target, target)
+        {
+            BreakOnDamage = true,
+            BreakOnHandChange = true,
+            BreakOnMove = true,
+            NeedHand = true,
+        };
+
+        _doAfter.TryStartDoAfter(doAfter);
+        EnsureComp<ReceivingCprComponent>(target);
+
+        var popupUser = Loc.GetString("cpr-start-user", ("target", target));
+        var popupTarget = Loc.GetString("cpr-start-patient", ("user", user));
+        var popupOthers = Loc.GetString("cpr-start-others", ("user", user), ("target", target));
+        var otherFilter = Filter.Pvs(target).RemovePlayersByAttachedEntity(user, target);
+
+        _popup.PopupEntity(popupUser, target, user);
+        _popup.PopupEntity(popupTarget, target, target);
+        _popup.PopupEntity(popupOthers, user, otherFilter, true);
+
+        return true;
+    }
+
+    private bool CanCpr(EntityUid user, EntityUid target)
+    {
+        if (!_blocker.CanInteract(user, target) || !_mobState.IsCritical(target))
+            return false;
+
+        if (HasComp<ReceivingCprComponent>(target))
+        {
+            var popup = Loc.GetString("cpr-already-receiving", ("target", target));
+            _popup.PopupEntity(popup, target, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        // ohhhh my hardcoded outerClothing.. how i hate her
+        if (_inventory.TryGetSlotEntity(target, "outerClothing", out var outer))
+        {
+            var popup = Loc.GetString("cpr-remove-item", ("item", outer));
+            _popup.PopupEntity(popup, target, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/_Impstation/CPR/ReceivingCprComponent.cs
+++ b/Content.Shared/_Impstation/CPR/ReceivingCprComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._Impstation.CPR;
+
+[RegisterComponent]
+public sealed partial class ReceivingCprComponent : Component;

--- a/Resources/Locale/en-US/_Impstation/cpr/cpr.ftl
+++ b/Resources/Locale/en-US/_Impstation/cpr/cpr.ftl
@@ -1,0 +1,10 @@
+cpr-already-receiving = {CAPITALIZE(THE($target))} is already receiving CPR.
+cpr-remove-item = You must remove {THE($item)} to perform CPR.
+
+cpr-start-user = You start performing CPR on {THE($target)}.
+cpr-start-patient = {CAPITALIZE(THE(user))} starts performing CPR on you.
+cpr-start-others = {CAPITALIZE(THE(user))} starts performing CPR on {THE($target)}.
+
+cpr-perform-user = You perform CPR on {THE($target)}.
+cpr-perform-patient = {CAPITALIZE(THE(user))} performs CPR on you.
+cpr-perform-others = {CAPITALIZE(THE(user))} performs CPR on {THE($target)}.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -223,6 +223,7 @@
     - DoorBumpOpener
     - AnomalyHost
   - type: LayingDown # WD EDIT
+  - type: CprGiver # imp
 
 - type: entity
   save: false


### PR DESCRIPTION
marking as draft because this really needs respiration to be moved to shared to work in a way that i'm happy with. other than that, this seems to work pretty fine

the exact way this works is by adding a `CritBreathCounter` to entities with respiration, which is increased by an amount every time a cpr do-after is performed. instead of taking asphyx damage with each respiration interval, an entity with a `CritBreathCounter` higher than 0 will breath normally and reduce the counter by 1, giving medical a way of slowly recovering asphyx without chemicals, and letting untrained personnel keep other crew in a more stable condition until proper treatment can be administered

in terms of math, the respiration interval is 2 seconds, at which a mob in critical condition will take 0.5 asphyx, and a mob in normal condition will heal 1 asphyx. when in critical condition, a mob that has received cpr will gain 1.5 asphyx over a mob that hasn't, making cpr effectively heal 0.75 asphyx per second. for comparison, dexalin heals 1 asphyx per tick, making cpr a slightly weaker version of the most basic current airloss treatment without a reliance on chemistry. dexalin also heals 0.5 bloodloss, which cpr does not treat at all

current known issues:
- due to `RespiratorSystem` being server-side, cpr cannot be predicted and leads to the strip menu momentarily appearing when clicking on a mob in critical condition
- some empty-hand interactions, like picking up mice, prevent `ReceivingCpr` from being removed and stop the mob from receiving any further cpr treatment

**Changelog**
:cl:
- add: CPR can now be performed by left clicking on critical patients.