### PR TITLE
Tweaks to HD's jumpskirts

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -187,7 +187,7 @@
 - type: entity
   parent: [ClothingUniformBase, ClothingUniformFoldableBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtHospitalityDirectorJanitor
-  name: lead custodial jumpsuit
+  name: lead custodial jumpskirt
   description: This uniform shows that if anyone should get the janitor trolley, it's you.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -174,7 +174,7 @@
       sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_turtle.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, ClothingUniformFoldableBase, BaseCommandContraband]
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtHospitalityDirectorBartender
   name: lead bartending uniform
   description: This uniform lets the people know you can make a really mean raktaccino.
@@ -185,7 +185,7 @@
     sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_bartender.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, ClothingUniformFoldableBase, BaseCommandContraband]
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtHospitalityDirectorJanitor
   name: lead custodial jumpskirt
   description: This uniform shows that if anyone should get the janitor trolley, it's you.


### PR DESCRIPTION
Two fixes to HD's jumpskirts:
- Renamed `lead custodial jumpsuit` to `lead custodial jumpskirt`. 
   - Both the jumpsuit and jumpskirt versions were named identically.
- Removed foldable clothing component from `lead custodial jumpskirt` and `lead bartending uniform` (jumpskirt version)
   - These didn't have sprites for the folded version, causing the entire clothing to disappear when folded.

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The lead custodial jumpskirt is no longer called a jumpsuit
- remove: The lead custodial jumpskirt and lead bartending uniform no longer have the option to be folded (wasn't implemented).
