### PR TITLE
makes hemp bags normal

### DIFF
--- a/Resources/Prototypes/_Impstation/Objects/Misc/sack.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Misc/sack.yml
@@ -15,6 +15,10 @@
     maxItemSize: Normal
     quickInsert: true
     areaInsert: true
+    whitelist:
+      components:
+        - Produce
+        - Seed
   - type: Dumpable
   - type: Construction
     graph: HempWovenSack


### PR DESCRIPTION
they are like plant bags now.

:cl:
- fix: Hemp bags no longer hold eight times the storage space they take up.
