### PR TITLE
Use Impstation sprites for lock box and water tank cargo orders

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_lockbox.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_lockbox.yml
@@ -1,7 +1,7 @@
 - type: cargoProduct
   id: CrateLockBoxEngineering
   icon:
-    sprite: Structures/Storage/Crates/lockbox.rsi
+    sprite: _Impstation/Structures/Storage/Crates/lockbox.rsi #imp edit
     state: icon
   product: CrateLockBoxEngineering
   cost: 100
@@ -11,7 +11,7 @@
 - type: cargoProduct
   id: CrateLockBoxMedical
   icon:
-    sprite: Structures/Storage/Crates/lockbox.rsi
+    sprite: _Impstation/Structures/Storage/Crates/lockbox.rsi #imp edit
     state: icon
   product: CrateLockBoxMedical
   cost: 100
@@ -21,7 +21,7 @@
 - type: cargoProduct
   id: CrateLockBoxScience
   icon:
-    sprite: Structures/Storage/Crates/lockbox.rsi
+    sprite: _Impstation/Structures/Storage/Crates/lockbox.rsi #imp edit
     state: icon
   product: CrateLockBoxScience
   cost: 100
@@ -31,7 +31,7 @@
 - type: cargoProduct
   id: CrateLockBoxSecurity
   icon:
-    sprite: Structures/Storage/Crates/lockbox.rsi
+    sprite: _Impstation/Structures/Storage/Crates/lockbox.rsi #imp edit
     state: icon
   product: CrateLockBoxSecurity
   cost: 100
@@ -41,7 +41,7 @@
 - type: cargoProduct
   id: CrateLockBoxService
   icon:
-    sprite: Structures/Storage/Crates/lockbox.rsi
+    sprite: _Impstation/Structures/Storage/Crates/lockbox.rsi #imp edit
     state: icon
   product: CrateLockBoxService
   cost: 100

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -122,7 +122,7 @@
   id: MaterialWaterTank
   icon:
     sprite: _Impstation/Structures/Storage/tanks.rsi # imp
-    state: watertank
+    state: watertank-2 # imp
   product: WaterTankFull
   cost: 1000
   category: cargoproduct-category-name-materials


### PR DESCRIPTION
Fixes lock box and water tank cargo orders using upstream sprites.

**Changelog**
:cl:
- fix: Lock boxes and water tank cargo orders now use our sprites in the request computer.
