### PR TITLE
PORT: Allows Markings to Set Custom Layers for Specific Sprites

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -135,7 +135,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
 
         var customBaseLayers = new Dictionary<HumanoidVisualLayers, CustomBaseLayerInfo>();
 
-        var speciesPrototype = _prototypeManager.Index<SpeciesPrototype>(profile.Species);
+        var speciesPrototype = _prototypeManager.Index(profile.Species);
         var markings = new MarkingSet(speciesPrototype.MarkingPoints, _markingManager, _prototypeManager);
 
         // Add markings that doesn't need coloring. We store them until we add all other markings that doesn't need it.
@@ -318,45 +318,113 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         }
     }
 
-    private void ApplyMarking(MarkingPrototype markingPrototype,
+    private void ApplyMarking(
+        MarkingPrototype markingPrototype,
         IReadOnlyList<Color>? colors,
         bool visible,
         HumanoidAppearanceComponent humanoid,
-        SpriteComponent sprite)
+        SpriteComponent sprite
+        )
     {
-        if (!sprite.LayerMapTryGet(markingPrototype.BodyPart, out int targetLayer))
+        // FLOOF ADD START
+        // make a handy dict of filename -> colors
+        // cus we might need to access it by filename to link
+        // one sprite's colors to another
+        var colorDict = new Dictionary<string, Color>();
+        for (var i = 0; i < markingPrototype.Sprites.Count; i++)
         {
-            return;
+            var spriteName = markingPrototype.Sprites[i] switch
+            {
+                SpriteSpecifier.Rsi rsi => rsi.RsiState,
+                SpriteSpecifier.Texture texture => texture.TexturePath.Filename,
+                _ => null
+            };
+
+            if (spriteName != null)
+            {
+                if (colors != null && i < colors.Count)
+                    colorDict.Add(spriteName, colors[i]);
+                else
+                    colorDict.Add(spriteName, Color.White);
+            }
         }
-
-        visible &= !IsHidden(humanoid, markingPrototype.BodyPart);
-        visible &= humanoid.BaseLayers.TryGetValue(markingPrototype.BodyPart, out var setting)
-           && setting.AllowsMarkings;
-
+        // now, rearrange them, copying any parented colors to children set to
+        // inherit them
+        if (markingPrototype.ColorLinks != null)
+        {
+            foreach (var (child, parent) in markingPrototype.ColorLinks)
+            {
+                if (colorDict.TryGetValue(parent, out var color))
+                {
+                    colorDict[child] = color;
+                }
+            }
+        }
+        // and, since we can't rely on the iterator knowing where the heck to put
+        // each sprite when we have one marking setting multiple layers,
+        // lets just kinda sorta do that ourselves
+        var layerDict = new Dictionary<string, int>();
+        // FLOOF ADD END
         for (var j = 0; j < markingPrototype.Sprites.Count; j++)
         {
+            // FLOOF CHANGE START
             var markingSprite = markingPrototype.Sprites[j];
-
             if (markingSprite is not SpriteSpecifier.Rsi rsi)
             {
                 continue;
             }
 
+            var layerSlot = markingPrototype.BodyPart;
+            // first, try to see if there are any custom layers for this marking
+            if (markingPrototype.Layering != null)
+            {
+                var name = rsi.RsiState;
+                if (markingPrototype.Layering.TryGetValue(name, out var layerName))
+                {
+                    layerSlot = Enum.Parse<HumanoidVisualLayers>(layerName);
+                }
+            }
+            // update the layerDict
+            // if it doesnt have this, add it at 0, otherwise increment it
+            if (layerDict.TryGetValue(layerSlot.ToString(), out var layerIndex))
+            {
+                layerDict[layerSlot.ToString()] = layerIndex + 1;
+            }
+            else
+            {
+                layerDict.Add(layerSlot.ToString(), 0);
+            }
+
+            if (!sprite.LayerMapTryGet(layerSlot, out var targetLayer))
+            {
+                continue;
+            }
+
+            visible &= !IsHidden(humanoid, markingPrototype.BodyPart);
+            visible &= humanoid.BaseLayers.TryGetValue(markingPrototype.BodyPart, out var setting)
+               && setting.AllowsMarkings;
+
             var layerId = $"{markingPrototype.ID}-{rsi.RsiState}";
+            // FLOOF CHANGE END
 
             if (!sprite.LayerMapTryGet(layerId, out _))
             {
-                var layer = sprite.AddLayer(markingSprite, targetLayer + j + 1);
+                // for layers that are supposed to be behind everything,
+                // adding 1 to the layer index makes it not be behind
+                // everything. fun! FLOOF ADD =3
+                // var targLayerAdj = targetLayer == 0 ? 0 + j : targetLayer + j + 1;
+                var targLayerAdj = targetLayer + layerDict[layerSlot.ToString()] + 1;
+                var layer = sprite.AddLayer(markingSprite, targLayerAdj);
                 sprite.LayerMapSet(layerId, layer);
                 sprite.LayerSetSprite(layerId, rsi);
             }
-			/// imp special via beck. check if there's a shader defined in the markingPrototype's shader datafield, and if there is...
+            // imp special via beck. check if there's a shader defined in the markingPrototype's shader datafield, and if there is...
 			if (markingPrototype.Shader != null)
 			{
-			/// use spriteComponent's layersetshader function to set the layer's shader to that which is specified.
+			// use spriteComponent's layersetshader function to set the layer's shader to that which is specified.
 				sprite.LayerSetShader(layerId, markingPrototype.Shader);
 			}
-			/// end imp special
+            // end imp special
             sprite.LayerSetVisible(layerId, visible);
 
             if (!visible || setting == null) // this is kinda implied
@@ -367,14 +435,18 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             // Okay so if the marking prototype is modified but we load old marking data this may no longer be valid
             // and we need to check the index is correct.
             // So if that happens just default to white?
-            if (colors != null && j < colors.Count)
-            {
-                sprite.LayerSetColor(layerId, colors[j]);
-            }
-            else
-            {
-                sprite.LayerSetColor(layerId, Color.White);
-            }
+            // FLOOF ADD =3
+            sprite.LayerSetColor(layerId, colorDict.TryGetValue(rsi.RsiState, out var color) ? color : Color.White);
+
+            // FLOOF CHANGE
+            // if (colors != null && j < colors.Count)
+            // {
+            //     sprite.LayerSetColor(layerId, colors[j]);
+            // }
+            // else
+            // {
+            //     sprite.LayerSetColor(layerId, Color.White);
+            // }
         }
     }
 
