### PR TITLE
my endless toil (more supermatter changes)

### DIFF
--- a/Content.Client/_EE/Supermatter/Consoles/SupermatterEntryContainer.xaml
+++ b/Content.Client/_EE/Supermatter/Consoles/SupermatterEntryContainer.xaml
@@ -104,7 +104,7 @@
                     <Label Name="MolesLabel" Text="{Loc 'supermatter-console-window-label-moles'}" HorizontalExpand="True" HorizontalAlignment="Left" />
                     <BoxContainer SetWidth="180" SetHeight="24" Orientation="Horizontal">
                         <PanelContainer Name="MolesBarBorder" HorizontalExpand="True" Margin="0">
-                            <ProgressBar Name="MolesBar" MinValue="0" MaxValue="100" Margin="1">
+                            <ProgressBar Name="MolesBar" MinValue="0" MaxValue="50" Margin="1">
                                 <Label Name="MolesBarLabel" HorizontalAlignment="Right" Margin="0 0 4 0" />
                             </ProgressBar>
                         </PanelContainer>

--- a/Content.Server/Lightning/LightningTargetSystem.cs
+++ b/Content.Server/Lightning/LightningTargetSystem.cs
@@ -28,7 +28,7 @@ public sealed class LightningTargetSystem : EntitySystem
         damage.DamageDict.Add("Structural", uid.Comp.DamageFromLightning);
         _damageable.TryChangeDamage(uid, damage, true);
 
