### PR TITLE
goodcode this time i think

### DIFF
--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -119,8 +119,8 @@ public sealed class HealingSystem : EntitySystem
         _audio.PlayPvs(healing.HealingEndSound, entity.Owner, AudioHelpers.WithVariation(0.125f, _random).WithVolume(1f));
 
         // imp edit, raise healing success event to handle after-effects
-        var ev = new HealingSuccessEvent(args.User, args.Target, args.Used);
-        RaiseLocalEvent(entity, ev);
+        var ev = new HealingSuccessEvent(args.User, entity.Owner, args.Used.Value);
+        RaiseLocalEvent(args.Used.Value, ev);
 
         // Logic to determine the whether or not to repeat the healing action
         args.Repeat = (HasDamage(entity, healing) && !dontRepeat);

--- a/Content.Server/_Impstation/Medical/StunOnHealSystem.cs
+++ b/Content.Server/_Impstation/Medical/StunOnHealSystem.cs
@@ -13,17 +13,14 @@ public sealed class StunOnHealSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<DamageableComponent, HealingSuccessEvent>(OnDoAfter);
+        SubscribeLocalEvent<StunOnHealComponent, HealingSuccessEvent>(OnDoAfter);
     }
 
-    private void OnDoAfter(Entity<DamageableComponent> ent, ref HealingSuccessEvent args)
+    private void OnDoAfter(Entity<StunOnHealComponent> ent, ref HealingSuccessEvent args)
     {
-        if (!TryComp<StunOnHealComponent>(args.Used, out var stun))
-            return;
+        var duration = ent.Comp.StunDuration;
+        var damage = ent.Comp.Damage;
 
-        var duration = stun.StunDuration;
-        var damage = stun.Damage;
-
-        _electrocution.TryDoElectrocution(ent, args.Used, damage, duration, true, ignoreInsulation: true);
+        _electrocution.TryDoElectrocution(args.Target, ent, damage, duration, true, ignoreInsulation: true);
     }
 }

--- a/Content.Shared/_Impstation/Medical/HealingSuccessEvent.cs
+++ b/Content.Shared/_Impstation/Medical/HealingSuccessEvent.cs
@@ -3,9 +3,9 @@ namespace Content.Shared._Impstation.Medical;
 /// <summary>
 /// This handles...
 /// </summary>
-public sealed class HealingSuccessEvent(EntityUid user, EntityUid? target, EntityUid? used) : EntityEventArgs
+public sealed class HealingSuccessEvent(EntityUid user, EntityUid target, EntityUid used) : EntityEventArgs
 {
     public readonly EntityUid User = user;
-    public readonly EntityUid? Target = target;
-    public readonly EntityUid? Used = used;
+    public readonly EntityUid Target = target;
+    public readonly EntityUid Used = used;
 }


### PR DESCRIPTION
thought about #2468 a little harder and realised i created the exact same issue where i couldnt subscribe to `HealingDoAfterEvent` since it would create a duplicate subscription. now the event is called on the entity itself so the relevant component can subscribe to the event. changed a bit more code to fit the conventions of `HealingSystem` too even though i dont like them much

**Changelog**
no