### PR TITLE
Thaven mood admin menu improvements

### DIFF
--- a/Content.Client/_Impstation/Thaven/Eui/ThavenMoodUi.xaml
+++ b/Content.Client/_Impstation/Thaven/Eui/ThavenMoodUi.xaml
@@ -9,6 +9,7 @@
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal" Align="End">
             <Button Name="NewMoodButton" Text="{Loc thaven-moods-admin-ui-new-mood}" MaxSize="256 64" StyleClasses="OpenRight"/>
+            <Button Name="ToggleSharedMoodButton" Text="{Loc thaven-moods-admin-ui-toggle-shared}" MaxSize="256 64" ToggleMode="True"/>
             <Button Name="SaveButton" Text="{Loc thaven-moods-admin-ui-save}" MaxSize="256 64" StyleClasses="OpenLeft"/>
         </BoxContainer>
     </BoxContainer>

--- a/Content.Client/_Impstation/Thaven/Eui/ThavenMoodUi.xaml.cs
+++ b/Content.Client/_Impstation/Thaven/Eui/ThavenMoodUi.xaml.cs
@@ -12,12 +12,18 @@ public sealed partial class ThavenMoodUi : FancyWindow
     public event Action? OnSave;
 
     private List<ThavenMood> _moods = new();
+    private bool _shouldFollowShared = false;
 
     public ThavenMoodUi()
     {
         RobustXamlLoader.Load(this);
         NewMoodButton.OnPressed += _ => AddNewMood();
         SaveButton.OnPressed += _ => OnSave?.Invoke();
+
+        ToggleSharedMoodButton.OnToggled += _ =>
+        {
+            _shouldFollowShared = !_shouldFollowShared;
+        };
     }
 
     private void AddNewMood()
@@ -52,6 +58,19 @@ public sealed partial class ThavenMoodUi : FancyWindow
         }
 
         return newMoods;
+    }
+
+    public bool ShouldFollowShared()
+    {
+        return _shouldFollowShared;
+    }
+
+    public void SetFollowShared(bool value)
+    {
+        if (value == _shouldFollowShared)
+            return;
+
+        _shouldFollowShared = value;
     }
 
     private void MoveUp(int index)

--- a/Content.Client/_Impstation/Thaven/Eui/ThavenMoodsEui.cs
+++ b/Content.Client/_Impstation/Thaven/Eui/ThavenMoodsEui.cs
@@ -18,7 +18,8 @@ public sealed class ThavenMoodsEui : BaseEui
     private void SaveMoods()
     {
         var newMoods = _thavenMoodUi.GetMoods();
-        SendMessage(new ThavenMoodsSaveMessage(newMoods, _target));
+        var toggle = _thavenMoodUi.ShouldFollowShared();
+        SendMessage(new ThavenMoodsSaveMessage(newMoods, toggle, _target));
         _thavenMoodUi.SetMoods(newMoods);
     }
 
@@ -33,6 +34,7 @@ public sealed class ThavenMoodsEui : BaseEui
             return;
 
         _target = s.Target;
+        _thavenMoodUi.SetFollowShared(s.FollowsShared);
         _thavenMoodUi.SetMoods(s.Moods);
     }
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -806,7 +806,12 @@ public sealed partial class AdminVerbSystem
                 Act = () =>
                 {
                     if (!EnsureComp<ThavenMoodsComponent>(args.Target, out moods))
-                        _moods.NotifyMoodChange((args.Target, moods));
+                    {
+                        //if we're adding moods to something that doesn't already have them (e.g. isn't a thaven), make them ignore the shared mood
+                        var targ = (args.Target, moods);
+                        _moods.SetMoods(targ, []);
+                        _moods.SetFollowsSharedmood(targ, false);
+                    }
                 },
                 Impact = LogImpact.High,
                 Message = Loc.GetString("admin-trick-give-moods-description"),

--- a/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
+++ b/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
@@ -356,6 +356,11 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
         return _moodProtos;
     }
 
+    public void SetFollowsSharedmood(Entity<ThavenMoodsComponent> ent, bool value)
+    {
+        ent.Comp.FollowsSharedMoods = value;
+    }
+
     /// <summary>
     /// Return a list of the moods that are affecting this entity.
     /// </summary>

