### PR TITLE
tcktck can emote again

### DIFF
--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -37,9 +37,9 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+  #blacklist: # imp - borgs can laugh
+  #  tags:
+  #  - SiliconEmotes
   chatMessages: ["chat-emote-msg-laugh"]
   chatTriggers:
     - laugh

--- a/Resources/Prototypes/_DV/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emotes.yml
@@ -9,8 +9,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [honks.]
   chatTriggers:
     - honk
@@ -28,8 +28,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [rings.]
   chatTriggers:
     - ring
@@ -48,8 +48,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [pews.]
   chatTriggers:
     - pew
@@ -66,8 +66,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [bangs.]
   chatTriggers:
     - bang
@@ -85,8 +85,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [beeps.]
   chatTriggers:
     - beep
@@ -104,8 +104,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [revs.]
   chatTriggers:
     - rev
@@ -123,8 +123,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [caws.]
   chatTriggers:
     - caw
@@ -144,8 +144,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: [snarls.]
   chatTriggers:
     - snarl

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/tcktck.yml
@@ -225,6 +225,7 @@
     - DoorBumpOpener
     - FootstepSound
     - CanPilot
+    - SiliconEmotes
   - type: Emoting
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/_Impstation/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_Impstation/Voice/speech_emotes.yml
@@ -9,8 +9,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-bubble"]
   chatTriggers:
     - bubbles
@@ -26,8 +26,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-pop"]
   chatTriggers:
     - pops
@@ -43,8 +43,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-hiss"]
   chatTriggers:
     - hiss
@@ -88,8 +88,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-coo"]
   chatTriggers:
   - coo
@@ -105,8 +105,8 @@
     components:
     - Hands
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-crack"]
   chatTriggers:
   - crack knuckles
@@ -130,8 +130,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-boom"]
   chatTriggers:
   - boom

--- a/Resources/Prototypes/_NF/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_NF/Voice/speech_emotes.yml
@@ -8,8 +8,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-goblin-muttering"]
   chatTriggers:
     - mutter
@@ -27,8 +27,8 @@
     components:
     - Vocal
   blacklist:
-    components:
-    - BorgChassis
+    tags:
+    - SiliconEmotes
   chatMessages: ["chat-emote-msg-goblin-throat-singing"]
   chatTriggers:
     - sing


### PR DESCRIPTION
upstream changed how silicons can emote to be tag based because of course they did. tcktck gets the correct tag to allow it access to silicon emotes and all our custom emotes have their blacklist updated to match how upstream handles it

**Changelog**
:cl:
- fix: Tck'tck can beep again!
