### PR TITLE
Quick replicators fix

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
@@ -126,7 +126,7 @@
   - type: Stamina
     critThreshold: 120
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: Replicator1
   - type: PassiveDamage # passive healing
     allowedStates:
@@ -275,7 +275,7 @@
       Dead:
         Base: dead_level2
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: Replicator2
   - type: Body
     prototype: Replicator2
@@ -332,7 +332,7 @@
       Dead:
         Base: dead_level2
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: Replicator2
   - type: Body
     prototype: Replicator2
@@ -390,7 +390,7 @@
   - type: NoSlip
   - type: Magboots
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: Replicator3
   - type: Speech
     speechVerb: Robotic


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Turns out replicators had the wrong damageContainer set. I fix.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Replicators now take structural damage as originally intended