### PR TITLE
Replicator Bugfixes

### DIFF
--- a/Content.Server/_Impstation/Replicator/ReplicatorSystem.cs
+++ b/Content.Server/_Impstation/Replicator/ReplicatorSystem.cs
@@ -101,7 +101,7 @@ public sealed class ReplicatorSystem : EntitySystem
         // then set that nest's spawned minions to our saved list of related replicators.
         // while we're in here, we might as well update all their pinpointers.
         HashSet<EntityUid> newMinions = [];
-        foreach (var (uid, _) in ent.Comp.RelatedReplicators)
+        foreach (var (uid, comp) in ent.Comp.RelatedReplicators)
         {
             newMinions.Add(uid);
 
@@ -109,6 +109,8 @@ public sealed class ReplicatorSystem : EntitySystem
                 continue;
             // set the target to the nest
             _pinpointer.SetTarget(pocket1.Value, myNest, pinpointer);
+
+            comp.MyNest = myNest;
         }
         myNestComp.SpawnedMinions = newMinions;
         // make sure the nest knows who we are, and vice versa.

--- a/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
+++ b/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
@@ -277,10 +277,18 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
         if (_net.IsClient || !_timing.IsFirstTimePredicted)
             return;
 
+        if (ent.Comp.MyNest == null)
+        {
+            _popup.PopupEntity(Loc.GetString("replicator-cant-find-nest"), ent, PopupType.MediumCaution);
+            return;
+        }
+
         UpgradeReplicator(ent, 2);
 
         QueueDel(ent);
         QueueDel(args.Action);
+
+        _popup.PopupEntity(Loc.GetString("replicator-upgrade-t2-others"), ent, PopupType.MediumCaution);
     }
 
     public void OnUpgrade3(Entity<ReplicatorComponent> ent, ref ReplicatorUpgrade3ActionEvent args)
@@ -289,10 +297,18 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
         if (_net.IsClient || !_timing.IsFirstTimePredicted)
             return;
 
+        if (ent.Comp.MyNest == null)
+        {
+            _popup.PopupEntity(Loc.GetString("replicator-cant-find-nest"), ent, PopupType.MediumCaution);
+            return;
+        }
+
         UpgradeReplicator(ent, 3);
 
         QueueDel(ent);
         QueueDel(args.Action);
+
+        _popup.PopupEntity(Loc.GetString("replicator-upgrade-t3-others"), ent, PopupType.MediumCaution);
     }
 
     public void UpgradeReplicator(Entity<ReplicatorComponent> ent, int desiredLevel)
@@ -318,6 +334,9 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
             return;
 
         _mind.TransferTo(mind, upgraded);
+
+        var messageSelf = desiredLevel == 2 ? "replicator-upgrade-t2-self" : "replicator-upgrade-t3-self";
+        _popup.PopupEntity(Loc.GetString(messageSelf), ent, PopupType.Medium);
 
         return;
     }

--- a/Resources/Locale/en-US/_Impstation/replicators/replicators.ftl
+++ b/Resources/Locale/en-US/_Impstation/replicators/replicators.ftl
@@ -6,8 +6,9 @@ laws-owner-replicatorhive = the Replicator hive.
 replicator-on-replicator-attack-fail = You cannot harm your kin.
 replicator-on-nest-attack-fail = You cannot harm the nest.
 
-replicator-nest-end-of-round = The Replicator Nest near [color=#d70aa0]{$location}[/color]:
-                               - Grew to [color=#d70aa0]Level {$level}[/color].
+replicator-nest-end-of-round = The Replicator Hive: 
+                               - Colonized [color=#d70aa0]{$location}[/color]
+                               - Grew to a maximum [color=#d70aa0]Level[/color] of [color=#d70aa0]{$level}[/color].
                                - Produced a total of [color=#d70aa0]{$replicators} Replicators[/color].
                                - Amassed a total of [color=#d70aa0]{$points} points[/color].
 
@@ -16,6 +17,8 @@ replicator-upgrade-t1-others = {CAPITALIZE(THE($replicator))} clicks and whirrs 
 
 replicator-upgrade-t2-self = More nanites coalesce. You can become stronger.
 replicator-upgrade-t2-others = {CAPITALIZE(THE($replicator))} chitters loudly.
+
+replicator-cant-find-nest = You are not linked to a nest. You cannot upgrade without it.
 
 # messages for when the nest is upgraded
 replicator-nest-level2 = The nest chitters loudly.

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -462,7 +462,6 @@
   - type: Tag
     tags:
     - Multitool
-    - DoorElectronicsConfigurator # imp
   - type: Prying
     enabled: false
   - type: Tool
@@ -471,12 +470,6 @@
     speedModifier: 1.2 # Kept for future adjustments. Currently 1.2x for balance
     useSound: /Audio/Items/drill_use.ogg
   - type: ToolTileCompatible
-  - type: NetworkConfigurator # imp
-    switchDisabled: true
-  - type: UserInterface # imp
-    interfaces:
-      enum.NetworkConfiguratorUiKey.Link:
-        type: NetworkConfiguratorBoundUserInterface
   - type: MultipleTool
     statusShowBehavior: true
     entries:

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-damage.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-damage.yml
@@ -23,9 +23,9 @@
 - type: damageModifierSet
   id: Replicator3
   coefficients:
-    Blunt: 0.7
+    Blunt: 0.5
     Slash: 0.5
-    Piercing: 0.6
+    Piercing: 0.5
     Shock: 1.2
     Structural: 1.5
   flatReductions:


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
tweak: Defender Replicators are a bit tougher.
tweak: The Replicator Hive now displays as one entity on the round-end screen.
tweak: The Replicator Nest no longer deletes steal targets, but *does* delete borgs.
fix: Replicators should no longer get Upgrade actions that don't work.
fix: Replicators should no longer be able to get multiple Manufacture Nest actions.
remove: Removed network configurator functionality from Omnitools, because it generally caused more problems than it solved.