### PR TITLE
removes the plasma vial from the chemistry locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -97,7 +97,7 @@
     - id: BoxPillCanister
     - id: BoxBottle
     - id: BoxVial
-    - id: PlasmaChemistryVial
+    # - id: PlasmaChemistryVial # imp
     - id: ChemBag
     - id: ClothingHandsGlovesLatex
     - id: ClothingHeadsetMedical


### PR DESCRIPTION
soft revert of #33871. the medical chems that require plasma are not urgent enough to remove one of the few vectors that encourages chemistry to interact with the rest of the station, issues raised in the pr in question are LRP ones that we don't have problems with, it's general consensus in the chemistry thread that this was an unneeded addition, etc etc

**Changelog**
:cl:
- remove: Chemists no longer start with plasma.
