### PR TITLE
removes fishing

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fishing/fishing_rods.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fishing/fishing_rods.yml
@@ -28,10 +28,10 @@
         enum.TetherVisualsStatus.Key:
           unshaded:
             True: { state: base-unshaded }
-            False: { state: base-unshaded-off }         
-    - type: Construction
-      graph: FishingRod
-      node: rod
+            False: { state: base-unshaded-off }
+    #- type: Construction # disabled until there is something to fish
+    #  graph: FishingRod
+    #  node: rod
 
 - type: entity
   name: plasma rod
@@ -85,7 +85,7 @@
     - type: Unremoveable
     - type: GenericVisualizer #The component that handles multiple states for the sprite
       visuals:
-        enum.AmmoVisuals.HasAmmo: 
+        enum.AmmoVisuals.HasAmmo:
           unshaded:
             True: { state: base-unshaded }
-            False: { state: base-unshaded-off }    
+            False: { state: base-unshaded-off }

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -38,7 +38,7 @@
       - SteelBriefcaseImp
     dynamicPacks:
       - CleanPackDynamic
-      - ServiceMiscPackDynamic
+      # - ServiceMiscPackDynamic # disabled until there is something to fish
       - FauxTiles
       - NFService # Frontier
   - type: EmagLatheRecipes

--- a/Resources/Prototypes/_Impstation/Recipes/Crafting/Graphs/improvised/fishing_rod.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Crafting/Graphs/improvised/fishing_rod.yml
@@ -1,17 +1,17 @@
-- type: constructionGraph
-  id: FishingRod
-  start: start
-  graph:
-  - node: start
-    edges:
-      - to: rod
-        steps:
-          - material: WoodPlank
-            amount: 5
-          - material: Cloth
-            amount: 2
-          - material: Steel
-            amount: 1
-            doAfter: 5
-  - node: rod
-    entity: FishingRodBase
+#- type: constructionGraph # disabled until there is something to fish
+#  id: FishingRod
+#  start: start
+#  graph:
+#  - node: start
+#    edges:
+#      - to: rod
+#        steps:
+#          - material: WoodPlank
+#            amount: 5
+#          - material: Cloth
+#            amount: 2
+#          - material: Steel
+#            amount: 1
+#            doAfter: 5
+#  - node: rod
+#    entity: FishingRodBase

--- a/Resources/Prototypes/_Impstation/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Crafting/improvised.yml
@@ -11,18 +11,18 @@
     state: icon
   objectType: Item
 
-- type: construction
-  name: fishing rod
-  id: FishingRod
-  graph: FishingRod
-  startNode: start
-  targetNode: rod
-  category: construction-category-tools
-  objectType: Item
-  description: A tool of the ages used to bring things out of reach closer.
-  icon:
-    sprite: _Impstation/Objects/Fishing/fishingrod.rsi
-    state: base
+#- type: construction # disabled until there is something to fish
+#  name: fishing rod
+#  id: FishingRod
+#  graph: FishingRod
+#  startNode: start
+#  targetNode: rod
+#  category: construction-category-tools
+#  objectType: Item
+#  description: A tool of the ages used to bring things out of reach closer.
+#  icon:
+#    sprite: _Impstation/Objects/Fishing/fishingrod.rsi
+#    state: base
 
 - type: construction
   name: yarn noodles

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
@@ -15,7 +15,7 @@
   recipes:
   - Drone
   - CleanerGrenade
-  - FishingRod
+#  - FishingRod # disabled until there is something to fish
   - ExosuitFabricatorMachineCircuitboard
   - ClothingEyesNightVisionGoggles # EE
   - ClothingEyesNightVisionDiagnosticGoggles # EE

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
@@ -90,10 +90,10 @@
     - ClothingBackpackWaterTank
     - CleanerGrenade
 
-- type: latheRecipePack
-  id: ServiceMiscPackDynamic
-  recipes:
-    - FishingRod
+#- type: latheRecipePack # disabled until there is something to fish
+#  id: ServiceMiscPackDynamic
+#  recipes:
+#    - FishingRod
 
 # Emagged
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/fishing.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/fishing.yml
@@ -1,8 +1,8 @@
-- type: latheRecipe
-  id: FishingRod
-  result: FishingRodPlasma
-  completetime: 3
-  materials:
-    Steel: 500
-    Durathread: 200
-    Plasma: 100
+#- type: latheRecipe # disabled until there is something to fish
+#  id: FishingRod
+#  result: FishingRodPlasma
+#  completetime: 3
+#  materials:
+#    Steel: 500
+#    Durathread: 200
+#    Plasma: 100

--- a/Resources/Prototypes/_Impstation/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Impstation/Research/civilianservices.yml
@@ -1,11 +1,11 @@
-- type: technology
-  id: Fishing
-  name: research-technology-basic-fishing
-  icon:
-    sprite: _Impstation/Objects/Fishing/fishingrod_plasma.rsi
-    state: base
-  discipline: CivilianServices
-  tier: 1
-  cost: 2500 #Making it cheap until I add the rest of it
-  recipeUnlocks:
-  - FishingRod
+#- type: technology # disabled until there is something to fish
+#  id: Fishing
+#  name: research-technology-basic-fishing
+#  icon:
+#    sprite: _Impstation/Objects/Fishing/fishingrod_plasma.rsi
+#    state: base
+#  discipline: CivilianServices
+#  tier: 1
+#  cost: 2500 #Making it cheap until I add the rest of it
+#  recipeUnlocks:
+#  - FishingRod

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -613,3 +613,8 @@ MailTeleporter: CargoMailTeleporter
 
 # 2025-03-12
 SmartFridge: DVSmartFridge
+
+# 2025-05-14
+# impstation: remove fishing rods until the system is done
+FishingRodBase: null
+FishingRodPlasma: null


### PR DESCRIPTION
its come up a few times in dev discussion that fishing as a project has had no update in a couple months and meanwhile the fishing rod is a persistent source of really bad physics glitches. in this pr i just comment out any ability for players to craft fishing rods. i don't want to fully rip the system out because i like it and changeling tentacle uses it but it does seem like it needs a pretty significant refactor. at least now it isn't actually impacting gameplay

**Changelog**
:cl:
- remove: Fishing rods have been disabled due to there being no fish.