### PR TITLE
Runahead pull of upstream PR 37056 - Fix NPCs stalling

### DIFF
--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -180,11 +180,24 @@ public sealed class HTNSystem : EntitySystem
         _planQueue.Process();
         var query = EntityQueryEnumerator<ActiveNPCComponent, HTNComponent>();
 
+        // Move ahead "count" entries in the query.
+        // This is to ensure that if we didn't process all the npcs the first time,
+        // we get to the remaining ones instead of iterating over the beginning again.
+        for (var i = 0; i < count; i++)
+        {
+            query.MoveNext(out _, out _);
+        }
+
+        // the amount of updates we've processed during this iteration.
+        var updates = 0;
         while (query.MoveNext(out var uid, out _, out var comp))
         {
             // If we're over our max count or it's not MapInit then ignore the NPC.
-            if (count >= maxUpdates)
-                break;
+            if (updates >= maxUpdates)
+            {
+                // Intentional return. We don't want to go to the end logic and reset count.
+                return;
+            }
 
             if (!comp.Enabled)
                 continue;
@@ -273,8 +286,12 @@ public sealed class HTNSystem : EntitySystem
             }
 
             Update(comp, frameTime);
-            count++;
+            updates++;
         }
+
+        // only reset our counter back to 0 if we finish iterating.
+        // otherwise it lets us know where we left off.
+        count = 0;
     }
 
     private void AppendDebugText(HTNTask task, StringBuilder text, List<int> planBtr, List<int> btr, ref int level)

--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -137,7 +137,6 @@ namespace Content.Server.NPC.Systems
             if (!Enabled)
                 return;
 
-            _count = 0;
             // Add your system here.
             _htn.UpdateNPC(ref _count, _maxUpdates, frameTime);
         }


### PR DESCRIPTION
Runahead pull of upstream PR 37056 - Fix NPCs stalling when too many exist.

Given that this fix isn't in #2465 and also that we keep running against this bug (limits active NPCs to 128), thought it best to take this now rather than wait for the next upstream merge after the ongoing one.

:cl:
- fix: NPC stalling issue (pulled from upstream real quicklike)