### PR TITLE
specialised topical  yaml hotfix

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -104,7 +104,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockMedicalFilled
-  cost: 2000 #IMP
+  cost: 1750
   category: cargoproduct-category-name-medical
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -8,7 +8,7 @@
     contents:
       - id: Brutepack
       - id: Ointment
-      - id: Tincture #IMP; replacing Gauze -> Tincture
+      - id: Gauze
       - id: PillCanisterTricordrazine
       # see https://github.com/tgstation/blob/master/code/game/objects/items/storage/firstaid.dm for example contents
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -1,16 +1,9 @@
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
-  startingInventory: # imp; see bottom line
+  startingInventory:
     HandheldHealthAnalyzer: 3
-    Brutepack: 3
-    SimpleSuture: 2
-    ElectrodePad: 2
-    Gauze: 2
-    Tincture: 5
-    Ointment: 3
-    ShockGel: 2
-    ColdPack: 2
-    EZGraft: 2
+    Brutepack: 5
+    Ointment: 5
     Bloodpack: 5
     ChemistryBottleEpinephrine: 3
     Syringe: 5
@@ -20,6 +13,3 @@
     ClothingEyesGlassesHudMedical: 2
   contrabandInventory:
     FoodApple: 1
-## Brute Packs Reduced 5 -> 3; added 2x S. Sutures, Electrode Pads, Gauze to compensate.
-## Ointment Reduced 5 -> 3; added 2x Shock Gel, Cold Pack, EZ-Grafts to compensate.
-## Added 5 Tinctures.


### PR DESCRIPTION
super happy to debate these later i just sped through with balance edits for the time being bc im tired

removed all of the new shit from nanomed, so theres more motivation to use the medifab
reduced nanomed price back
swapped tincture in first aid kit back to gauze bc salvagers will hate not being able to heal bloodloss

left everything else as is for now it looks fine at a glance maybe i can look at this more later or some fuck

:cl:
- tweak: Advanced topicals removed from nanomed pending further discussion. craft them in the medifab