### PR TITLE
Update pins

### DIFF
--- a/Resources/Locale/en-US/_Impstation/obvious.ftl
+++ b/Resources/Locale/en-US/_Impstation/obvious.ftl
@@ -47,6 +47,7 @@ obvious-type-pride-gf = [color=#FF76A4]genderfluid[/color] [color=#2F3CBE]pride[
 obvious-type-pride-aut = [color=#FFD700]autism[/color] [color=white]pride[/color]
 obvious-type-pride-straightally = [color=#7c7c7c]straight[/color] [color=#d479d4]LGBTQ ally[/color]
 obvious-type-pride-gq = [color=#B57EDC]genderqueer[/color] [color=#4A8123]pride[/color]
+obvious-type-pride-plural = [color=#31C69E]plural[/color] [color=#6B3FBD]pride[/color]
 
 # lawyers
 obvious-type-law = [color=white]certified[/color] [color=#FFD700]lawyer[/color]

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -174,6 +174,8 @@
     state: plural
   - type: Clothing
     equippedPrefix: plural
+  - type: WearerGetsExamineText # imp
+    thingType: obvious-type-pride-plural
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -211,6 +213,8 @@
     state: fluid
   - type: Clothing
     equippedPrefix: fluid
+  - type: WearerGetsExamineText # imp
+    thingType: obvious-type-pride-gf
 
 - type: entity
   parent: ClothingNeckPinBase

--- a/Resources/Prototypes/_Impstation/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Jobs/Fun/misc_startinggear.yml
@@ -24,7 +24,7 @@
 - type: startingGear
   id: GoblinKnightArmor
   equipment:
-#    neck: ClothingNeckGenderfluidPin #to be uncommented when pin gets merged from upstream https://github.com/space-wizards/space-station-14/pull/35854
+    neck: ClothingNeckGenderfluidPin
     outerClothing: ClothingOuterGoblinKnightArmor
     back: ClothingBackpackSatchelLeather
   inhand:


### PR DESCRIPTION
Tiny hotfix for #2462 which updates the implementation of `WearerGetsExamineText` for the new pins. Also at long last implements the genderfluid pin for Gollylad (last mentioned #2187).

**Changelog**
:cl:
- fix: The new pins added in the upstream merge can now be seen on full display!
- add: The brave knight Gollylad now shows his/her/their pride.
