### PR TITLE
Give the requests section of the cargo requests console more space

### DIFF
--- a/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
@@ -30,7 +30,7 @@
                 <Control MinHeight="5"/>
                 <ScrollContainer HorizontalExpand="True"
                                  VerticalExpand="True"
-                                 SizeFlagsStretchRatio="2">
+                                 SizeFlagsStretchRatio="1"> <!-- imp edit - reduced to 1 to make the ui less bad-->
                     <BoxContainer Name="Products"
                                   Orientation="Vertical"
                                   HorizontalExpand="True"


### PR DESCRIPTION
w/ requests being a larger part of cargo now, makes sense to give the panel more space. 
Ideally this PR would actually be putting the two elements inside a SplitContainer to allow them to be dynamically resized, but whenever I tried that the client would instantly crash, so I'm just doing this instead.
