### PR TITLE
Replicator resistance, damage, and other related balance changes

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-damage.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-damage.yml
@@ -2,37 +2,37 @@
   id: Replicator1
   coefficients:
     Blunt: 0.9
-    Slash: 0.7
+    Slash: 0.8
     Piercing: 1.1
     Shock: 1.9
     Heat: 0.8
-    Structural: 0.9
+    Structural: 0.8
   flatReductions:
-    Structural: 7
+    Structural: 9
 
 - type: damageModifierSet
   id: Replicator2
   coefficients:
-    Blunt: 0.7
-    Slash: 0.7
+    Blunt: 0.9
+    Slash: 0.8
     Piercing: 0.7
     Shock: 1.7
     Heat: 0.8
-    Structural: 0.65
+    Structural: 0.4
   flatReductions:
-    Structural: 7
+    Structural: 9
 
 - type: damageModifierSet
   id: Replicator3
   coefficients:
-    Blunt: 0.15
-    Slash: 0.15
-    Piercing: 0.15
+    Blunt: 0.3
+    Slash: 0.2
+    Piercing: 0.2
     Shock: 1.2
     Heat: 0.25
-    Structural: 0.45
+    Structural: 0.3
   flatReductions:
-    Structural: 7
+    Structural: 10
 
 - type: damageModifierSet # ideally the nest should be able to be destroyed relatively easily with a couple grenades or a brave soul with a pickaxe.
   id: ReplicatorNest

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-damage.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-damage.yml
@@ -2,34 +2,37 @@
   id: Replicator1
   coefficients:
     Blunt: 0.9
-    Slash: 0.5
-    Piercing: 0.8
-    Shock: 1.2
-    Structural: 1.5
+    Slash: 0.7
+    Piercing: 1.1
+    Shock: 1.9
+    Heat: 0.8
+    Structural: 0.9
   flatReductions:
-    Heat: 5
+    Structural: 7
 
 - type: damageModifierSet
   id: Replicator2
   coefficients:
-    Blunt: 0.8
-    Slash: 0.5
+    Blunt: 0.7
+    Slash: 0.7
     Piercing: 0.7
-    Shock: 1.2
-    Structural: 1.5
+    Shock: 1.7
+    Heat: 0.8
+    Structural: 0.65
   flatReductions:
-    Heat: 5
+    Structural: 7
 
 - type: damageModifierSet
   id: Replicator3
   coefficients:
-    Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.5
+    Blunt: 0.15
+    Slash: 0.15
+    Piercing: 0.15
     Shock: 1.2
-    Structural: 1.5
+    Heat: 0.25
+    Structural: 0.45
   flatReductions:
-    Heat: 6
+    Structural: 7
 
 - type: damageModifierSet # ideally the nest should be able to be destroyed relatively easily with a couple grenades or a brave soul with a pickaxe.
   id: ReplicatorNest
@@ -37,7 +40,7 @@
     Blunt: 0.5
     Slash: 0.5
     Piercing: 0.5
-    Shock: 1.2
+    Shock: 0.85
   flatReductions:
     Blunt: 10
     Slash: 10

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-loadout.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-loadout.yml
@@ -47,7 +47,7 @@
     state: t1weapon
   - type: Appearance
   - type: Gun
-    fireRate: 0.5
+    fireRate: 1
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/stunprojector.ogg
   - type: HitscanBatteryAmmoProvider
@@ -123,15 +123,14 @@
     sprite: _Impstation/Mobs/Replicator/replicator.rsi
     state: t3weapon
   - type: MeleeWeapon
-    attackRate: 0.8
+    attackRate: 0.5
     wideAnimationRotation: 180
     soundHit: 
       path: "/Audio/Effects/metal_slam4.ogg"
     animation: WeaponArcSlash
     damage:
       types:
-        Blunt: 20
-        Shock: 5
+        Blunt: 30
         Structural: 45
   - type: Unremoveable
   - type: Prying
@@ -193,10 +192,11 @@
 
 - type: hitscan
   id: HitscanReplicator
-  staminaDamage: 28
+  staminaDamage: 12.5
   damage:
     types:
