### PR TITLE
re-antagged the rat king

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -92,7 +92,7 @@
     makeSentient: true
     name: ghost-role-information-rat-king-name
     description: ghost-role-information-rat-king-description
-    rules: ghost-role-information-freeagent-rat-king-rules
+    rules: ghost-role-information-antagonist-rat-king-rules # IMP
     mindRoles:
     - MindRoleGhostRoleSoloAntagonist
     raffle:


### PR DESCRIPTION
Rat king antagonist again

:cl:
- fix: Rat king ghost role rules are once again properly antagonist after upstream merge convinced the king to be nice.
