### PR TITLE
Added Contraband Tags to Seed Packets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -734,7 +734,7 @@
 
 - type: entity
   name: extradimensional orange
-  parent: [FoodProduceBase, TierXContraband]
+  parent: FoodProduceBase
   id: FoodExtradimensionalOrange
   description: You can hardly wrap your head around this thing.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -734,7 +734,7 @@
 
 - type: entity
   name: extradimensional orange
-  parent: FoodProduceBase
+  parent: [FoodProduceBase, TierXContraband]
   id: FoodExtradimensionalOrange
   description: You can hardly wrap your head around this thing.
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -528,7 +528,7 @@
       sprite: Objects/Specific/Hydroponics/glasstle.rsi
 
 - type: entity
-  parent: [SeedBase, BaseMinorContraband]
+  parent: [SeedBase, BaseMajorContraband]
   name: packet of fly amanita spores
   description: "The iconic, extremely deadly mushroom to be used for purely ornamental purposes."
   id: FlyAmanitaSeeds

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -725,7 +725,7 @@
       sprite: Objects/Specific/Hydroponics/cotton.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, BaseMinorContraband]
   name: packet of pyrotton seeds
   id: PyrottonSeeds
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -171,7 +171,7 @@
       sprite: Objects/Specific/Hydroponics/orange.rsi
 
 - type: entity
-  parent: [SeedBase, TierXContraband]
+  parent: SeedBase
   name: packet of extradimensional orange seeds
   description: "Polygonal seeds."
   id: ExtradimensionalOrangeSeeds

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -171,7 +171,7 @@
       sprite: Objects/Specific/Hydroponics/orange.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, TierXContraband]
   name: packet of extradimensional orange seeds
   description: "Polygonal seeds."
   id: ExtradimensionalOrangeSeeds
@@ -282,7 +282,7 @@
       sprite: Objects/Specific/Hydroponics/blood_tomato.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, BaseMajorContraband]
   name: packet of killer tomato seeds
   id: KillerTomatoSeeds
   components:
@@ -385,7 +385,7 @@
       sprite: Objects/Specific/Hydroponics/cannabis.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, BaseMinorContraband]
   name: packet of rainbow cannabis seeds
   description: "These seeds grow into rainbow weed. Groovy... and also highly addictive."
   id: RainbowCannabisSeeds
@@ -407,7 +407,7 @@
       sprite: Objects/Specific/Hydroponics/nettle.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, BaseMajorContraband]
   name: packet of death nettle seeds
   description: "Handle with very thick gloves."
   id: DeathNettleSeeds
@@ -528,7 +528,7 @@
       sprite: Objects/Specific/Hydroponics/glasstle.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, BaseMinorContraband]
   name: packet of fly amanita spores
   description: "The iconic, extremely deadly mushroom to be used for purely ornamental purposes."
   id: FlyAmanitaSeeds

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -63,9 +63,9 @@
     sprite: _Impstation/Objects/Specific/Hydroponics/employedhops.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, Tier2Contraband]
   name: packet of agent grain seeds
-  id: [AgentGrainSeeds, Tier2Contraband]
+  id: AgentGrainSeeds
   components:
   - type: Seed
     seedId: agentgrain

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -10,7 +10,7 @@
       sprite: _Impstation/Objects/Specific/Hydroponics/rose.rsi
 
 - type: entity
-  parent: SeedBase
+  parent: [SeedBase, BaseMajorContraband]
   name: packet of black rose seeds
   description: "Seeds of a most diabolical variety."
   id: BlackRoseSeeds
@@ -65,7 +65,7 @@
 - type: entity
   parent: SeedBase
   name: packet of agent grain seeds
-  id: AgentGrainSeeds
+  id: [AgentGrainSeeds, Tier2Contraband]
   components:
   - type: Seed
     seedId: agentgrain


### PR DESCRIPTION
**Media**
These were all the changes made. Let me know if I missed any important ones!
![image](https://github.com/user-attachments/assets/fc798249-e4a2-4e21-bcb6-e9729b39cd44)
![image](https://github.com/user-attachments/assets/22bf1a35-38a2-487b-b957-ba1040a21110)
![image](https://github.com/user-attachments/assets/c911154b-bd81-423c-98ef-adee87f611e9)
![image](https://github.com/user-attachments/assets/aa1d704d-f6e1-40bc-8299-b0e8cbcf4983)
![image](https://github.com/user-attachments/assets/83a573f9-1b35-4dfe-9db0-162d3993cb6a)
![image](https://github.com/user-attachments/assets/caedf652-1ff0-44c2-8043-c4d2eb35e1a1)


**Changelog**
:cl:
- tweak: Seeds are now properly tagged as contraband based off of what they grow.