### PR TITLE
remove roundstart aa

### DIFF
--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -18,7 +18,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -20,7 +20,6 @@
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ] # imp
-            AdministrativeAssistant : [ 1, 1 ] # imp
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chef: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -22,7 +22,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -22,7 +22,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -19,7 +19,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -19,7 +19,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -19,7 +19,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -22,7 +22,6 @@
             #command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -19,7 +19,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -22,7 +22,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/xeno.yml
+++ b/Resources/Prototypes/Maps/xeno.yml
@@ -22,7 +22,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # Imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -79,7 +79,6 @@
   - ERTEngineer
   - DeathSquad
   - HospitalityDirector #Imp
-  - AdministrativeAssistant # Delta V
   primary: false
   weight: 100
 

--- a/Resources/Prototypes/_DV/Maps/submarine.yml
+++ b/Resources/Prototypes/_DV/Maps/submarine.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Harmony/Maps/Eclipse.yml
+++ b/Resources/Prototypes/_Harmony/Maps/Eclipse.yml
@@ -22,7 +22,6 @@
             #command
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Harmony/Maps/barratry.yml
+++ b/Resources/Prototypes/_Harmony/Maps/barratry.yml
@@ -22,7 +22,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/banana.yml
+++ b/Resources/Prototypes/_Impstation/Maps/banana.yml
@@ -22,7 +22,6 @@
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/bedlam.yml
+++ b/Resources/Prototypes/_Impstation/Maps/bedlam.yml
@@ -22,7 +22,6 @@
             # command
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/boat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/boat.yml
@@ -23,7 +23,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/hash.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hash.yml
@@ -22,7 +22,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # imp
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/lilboat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/lilboat.yml
@@ -29,9 +29,8 @@
             ResearchDirector: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ]
-            # service - 10 
+            # service - 10
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/luna.yml
+++ b/Resources/Prototypes/_Impstation/Maps/luna.yml
@@ -22,7 +22,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/refsdal.yml
+++ b/Resources/Prototypes/_Impstation/Maps/refsdal.yml
@@ -22,7 +22,6 @@
             # command
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/union.yml
+++ b/Resources/Prototypes/_Impstation/Maps/union.yml
@@ -20,7 +20,6 @@
             # command - 9
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]


### PR DESCRIPTION
same treatment as #2423 but for aa. im pulling the trigger, piglet

**Why?**
- DV, the place we ported it from, removed it
- it was originally intended to be an intern role but no longer fulfills that job
- we get so many goddamn ahelps about aa. its ridiculous
- its just hop 2
- makes antag harder because theres ANOTHER bridge monkey
- makes the command headset objective easier

In general, AA has always felt like a really awkward role, and as the person who ported it i know im not alone in saying i think its overstayed its welcome. i'd love to push people who play AA into doing the same thing as HoP, since that role has a much greater weight on the round with an almost-identical scope. if people want to have an intern friend, they can still do that! just go to the HoP and get someone an intern promotion. great roleplay opportunity.

AA is still in the code. in the future it's going to be made a unique job for distribution errors. but in the meantime it just has so many issues that i do not feel bad at all removing it until then

did not touch maps or locker protos, mappers can do whateverrrr

:cl:
- remove: Administrative Assistants have been recalled due to mass workplace coffee incidents.