### PR TITLE
robotic arm static power draw

### DIFF
--- a/Content.Shared/_Goobstation/Factory/RoboticArmSystem.cs
+++ b/Content.Shared/_Goobstation/Factory/RoboticArmSystem.cs
@@ -391,23 +391,14 @@ public sealed class RoboticArmSystem : EntitySystem
 
     private void StartMoving(Entity<RoboticArmComponent> ent)
     {
-        SetPowerDraw(ent, ent.Comp.MovingPowerDraw);
         ent.Comp.NextMove = _timing.CurTime + ent.Comp.MoveDelay;
         DirtyField(ent, ent.Comp, nameof(RoboticArmComponent.NextMove));
     }
 
     private void StopMoving(Entity<RoboticArmComponent> ent)
     {
-        SetPowerDraw(ent, ent.Comp.IdlePowerDraw);
         ent.Comp.NextMove = null;
         DirtyField(ent, ent.Comp, nameof(RoboticArmComponent.NextMove));
-    }
-
-    private void SetPowerDraw(EntityUid uid, float draw)
-    {
-        SharedApcPowerReceiverComponent? receiver = null;
-        if (_power.ResolveApc(uid, ref receiver))
-            _power.SetLoad(receiver, draw);
     }
 
     public EntityCoordinates OutputPosition(EntityUid uid)

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
@@ -110,5 +110,5 @@
     range: 5
   # Power
   - type: ApcPowerReceiver
-    powerLoad: 50 # Idle power usage, increases when active
+    powerLoad: 300 # imp, static 300 power draw instead of idle 50 -> active 3000
   - type: PowerSwitch


### PR DESCRIPTION
i don't _think_ this is the cause of recent power flickering issues but you never know. even if it isn't, the fluctuating power draw is inconsistent with how other machines work, and even though i think they _should_ work that way, the current power system is not made with it in mind

**Changelog**
:cl:
- tweak: Robotic arms now have a consistent power draw, rather than increasing while moving. This may help alleviate light flickering issues, but no prommies.
