### PR TITLE
reduced vomiting and jitter on synthflesh

### DIFF
--- a/Resources/Prototypes/_Impstation/Reagents/biological.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/biological.yml
@@ -103,8 +103,9 @@
           types:
             Cellular: 2
       - !type:ChemVomit
-        probability: 0.75
+        probability: 0.25
       - !type:Jitter
+        probability: 0.25
 
 - type: reagent # can't parent it to blood because anybody should be able to drink it, the flesh/organs are the toxic parts (fugu moment)
   id: ShimmeringBlood


### PR DESCRIPTION
Current effects:

https://github.com/user-attachments/assets/edc157b2-638d-49aa-ae9c-d92c7ce6ec06


This pr reduces the rates for both the vomit and jitter effects down to .25 from .75 (ipecac is .3 for reference). Not touching the damage for now since I don't feel like 2 cellular/u isn't too insane when not combined with enough stacking vomiting to reduce movement speed to 0. Reducing the jitter is mostly for flavor. AFAIK the only things with 100% jitter are stims so this it meant to just tone it down to make it look like a painful convulsion rather than tweaking out.

:cl:
- tweak: Reduced vomit and jittering rates for synthflesh