### PR TITLE
lowers the difficulty of most traitor objectives

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -6,7 +6,7 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
-    TraitorGimmickObjectives: 0.06 #Imp: Gimmick Objectives
+    TraitorGimmickObjectives: 0.25 #Imp: Gimmick Objectives
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -244,7 +244,7 @@
   - type: NotJobRequirement
     job: HeadOfPersonnel
   - type: ObjectiveLimit
-    limit: 2.5 # ian only has 2 slices, 3 obj for drama # imp - increase chance of multiple objectives
+    limit: 3 # ian only has 2 slices, 3 obj for drama
   - type: StealCondition
     stealGroup: FoodMeatCorgi
     owner: objective-condition-steal-Ian

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -28,7 +28,7 @@
   - type: StealCondition
     verifyMapExistence: false
   - type: Objective
-    difficulty: 2.75
+    difficulty: 2 # imp - increase chance of multiple objectives
   - type: ObjectiveLimit
     limit: 2 # there is usually only 1 of each steal objective, have 2 max for drama
 
@@ -41,7 +41,7 @@
   description: One of our undercover agents will debrief you when you arrive. Don't show up in cuffs.
   components:
   - type: Objective
-    difficulty: 1.3
+    difficulty: 0.5 # imp - increase chance of multiple objectives + escape
     icon:
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
@@ -187,7 +187,7 @@
     stealGroup: ClothingOuterHardsuitRd
   - type: Objective
     # This item must be worn or stored in a slowing duffelbag, very hard to hide.
-    difficulty: 3
+    difficulty: 2.5 # imp - increase chance of multiple objectives
 
 - type: entity
   parent: BaseRDStealObjective
@@ -204,7 +204,7 @@
   components:
   - type: Objective
     # HoS will have this on them a lot of the time so..
-    difficulty: 3
+    difficulty: 2.5 # imp - increase chance of multiple objectives
   - type: NotJobRequirement
     job: HeadOfSecurity
   - type: StealCondition
@@ -244,7 +244,7 @@
   - type: NotJobRequirement
     job: HeadOfPersonnel
   - type: ObjectiveLimit
-    limit: 3 # ian only has 2 slices, 3 obj for drama
+    limit: 2.5 # ian only has 2 slices, 3 obj for drama # imp - increase chance of multiple objectives
   - type: StealCondition
     stealGroup: FoodMeatCorgi
     owner: objective-condition-steal-Ian
@@ -258,7 +258,7 @@
   components:
   - type: Objective
     # sorry ce but your jordans are not as high security as the caps gear
-    difficulty: 3.5
+    difficulty: 3 # imp - increase chance of multiple objectives
   - type: NotJobRequirement
     job: Captain
 


### PR DESCRIPTION
and also makes gimmick objectives most common. result of admin/maints discussion about traitor objective variety being quite low. biggest change is that the difficulty of "escape to centcomm" is lowered from 1.3 to 0.5, making it much more likely that you are going to get at least two other objectives, but i also lowered the difficulty of all the theft objectives except nuke disk so you have the opportunity to use the cool toy you stole

**Changelog**
:cl:
- tweak: Traitors are more likely to roll more than two objectives.