-      Shock: 8
+      Heat: 4
+      Shock: 3
   muzzleFlash:
     sprite: _Impstation/Mobs/Replicator/replicator_gun.rsi
     state: muzzle_repli

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-loadout.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-loadout.yml
@@ -47,7 +47,7 @@
     state: t1weapon
   - type: Appearance
   - type: Gun
-    fireRate: 0.3
+    fireRate: 0.5
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/stunprojector.ogg
   - type: HitscanBatteryAmmoProvider
@@ -123,15 +123,15 @@
     sprite: _Impstation/Mobs/Replicator/replicator.rsi
     state: t3weapon
   - type: MeleeWeapon
-    attackRate: 0.7
+    attackRate: 0.8
     wideAnimationRotation: 180
     soundHit: 
       path: "/Audio/Effects/metal_slam4.ogg"
     animation: WeaponArcSlash
     damage:
       types:
-        Blunt: 15
-        Shock: 10
+        Blunt: 20
+        Shock: 5
         Structural: 45
   - type: Unremoveable
   - type: Prying
@@ -193,10 +193,10 @@
 
 - type: hitscan
   id: HitscanReplicator
-  staminaDamage: 25
+  staminaDamage: 28
   damage:
     types:
-      Shock: 7
+      Shock: 8
   muzzleFlash:
     sprite: _Impstation/Mobs/Replicator/replicator_gun.rsi
     state: muzzle_repli

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
@@ -84,7 +84,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      75: Dead
+      100: Dead
   - type: Destructible
     thresholds:
     - trigger:
@@ -135,6 +135,9 @@
       groups:
         Brute: -0.5
         Burn: -0.5
+      types:
+        Shock: -0.5
+        Structural: -0.5
   - type: ThermalVision
     lightRadius: 7
     color: "#d70aa0"
@@ -194,7 +197,7 @@
   - type: SyncSprite
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
-    baseSprintSpeed: 4
+    baseSprintSpeed: 4.5 # same as a person
     weightlessFriction: 1
     weightlessFrictionNoInput: 2
     weightlessAcceleration: 1.8
@@ -363,6 +366,8 @@
     applySpeedModifier: false
   - type: MovementAlwaysTouching
   - type: MovementSpeedModifier
+    baseWalkSpeed: 2 # same as slime
+    baseSprintSpeed: 2.835 # this is the same speed as an engineering hardsuit + duffel
     friction: 30 # these fellas are the tanks, they rely on the smaller guys stunning things for them.
   - type: Sprite
     granularLayersRendering: true
@@ -392,6 +397,16 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Replicator3
+  - type: PassiveDamage # passive healing
+    allowedStates:
+    - Alive
+    damage:
+      groups:
+        Brute: -0.75
+        Burn: -0.75
+      types:
+        Shock: -0.75
+        Structural: -0.75
   - type: Speech
     speechVerb: Robotic
     speechSounds: Replicator

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
@@ -197,7 +197,7 @@
   - type: SyncSprite
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
-    baseSprintSpeed: 4.5 # same as a person
+    baseSprintSpeed: 4.2
     weightlessFriction: 1
     weightlessFrictionNoInput: 2
     weightlessAcceleration: 1.8
@@ -253,7 +253,7 @@
     needsHands: false
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
-    baseSprintSpeed: 4
+    baseSprintSpeed: 4.2
     weightlessFriction: 1
     weightlessFrictionNoInput: 2
     weightlessAcceleration: 1.2
@@ -310,7 +310,7 @@
     needsHands: false
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
-    baseSprintSpeed: 4
+    baseSprintSpeed: 4.2
     weightlessFriction: 1
     weightlessFrictionNoInput: 2
     weightlessAcceleration: 1.2
@@ -405,8 +405,8 @@
         Brute: -0.75
         Burn: -0.75
       types:
-        Shock: -0.75
-        Structural: -0.75
+        Shock: -0.5
+        Structural: -0.5
   - type: Speech
     speechVerb: Robotic
     speechSounds: Replicator


### PR DESCRIPTION
All of these are number tweaks, no new or removed features.

There are four main goals here:

