### PR TITLE
Add gildgrail splashing and make fancy holy waters better.

### DIFF
--- a/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Misc/nullrod.yml
@@ -112,6 +112,12 @@
     - Gildgrail #mix changed to make half holy water and half aquam divinos
     - Shake
     mixMessage: "null-grail-mix-success"
+  - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
+    damage:
+      types:
+        Blunt: 0
 
 - type: entity
   name: divine grasp

--- a/Resources/Prototypes/_Impstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/medicine.yml
@@ -118,11 +118,11 @@
         damage:
           types:
             Holy: 0.5
-            Blunt: -0.2
+            Blunt: -0.1
 #            Poison: -0.2
-            Heat: -0.2
-            Shock: -0.2
-            Cold: -0.2
+            Heat: -0.1
+            Shock: -0.1
+            Cold: -0.1
   tileReactions:
   - !type:ExtinguishTileReaction { }
 

--- a/Resources/Prototypes/_Impstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/medicine.yml
@@ -119,7 +119,7 @@
           types:
             Holy: 0.5
             Blunt: -0.2
-            Poison: -0.2
+#            Poison: -0.2
             Heat: -0.2
             Shock: -0.2
             Cold: -0.2

--- a/Resources/Prototypes/_Impstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/medicine.yml
@@ -109,6 +109,20 @@
       methods: [ Touch ]
       effects:
       - !type:ExtinguishReaction
+    Acidic:
+      methods: [ Touch ]
+      effects:
+      - !type:HealthChange
+        scaleByQuantity: true
+        ignoreResistances: false
+        damage:
+          types:
+            Holy: 0.5
+            Blunt: -0.2
+            Poison: -0.2
+            Heat: -0.2
+            Shock: -0.2
+            Cold: -0.2
   tileReactions:
   - !type:ExtinguishTileReaction { }
 

--- a/Resources/Prototypes/_Impstation/Reagents/toxins.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/toxins.yml
@@ -1,5 +1,5 @@
 - type: reagent
-  id: AquaAvari 
+  id: AquaAvari
   name: reagent-name-aquaavari
   group: Toxins
   desc: reagent-desc-aquaavari
@@ -30,5 +30,19 @@
       methods: [ Touch ]
       effects:
       - !type:ExtinguishReaction
+    Acidic:
+      methods: [ Touch ]
+      effects:
+      - !type:HealthChange
+        scaleByQuantity: true
+        ignoreResistances: false
+        damage:
+          types:
+            Holy: 0.5
+            Blunt: 0.1
+            Poison: 0.1
+            Heat: 0.1
+            Shock: 0.1
+            Cold: 0.1
   tileReactions:
   - !type:ExtinguishTileReaction { }

--- a/Resources/Prototypes/_Impstation/Reagents/toxins.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/toxins.yml
@@ -40,7 +40,7 @@
           types:
             Holy: 0.5
             Blunt: 0.1
-            Poison: 0.1
+#            Poison: 0.1
             Heat: 0.1
             Shock: 0.1
             Cold: 0.1


### PR DESCRIPTION
Noticed while developing syndicate upgrades to null rod items that the gildgrail can't splash people? Also gave the fancy holy waters a little healing/damage on contact. Prepared to dial these back if they're too fucked up.

:cl:
- tweak: Aquam divinos and aqua avari now have small effects on contact.
- tweak: Gildgrail can new be used to splash liquids on heathens and the faithful alike.