### PR TITLE
Reduce frilly apron timers + give HD access to them

### DIFF
--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/bartender.yml
@@ -1,8 +1,17 @@
+- type: loadoutEffectGroup
+  id: SeniorBartenderApron
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBartender
+      time: 36000 #10 hrs ~7 rounds
+
 - type: loadout
   id: BartenderCuteApron
   effects:
   - !type:GroupLoadoutEffect
-    proto: SeniorBartender
+    proto: SeniorBartenderApron
   equipment:
     outerClothing: ClothingOuterApronCuteBar
 
@@ -31,4 +40,3 @@
     proto: SeniorBartender
   equipment:
     jumpsuit: ClothingUniformSeniorBartenderSkirt #imp
-    

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/chef.yml
@@ -1,8 +1,17 @@
+- type: loadoutEffectGroup
+  id: SeniorChefApron
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChef
+      time: 36000 #10 hrs ~7 rounds
+
 - type: loadout
   id: ChefCuteApron
   effects:
   - !type:GroupLoadoutEffect
-    proto: SeniorChef
+    proto: SeniorChefApron
   equipment:
     outerClothing: ClothingOuterApronCuteChef
 

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/hospitality_director.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/hospitality_director.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHospitalityDirector
-      time: 72000 #10 hrs ~7 rounds
+      time: 72000 #20 hrs ~14 rounds
 
 # For the veteran hospitality director cosmetics
 - type: loadoutEffectGroup

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -405,6 +405,8 @@
   - HospitalityDirectorApron
   - HospitalityDirectorVest
   - HospitalityDirectorWintercoat
+  - BartenderCuteApron
+  - ChefCuteApron
 
 - type: loadoutGroup
   id: HospitalityDirectorShoes


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
This PR reduces the time to unlock the fancy cute aprons for bartender and chef from 30 to 10. theyre not really a prestige item so I think this is fine. I also added them to the HD's loadout choice if they want it

![image](https://github.com/user-attachments/assets/4b9bbfa6-969a-49e3-a3f4-6c4f46eed046)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The frilly aprons for bartender and chef are now unlocked at 10 hours each, down from 30.
- tweak: Hospitality directors can now choose a frilly apron if they have it unlocked.

