### PR TITLE
Fix Banana cargo shuttle offset

### DIFF
--- a/Resources/Maps/_Impstation/Shuttles/cargo_banana.yml
+++ b/Resources/Maps/_Impstation/Shuttles/cargo_banana.yml
@@ -15,7 +15,6 @@ entities:
     - type: MetaData
       name: Cargo shuttle
     - type: Transform
-      pos: 449.6617,358.23438
       parent: invalid
     - type: MapGrid
       chunks:


### PR DESCRIPTION
Banana's cargo shuttle position had a pretty substantial offset in its transform component, which is likely what was causing it to spawn inside other grids such as the vgroid at times. This should fix that.

:cl:
- fix: Banana's cargo shuttle should be less likely to start clipped inside of other grids.

