### PR TITLE
early merge upstream epilepsy fixes

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegGeneratorComponent.cs
+++ b/Content.Server/Power/Generation/Teg/TegGeneratorComponent.cs
@@ -75,4 +75,10 @@ public sealed partial class TegGeneratorComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("volumeMax")]
     public float VolumeMax = -4;
+
+    /// <summary>
+    /// Smoothing factor used to smooth out power generation.
+    /// </summary>
+    [DataField]
+    public float PowerSmoothingFactor = 0.2f;
 }

--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -183,8 +183,12 @@ public sealed class TegSystem : EntitySystem
 
         // Turn energy (at atmos tick rate) into wattage.
         var power = electricalEnergy / args.dt;
+
         // Add ramp factor. This magics slight power into existence, but allows us to ramp up.
-        supplier.MaxSupply = power * component.RampFactor;
+        // Also apply an exponential moving average to smooth out fluttering, as it was causing
+        // seizures.
+        supplier.MaxSupply = component.PowerSmoothingFactor * (power * component.RampFactor) +
+                             (1 - component.PowerSmoothingFactor) * supplier.MaxSupply;
 
         var circAComp = Comp<TegCirculatorComponent>(circA);
         var circBComp = Comp<TegCirculatorComponent>(circB);

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -56,19 +56,19 @@
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     state: coil
   - type: Battery
-    maxCharge: 1000000
+    maxCharge: 5000000
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
-    chargeFromLightning: 2000000
+    chargeFromLightning: 5000000
   - type: LightningTarget
     priority: 4
     hitProbability: 0.5
     lightningResistance: 10
     lightningExplode: false
   - type: PowerNetworkBattery
-    maxSupply: 1000000
-    supplyRampTolerance: 1000000
+    maxSupply: 3500000
+    supplyRampTolerance: 3500000
   - type: Anchorable
   - type: Rotatable
   - type: Pullable


### PR DESCRIPTION
port/early merge of https://github.com/space-wizards/space-station-14/pull/37626 and https://github.com/space-wizards/space-station-14/pull/37658. the upstream prs are still under review but i wanted to get them on imp early since our players have been directly affected.

no imp comments, these are upstream changes.

:cl: ArtisticRoomba
- tweak: Tesla coils can now hold a max capacity of 5 MJ, and receive 5 MJ of energy when struck by lightning.
- tweak: Tesla coils can now only output a maximum of 350 kW to the grid. This was done to make power flow smoother (it was triggering epilepsy in extreme circumstances).
- fix: The TEG now outputs smoother power when pressure across the circulators flutter. (This was causing epilepsy in extreme circumstances).
