### PR TITLE
Increase interact delay on annoying sounds for windows, blast door, and shutters

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -48,6 +48,7 @@
     messagePerceivedByOthers: comp-window-knock
     interactSuccessSound:
       path: /Audio/Effects/glass_knock.ogg
+    interactDelay: 2.5 #imp edit, help sensory issues
 
 - type: entity
   id: BlastDoorOpen

--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -30,6 +30,7 @@
     messagePerceivedByOthers: comp-window-knock
     interactSuccessSound:
       path: /Audio/Effects/glass_knock.ogg
+    interactDelay: 2.5 #imp edit, help with sensory issues
   - type: Appearance
   - type: StaticPrice
     price: 100

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -79,6 +79,7 @@
     messagePerceivedByOthers: comp-window-knock
     interactSuccessSound:
       path: /Audio/Effects/glass_knock.ogg
+    interactDelay: 2.5 #imp edit, help sensory issues
   - type: Construction
     graph: Window
     node: window
@@ -151,6 +152,7 @@
     messagePerceivedByOthers: comp-window-knock
     interactSuccessSound:
       path: /Audio/Effects/glass_knock.ogg
+    interactDelay: 2.5 #imp edit, help with sensory issues
   - type: Physics
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
Increases the interact delay for knocking on windows, blast doors, and shutters from 1 second to 2.5 seconds. The window knocking sound is one of the most grating sounds in the game with how often it can be played and can be outright overwhelming for people with audio sensory issues. The shutter sound isn't as bad, but I thought it would be best to be consistent. Kind of surprised I haven't done this earlier.

**Changelog**

:cl:
- tweak: The time between being able to knock on the same window, blast door, or shutter has increased to be less annoying.
