### PR TITLE
RDNR people can now be cloned and fixed DNR not working

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -222,7 +222,7 @@ public sealed class DefibrillatorSystem : EntitySystem
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString(unrevivable.ReasonMessage),
                 InGameICChatType.Speak, true);
 
-            return;
+            return; //imp
         }
 
         if (HasComp<RandomUnrevivableComponent>(target))
@@ -234,9 +234,9 @@ public sealed class DefibrillatorSystem : EntitySystem
                 if (component.ShowMessages)
                     _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-unrevivable"), InGameICChatType.Speak, true);
                 dnrComponent.Chance = 0f;
-                var unrevivable = AddComp<UnrevivableComponent>(target);
-                unrevivable.Cloneable = true;
-                RemComp<RandomUnrevivableComponent>(target);
+                var unrevivable = AddComp<UnrevivableComponent>(target); //imp
+                unrevivable.Cloneable = true; //imp
+                RemComp<RandomUnrevivableComponent>(target); //imp
 
                 return;
             }

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -221,6 +221,8 @@ public sealed class DefibrillatorSystem : EntitySystem
         {
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString(unrevivable.ReasonMessage),
                 InGameICChatType.Speak, true);
+
+            return;
         }
 
         if (HasComp<RandomUnrevivableComponent>(target))
@@ -234,6 +236,8 @@ public sealed class DefibrillatorSystem : EntitySystem
                 dnrComponent.Chance = 0f;
                 var unrevivable = AddComp<UnrevivableComponent>(target);
                 unrevivable.Cloneable = true;
+                RemComp<RandomUnrevivableComponent>(target);
+
                 return;
             }
             else

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -231,8 +231,9 @@ public sealed class DefibrillatorSystem : EntitySystem
             {
                 if (component.ShowMessages)
                     _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-unrevivable"), InGameICChatType.Speak, true);
-                    dnrComponent.Chance = 0f;
-                    AddComp<UnrevivableComponent>(target);
+                dnrComponent.Chance = 0f;
+                var unrevivable = AddComp<UnrevivableComponent>(target);
+                unrevivable.Cloneable = true;
                 return;
             }
             else


### PR DESCRIPTION
Adjusts the rdnr part of the defibrillator system to work with the upstream cloning refactor (just makes the cloneable variable true) and fixes unrevivable not working by readding a return that mysteriously disappeared (probably a mistake in one of the upstream merges).

**Changelog**
:cl: Oberonics
- tweak: You can now be cloned no matter your body composition.
- fix: Being unrevivable now actually means you can't be revived.

