### PR TITLE
Reduce reoundstart drone spawns to 1 on all maps

### DIFF
--- a/Resources/Maps/_Impstation/barratry.yml
+++ b/Resources/Maps/_Impstation/barratry.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 250.0.0
+  engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/23/2025 08:10:35
-  entityCount: 17734
+  time: 05/09/2025 04:07:47
+  entityCount: 17731
 maps:
 - 5005
 grids:
@@ -20934,6 +20934,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-14.5
+      parent: 1
+- proto: BorgChargerDroneSpawner
+  entities:
+  - uid: 13745
+    components:
+    - type: Transform
+      pos: -54.5,28.5
       parent: 1
 - proto: BoxBodyBag
   entities:
@@ -101083,7 +101090,7 @@ entities:
       pos: 16.5,48.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -44602.73
+      secondsUntilStateChange: -44722.383
       state: Opening
 - proto: SpaceCash10000
   entities:
@@ -101233,28 +101240,6 @@ entities:
     components:
     - type: Transform
       pos: -80.5,33.5
-      parent: 1
-- proto: SpawnMobDrone
-  entities:
-  - uid: 17636
-    components:
-    - type: Transform
-      pos: -8.5,-15.5
-      parent: 1
-  - uid: 17744
-    components:
-    - type: Transform
-      pos: -52.5,28.5
-      parent: 1
-  - uid: 17745
-    components:
-    - type: Transform
-      pos: -53.5,28.5
-      parent: 1
-  - uid: 17746
-    components:
-    - type: Transform
-      pos: -54.5,28.5
       parent: 1
 - proto: SpawnMobFoxRenault
   entities:

--- a/Resources/Maps/_Impstation/boat.yml
+++ b/Resources/Maps/_Impstation/boat.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 247.2.0
+  engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/21/2025 02:39:43
-  entityCount: 25159
+  time: 05/09/2025 04:11:38
+  entityCount: 25156
 maps:
 - 1
 grids:
@@ -9967,7 +9967,7 @@ entities:
       pos: 10.5,-35.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -2672.4285
+      secondsUntilStateChange: -2801.1536
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10219,7 +10219,7 @@ entities:
       pos: 30.5,-49.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -8977.724
+      secondsUntilStateChange: -9106.448
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10366,7 +10366,7 @@ entities:
       pos: 10.5,88.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -156170.55
+      secondsUntilStateChange: -156299.27
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10377,7 +10377,7 @@ entities:
       pos: 10.5,87.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -156172.42
+      secondsUntilStateChange: -156301.14
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11132,7 +11132,7 @@ entities:
       pos: 38.5,-21.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -351741.53
+      secondsUntilStateChange: -351870.25
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11668,7 +11668,7 @@ entities:
       pos: 44.5,15.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -26938.143
+      secondsUntilStateChange: -27066.867
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13817,6 +13817,9 @@ entities:
     - type: Transform
       pos: 64.512146,89.350044
       parent: 2
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: BananaPhoneInstrument
   entities:
   - uid: 10247
@@ -17102,6 +17105,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,61.5
+      parent: 2
+- proto: BorgChargerDroneSpawner
+  entities:
+  - uid: 3344
+    components:
+    - type: Transform
+      pos: 63.5,-15.5
       parent: 2
 - proto: BorgModuleAnomaly
   entities:
@@ -46400,6 +46410,9 @@ entities:
     - type: Transform
       pos: 19.229002,75.89003
       parent: 2
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
   - uid: 13775
     components:
     - type: Transform
@@ -46548,6 +46561,13 @@ entities:
     components:
     - type: Transform
       pos: 28.503239,8.904896
+      parent: 2
+- proto: CargoMailTeleporter
+  entities:
+  - uid: 3935
+    components:
+    - type: Transform
+      pos: 16.5,-43.5
       parent: 2
 - proto: CargoPallet
   entities:
@@ -59961,6 +59981,25 @@ entities:
     - type: Transform
       pos: 51.5,-53.5
       parent: 2
