### PR TITLE
Add evidence room station beacon prototype

### DIFF
--- a/Resources/Locale/en-US/_Impstation/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/_Impstation/navmap-beacons/station-beacons.ftl
@@ -4,6 +4,9 @@ station-beacon-paramedic = Paramedic
 # Science
 station-beacon-xenoarchaeology = Xenoarch
 
+# Security
+station-beacon-evidence = Evidence
+
 # Supply
 station-beacon-mailroom = Mail
 

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/station_beacon.yml
@@ -1,6 +1,6 @@
 #Medical
 - type: entity
-  parent: DefaultStationBeaconScience
+  parent: DefaultStationBeaconMedical
   id: DefaultStationBeaconParamedic
   suffix: Paramedic
   components:
@@ -15,6 +15,15 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-xenoarchaeology
+
+#Security
+- type: entity
+  parent: DefaultStationBeaconSecurity
+  id: DefaultStationBeaconEvidence
+  suffix: Evidence
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-evidence
 
 #Supply
 - type: entity
@@ -195,7 +204,7 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-solars-science
-    
+
 - type: entity
   parent: DefaultStationBeaconEngineering
   id: DefaultStationBeaconSolarsSecurity
@@ -219,7 +228,7 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-solars-engineering
-   
+
 - type: entity
   parent: DefaultStationBeaconEngineering
   id: DefaultStationBeaconSolarsMedical


### PR DESCRIPTION
Back at it again with a new station beacon prototype. Also fixes the paramedic station beacon being parented to the science beacons instead of medical.