### PR TITLE
Add medglasses to medical doctor/CMO loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1545,6 +1545,7 @@
   loadouts:
   - MedicalHud
   - MedicalEyePatchHud
+  - MedicalGlassesHud #imp
   - Glasses
   - GlassesJamjar
   - GlassesJensen

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -25,7 +25,7 @@
   id: VirologyJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtVirology
-    
+
 - type: loadout
   id: GeneticsJumpsuit
   equipment:
@@ -35,21 +35,27 @@
   id: GeneticsJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtGenetics
-    
-    
+
+
 # Outer Clothing
 - type: loadout
   id: BomberMedical
   equipment:
     outerClothing: ClothingOuterCoatBomberMedical
-    
+
 - type: loadout
   id: GeneticsWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterGen
-    
+
 - type: loadout
   id: VirologyWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterViro
 
+# Eyewear
+
+- type: loadout
+  id: MedicalGlassesHud
+  equipment:
+    eyes: ClothingEyesGlassesHudMedical


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Latest upstream merge (?) added the medhud and med eyepatch to the medical doctor + CMO loadouts, but medical glasses were excluded so I added those.

![Screenshot 2025-06-08 034844](https://github.com/user-attachments/assets/35840992-aa07-4d01-93f7-669e27fd16e9)

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Medhud glasses are now also selectable in Medical Doctor and CMO loadouts.
