### PR TITLE
Replace the PKA RoF upgrade with an ammo recharge rate upgrade

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/RechargeBasicEntityAmmoSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/RechargeBasicEntityAmmoSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Impstation.Weapons.Ranged.Events;
 using Content.Shared.Examine;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Audio;
@@ -53,7 +54,15 @@ public sealed class RechargeBasicEntityAmmoSystem : EntitySystem
                 continue;
             }
 
-            recharge.NextCharge = recharge.NextCharge.Value + TimeSpan.FromSeconds(recharge.RechargeCooldown);
+            //imp edit begin - event-ify the recharge cd
+            var rechargeEv = new GetAmmoRechargeTimeEvent
+            {
+                Time = recharge.RechargeCooldown
+            };
+            RaiseLocalEvent(uid, ref rechargeEv);
+            //imp edit end
+
+            recharge.NextCharge = recharge.NextCharge.Value + TimeSpan.FromSeconds(rechargeEv.Time); //imp edit - changed from recharge.RechargeCooldown
             Dirty(uid, recharge);
         }
     }
@@ -88,7 +97,15 @@ public sealed class RechargeBasicEntityAmmoSystem : EntitySystem
 
         if (recharge.NextCharge == null || recharge.NextCharge < _timing.CurTime)
         {
-            recharge.NextCharge = _timing.CurTime + TimeSpan.FromSeconds(recharge.RechargeCooldown);
+            //imp edit begin - event-ify the recharge cd
+            var rechargeEv = new GetAmmoRechargeTimeEvent
+            {
+                Time = recharge.RechargeCooldown
+            };
+            RaiseLocalEvent(uid, ref rechargeEv);
+            //imp edit end
+
+            recharge.NextCharge = _timing.CurTime + TimeSpan.FromSeconds(rechargeEv.Time); //imp edit - changed from recharge.RechargeCooldown
             Dirty(uid, recharge);
         }
     }

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._Impstation.Weapons.Ranged.Events;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;
@@ -38,6 +39,8 @@ public sealed class GunUpgradeSystem : EntitySystem
         SubscribeLocalEvent<GunUpgradeFireRateComponent, GunRefreshModifiersEvent>(OnFireRateRefresh);
         SubscribeLocalEvent<GunUpgradeSpeedComponent, GunRefreshModifiersEvent>(OnSpeedRefresh);
         SubscribeLocalEvent<GunUpgradeDamageComponent, GunShotEvent>(OnDamageGunShot);
+
+        SubscribeLocalEvent<UpgradeableGunComponent, GetAmmoRechargeTimeEvent>(RelayEvent); //imp edit for recharge time modifiers
     }
 
     private void RelayEvent<T>(Entity<UpgradeableGunComponent> ent, ref T args) where T : notnull

--- a/Content.Shared/_Impstation/Weapons/Ranged/AmmoRechargeTimeModifierSystem.cs
+++ b/Content.Shared/_Impstation/Weapons/Ranged/AmmoRechargeTimeModifierSystem.cs
@@ -1,0 +1,21 @@
+using Content.Shared._Impstation.Weapons.Ranged.Events;
+using Content.Shared._Impstation.Weapons.Ranged.Upgrades.Components;
+
+namespace Content.Shared._Impstation.Weapons.Ranged;
+
+/// <summary>
+/// This handles...
+/// </summary>
+public sealed class AmmoRechargeTimeModifierSystem : EntitySystem
+{
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GunUpgradeAmmoRechargeTimeComponent, GetAmmoRechargeTimeEvent>(ModifyRechargeTime);
+    }
+
+    private void ModifyRechargeTime(Entity<GunUpgradeAmmoRechargeTimeComponent> ent, ref GetAmmoRechargeTimeEvent args)
+    {
+        args.Time *= ent.Comp.Coefficient;
+    }
+}

--- a/Content.Shared/_Impstation/Weapons/Ranged/Events/GetAmmoRechargeTimeEvent.cs
+++ b/Content.Shared/_Impstation/Weapons/Ranged/Events/GetAmmoRechargeTimeEvent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._Impstation.Weapons.Ranged.Events;
+
+/// <summary>
+/// raised on a gun when it calculates what the next ammo recharge delay should be.
+/// </summary>
+[ByRefEvent]
+public record struct GetAmmoRechargeTimeEvent
+{
+    public float Time;
+}
+

--- a/Content.Shared/_Impstation/Weapons/Ranged/Upgrades/Components/GunUpgradeAmmoRechargeTimeComponent.cs
+++ b/Content.Shared/_Impstation/Weapons/Ranged/Upgrades/Components/GunUpgradeAmmoRechargeTimeComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Impstation.Weapons.Ranged.Upgrades.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class GunUpgradeAmmoRechargeTimeComponent : Component
+{
+    /// <summary>
+    /// Multiplier for the speed of a gun's ammo regen. lower is better.
+    /// </summary>
+    [DataField]
+    public float Coefficient = 1;
+}

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -76,5 +76,8 @@
   - type: GunUpgrade
     tags: [ GunUpgradeReloadSpeed ]
     examineText: gun-upgrade-examine-text-reload
-  - type: GunUpgradeFireRate
-    coefficient: 1.5
+  #imp edit - removed in favour of the recharge time comp because we handle PKA rof by recharge time instead of rof
+  #- type: GunUpgradeFireRate
+  #  coefficient: 1.5
+  - type: GunUpgradeAmmoRechargeTime
+    coefficient: 0.667 # 1/1.5 because recharge time is sec / recharge while rof is shots / sec


### PR DESCRIPTION
pka modkits are real now but since we've changed pka rof to be handled by ammo regen instead of rof, one of them didn't do anything, this fixes that.

I banged this out in like 15 minutes and it seems to Just Work but that's scary, probably needs a second set of eyes on it.

