### PR TITLE
Small no contractions accent fix

### DIFF
--- a/Resources/Locale/en-US/_Impstation/accent/nocontractions.ftl
+++ b/Resources/Locale/en-US/_Impstation/accent/nocontractions.ftl
@@ -412,8 +412,8 @@ accent-nocontractions-words-replace-136 = that is
 accent-nocontractions-words-137 = thats
 accent-nocontractions-words-replace-137 = that is
 
-accent-nocontractions-words-138 = I'd
-accent-nocontractions-words-replace-138 = I would
+accent-nocontractions-words-138 = i'd
+accent-nocontractions-words-replace-138 = i would
 
 accent-nocontractions-words-139 = y'all
 accent-nocontractions-words-replace-139 = you all

--- a/Resources/Locale/en-US/_Impstation/accent/nocontractions.ftl
+++ b/Resources/Locale/en-US/_Impstation/accent/nocontractions.ftl
@@ -405,3 +405,33 @@ accent-nocontractions-words-replace-134 = of the clock
 
 accent-nocontractions-words-135 = whyd
 accent-nocontractions-words-replace-135 = why did
+
+accent-nocontractions-words-136 = that's
+accent-nocontractions-words-replace-136 = that is
+
+accent-nocontractions-words-137 = thats
+accent-nocontractions-words-replace-137 = that is
+
+accent-nocontractions-words-138 = I'd
+accent-nocontractions-words-replace-138 = I would
+
+accent-nocontractions-words-139 = y'all
+accent-nocontractions-words-replace-139 = you all
+
+accent-nocontractions-words-140 = what'd
+accent-nocontractions-words-replace-140 = what did
+
+accent-nocontractions-words-141 = whatd
+accent-nocontractions-words-replace-141 = what did
+
+accent-nocontractions-words-142 = whered
+accent-nocontractions-words-replace-142 = where did
+
+accent-nocontractions-words-143 = where've
+accent-nocontractions-words-replace-143 = where have
+
+accent-nocontractions-words-144 = ain't
+accent-nocontractions-words-replace-144 = is not
+
+accent-nocontractions-words-145 = aint
+accent-nocontractions-words-replace-145 = is not

--- a/Resources/Prototypes/_Impstation/Accents/nocontractions_replacements.yml
+++ b/Resources/Prototypes/_Impstation/Accents/nocontractions_replacements.yml
@@ -147,4 +147,3 @@
     accent-nocontractions-words-143: accent-nocontractions-words-replace-143
     accent-nocontractions-words-144: accent-nocontractions-words-replace-144
     accent-nocontractions-words-145: accent-nocontractions-words-replace-145
-    accent-nocontractions-words-146: accent-nocontractions-words-replace-146

--- a/Resources/Prototypes/_Impstation/Accents/nocontractions_replacements.yml
+++ b/Resources/Prototypes/_Impstation/Accents/nocontractions_replacements.yml
@@ -136,3 +136,15 @@
     accent-nocontractions-words-132: accent-nocontractions-words-replace-132
     accent-nocontractions-words-133: accent-nocontractions-words-replace-133
     accent-nocontractions-words-134: accent-nocontractions-words-replace-134
+    accent-nocontractions-words-135: accent-nocontractions-words-replace-135
+    accent-nocontractions-words-136: accent-nocontractions-words-replace-136
+    accent-nocontractions-words-137: accent-nocontractions-words-replace-137
+    accent-nocontractions-words-138: accent-nocontractions-words-replace-138
+    accent-nocontractions-words-139: accent-nocontractions-words-replace-139
+    accent-nocontractions-words-140: accent-nocontractions-words-replace-140
+    accent-nocontractions-words-141: accent-nocontractions-words-replace-141
+    accent-nocontractions-words-142: accent-nocontractions-words-replace-142
+    accent-nocontractions-words-143: accent-nocontractions-words-replace-143
+    accent-nocontractions-words-144: accent-nocontractions-words-replace-144
+    accent-nocontractions-words-145: accent-nocontractions-words-replace-145
+    accent-nocontractions-words-146: accent-nocontractions-words-replace-146


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
I noticed a few contractions were missing from the no contractions wordlist, so I added them.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The no contractions accent should now cover more contractions.