First, fine tune replicator defenses so that the crew feels they have viable options beyond simply shooting them to death with a standard gun like any other antagonist. Make the strengths and weaknesses notable without there being a defacto best option. In otherwords, crew with PKAs should shine but not do security's job better than them.

Second, make the danger posed by the tier 1 replicator and tier 2 defender significant enough to be the main damage source of the replicators. Rather than relying on tier 3 protectors, the lasers will be the greater threat in terms of immediate damage to the crew. To this end, the ability for protectors to go on the offensive is diminished.

Third, make upgrading into the tier 3 protector a strategic choice. Protectors should sacrifice the flexibility of the tier 2 defender to be a tanking powerhouse that is essentially a moving wall for the hive. Protectors embody their name and are greatly incentivized to work in tandem with defenders, providing them cover and warding off crew from getting too close.

The idea behind all of this is to reinforce what I feel is the best part about replicators: prolonged engagements and the ticking timebomb behind their ramping power. I think the true replicator "win" condition is reaching a point where the crew realizes they can no longer hold back the encroaching tide and are forced to evac. Replicators do not have to go on the offensive to achieve this, dismantling the station and fending off retaliatory attacks that slowly whittle down the crew is more than enough.

/-/

In the changelog I have included the number of attacks to kill (AtK) a replicator for the new resistances and compared them to the old. I've done the same for their weapons versus crew as attacks to crit (AtC). I am using the following weapons/ammo for each resistance type:

Blunt: Truncheon (20 damage)
Slash: Combat Knife (12 damage)
Piercing: .20 rifle (19 damage)
Shock: .50 stun (7.5 damage)
Heat: Laser Carbine (14 damage)
Structural: PKA (30 damage)

Note that the PKA also deals 25 blunt which is included in the AtK. Also I'm aware it's being messed with by upstream, apparently it's being reverted so I'm not gonna worry about it.

Regarding structural damage, replicators are being given resistance and flat reduction to it. This does NOT mean it is no longer a weakness. Sources of structural damage often deal a lot of it in addition to other damage types. Being vulnerable to structural in the first place is a major downside without also having negative resistances to it.

/-/

- Increased replicator HP from 75 to 100. This is mainly to make dealing with resistances easier on the math. Some resistances are lowered to compensate for this and keep AtK the same or similar.
- Laser fire rate increased from 0.3 to 1.
- Laser damage changed from 7 shock to 4 heat and 3 shock. AtC of 14.28 unchanged against unarmored. AtC from 14.28 to 16.33 against security hardsuits. 
- Laser stamina damage decreased from 25 to 12.5. (it takes exactly 8 seconds of continous fire to stun)

Tier 1:
- Blunt resistance of 10% unchanged. AtK from 4.16 to 5.55.
- Slash resistance from 50% to 20%. AtK from 12.5 to 10.41.
- Piercing resistance from 20% to -10%. AtK from 4.93 to 4.78.
- Shock resistance from -20% to -90%. AtK from 8.33 to 7.01.
- Heat resistance from 0% to 20%. Removed flat damage reduction of 5. AtK from 8.33 to 8.92.
- Structural resistance from -50% to 20%. Added flat damage reduction of 9. AtK from 1.11 to 2.54.

- Increased sprint speed from 4 to 4.2

Tier 2:
- Blunt resistance from 20% to 10%. AtK from 4.68 to 5.55.
- Slash resistance from 50% to 20%. AtK from 12.5 to 10.41.
- Piercing resistance of 30% unchanged. AtK from 5.63 to 7.51.
- Shock resistance from -20% to -90%. AtK from 8.33 to 7.01.
- Heat resistance from 0% to 20%. Removed flat damage reduction of 5. AtK from 8.33 to 8.92.
- Structural resistance from -50% to 60%. Added flat damage reduction of 9. AtK from 1.11 to 3.23.

- Increased sprint speed from 4 to 4.2