@@ -412,7 +484,8 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         {
             if (!visible)
                 return;
-            index = sprite.LayerMapReserveBlank(layer);
+            else
+                index = sprite.LayerMapReserveBlank(layer);
         }
 
         var spriteLayer = sprite[index];
@@ -422,7 +495,6 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         spriteLayer.Visible = visible;
 
         // I fucking hate this. I'll get around to refactoring sprite layers eventually I swear
-        // Just a week away...
 
         foreach (var markingList in ent.Comp.MarkingSet.Markings.Values)
         {

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -408,12 +408,37 @@ public sealed partial class MarkingPicker : Control
         List<ColorSelectorSliders> colorSliders = new();
         for (int i = 0; i < prototype.Sprites.Count; i++)
         {
+            // first, check if the coloration is parented to another marking
+            // and if so, just kinda sorta dont display it
+            var skipdraw = false;
+            if (prototype.ColorLinks?.Count > 0)
+            {
+                var name = prototype.Sprites[i] switch
+                {
+                    SpriteSpecifier.Rsi rsi => rsi.RsiState,
+                    SpriteSpecifier.Texture texture => texture.TexturePath.Filename,
+                    _ => null
+                };
+
+                if (name != null && prototype.ColorLinks.ContainsKey(name))
+                {
+                    // dont show it, cus its parented to another marking
+                    skipdraw = true;
+                }
+            }
             var colorContainer = new BoxContainer
             {
                 Orientation = LayoutOrientation.Vertical,
             };
 
-            CMarkingColors.AddChild(colorContainer);
+            // so.
+            // the color selector sliders decide which destination color to modify
+            // based on its index in the list of color selectors.
+            // this is a problem if we, say, want to *not* show a certain slider
+            // cus then it'll modify the wrong color, unless the color happened to
+            // be in index 0.
+            if(!skipdraw)
+                CMarkingColors.AddChild(colorContainer);
 
             ColorSelectorSliders colorSelector = new ColorSelectorSliders();
             colorSliders.Add(colorSelector);

--- a/Content.Shared/Humanoid/HumanoidVisualLayers.cs
+++ b/Content.Shared/Humanoid/HumanoidVisualLayers.cs
@@ -3,6 +3,10 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Humanoid
 {
+    /// <summary>
+    ///  These are the layer defines for the humanoid sprite system.
+    ///  If you want to add a new layer slot to species? Scroll down~
+    /// </summary>
     [Serializable, NetSerializable]
     public enum HumanoidVisualLayers : byte
     {
@@ -17,6 +21,8 @@ namespace Content.Shared.Humanoid
         Snout,
         HeadSide, // side parts (i.e., frills)
         HeadTop,  // top parts (i.e., ears)
+        TailBehind, // FLOOF - add tails that dont have to go through a brutal cookiecutter to work
+        TailOversuit, // FLOOF - add tails that dont have to go through a brutal cookiecutter to work
         Eyes,
         RArm,
         LArm,
@@ -35,3 +41,39 @@ namespace Content.Shared.Humanoid
 
     }
 }
+
+/* * * * * * * * * * * * * * * * * * * * * * * * *
+ * HOW 2 ADD A NEW LAYER FOR MOB NON-EQUIPMENT APPEARANCE STUFF
+ * by Dank Elly
+ * Lets say you want to add something like socks to be selectable through markings
+ * Since people tend to have two feet, you'll actually need two new layers! one for each foot.
+ * First, add in the enum above a new layer slot, like so:
+ *     LSock,
+ *     RSock,
+ *   Easy huh? Note that this enum does *not* define which layer in relation to other layers it will be layered!
+ * Next, since these'll be a whole new marking type, we'll need to add in a new marking category.
+ *   in Content.Shared/Humanoid/Markings/MarkingCategories.cs, add in a new category for the socks
+ *   lets assume we'll let the player pick two different socks, which means two different categories
+ *   Its done the same way as this enum here
+ * Next, go to Content.Shared/Humanoid/HumanoidVisualLayersExtension.cs
+ *   In here, find Sublayers() and add in the new layers to the switch statement
+ *     case HumanoidVisualLayers.LFoot:
+ *     yield return HumanoidVisualLayers.LSock;
+ *   and so on. This will make it so if your leg/foot stops being visible, the sock will vanish as well! i think
+ * Next, we'll have to go through a lot of species files, to change a few things:
+ *   speciesBaseSprites
+ *     I'm not sure what this does, but you'll want to add in an entry under sprites for the new layer
+ *       LSock: MobHumanoidAnyMarking <- I think this makes it selectable in the editor, and blank by default?
+ *       RSock: MobHumanoidAnyMarking
+ *   layers
+ *     This is part of the species entity prototype, and this is where the sprite layering is defined.
+ *     Note that this includes equipment layers, which means you can totally, say, have a tail sit between your suit and your backpack!
+ *       - map: [ "enum.HumanoidVisualLayers.LFoot" ]
+ *       - map: [ "enum.HumanoidVisualLayers.LSock" ]
+ *       - map: [ "enum.HumanoidVisualLayers.RFoot" ]
+ *       - map: [ "enum.HumanoidVisualLayers.RSock" ]
+ *     This will make it so the socks are drawn on top of the feet, and not behind them.
+ *   I'd list which files these are in, but there are a million different species files, all with the same name, in different folders
+ *   So just search for "speciesBaseSprites" and "enum.HumanoidVisualLayers.Chest" and you'll find them all
+ *     If you miss some, dont sweat it, someone'll point it out and then you can fix it! Hotties like you make the hottest hotfixes~
+ */

--- a/Content.Shared/Humanoid/HumanoidVisualLayersExtension.cs
+++ b/Content.Shared/Humanoid/HumanoidVisualLayersExtension.cs
@@ -62,6 +62,8 @@ namespace Content.Shared.Humanoid
                 case HumanoidVisualLayers.Chest:
                     yield return HumanoidVisualLayers.Chest;
                     yield return HumanoidVisualLayers.Tail;
+                    yield return HumanoidVisualLayers.TailBehind;
+                    yield return HumanoidVisualLayers.TailOversuit;
                     break;
                 default:
                     yield break;

--- a/Content.Shared/Humanoid/Markings/MarkingColoring.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingColoring.cs
@@ -26,12 +26,12 @@ public static class MarkingColoring
     /// <summary>
     ///     Returns list of colors for marking layers
     /// </summary>
-    public static List<Color> GetMarkingLayerColors
-    (
+    public static List<Color> GetMarkingLayerColors(
         MarkingPrototype prototype,
         Color? skinColor,
         Color? eyeColor,
-        MarkingSet markingSet
+        MarkingSet markingSet,
+        List<string>? ignores = null
     )
     {
         var colors = new List<Color>();

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Humanoid.Markings
 {
-    [Prototype]
+    [Prototype("marking")]
     public sealed partial class MarkingPrototype : IPrototype
     {
         [IdDataField]
@@ -34,13 +34,112 @@ namespace Content.Shared.Humanoid.Markings
 
         [DataField("sprites", required: true)]
         public List<SpriteSpecifier> Sprites { get; private set; } = default!;
-		
-		[DataField("shader")]
-		public string? Shader { get; private set; } = null;
-		
+
+        [DataField("shader")]
+        public string? Shader { get; private set; } = null;
+
+        /// <summary>
+        /// Allows specific images to be put into any arbitrary layer on the mob.
+        /// Whole point of this is to have things like tails be able to be
+        /// behind the mob when facing south-east-west, but in front of the mob
+        /// when facing north. This requires two+ sprites, each in a different
+        /// layer.
+        /// Is a dictionary: sprite name -> layer name,
+        /// e.g. "tail-cute-vulp" -> "tail-back", "tail-cute-vulp-oversuit" -> "tail-oversuit"
+        /// also, FLOOF ADD =3
+        /// </summary>
+        [DataField("layering")]
+        public Dictionary<string, string>? Layering { get; private set; }
+
+        /// <summary>
+        /// Allows you to link a specific sprite's coloring to another sprite's coloring.
+        /// This is useful for things like tails, which while they have two sets of sprites,
+        /// the two sets of sprites should be treated as one sprite for the purposes of
+        /// coloring. Just more intuitive that way~
+        /// Format: spritename getting colored -> spritename which colors it
+        /// so if we have a Tail Behind with 'cooltail' as the sprite name, and a Tail Oversuit
+        /// with 'cooltail-oversuit' as the sprite name, and we want to have the Tail Behind
+        /// inherit the color of the Tail Oversuit, we would do:
+        /// cooltail -> cooltail-oversuit
+        /// cooltail will be hidden from the color picker, and just use whatevers set for
+        /// cooltail-oversuit. Easy huh?
+        /// also, FLOOF ADD =3
+        /// </summary>
+        [DataField("colorLinks")]
+        public Dictionary<string, string>? ColorLinks { get; private set; }
+
         public Marking AsMarking()
         {
             return new Marking(ID, Sprites.Count);
         }
     }
 }
+
+/* * * * * * * * * * * * * * * * * * * * * * * * *
+ * HOW 2 MAKE MARKINGS WITH MULTIPLE LAYERS
+ * by Dank Elly
+ *
+ * So, since the dawn of SS14, markings have been a single layer.
+ * This is fine, since most markings are simple in terms of how they appear on a mob.
+ * Just a cool skin color, or a pattern, or something.
+ *
+ * Then, tails were added.
+ * Tails are different, if you think about it!
+ * They tend to hang from the body, and appear behind the mob from some angles, and
+ * in front of the mob from others. No real way around it, otherwise it'll look wierd!
+ *
+ * But, markings are still a single layer, which means that all the images sit in the
+ * stacked deck of cards that is our sprite layers. If a marking is set to be in the
+ * Underwear layer, that marking will only ever be in the Underwear layer, no matter
+ * which way you turn! Fine and all for most markings, but not for tails.
+ *
+ * The previous solution was to just cookie-cut out a human shape from some directions
+ * of the tail sprites, then layer then on top of the mob, over clothes and such.
+ * This worked! Sort of! It wouldnt support missing legs, it only worked if you were
+ * wearing skin-tight jumpsuits, and it made it so that you can't have any fancy leg
+ * shapes (digilegs my beloved~)
+ *
+ * However, SS13 had solved this years ago, which I am totally taking credit for cus
+ * I made roughly this system for Goonstation! The solution here was to just use
+ * two layers lmao! A layer for the tail from most angles, and a layer for the tail
+ * when youre facing away. This is known as the Behind and Oversuit layers, cus one
+ * goes behind the mob, the other goes over your suit (and ideally under the backpack).
+ *
+ * LOREDUMP OVER HOW TO MAKE IT DO THIS
+ *
+ * First, make your marking prototype as normal.
+ *   Note, you'll need extra sprites for every layer you want to add.
+ *   This includes things like colorable accessories, which will need to be
+ *   added to the new layers as well.
+ * Next, add in a 'layering' entry to the marking prototype.
+ * Then, add in a new entry to the 'layering' dictionary, like so:
+ *   layering:
+ *     name_of_image: LayerToPutItIn
+ *     name_of_another_image: LayerToPutItIn
+ *   I'll have a complete example later, but this is the basic idea.
+ *   The first part of the entry is what you put for the state of that sprite
+ *     Its how the game knows which sprite to mess with!
+ *   The second part is the layer you want to put it in.
+ *     This points to an entry in the enum stored in this file:
+ *       Content.Shared/Humanoid/HumanoidVisualLayers.cs
+ *     Capitalization matters!
+ * todo: a way to link the colorations between layers
+ *
+ * Heres an example from Resources/Prototypes/Floof/Entities/Mobs/Customization/Markings/debug.yml
+ *
+- type: marking
+  id: TailDebugPro
+  bodyPart: Tail
+  markingCategory: Tail
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  layering:
+    tail_oversuit: TailOversuit <--------------\
+    tail_behind: TailBehind   <----------------+--------\
+  sprites:                                     |        |
+  - sprite: _Floof/Mobs/Customization/debug.rsi |        |
+    state: tail_oversuit   >-------------------/        |
+  - sprite: _Floof/Mobs/Customization/debug.rsi          |
+    state: tail_behind   >------------------------------/
+ *
+ * (dont include the arrows lol)
+ */

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -76,6 +76,7 @@
     proto: spider
   - type: Sprite # I'd prefer if these maps were better. Insert map pun here.
     layers:
+      - map: [ "enum.HumanoidVisualLayers.TailBehind" ] # Floof
       - map: [ "enum.HumanoidVisualLayers.Chest" ]
       - map: [ "enum.HumanoidVisualLayers.Head" ]
       - map: [ "enum.HumanoidVisualLayers.Snout" ]
@@ -100,6 +101,7 @@
       - map: [ "outerClothing" ]
       - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
       - map: [ "back" ]
+      - map: [ "enum.HumanoidVisualLayers.TailOversuit" ] # Floof
       - map: [ "neck" ]
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
       - map: [ "enum.HumanoidVisualLayers.Hair" ] # Do these need to be here? (arachnid hair arachnid hair)

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -11,6 +11,7 @@
   components:
   - type: Sprite
     layers:
+    - map: [ "enum.HumanoidVisualLayers.TailBehind" ] # Floof
     - map: [ "enum.HumanoidVisualLayers.Chest" ]
     - map: [ "enum.HumanoidVisualLayers.Head" ]
     - map: [ "enum.HumanoidVisualLayers.Snout" ]
@@ -34,6 +35,7 @@
     - map: [ "id" ]
     - map: [ "outerClothing" ]
     - map: [ "back" ]
+    - map: [ "enum.HumanoidVisualLayers.TailOversuit" ] # Floof
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
@@ -309,6 +311,7 @@
     noRot: true
     # TODO BODY Turn these into individual body parts?
     layers:
+    - map: [ "enum.HumanoidVisualLayers.TailBehind" ]
     - map: [ "enum.HumanoidVisualLayers.Chest" ]
     - map: [ "enum.HumanoidVisualLayers.Head" ]
     - map: [ "enum.HumanoidVisualLayers.Snout" ]
@@ -337,6 +340,7 @@
     - map: [ "id" ]
     - map: [ "outerClothing" ]
     - map: [ "back" ]
+    - map: [ "enum.HumanoidVisualLayers.TailOversuit" ]
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -77,6 +77,7 @@
     noRot: true
     drawdepth: Mobs
     layers:
+      - map: [ "enum.HumanoidVisualLayers.TailBehind" ] # Floof
       - map: [ "enum.HumanoidVisualLayers.Chest" ]
       - map: [ "enum.HumanoidVisualLayers.Head" ]
       - map: [ "enum.HumanoidVisualLayers.Snout" ]
@@ -106,6 +107,7 @@
       - map: [ "outerClothing" ]
       - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everyhting doesn't break
       - map: [ "back" ]
+      - map: [ "enum.HumanoidVisualLayers.TailOversuit" ] # Floof
       - map: [ "neck" ]
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
       - map: [ "enum.HumanoidVisualLayers.Hair" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -72,6 +72,7 @@
         Slash: 5 # Reduce?
   - type: Sprite # Need to redefine the whole order to draw the tail over their gas tank
     layers:
+    - map: [ "enum.HumanoidVisualLayers.TailBehind" ] # Floof
     - map: [ "enum.HumanoidVisualLayers.Chest" ]
     - map: [ "enum.HumanoidVisualLayers.Head" ]
     - map: [ "enum.HumanoidVisualLayers.Snout" ]
@@ -95,6 +96,7 @@
     - map: [ "id" ]
     - map: [ "outerClothing" ]
     - map: [ "back" ]
+    - map: [ "enum.HumanoidVisualLayers.TailOversuit" ] # Floof
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]

--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -19,6 +19,8 @@
 - type: speciesBaseSprites
   id: MobArachnidSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobArachnidHead
     Snout: MobHumanoidAnyMarking
     Hair: MobHumanoidAnyMarking # imp, arachnid hair arachnid hair!

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -20,6 +20,8 @@
 - type: speciesBaseSprites
   id: MobDionaSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobDionaHead
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking

--- a/Resources/Prototypes/Species/gingerbread.yml
+++ b/Resources/Prototypes/Species/gingerbread.yml
@@ -12,6 +12,8 @@
 - type: speciesBaseSprites
   id: MobGingerbreadSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof. just in case i guess?
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobGingerbreadHead
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -21,6 +21,8 @@
 - type: speciesBaseSprites
   id: MobHumanSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Special: MobHumanoidAnyMarking
     Head: MobHumanHead
     Hair: MobHumanoidAnyMarking

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -19,6 +19,8 @@
 - type: speciesBaseSprites
   id: MobMothSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobMothHead
     Snout: MobHumanoidAnyMarking
     UndergarmentTop: MobHumanoidAnyMarking

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -19,6 +19,8 @@
 - type: speciesBaseSprites
   id: MobReptilianSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobReptilianHead
     Snout: MobHumanoidAnyMarking
     UndergarmentTop: MobHumanoidAnyMarking

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -16,6 +16,8 @@
 - type: speciesBaseSprites
   id: MobSlimeSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobSlimeHead
     Hair: MobSlimeMarkingFollowSkin
     FacialHair: MobSlimeMarkingFollowSkin

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -25,6 +25,8 @@
 - type: speciesBaseSprites
   id: MobVoxSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobVoxHead
     Snout: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking #imp

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -32,6 +32,7 @@
         Asphyxiation: -1.0
   - type: Sprite
     layers: # Need to redefine the whole order to draw the legs and claw correctly
+    - map: [ "enum.HumanoidVisualLayers.TailBehind" ] # hivehum edit i just saw this layer order and got really scared but this probably wants to render under the back legs
     - map: [ "enum.HumanoidVisualLayers.RFoot" ] # this is the back feet TODO: fix the fact that only the feet render
     - map: [ "enum.HumanoidVisualLayers.RLeg" ] # this is the back legs
     - map: [ "enum.HumanoidVisualLayers.Chest" ]
@@ -49,6 +50,7 @@
     - map: [ "eyes" ]
     - map: [ "belt" ]
     - map: [ "id" ]
+    - map: [ "enum.HumanoidVisualLayers.TailOversuit" ] # hivehum edit well i hope this works
     - map: [ "back" ]
     - map: [ "enum.HumanoidVisualLayers.LLeg" ] # this is the front legs
     - map: [ "enum.HumanoidVisualLayers.LFoot" ] # this is the front feet

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/kodepiia.yml
@@ -43,6 +43,7 @@
         requireInputValidation: false
   - type: Sprite
     layers:
+    - map: [ "enum.HumanoidVisualLayers.TailBehind" ]
     - map: [ "enum.HumanoidVisualLayers.Chest" ]
     - map: [ "enum.HumanoidVisualLayers.Head" ]
     - map: [ "enum.HumanoidVisualLayers.Snout" ]
@@ -83,6 +84,7 @@
       visible: false
     - map: [ "enum.HumanoidVisualLayers.RArmExtension" ]
     - map: [ "enum.HumanoidVisualLayers.Tail" ]
+    - map: [ "enum.HumanoidVisualLayers.TailOversuit" ] # subject to change, really finicky with the arms im afraid
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
     - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
     - map: [ "mask" ]
@@ -96,7 +98,7 @@
     hideLayersOnEquip:
     - HeadTop
     - HeadSide
-    - Hair 
+    - Hair
     - Tail
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.

--- a/Resources/Prototypes/_Impstation/Species/apid.yml
+++ b/Resources/Prototypes/_Impstation/Species/apid.yml
@@ -19,6 +19,8 @@
 - type: speciesBaseSprites
   id: MobApidSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Eyes: MobHumanoidAnyMarking
     Head: MobApidHead
     HeadTop: MobHumanoidAnyMarking

--- a/Resources/Prototypes/_Impstation/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Species/decapoid.yml
@@ -17,6 +17,8 @@
 - type: speciesBaseSprites
   id: MobDecapoidSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Eyes: MobHumanoidAnyMarking
     Head: MobDecapoidHead
     HeadTop: MobHumanoidAnyMarking

--- a/Resources/Prototypes/_Impstation/Species/gastropoid.yml
+++ b/Resources/Prototypes/_Impstation/Species/gastropoid.yml
@@ -17,6 +17,8 @@
 - type: speciesBaseSprites
   id: MobGastropoidSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Eyes: MobGastropoidEyes
     Head: MobGastropoidHead
     HeadTop: MobHumanoidAnyMarking

--- a/Resources/Prototypes/_Impstation/Species/gray.yml
+++ b/Resources/Prototypes/_Impstation/Species/gray.yml
@@ -21,6 +21,8 @@
 - type: speciesBaseSprites
   id: MobGraySprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobGrayHead
     Chest: MobGrayTorso
     Eyes: MobGrayEyes

--- a/Resources/Prototypes/_Impstation/Species/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Species/kodepiia.yml
@@ -16,6 +16,8 @@
 - type: speciesBaseSprites
   id: MobKodepiiaSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Head: MobKodepiiaHead
     Hair: MobHumanoidAnyMarking
     FacialHair: MobHumanoidAnyMarking

--- a/Resources/Prototypes/_Impstation/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Species/thaven.yml
@@ -19,6 +19,8 @@
 - type: speciesBaseSprites
   id: MobThavenSprites
   sprites:
+    TailBehind: MobHumanoidAnyMarking # floof
+    TailOversuit: MobHumanoidAnyMarking # floof
     Hair: MobHumanoidAnyMarking
     Eyes: MobThavenEyes
     Head: MobThavenHead


### PR DESCRIPTION
this is a DRAFT port of Fansana/floofstation1#742 because it appears to be the hail mary savior to literally every complaint we have regarding markings. im probably going to leave this up as a draft for a bit to give carousel and other markings artists time to play with the new tech and adjust current markings/make new markings

the tl;dr for this is that it allows you to define multiple layers for markings and define what humanoid visual layer each marking layer appears on. this allows for a lot more freedom for things like tails and kodepiiae arms, may prove a possible solution for the problems we have with foot/leg marking layering, and could possibly enable a lot more decapoid customization. doops also complained about this exact issue a lot regarding anomalocarid development so will be a big help there

this PR builds and loads ingame without complaining. ive done minimal actual testing outside of this

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