--- a/Content.Server/_Impstation/Thaven/ThavenMoodsEui.cs
+++ b/Content.Server/_Impstation/Thaven/ThavenMoodsEui.cs
@@ -18,6 +18,7 @@ public sealed class ThavenMoodsEui : BaseEui
     private List<ThavenMood> _sharedMoods = new();
     private ISawmill _sawmill = default!;
     private EntityUid _target;
+    private bool _followsShared = false;
 
     public ThavenMoodsEui(ThavenMoodsSystem thavenMoodsSystem, EntityManager entityManager, IAdminManager manager)
     {
@@ -29,7 +30,7 @@ public sealed class ThavenMoodsEui : BaseEui
 
     public override EuiStateBase GetNewState()
     {
-        return new ThavenMoodsEuiState(_moods, _entMan.GetNetEntity(_target));
+        return new ThavenMoodsEuiState(_moods, _followsShared, _entMan.GetNetEntity(_target));
     }
 
     public void UpdateMoods(Entity<ThavenMoodsComponent> ent)
@@ -40,6 +41,7 @@ public sealed class ThavenMoodsEui : BaseEui
         _target = ent;
         _moods = ent.Comp.Moods;
         _sharedMoods = _moodsSystem.SharedMoods.ToList();
+        _followsShared = ent.Comp.FollowsSharedMoods;
         StateDirty();
     }
 
@@ -60,6 +62,7 @@ public sealed class ThavenMoodsEui : BaseEui
             return;
         }
 
+        _moodsSystem.SetFollowsSharedmood((uid, comp), message.FollowShared);
         _moodsSystem.SetMoods((uid, comp), message.Moods);
     }
 

--- a/Content.Shared/_Impstation/Thaven/ThavenMoodsEuiState.cs
+++ b/Content.Shared/_Impstation/Thaven/ThavenMoodsEuiState.cs
@@ -7,10 +7,12 @@ namespace Content.Shared._Impstation.Thaven;
 public sealed class ThavenMoodsEuiState : EuiStateBase
 {
     public List<ThavenMood> Moods { get; }
+    public bool FollowsShared { get; }
     public NetEntity Target { get; }
-    public ThavenMoodsEuiState(List<ThavenMood> moods, NetEntity target)
+    public ThavenMoodsEuiState(List<ThavenMood> moods, bool followsShared, NetEntity target)
     {
         Moods = moods;
+        FollowsShared = followsShared;
         Target = target;
     }
 }
@@ -19,11 +21,13 @@ public sealed class ThavenMoodsEuiState : EuiStateBase
 public sealed class ThavenMoodsSaveMessage : EuiMessageBase
 {
     public List<ThavenMood> Moods { get; }
+    public bool FollowShared { get; }
     public NetEntity Target { get; }
 
-    public ThavenMoodsSaveMessage(List<ThavenMood> moods, NetEntity target)
+    public ThavenMoodsSaveMessage(List<ThavenMood> moods, bool followShared, NetEntity target)
     {
         Moods = moods;
+        FollowShared = followShared;
         Target = target;
     }
 }

--- a/Resources/Locale/en-US/_Impstation/thavens/ui.ftl
+++ b/Resources/Locale/en-US/_Impstation/thavens/ui.ftl
@@ -5,6 +5,7 @@ thaven-moods-update-notify = You feel a shift in your moods!
 thaven-moods-ui-verb = Edit Moods
 thaven-moods-admin-ui-title = Edit Moods
 thaven-moods-admin-ui-new-mood = New Mood
+thaven-moods-admin-ui-toggle-shared = Follows Shared Mood
 thaven-moods-admin-ui-save = Save
 thaven-mood-admin-ui-move-up = Move Up
 thaven-mood-admin-ui-move-down = Move Down


### PR DESCRIPTION
Does some small improvements to the "edit moods" admin action & menu - 
When adding moods, an entity will start with no moods & the shared mood hidden by default (might also want a second moods verb that does the mood generation?).
The edit moods UI now has a "follow shared mood" toggle so that you don't need to go into the vv menu to toggle it.