+- proto: ChemistryBottlePotassium
+  entities:
+  - uid: 5680
+    components:
+    - type: Transform
+      pos: 49.598484,-55.08549
+      parent: 2
+- proto: ChemistryBottleRobustHarvest
+  entities:
+  - uid: 13170
+    components:
+    - type: Transform
+      pos: -2.6835227,60.176945
+      parent: 2
+  - uid: 13171
+    components:
+    - type: Transform
+      pos: -2.6835227,59.871178
+      parent: 2
 - proto: ChemistryEmptyBottle04
   entities:
   - uid: 771
@@ -60819,6 +60858,13 @@ entities:
     - type: Transform
       pos: 55.5,56.5
       parent: 2
+- proto: ClosetWallEmergencyN2
+  entities:
+  - uid: 16905
+    components:
+    - type: Transform
+      pos: 32.5,101.5
+      parent: 2
 - proto: ClosetWallEmergencyN2FilledRandom
   entities:
   - uid: 610
@@ -60858,13 +60904,6 @@ entities:
     components:
     - type: Transform
       pos: 56.5,56.5
-      parent: 2
-- proto: ClosetWallEmergencyN2
-  entities:
-  - uid: 16905
-    components:
-    - type: Transform
-      pos: 32.5,101.5
       parent: 2
 - proto: ClosetWallFireFilledRandom
   entities:
@@ -61448,6 +61487,9 @@ entities:
     - type: Transform
       pos: 15.310713,-50.23491
       parent: 2
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: ClothingHeadHatBlacksoft
   entities:
   - uid: 10214
@@ -65583,7 +65625,7 @@ entities:
       pos: 60.5,76.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -80490.234
+      secondsUntilStateChange: -80618.96
       state: Opening
   - uid: 18653
     components:
@@ -66737,6 +66779,9 @@ entities:
     - type: Transform
       pos: 19.251242,73.33807
       parent: 2
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
   - uid: 16598
     components:
     - type: Transform
@@ -76635,7 +76680,7 @@ entities:
       pos: 34.5,-25.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -383079.8
+      secondsUntilStateChange: -383208.53
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -113389,13 +113434,6 @@ entities:
     - type: Transform
       pos: 29.5,57.5
       parent: 2
-- proto: MailTeleporter
-  entities:
-  - uid: 3935
-    components:
-    - type: Transform
-      pos: 16.5,-43.5
-      parent: 2
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 1879
@@ -118236,13 +118274,6 @@ entities:
     - type: Transform
       pos: 13.5,-5.5
       parent: 2
-- proto: PotassiumChemistryBottle
-  entities:
-  - uid: 5680
-    components:
-    - type: Transform
-      pos: 49.598484,-55.08549
-      parent: 2
 - proto: PottedPlant0
   entities:
   - uid: 13152
@@ -122720,11 +122751,6 @@ entities:
     - type: Transform
       pos: 20.5,-29.5
       parent: 2
-  - uid: 6581
-    components:
-    - type: Transform
-      pos: 63.5,-15.5
-      parent: 2
 - proto: PsychBed
   entities:
   - uid: 11114
@@ -124790,18 +124816,6 @@ entities:
     components:
     - type: Transform
       pos: 40.48715,81.52913
-      parent: 2
-- proto: RobustHarvestChemistryBottle
-  entities:
-  - uid: 13170
-    components:
-    - type: Transform
-      pos: -2.6835227,60.176945
-      parent: 2
-  - uid: 13171
-    components:
-    - type: Transform
-      pos: -2.6835227,59.871178
       parent: 2
 - proto: RollerBed
   entities:
@@ -131819,6 +131833,9 @@ entities:
     - type: Transform
       pos: 15.62253,-50.09342
       parent: 2
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: SoapDeluxe
   entities:
   - uid: 9253
@@ -133066,23 +133083,6 @@ entities:
     components:
     - type: Transform
       pos: 62.5,-5.5
