### PR TITLE
make heavy nitrile gloves obscure fingerprints

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Hands/gloves.yml
@@ -11,6 +11,7 @@
   - type: Fiber
     fiberMaterial: fibers-rubber
     fiberColor: fibers-black
+  - type: FingerprintMask
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
Adds the fingerprintmask component to heavy nitrile gloves, making them obscure fingerprints properly.

:cl:
- fix: Heavy nitrile gloves are now thick enough to actually obscure fingerprints!