### PR TITLE
robotic arm power draw "fix"

### DIFF
--- a/Content.Shared/_Goobstation/Factory/RoboticArmComponent.cs
+++ b/Content.Shared/_Goobstation/Factory/RoboticArmComponent.cs
@@ -153,7 +153,7 @@ public sealed partial class RoboticArmComponent : Component
     /// Power used when moving items.
     /// </summary>
     [DataField]
-    public float MovingPowerDraw = 3000f;
+    public float MovingPowerDraw = 1000f;
 
     #endregion
 }


### PR DESCRIPTION
lowered the active power draw of robotic arms from 3k to 1k to stop lights flickering every fucking time a robotic arm moves

**Changelog**
:cl:
- fix: Robotic arms now draw 1,000 watts instead of 3,000, preventing them from flickering lights every time they rotate.