### PR TITLE
Nerf space cleaner dispenser

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -58,7 +58,7 @@
       tank:
         reagents:
         - ReagentId: SpaceCleaner
-          Quantity: 5000
+          Quantity: 500 #imp edit, was 5000
   - type: DrainableSolution
     solution: tank
   - type: ReagentTank


### PR DESCRIPTION
Reduces the amount of space cleaner that spawns in the space cleaner dispenser from 5000 units to 500 units. 5000 is a pretty egregious amount of space cleaner to have and pretty much removes any sort of need to ask chemistry to make more. 500 is still probably more than enough to last most shifts, but on particular messy shifts with janitors actively using space cleaner, it should cause at least a few more opportunities for chemists to be asked to make space cleaner.

:cl:
- tweak: Space cleaner dispensers start with considerably less space cleaner in them. Ask your local chemist for a resupply if you need more!
