### PR TITLE
Remove ambuzol from random pill canister prototye

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -342,7 +342,7 @@
 - type: entity
   name: aloe cream
   description: A topical cream for burns.
-  parent: BaseHealingItem 
+  parent: BaseHealingItem
   id: AloeCream
   components:
   - type: Healing
@@ -353,7 +353,7 @@
         Heat: -10
     healingBeginSound:
       path: "/Audio/Items/Toys/ToyFall2.ogg"
-    healingEndSound: 
+    healingEndSound:
       path: "/Audio/Items/Medical/ointment_end.ogg"
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/aloe.rsi
@@ -865,20 +865,22 @@
       prob: 0.10
       maxAmount: 7
       orGroup: RandomPill
-    - id: PillAmbuzol
-      prob: 0.075
-      maxAmount: 7
-      orGroup: RandomPill
-    - id: PillAmbuzolPlus
-      prob: 0.075
-      maxAmount: 7
-      orGroup: RandomPill
+    # imp edit start, removed ambuzol spawns
+    #- id: PillAmbuzol
+    #  prob: 0.075
+    #  maxAmount: 7
+    #  orGroup: RandomPill
+    #- id: PillAmbuzolPlus
+    #  prob: 0.075
+    #  maxAmount: 7
+    #  orGroup: RandomPill
+    # imp edit end
     - id: PillSpaceDrugs
-      prob: 0.075
+      prob: 0.10 #imp edit
       maxAmount: 7
       orGroup: RandomPill
     - id: StrangePill
-      prob: 0.075
+      prob: 0.10 #imp edit
       maxAmount: 7
       orGroup: RandomPill
 


### PR DESCRIPTION
For whatever reason, the pill canister prototype had a chance to spawn up to 7 Ambuzol or Ambuzol Plus pills, which seems insane in the event that a zombie infection happens. I've removed Ambuzol and Ambuzol Plus from the random pill canister pool and increased the chance of space drugs and strange pills to 10% to match the other pills. (The probabilities for all of the pills in this pool was already greater than 100%, I don't what the effect of that is exactly, I assume it works more like a weighting at that point.)


**Changelog**

:cl:
- remove: Ambuzol and Ambuzol Plus pills can no longer spawn in randomized pill canisters.