-      parent: 2
-- proto: SpawnMobDrone
-  entities:
-  - uid: 5218
-    components:
-    - type: Transform
-      pos: 56.5,-15.5
-      parent: 2
-  - uid: 18083
-    components:
-    - type: Transform
-      pos: 56.5,-16.5
-      parent: 2
-  - uid: 18084
-    components:
-    - type: Transform
-      pos: 56.5,-14.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:
@@ -138127,6 +138127,9 @@ entities:
     - type: Transform
       pos: 64.548836,87.58884
       parent: 2
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: SyringeCryostasis
   entities:
   - uid: 15939
@@ -140943,6 +140946,7 @@ entities:
     - type: Transform
       pos: 65.5,89.5
       parent: 2
+    - type: Conveyed
 - proto: TegCenter
   entities:
   - uid: 5060

--- a/Resources/Maps/_Impstation/core.yml
+++ b/Resources/Maps/_Impstation/core.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 250.0.0
+  engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/23/2025 08:13:25
-  entityCount: 22644
+  time: 05/09/2025 04:18:09
+  entityCount: 22642
 maps:
 - 17546
 grids:
@@ -13151,9 +13151,9 @@ entities:
     - type: DeviceList
       devices:
       - 8759
-      - 18516
       - 18233
       - 18515
+      - 17505
   - uid: 8444
     components:
     - type: Transform
@@ -17522,6 +17522,15 @@ entities:
       deviceLists:
       - 15597
       - 15596
+  - uid: 17505
+    components:
+    - type: Transform
+      pos: 32.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8443
+      - 17614
   - uid: 17875
     components:
     - type: Transform
@@ -17720,12 +17729,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 60.5,2.5
-      parent: 2
-  - uid: 18516
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,-0.5
       parent: 2
   - uid: 18532
     components:
@@ -21867,6 +21870,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-52.5
+      parent: 2
+- proto: BorgChargerDroneSpawner
+  entities:
+  - uid: 17503
+    components:
+    - type: Transform
+      pos: 34.5,-0.5
       parent: 2
 - proto: BoxBodyBag
   entities:
@@ -72438,7 +72448,7 @@ entities:
     - type: DeviceList
       devices:
       - 8759
-      - 18516
+      - 17505
   - uid: 17615
     components:
     - type: Transform
@@ -122048,23 +122058,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-11.5
-      parent: 2
-- proto: SpawnMobDrone
-  entities:
-  - uid: 17503
-    components:
-    - type: Transform
-      pos: 34.5,-0.5
-      parent: 2
-  - uid: 17505
-    components:
-    - type: Transform
-      pos: 33.5,-0.5
-      parent: 2
-  - uid: 17512
-    components:
-    - type: Transform
-      pos: 32.5,-0.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:

--- a/Resources/Maps/_Impstation/meta.yml
+++ b/Resources/Maps/_Impstation/meta.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/24/2025 17:16:47
-  entityCount: 28696
+  time: 05/09/2025 04:20:50
+  entityCount: 28694
 maps:
 - 951
 grids:
@@ -14586,7 +14586,7 @@ entities:
       pos: -29.5,15.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -260665.7
+      secondsUntilStateChange: -260701.36
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14834,7 +14834,7 @@ entities:
       pos: -4.5,53.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -115319.44
+      secondsUntilStateChange: -115355.09
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -22813,6 +22813,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,0.5
+      parent: 5350
+- proto: BorgChargerDroneSpawner
+  entities:
+  - uid: 25337
+    components:
+    - type: Transform
+      pos: 42.5,-2.5
       parent: 5350
 - proto: BoxBeaker
   entities:
@@ -84367,7 +84374,7 @@ entities:
       pos: 31.5,-33.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -38158.473
+      secondsUntilStateChange: -38194.13
       state: Closing
   - uid: 9615
     components:
@@ -151558,23 +151565,6 @@ entities:
     - type: Transform
       pos: 58.5,-11.5
       parent: 5350
