### PR TITLE
2 tiny accent/word replacement tweaks

### DIFF
--- a/Resources/Locale/en-US/_Impstation/accent/nocontractions.ftl
+++ b/Resources/Locale/en-US/_Impstation/accent/nocontractions.ftl
@@ -435,3 +435,9 @@ accent-nocontractions-words-replace-144 = is not
 
 accent-nocontractions-words-145 = aint
 accent-nocontractions-words-replace-145 = is not
+
+accent-nocontractions-words-146 = doesn't
+accent-nocontractions-words-replace-146 = does not
+
+accent-nocontractions-words-147 = doesnt
+accent-nocontractions-words-replace-147 = does not

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -467,7 +467,7 @@
     chatsan-word-5: chatsan-replacement-5
     chatsan-word-6: chatsan-replacement-6
     chatsan-word-7: chatsan-replacement-7
-    chatsan-word-8: chatsan-replacement-8
+    # chatsan-word-8: chatsan-replacement-8 imp edit
     chatsan-word-9: chatsan-replacement-9
     chatsan-word-10: chatsan-replacement-10
     chatsan-word-11: chatsan-replacement-11

--- a/Resources/Prototypes/_Impstation/Accents/nocontractions_replacements.yml
+++ b/Resources/Prototypes/_Impstation/Accents/nocontractions_replacements.yml
@@ -147,3 +147,5 @@
     accent-nocontractions-words-143: accent-nocontractions-words-replace-143
     accent-nocontractions-words-144: accent-nocontractions-words-replace-144
     accent-nocontractions-words-145: accent-nocontractions-words-replace-145
+    accent-nocontractions-words-146: accent-nocontractions-words-replace-146
+    accent-nocontractions-words-147: accent-nocontractions-words-replace-147


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Two (semi-related) changes:
-Adds "doesn't" to the no contractions accent.
-Removes the "ik -> i know" word replacement from default chat sanitization. This is why:
![Screenshot 2025-06-06 225234](https://github.com/user-attachments/assets/a2d20f34-6871-4ed4-8963-0a8af2b5f561)
Ik is not a common abbreviation, I don't think I've ever actually seen it used, so it should be fine to remove.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
