### PR TITLE
Randomized antag appearances + Remove listop accent

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -246,6 +246,7 @@
         - NamesNinjaTitle
         - NamesNinja
         nameFormat: name-format-ninja
+      - type: RandomHumanoidAppearance # Imp
       mindRoles:
       - MindRoleNinja
 
@@ -333,6 +334,7 @@
         - NamesWizardFirst
         - NamesWizardLast
         nameFormat: name-format-wizard
+      - type: RandomHumanoidAppearance # Imp
       mindRoles:
       - MindRoleWizard
 
@@ -485,6 +487,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: RandomHumanoidAppearance # Imp
       mindRoles:
       - MindRoleNukeopsLone #imp edit to separate playtime tracking from regular nukies
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -135,6 +135,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: RandomHumanoidAppearance # Imp
       mindRoles:
       - MindRoleNukeopsCommander
     - prefRoles: [ NukeopsMedic ]
@@ -152,6 +153,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: RandomHumanoidAppearance # Imp
       mindRoles:
       - MindRoleNukeopsMedic
     - prefRoles: [ Nukeops ]
@@ -171,6 +173,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: RandomHumanoidAppearance # Imp
       mindRoles:
       - MindRoleNukeops
 

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -63,5 +63,6 @@
         - NamesWizardFirst
         - NamesWizardLast
         nameFormat: name-format-wizard
+      - type: RandomHumanoidAppearance # Imp
       mindRoles:
       - MindRoleWizard

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -57,6 +57,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: Accentless # Imp
       mindRoles:
       - MindRolePostOperator
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bdaf803e-a617-454a-8297-b6b2381b07df)

as promised. turns out this was a comically easy change

this should affect NukeOps, LoneOps, Ninja, Wizard and MidRoundWizard.
tossed up the idea of randomizing listops too, but nobodys goin to that planet so it dont matter. got rid of the species accent they spawn with just bc i was there and it was easy

:cl:
- tweak: Nukies, Wizards, and Ninjas will now have a randomized appearance (but not species) when they spawn. Go forth and spread anonymous chaos!
- tweak: Listening Post Operatives will no longer be restricted by their species' accent.