### PR TITLE
Decapoid clicking and chittering

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -962,6 +962,11 @@
     speechVerb: Arachnid
     speechSounds: Arachnid
     allowedEmotes: ['Click', 'Chitter']
+  - type: Vocal # imp
+    sounds:
+      Male: UnisexDecapoid
+      Female: UnisexDecapoid
+      Unsexed: UnisexDecapoid
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -181,6 +181,7 @@
             state: neck
   - type: Speech
     speechSounds: Decapoid
+    allowedEmotes: ['Chitter', 'Click']
   - type: TypingIndicator
     proto: robot # todo: custom
   - type: HumanoidAppearance

--- a/Resources/Prototypes/_Impstation/Voice/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Voice/decapoid.yml
@@ -48,6 +48,10 @@
       collection: Wuhey
     Ungh:
       collection: Ungh
+    Chitter:
+      path: /Audio/Voice/Arachnid/arachnid_chitter.ogg
+    Click:
+      path: /Audio/Voice/Arachnid/arachnid_click.ogg
     Gasp:
       path: /Audio/_Impstation/Voice/Decapoid/decapoid_gasp.ogg
     DefaultDeathgasp:


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Pretty simple change, just adds clicking and chittering to decapoids. The arachnid emotes, not the moth ones.
Also added a vocal component to crabs (like the animal) that enables them to scream, cry, etc. and they sound like a decapoid when doing so.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Decapoids can now click and chitter like arachnids!