Tier 3:
- Blunt resistance from 50% to 70%. AtK from 7.5 to 16.6.
- Slash resistance from 50% to 80%. AtK from 12.5 to 41.66.
- Piercing resistance from 50% to 80%. AtK from 7.89 to 26.31.
- Shock resistance from -20% to 15%. AtK from 8.33 to 15.33.
- Heat resistance from 0% to 75%. Removed flat damage reduction of 6. AtK from 8.33 to 27.57.
- Structural resistances from -50% to 70%. Added flat damage reduction of 10. AtK from 1.3 to 7.40.

- Increased passive healing from 0.5 to 0.75 against brute and burn. (full heal within 2 minutes)
- Reduced sprint speed from 4 to 2.835 (this is the same speed as an engineering hardsuit + duffel).

- Reduced attack speed from 0.7 to 0.5.
- Changed melee damage from 15 blunt and 10 shock to 30 blunt. AtC from 4 to 3.84. AtC from 5.43 to 5.95 against security hardsuit.

/-/

Numbers only convey so much, so here's an explanation of these changes and how they will (theoretically) play out:

The tier 3 protector is now essentially a living jugg suit with innate healing that lets it retreat and return to battle relatively quickly. Of course this comes with the huge downside of being strictly melee with an awful movespeed. This drastically changes the role of the protector, it is no longer able to chase down crew on its own. Instead, it is heavily incentivized to stay with other replicators and hold positions to prevent the crew from pushing in on the hive, something it now incredibly strong at doing. Protectors can comfortably soak a ton of fire (an entire lecter mag and then some) but because of their very low speed they are easy targets allowing coordinated fire to make quick work of them if caught in the open. These weaknesses are mitigated through teamwork with the tier 1 replicator and tier 2 defender whose lasers are now a greater threat and more capable of inflicting stuns that let the protector close the gap.

The structural damage vulnerability may not seem like a whole lot, 8 PKA shots to kill a protector is not great with its slow fire rate, however adding just one or two PKAs in a large fight can really ramp up damage with the risk of needing to be a little too close for comfort. EMPs and stuns are also a lot better against the protector which will struggle to dodge them. One secoff with a stun shotgun and another with a rifle will be able to comfortably kill a lone protector without much threat of retaliation, again reinforcing the need for it to stick with its teammates.

In practice we should see less protectors as many players will favor the defender for its ranged weapon. Replicators are very good at the war of attrition but only with the threat that their infinite charge lasers pose. The main job of protectors will be to... well, protect, so that its allies can continue their job unimpeded. A tier 1 and 2 on its own isn't much of a threat to the crew, but with a protector in the mix it's free to pew pew away without much retaliation.

/-/

Initial concerns:

These are quite big number changes and I predict people will not know or underestimate how extremely tanky a protector is, causing crew to overextend, get cornered, and mercilessly beaten to death. The initial reaction to seeing a protector survive an entire magdump is going to be mixed and contentious, as will their very slow speed and inability to chase. It will probably take some time for the role of the protector to become clear for players to be comfortable with it.

The increased fire rate of the laser could become an issue. The replicator stuns were powerful in the early tests and it was unpopular. I don't want to bring it back to that level but with the changes to the protector it needs the support of the lasers to be able to go on the offensive against an organized crew.

Shock resistance is set so low because currently the only real viable way for crew to deal shock damage is with stun shells which do a lousy 7.5 damage. In the future if other decently avaliable sources of shock damage are given to the crew then this resistance would need to be bumped up.

Crushers kill in approximately the same amount of hits as PKAs but with a MUCH higher attack rate. I can see this potentially being the undisputed best option versus replicators, protectors included, which is not ideal. I'm hoping that the lack of a wide swing and it being melee makes it a high risk high reward weapon. Diamond tip mining drills could also trivilize replicators with a 4.19 AtK versus a protector. Diamonds aren't that common so that could keep it in check but it still needs to be watched for.

**Changelog**
:cl:
- tweak: rebalanced replicators to greatly favor a more defensive team orientated play style, check out the pr for a full changelog
- tweak: structural damage no longer two shots replicators, however it remains a great option against them so grab your PKAs and crushers!
- tweak: tier 3 protector is now extremely tanky at the cost of being significantly slower, don't underestimate them or you might get cornered!
- tweak: replicator lasers now fire a lot faster but deal less stun, they don't do that much damage but if they work together it can really add up!