-        if (uid.Comp.LightningExplode)
+        if (uid.Comp.LightningExplode && args.CanExplode) // imp - added CanExplode
         {
             _explosionSystem.QueueExplosion(
                 _transform.GetMapCoordinates(uid),

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -105,8 +105,8 @@ public sealed partial class SupermatterSystem
         // Ramps up or down in increments of 0.02 up to the proportion of CO2
         // Given infinite time, powerloss_dynamic_scaling = co2comp
         // Some value from 0-1
-        if (moles > _config.GetCVar(EECCVars.SupermatterPowerlossInhibitionMoleThreshold) &&
-            gasComposition.GetMoles(Gas.CarbonDioxide) > _config.GetCVar(EECCVars.SupermatterPowerlossInhibitionGasThreshold))
+        if (moles > _config.GetCVar(EECCVars.SupermatterPowerlossInhibitionMoleThreshold) && // if there are more than 6 mols,
+            gasComposition.GetMoles(Gas.CarbonDioxide) > _config.GetCVar(EECCVars.SupermatterPowerlossInhibitionGasThreshold)) // and more than 20% co2
         {
             var co2powerloss = Math.Clamp(gasComposition.GetMoles(Gas.CarbonDioxide) - sm.PowerlossDynamicScaling, -0.02f, 0.02f);
             sm.PowerlossDynamicScaling = Math.Clamp(sm.PowerlossDynamicScaling + co2powerloss, 0f, 1f);
@@ -114,7 +114,7 @@ public sealed partial class SupermatterSystem
         else
             sm.PowerlossDynamicScaling = Math.Clamp(sm.PowerlossDynamicScaling - 0.05f, 0f, 1f);
 
-        // Ranges from 0~1(1 - (0~1 * 1~(1.5 * (mol / 500))))
+        // Ranges from 0~1(1 - (0~1 * 1~(1.5 * (mol / 150))))
         // We take the mol count, and scale it to be our inhibitor
         sm.PowerlossInhibitor = Math.Clamp(
             1 - sm.PowerlossDynamicScaling * Math.Clamp(moles / _config.GetCVar(EECCVars.SupermatterPowerlossInhibitionMoleBoostThreshold), 1f, 1.5f),
@@ -217,7 +217,7 @@ public sealed partial class SupermatterSystem
         }
 
         if (zapCount >= 1)
-            _lightning.ShootRandomLightnings(uid, zapRange, zapCount, sm.LightningPrototypes[zapPower], hitCoordsChance: sm.ZapHitCoordinatesChance);
+            _lightning.ShootRandomLightnings(uid, zapRange, zapCount, sm.LightningPrototypes[zapPower], hitCoordsChance: sm.ZapHitCoordinatesChance, canExplode: false);
     }
 
     /// <summary>
@@ -761,7 +761,7 @@ public sealed partial class SupermatterSystem
         foreach (var mob in lookup)
         {
             // Not in line of sight, or is dead
-            if (!_examine.InRangeUnOccluded(uid, mob, 20f) ||
+            if (!_examine.InRangeUnOccluded(uid, mob, 6f) ||
                 mob.Comp.CurrentState == MobState.Dead)
                 continue;
 

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -761,7 +761,7 @@ public sealed partial class SupermatterSystem
         foreach (var mob in lookup)
         {
             // Not in line of sight, or is dead
-            if (!_examine.InRangeUnOccluded(uid, mob, 6f) ||
+            if (!_examine.InRangeUnOccluded(uid, mob, sm.HallucinationRange) ||
                 mob.Comp.CurrentState == MobState.Dead)
                 continue;
 

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
@@ -283,7 +283,7 @@ public sealed partial class SupermatterSystem : EntitySystem
         if (!sm.HasBeenPowered)
             LogFirstPower(uid, sm, target);
 
-        if (!HasComp<ProjectileComponent>(target))
+        if (!TryComp<ProjectileComponent>(target, out var projectile))
         {
             var popup = "supermatter-collide";
 
@@ -312,7 +312,7 @@ public sealed partial class SupermatterSystem : EntitySystem
 
         if (TryComp<SupermatterFoodComponent>(target, out var food))
             sm.Power += food.Energy;
-        else if (TryComp<ProjectileComponent>(target, out var projectile))
+        else if (projectile != null)
             sm.Power += (float)projectile.Damage.GetTotal();
         else
             sm.Power++;

--- a/Content.Shared/_EE/CCVar/EECCVars.cs
+++ b/Content.Shared/_EE/CCVar/EECCVars.cs
@@ -115,7 +115,7 @@ public sealed partial class EECCVars : CVars
     ///     The amount of matter power generated for every mole of ammonia consumed.
     /// </summary>
     public static readonly CVarDef<float> SupermatterAmmoniaPowerGain =
-        CVarDef.Create("supermatter.ammonia_power_gain", 10f, CVar.SERVER);
+        CVarDef.Create("supermatter.ammonia_power_gain", 30f, CVar.SERVER);
 
     /// <summary>
     ///     When true, bypass the normal checks to determine delam type, and instead use the type chosen by supermatter.forced_delam_type
@@ -159,7 +159,7 @@ public sealed partial class EECCVars : CVars
     ///     Below this threshold, the supermatter can heal damage.
     /// </summary>
     public static readonly CVarDef<float> SupermatterMolePenaltyThreshold =
-        CVarDef.Create("supermatter.mole_penalty_threshold", 1800f, CVar.SERVER);
+        CVarDef.Create("supermatter.mole_penalty_threshold", 600f, CVar.SERVER);
 
     /// <summary>
     ///     Divisor on the amount of oxygen released during atmospheric reactions.
@@ -184,13 +184,13 @@ public sealed partial class EECCVars : CVars
     ///     Scales powerloss inhibition down until this amount of moles is reached.
     /// </summary>
     public static readonly CVarDef<float> SupermatterPowerlossInhibitionMoleThreshold =
-        CVarDef.Create("supermatter.powerloss_inhibition_mole_threshold", 20f, CVar.SERVER);
+        CVarDef.Create("supermatter.powerloss_inhibition_mole_threshold", 6f, CVar.SERVER);
 
     /// <summary>
     ///     Bonus powerloss inhibition boost if this amount of moles is reached.
     /// </summary>
     public static readonly CVarDef<float> SupermatterPowerlossInhibitionMoleBoostThreshold =
-        CVarDef.Create("supermatter.powerloss_inhibition_mole_boost_threshold", 500f, CVar.SERVER);
+        CVarDef.Create("supermatter.powerloss_inhibition_mole_boost_threshold", 150f, CVar.SERVER);
 
     /// <summary>
     ///     Base amount of radiation that the supermatter emits.

--- a/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
@@ -33,6 +33,9 @@ public sealed partial class SupermatterComponent : Component
     [DataField]
     public Color LightColorDelam = Color.FromHex("#ffe000");
 
+    [DataField]
+    public float HallucinationRange = 6f;
+
     #endregion
 
     #region Prototypes


### PR DESCRIPTION
back at it again at krispy kreme

detailed changes:
- reduced the supermatter vision range that paracusia is applied at from 20 tiles to 6. why was it 20? i dont know. i just type number
- adjusted a lot of moles-based values to accomodate for the change from 15% moles absorbed to 5% made in #1928
- reduced the max value of the "absorbed moles" by half because it feels good
- added `CanExplode` to `HitByLightningEvent` to prevent supermatter lightning from venting the chamber, without interfering with tesla coil charging or tesla balls

**Changelog**
:cl:
- remove: Supermatter lightning can no longer explode nearby airlocks, air alarms, or other objects.
- tweak: Reduced the range at which direct eye contact with the supermatter induces hallucinations.
- tweak: Carbon dioxide affects the supermatter more strongly at lower values, and tesla/singularity delaminations are easier to trigger.