### PR TITLE
AAC can be crafted in the medfab now

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/medical.yml
@@ -9,6 +9,7 @@
   - BlindingLens
   - Dropper
   - WalkingCane
+  - AACTablet
 
 # Dynamic
 


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
How the fuck did I miss this
**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: AAC tablets can now be crafted in the medical techfab

