### PR TITLE
remove upstream feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,3 @@ contact_links:
   - name: Report a Security Vulnerability
     url: https://github.com/space-wizards/space-station-14/blob/master/SECURITY.md
     about: Please report security vulnerabilities privately so we can fix them before they are publicly disclosed.
-  - name: Request a Feature
-    url: https://discord.gg/rGvu9hKffJ
-    about: Submit feature requests on our Discord server (https://discord.gg/rGvu9hKffJ).


### PR DESCRIPTION
i want to promote making feature requests through github issues but this entry is confusing and links to the upstream discord. we dont need it

![image](https://github.com/user-attachments/assets/45a96a9e-5e3a-4e3f-997d-9a46468e4d98)

**Changelog**
this shit doesnt even affect the video game