### PR TITLE
rebalanced null rod options

### DIFF
--- a/Resources/Locale/en-US/_Impstation/chemistry/components/mixing-component.ftl
+++ b/Resources/Locale/en-US/_Impstation/chemistry/components/mixing-component.ftl
@@ -1,0 +1,2 @@
+# Types
+mixing-verb-gildgrail = swirl

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -57,15 +57,3 @@
       amount: 1
   products:
     Holywater: 1
-
-- type: reaction
-  id: WatertoHolyAquam
-  impact: Low
-  requiredMixerCategories:
-  - Gildgrail
-  reactants:
-    Water:
-      amount: 1
-  products:
-    Holywater: 0.5
-    AquamDivinos: 0.5

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -57,3 +57,15 @@
       amount: 1
   products:
     Holywater: 1
+
+- type: reaction
+  id: WatertoHolyAquam
+  impact: Low
+  requiredMixerCategories:
+  - Gildgrail
+  reactants:
+    Water:
+      amount: 1
+  products:
+    Holywater: 0.5
+    AquamDivinos: 0.5

--- a/Resources/Prototypes/_Impstation/Chemistry/mixing_types.yml
+++ b/Resources/Prototypes/_Impstation/Chemistry/mixing_types.yml
@@ -1,0 +1,6 @@
+- type: mixingCategory
+  id: Gildgrail
+  verbText: mixing-verb-gildgrail
+  icon:
+    sprite: _Impstation/Objects/Misc/nullrod_grail.rsi
+    state: grail

--- a/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
@@ -67,7 +67,7 @@
   - type: SolutionContainerManager
     solutions:
       grail:
-        maxVol: 30
+        maxVol: 60
   - type: MixableSolution
     solution: grail
   - type: RefillableSolution
@@ -142,7 +142,7 @@
         variation: 0.35
     mustBeEquippedToUse: true
   - type: MeleeThrowOnHit
-    disctance: 1 # Down from 20 if this variable even does anything
+    distance: 1 # Down from 20 if this variable even does anything
     speed: 1 # Down from 7
   - type: Reflect
     reflectProb: .22

--- a/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
@@ -62,14 +62,12 @@
         visible: false
   - type: Item
     size: Small
-    shape:
-    - 0,0,1,1
   - type: FitsInDispenser
     solution: grail
   - type: SolutionContainerManager
     solutions:
       grail:
-        maxVol: 200
+        maxVol: 30
   - type: MixableSolution
     solution: grail
   - type: RefillableSolution
@@ -101,7 +99,7 @@
     inHandsMaxFillLevels: 1
     inHandsFillBaseName: -fill-
   - type: Shakeable
-    shakeDuration: 1.6
+    shakeDuration: 3
     requireInHand: true
     shakeVerbText: null-grail-verb
     shakePopupMessageOthers: null-grail-popup-others
@@ -111,7 +109,7 @@
   - type: ReactionMixer
     mixOnInteract: false
     reactionTypes:
-    - Holy
+    - Gildgrail #mix changed to make half holy water and half aquam divinos
     - Shake
     mixMessage: "null-grail-mix-success"
 
@@ -131,12 +129,12 @@
   - type: Clothing
     sprite: _Impstation/Objects/Misc/nullrod_glove.rsi
   - type: StaminaDamageOnHit
-    damage: 23
+    damage: 5 # Down from 24
   - type: MeleeWeapon
     attackRate: 0.68
     damage:
       types:
-        Blunt: 14
+        Blunt: 10 # Down from 14
         Holy: 20
     soundHit:
       path: /Audio/_Impstation/Weapons/nullglove.ogg
@@ -144,7 +142,8 @@
         variation: 0.35
     mustBeEquippedToUse: true
   - type: MeleeThrowOnHit
-    speed: 7
+    disctance: 1 # Down from 20 if this variable even does anything
+    speed: 1 # Down from 7
   - type: Reflect
     reflectProb: .22
     spread: 120

--- a/Resources/Prototypes/_Impstation/Recipes/Reactions/misc.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Reactions/misc.yml
@@ -26,3 +26,15 @@
   effects:
   - !type:CreateEntityReactionEffect
     entity: Homunculus
+
+- type: reaction
+  id: WatertoHolyAquam
+  impact: Low
+  requiredMixerCategories:
+  - Gildgrail
+  reactants:
+    Water:
+      amount: 1
+  products:
+    Holywater: 0.5
+    AquamDivinos: 0.5


### PR DESCRIPTION
Nerfed the ever loving hell out of the divine grasp. Did my best to keep the fantasy of the toy without having syndicate gear's level of power for a passenger plus item. I feel confident about the numbers on this one.

Also changed the gildgrail to make it more useful and not worse than a bucket and bible. Changed the reaction to make half holy water half aquam divinos. I'm not 100% sold on my numbers here, so I'm open to adjustments.

Overall goal here was to use the bow as a baseline and try to bring the other two at least a little closer to that in effectiveness.

:cl:
- tweak: Adjusted divine grasp and gildgrail. Take a sip, babes!
