### PR TITLE
made the nuke less allergic to space

### DIFF
--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -189,5 +189,11 @@ namespace Content.Server.Nuke
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("requiredFloorRadius")]
         public float RequiredFloorRadius = 5;
+
+        /// <summary>
+        /// imp edit - if more than this % of neaby tiles are space, block anchoring the nuke
+        /// </summary>
+        [DataField]
+        public float MaxAllowedSpaceFrac = 0.25f;
     }
 }

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -193,16 +193,25 @@ public sealed class NukeSystem : EntitySystem
 
             var worldPos = _transform.GetWorldPosition(xform);
 
+            //imp edit start - make the nuke check for some number of nearby space tiles instead of failing on the first once
+            var total = 1f;
+            var space = 0f;
             foreach (var tile in _map.GetTilesIntersecting(xform.GridUid.Value, grid, new Circle(worldPos, component.RequiredFloorRadius), false))
             {
-                if (!tile.IsSpace(_tileDefManager))
-                    continue;
+                if (tile.IsSpace(_tileDefManager))
+                    space++;
 
+                total++;
+            }
+
+            if (space / total > component.MaxAllowedSpaceFrac)
+            {
                 var msg = Loc.GetString("nuke-component-cant-anchor-floor");
                 _popups.PopupEntity(msg, uid, args.Actor, PopupType.MediumCaution);
 
                 return;
             }
+            //imp edit end
 
             _transform.SetCoordinates(uid, xform, xform.Coordinates.SnapToGrid());
             _transform.AnchorEntity(uid, xform);


### PR DESCRIPTION
Been meaning to PR this for a while but it happened in a round & reminded me to do it
This makes it so that the nuke will refuse to be anchored if 25% of the tiles it checks are space (comes out to allowing ~20 tiles w/ the current radius) so that it's hopefully less frustrating for nukeops / loneops on the stations where the vault is wierdly close to space.

**Changelog**
:cl:
- tweak: The Nuke is slightly less allergic to space
