### PR TITLE
Bunny ears in autodrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -3,6 +3,7 @@
   startingInventory:
     ClothingEyesBlindfold: 1
     ClothingHeadHatBeretFrench: 2
+    ClothingHeadHatBunny: 2
     ClothingHeadHatCardborg: 2
     ClothingHeadHatCasa: 1
     ClothingHeadHatChickenhead: 2


### PR DESCRIPTION
Adds two sets of bunny ears to the autodrobe's inventory! I just think they fit into the theater props category and should be a biiit more accessible than pure random chance :>
very very first commit/PR but should be simple enough i hope

:cl: Ominashi
- add: Bunny ears can now be found in your local autodrobe!