-- proto: SpawnMobDrone
-  entities:
-  - uid: 28671
-    components:
-    - type: Transform
-      pos: 43.5,-2.5
-      parent: 5350
-  - uid: 28672
-    components:
-    - type: Transform
-      pos: 42.5,-2.5
-      parent: 5350
-  - uid: 28673
-    components:
-    - type: Transform
-      pos: 42.5,-1.5
-      parent: 5350
 - proto: SpawnMobFoxRenault
   entities:
   - uid: 1083
@@ -184710,7 +184700,7 @@ entities:
       pos: -28.5,-5.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -43870.383
+      secondsUntilStateChange: -43906.04
       state: Opening
   - uid: 17570
     components:

--- a/Resources/Maps/_Impstation/plasma.yml
+++ b/Resources/Maps/_Impstation/plasma.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/30/2025 03:49:52
-  entityCount: 26429
+  time: 05/09/2025 04:28:42
+  entityCount: 26431
 maps:
 - 1
 grids:
@@ -133532,6 +133532,12 @@ entities:
     - type: Transform
       pos: -98.5,11.5
       parent: 2
+  - uid: 26431
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -99.5,-35.5
+      parent: 2
 - proto: PoweredStrobeLightEmpty
   entities:
   - uid: 3985
@@ -140827,6 +140833,13 @@ entities:
     components:
     - type: Transform
       pos: -101.5,25.5
+      parent: 2
+- proto: SignDrones
+  entities:
+  - uid: 26430
+    components:
+    - type: Transform
+      pos: -107.5,-30.5
       parent: 2
 - proto: SignElectricalMed
   entities:
@@ -167756,7 +167769,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -207976.1
+      secondsUntilStateChange: -208065.02
       state: Opening
     - type: Airlock
       autoClose: False

--- a/Resources/Maps/_Impstation/union.yml
+++ b/Resources/Maps/_Impstation/union.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/23/2025 18:18:47
-  entityCount: 21502
+  time: 05/09/2025 04:25:06
+  entityCount: 21500
 maps:
 - 1
 grids:
@@ -9615,15 +9615,13 @@ entities:
     - type: Transform
       pos: -6.5,23.5
       parent: 2
-  - uid: 11807
-    components:
-    - type: MetaData
-      name: tech vault (command-only)
-    - type: Transform
-      pos: 45.5,-46.5
-      parent: 2
 - proto: AirlockCommandLocked
   entities:
+  - uid: 11807
+    components:
+    - type: Transform
+      pos: 43.5,-43.5
+      parent: 2
   - uid: 20449
     components:
     - type: Transform
@@ -10028,7 +10026,7 @@ entities:
       pos: -36.5,0.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -102885.9
+      secondsUntilStateChange: -102980.64
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -10368,7 +10366,7 @@ entities:
       pos: 33.5,-43.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -231223.02
+      secondsUntilStateChange: -231317.77
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11073,7 +11071,7 @@ entities:
       pos: 37.5,-46.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -53558.434
+      secondsUntilStateChange: -53653.176
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11707,7 +11705,7 @@ entities:
       pos: -8.5,-0.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -45682.06
+      secondsUntilStateChange: -45776.8
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -99774,7 +99772,7 @@ entities:
   - uid: 5998
     components:
     - type: Transform
-      pos: 43.5,-43.5
+      pos: 45.5,-46.5
       parent: 2
 - proto: HighSecDoor
   entities:
@@ -117030,20 +117028,10 @@ entities:
       parent: 2
 - proto: SpawnMobDrone
   entities:
-  - uid: 21450
-    components:
-    - type: Transform
-      pos: 45.5,-42.5
-      parent: 2
   - uid: 21451
     components:
     - type: Transform
       pos: 46.5,-43.5
-      parent: 2
-  - uid: 21452
-    components:
-    - type: Transform
-      pos: 45.5,-44.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:


### PR DESCRIPTION
Most maps should already have had the number of roundstart drones limited to one, this PR should adjust the remaining maps to keep this standard.
