### PR TITLE
Make scarves warm clothing, nerf winter boots

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
@@ -43,5 +43,5 @@
   # imp edit start
   - type: TemperatureProtection
     heatingCoefficient: 1.025
-    coolingCoefficient: 0.5
+    coolingCoefficient: 0.75
   # imp edit end

--- a/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
@@ -40,3 +40,8 @@
     - Scarf
     - ClothMade
     - WhitelistChameleon
+  # imp edit start
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
+  # imp edit end

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -70,4 +70,4 @@
   components:
   - type: TemperatureProtection
     heatingCoefficient: 1.025
-    coolingCoefficient: 0.5
+    coolingCoefficient: 0.75 #imp edit, winter boots too strong, made scarves give same protection

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Head/eva-helmets.yml
@@ -3,9 +3,12 @@
   parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetWinterEVALarge
   name: winter EVA mask
-  description: An helps against the biting cold and blinding sno.
+  description: An helps against the biting cold and blinding snow.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Head/Helmets/eva_winter.rsi
   - type: Clothing
     sprite: _Impstation/Clothing/Head/Helmets/eva_winter.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/softsuits.yml
@@ -14,7 +14,7 @@
     sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: TemperatureProtection
-    heatingCoefficient: 1.2
+    heatingCoefficient: 1.1
     coolingCoefficient: 0.1
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetWinterEVALarge


### PR DESCRIPTION
This PR gives scarves temperature protection and nerfs the amount of cooling protection winter boots give, giving them both a 2.5% increase to heating and a 25% reduction to cooling when worn. 50% cooling reduction from a shoe slot just seemed a bit too strong and this adds a way to stack more warm items. You will have slightly lower cooling reduction wearing both a scarf and boots than you would if you previously just wore boots since these protection stats are multiplicative (43.75% instead of 50%), but the added heating increase should offset this a bit.

Also tweaked the emergency winter EVA suit and helmet used for my work in progress ice station map to be more inline with winter coats and hoods (which turn out also give temperature protection!)

:cl:
- tweak: Winter boots have had their cooling protection reduced.
- add: Scarves now help keep you warm and protect from the cold, similar to winter boots.