### PR TITLE
Fix resistance bypass not working on melee wideswings

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -565,6 +565,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         var damage = GetDamage(meleeUid, user, component);
         var entities = GetEntityList(ev.Entities);
+        var resistanceBypass = GetResistanceBypass(meleeUid, user, component); // imp edit, fix resistance bypass
 
         if (entities.Count == 0)
         {
@@ -668,7 +669,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             RaiseLocalEvent(entity, attackedEvent);
             var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
 
-            var damageResult = Damageable.TryChangeDamage(entity, modifiedDamage, origin:user);
+            var damageResult = Damageable.TryChangeDamage(entity, modifiedDamage, origin:user, ignoreResistances:resistanceBypass); //imp edit, fix resistance bypass
 
             if (damageResult != null && damageResult.GetTotal() > FixedPoint2.Zero)
             {


### PR DESCRIPTION
The armor piercing effect on the MeleeWeapon component currently only works on precise attacks and not wideswings, which is seemingly an oversight in how it's implemented. This PR fixes this, allowing melee weapons with the resistanceBypass variable enabled to function correctly. I had planned to make a PR for this upstream at some point, but no melee weapons actually utilize reistanceBypass currently and someone here has expressed interest in making a weapon that does, so I figured it would be best to PR this here first.

Examples:
3 wideswings with captain's saber with resistanceBypass enabled, no fix:
![WRB7OY0](https://github.com/user-attachments/assets/18d044d0-de42-46d4-ba84-c0adcf0c37a5)
3 wideswings with captain's saber with resistanceBypass enabled, with fix:
![42MbzVQ](https://github.com/user-attachments/assets/86c71d58-3be2-49a3-b3e5-05b5a7d16922)

No cl, not player facing.
