### PR TITLE
Simple Suture lathe recipe nerf

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/medical.yml
@@ -34,8 +34,8 @@
   result: SimpleSuture1
   completetime: 1
   materials:
-    Cloth: 25
-    Plastic: 25
+    Cloth: 50
+    Plastic: 50
 
 - type: latheRecipe
   id: ElectrodePad


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Simple Sutures are a newer topical that are a counterpart to Gauze; halting bleeding and healing 10 slashing and 5 piercing.
They are curently the same price as most other topicals in the Medical Lathe despite their additional functionality. This PR will make the Simple Suture lathe recipe twice as expensive, with the materials required totalling to 1, matching the recipe for Gauze requiring 1 Cloth.
**Changelog**
- tweak: Simple suture recipe made slightly more expensive.
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Simple Sutures are now twice as expensive in the medical lathe

