### PR TITLE
cmo no longer has two survival boxes

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -559,7 +559,7 @@
   - ChiefMedicalOfficerBackpack #imp
   - SurvivalCommand #imp
   - MedicalEyewear
-  - SurvivalMedical
+  # - SurvivalMedical # imp
   - Trinkets
   - GroupSpeciesBreathToolMedical
   - GroupTankHarnessCommandWithOuterwear


### PR DESCRIPTION
**Changelog**
:cl:
- remove: CMOs start with one survival box now. Don't get greedy.
