### PR TITLE
hop starts with paperwork belt

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -75,7 +75,7 @@
   equipment:
     id: HoPPDA
     gloves: ClothingHandsGlovesHop
-    belt: BoxFolderClipboard
+    belt: ClothingBeltPaperworkFilled # imp edit
   storage:
     back:
     - Flash


### PR DESCRIPTION
i feel like it makes sense
![image](https://github.com/user-attachments/assets/b0dd6d2b-a776-43c7-aeed-e198673906e3)
don't know whether i should make a prototype without the vacuum flask for the hop since that's not really their thing?

:cl:
- tweak: Head of Personnel now starts with a paperwork belt instead of a clipboard