### PR TITLE
add the generic command clothes to command's loadouts

### DIFF
--- a/Resources/Changelog/Impstation.yml
+++ b/Resources/Changelog/Impstation.yml
@@ -1,17 +1,4 @@
 ﻿Entries:
-- author: Tyranex
-  changes:
-  - message: Added a new basic mining module for salvage cyborg!
-    type: Add
-  - message: Cyborgs can now scream! And syndicate assault cyborgs can now laugh.
-      Go give the crew a heart attack.
-    type: Add
-  - message: The mining module is no longer given to the salvage chassis, it must
-      instead be researched and crafted.
-    type: Tweak
-  id: 1266
-  time: '2025-03-10T19:12:47.0000000+00:00'
-  url: https://github.com/impstation/imp-station-14/pull/1884
 - author: MintyTheBinty
   changes:
   - message: New uniforms and medals for the recent wing of the ERT Positivity Force.
@@ -4222,3 +4209,12 @@
   id: 1765
   time: '2025-06-08T02:52:04.0000000+00:00'
   url: https://github.com/impstation/imp-station-14/pull/2673
+- author: AvianMaiden, Cutinup99
+  changes:
+  - message: Televisions and computers give off cozier lights!
+    type: Add
+  - message: New variant of the desk lamp with a warmer glow!
+    type: Add
+  id: 1766
+  time: '2025-06-08T02:53:16.0000000+00:00'
+  url: https://github.com/impstation/imp-station-14/pull/2644

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -158,6 +158,8 @@
   - CaptainBeret # imp
   - CaptainCrusherCap #imp
   - CaptainTricorne # imp
+  - CommandBeret # imp
+  - CommandSoftHat # imp
 
 - type: loadoutGroup
   id: CaptainJumpsuit
@@ -168,6 +170,8 @@
   - CaptainFormalSuit
   - CaptainFormalSkirt
   - CaptainEveningAttire #imp
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: CaptainNeck
@@ -206,6 +210,8 @@
   minLimit: 0
   loadouts:
   - HoPHead
+  - CommandBeret # imp
+  - CommandSoftHat # imp
 
 - type: loadoutGroup
   id: HoPJumpsuit
@@ -214,6 +220,8 @@
   - HoPJumpsuit
   - HoPJumpskirt
   - HoPBoatswain # DeltaV
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: HoPNeck
@@ -730,6 +738,8 @@
   loadouts:
   - QuartermasterHead
   - QuartermasterBeret
+  - CommandBeret # imp
+  - CommandSoftHat # imp
 
 - type: loadoutGroup
   id: QuartermasterJumpsuit
@@ -740,6 +750,8 @@
   - QuartermasterTurtleneck
   - QuartermasterTurtleneckSkirt
   - QuartermasterFormalSuit
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: QuartermasterNeck
@@ -841,6 +853,8 @@
   loadouts:
   - ChiefEngineerHead
   - ChiefEngineerBeret
+  - CommandBeret # imp
+  - CommandSoftHat # imp
 
 - type: loadoutGroup
   id: ChiefEngineerJumpsuit
@@ -850,6 +864,8 @@
   - ChiefEngineerJumpskirt
   - ChiefEngineerTurtleneck
   - ChiefEngineerTurtleneckSkirt
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: ChiefEngineerNeck
@@ -990,6 +1006,8 @@
   loadouts:
   - ResearchDirectorBeret
   - ResearchDirectorHood # DeltaV
+  - CommandBeret # imp
+  - CommandSoftHat # imp
 
 - type: loadoutGroup
   id: ResearchDirectorNeck
@@ -1007,6 +1025,8 @@
   loadouts:
   - ResearchDirectorJumpsuit
   - ResearchDirectorJumpskirt
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: ResearchDirectorOuterClothing
@@ -1126,6 +1146,8 @@
   - HeadofSecurityHeadDV # DeltaV
   - HeadofSecurityBeret
   - HeadofSecurityPatrolCap # imp
+  - CommandBeret # imp
+  - CommandSoftHat # imp
 
 - type: loadoutGroup
   id: HeadofSecurityJumpsuit
@@ -1141,6 +1163,8 @@
   - HeadofSecurityProfessionalJumpskirt # imp
   - HeadofSecurityFormalSuit
   - HeadofSecurityFormalSkirt
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: HeadofSecurityNeck
@@ -1350,6 +1374,8 @@
   loadouts:
   - ChiefMedicalOfficerBeret
   - CMOMedicalHeadMirror
+  - CommandBeret # imp
+  - CommandSoftHat # imp
 
 - type: loadoutGroup
   id: ChiefMedicalOfficerJumpsuit
@@ -1359,6 +1385,8 @@
   - ChiefMedicalOfficerJumpskirt
   - ChiefMedicalOfficerTurtleneckJumpsuit
   - ChiefMedicalOfficerTurtleneckJumpskirt
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: ChiefMedicalOfficerOuterClothing

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -47,6 +47,8 @@
   - ClerkJumpsuit # imp - no clerk
   - ClothingUniformNightclubSuit #imp
   - ClothingUniformNightclubSuitSkirt #imp
+  - CommandJumpsuit # imp
+  - CommandJumpskirt # imp
 
 - type: loadoutGroup
   id: AdminAssistantShoes

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -83,11 +83,3 @@
   loadouts:
   - BlackGloves
   - WhiteGloves
-
-- type: loadoutGroup # imp addition
-  id: AdminAssistantHead
-  name: loadout-group-admin-assistant-head
-  minLimit: 0
-  loadouts:
-  - CommandBeret
-  - CommandSoftHat

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -20,6 +20,7 @@
   - AdminAssistantShoes
   - AdminAssistantEar
   - AdminAssistantBackpack #imp
+  - AdminAssistantHead # imp
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/generic_command.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Command/generic_command.yml
@@ -47,3 +47,25 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: VeteranCommand
+
+# Jumpsuit
+- type: loadout
+  id: CommandJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCommandGeneric
+
+- type: loadout
+  id: CommandJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCommandGeneric
+
+# Head
+- type: loadout
+  id: CommandBeret
+  equipment:
+    head: ClothingHeadHatBeretCommand
+
+- type: loadout
+  id: CommandSoftHat
+  equipment:
+    head: ClothingHeadHatCommandSoft

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -344,6 +344,14 @@
   - CommonDuffel
   - LeatherSatchel
 
+- type: loadoutGroup
+  id: AdminAssistantHead
+  name: loadout-group-admin-assistant-head
+  minLimit: 0
+  loadouts:
+  - CommandBeret
+  - CommandSoftHat
+
 # service
 
 - type: loadoutGroup
@@ -363,6 +371,8 @@
   - BartenderHead
   - HospitalityDirectorBeret
   - HospitalityDirectorBellhopHD
+  - CommandBeret
+  - CommandSoftHat
 
 - type: loadoutGroup
   id: HospitalityDirectorNeck
@@ -387,6 +397,8 @@
   - HospitalityDirectorBartenderJumpskirt
   - HospitalityDirectorBotanyJumpsuit
   - HospitalityDirectorProprietorJumpsuit
+  - CommandJumpsuit
+  - CommandJumpskirt
 
 - type: loadoutGroup
   id: HospitalityDirectorGloves


### PR DESCRIPTION
they look nice and I wanna be able to use them without needing to ask the hop for them
obviously messes with color coordination for the department heads but i feel like it's probably fine?

:cl:
- tweak: Command members may now choose the generic command clothes in their loadout
