### PR TITLE
Make the OL-71 laser rifle full auto

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -482,6 +482,8 @@
     fireRate: 4.5 #imp
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/lasermil.ogg #imp
+    availableModes: FullAuto #imp
+    selectedMode: FullAuto #imp
   - type: HitscanBatteryAmmoProvider
     proto: RedHeavyLaser
     fireCost: 40 #imp


### PR DESCRIPTION
It was meant to be like this all along.

no cl; not impactful enough.
