### PR TITLE
Fix Handheld Mass Scanner size

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -49,7 +49,6 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
   - type: Item
-    size: Normal
     sprite: _Impstation/Objects/Tools/handheld_mass_scanner.rsi # imp
   - type: Sprite
     sprite: _Impstation/Objects/Tools/handheld_mass_scanner.rsi # imp

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -5,7 +5,6 @@
   description: A hand-held mass scanner.
   components:
   - type: Item
-    size: Normal
     sprite: _Impstation/Objects/Tools/handheld_mass_scanner.rsi # imp
   - type: Sprite
     sprite: _Impstation/Objects/Tools/handheld_mass_scanner.rsi # imp


### PR DESCRIPTION
Just implements the fix implemented upstream space-wizards#36013 that wasn't in the last upstream merge.

**Changelog**
:cl: Oberonics
- fix: Handheld Mass Scanners are no longer comically large (and can fit in your pocket again).

