### PR TITLE
fix earrings from #2059

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -22,6 +22,8 @@
     - Hair
     - Snout
     - FacialHair #imp
+    - HeadSide #imp
+    - HeadTop #imp
   - type: Inventory
     femaleDisplacements:
       jumpsuit:

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -63,7 +63,7 @@
       points: 1
       required: false
     HeadSide: #imp
-      points: 1
+      points: 2 #up from 1 because i moved earrings here
       required: false
     UndergarmentTop:
       points: 1

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -23,6 +23,8 @@
     UndergarmentBottom: MobHumanoidAnyMarking
     Chest: MobSlimeTorso
     Eyes: MobHumanoidAnyMarking #imp, so they can pick their eyes
+    HeadTop: MobHumanoidAnyMarking #imp
+    HeadSide: MobHumanoidAnyMarking #imp
     LArm: MobSlimeLArm
     RArm: MobSlimeRArm
     LHand: MobSlimeLHand
@@ -39,6 +41,12 @@
       points: 1
       required: true
       defaultMarkings: [ SlimeEyesDefault ]
+    HeadTop: #imp
+      points: 1
+      required: false
+    HeadSide: #imp
+      points: 1
+      required: false
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/humanoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/humanoid.yml
@@ -1613,8 +1613,8 @@
 
 - type: marking
   id: HeadEarrings
-  bodyPart: HeadTop
-  markingCategory: HeadTop
+  bodyPart: HeadSide
+  markingCategory: HeadSide
   speciesRestriction: [ Human, Dwarf, SlimePerson ]
   coloring:
     default:
@@ -1629,8 +1629,8 @@
 
 - type: marking
   id: HeadEarringsDrop
-  bodyPart: HeadTop
-  markingCategory: HeadTop
+  bodyPart: HeadSide
+  markingCategory: HeadSide
   speciesRestriction: [ Human, Dwarf, SlimePerson ]
   coloring:
     default:
@@ -1645,8 +1645,8 @@
 
 - type: marking
   id: HeadEarringsWeights
-  bodyPart: HeadTop
-  markingCategory: HeadTop
+  bodyPart: HeadSide
+  markingCategory: HeadSide
   speciesRestriction: [ Human, Dwarf, SlimePerson ]
   coloring:
     default:


### PR DESCRIPTION
added proper support for headtop and headside for humans and slimes, including hiding the layers on helmet toggle
changed the earrings from #2059 to headside instead of headtop, changed the marking limit for human headside to 2

**Changelog**
:cl:
- fix: slimes can actually have earrings now
