### PR TITLE
reverts and annotates role time changes

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -9,7 +9,7 @@
       time: 21600 #6 hrs, imp
     - !type:RoleTimeRequirement
       role: JobSalvageSpecialist
-      time: 21600 #6 hrs
+      time: 21600 #6 hrs, imp
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 72000 #20 hours, imp

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -6,9 +6,9 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 36000 # 10 hrs, imp
-    - !type:RoleTimeRequirement
+    - !type:RoleTimeRequirement # imp
       role: JobSecurityOfficer
-      time: 7200 #2 hrs, imp
+      time: 7200 #2 hrs
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-hd

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -7,7 +7,6 @@
   icon: "JobIconMusician"
   supervisors: job-supervisors-hire
   access:
-
   - Maintenance # TODO Remove maint access for all gimmick jobs once access work is completed
   - Theatre
   #imp edit start

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -11,13 +11,13 @@
       department: Medical
       time: 54000 # 15 hours, imp
     - !type:DepartmentTimeRequirement
-      department: Science
-      time: 54000 # 15 hours, imp
-    - !type:DepartmentTimeRequirement
       department: Security
       time: 54000 # 15 hours
     - !type:DepartmentTimeRequirement #imp
       department: Cargo
+      time: 54000 # 15 hours
+    - !type:DepartmentTimeRequirement #imp
+      department: Science
       time: 54000 # 15 hours
     - !type:DepartmentTimeRequirement
       department: Command

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -11,13 +11,13 @@
       department: Medical
       time: 36000 # 10 hours, imp
     - !type:DepartmentTimeRequirement
-      department: Science
-      time: 36000 # 10 hours, imp
-    - !type:DepartmentTimeRequirement
       department: Security
-      time: 36000 # 10 hrs
+      time: 36000 # 10 hrs, imp
     - !type:DepartmentTimeRequirement #imp
       department: Cargo
+      time: 36000 # 10 hrs
+    - !type:DepartmentTimeRequirement #imp
+      department: Science
       time: 36000 # 10 hrs
     - !type:DepartmentTimeRequirement
       department: Command

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -14,7 +14,7 @@
       department: Engineering
       time: 72000 #20 hrs, imp
     - !type:OverallPlaytimeRequirement
-      time: 144000 #40 hrs
+      time: 144000 #40 hrs, imp
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 18000 #5 hrs
+      time: 14000 #4 hrs, imp
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -8,7 +8,7 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 36000 # 10 hrs, imp
+    time: 18000 # 5 hrs, imp
   canBeAntag: false
   joinNotifyCrew: true
   icon: JobIconStationAi


### PR DESCRIPTION
upstream changed a bunch of role timers and merge missed two, station ai and chemist

**Changelog**
:cl:
- tweak: Station AI and Chemist have had their role time requirements reduced.
