### PR TITLE
imp species can trigger blood reactions

### DIFF
--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -242,6 +242,10 @@
     - Slime
     - AmmoniaBlood
     - ZombieBlood
+    # imp below
+    - ShimmeringBlood
+    - BloodKodepiia
+    - GrayBlood
 
 - type: xenoArchTrigger
   id: TriggerThrow


### PR DESCRIPTION
**Changelog**
:cl:
- fix: Kodepiia, grays, and thaven are no longer discriminated against by bloodthirsty artifacts.
