### PR TITLE
a body has been discovered

### DIFF
--- a/Resources/Locale/en-US/_Impstation/station-events/events/vent-pest.ftl
+++ b/Resources/Locale/en-US/_Impstation/station-events/events/vent-pest.ftl
@@ -1,0 +1,1 @@
+﻿station-event-corpse-ejected-from-vents-announcement = The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.

--- a/Resources/Prototypes/Announcers/mesavox.yml
+++ b/Resources/Prototypes/Announcers/mesavox.yml
@@ -106,6 +106,8 @@
     #   path: events/solar_flare-complete.ogg
     - id: ventClog # A random reagent is coming out of a scrubber
       path: events/vent_clog.ogg
+    - id: corpseEjectedFromVents # vent clog, kind of
+      path: events/vent_clog.ogg
     - id: slimesSpawn # Some simple slimes are appearing in vents
       path: events/vent_critters.ogg
     - id: spiderSpawn # Some simple spiders are appearing in vents

--- a/Resources/Prototypes/Announcers/michael.yml
+++ b/Resources/Prototypes/Announcers/michael.yml
@@ -108,6 +108,8 @@
     #   path: events/solar_flare-complete.ogg
     - id: ventClog # A random reagent is coming out of a scrubber
       path: events/vent_clog.ogg
+    - id: corpseEjectedFromVents # vent clog, kind of
+      path: events/vent_clog.ogg
     # - id: slimesSpawn # Some simple slimes are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents

--- a/Resources/Prototypes/Announcers/neil.yml
+++ b/Resources/Prototypes/Announcers/neil.yml
@@ -108,6 +108,8 @@
     #   path: events/solar_flare-complete.ogg
     - id: ventClog # A random reagent is coming out of a scrubber
       path: events/vent_clog.ogg
+    - id: corpseEjectedFromVents # vent clog, kind of
+      path: events/vent_clog.ogg
     # - id: slimesSpawn # Some simple slimes are appearing in vents
     #   path: events/vent_critters.ogg
     # - id: spiderSpawn # Some simple spiders are appearing in vents

--- a/Resources/Prototypes/Announcers/sinister.yml
+++ b/Resources/Prototypes/Announcers/sinister.yml
@@ -112,6 +112,8 @@
       collection: SinisterVentcloggedAnnouncements
     - id: immovableRodSpawn # The station is moving into an immovable rod, don't die or something, ask Engineering for help repairing it
       collection: SinisterImmovablerodAnnouncements
+    - id: corpseEjectedFromVents # vent clog, kind of
+      collection: SinisterVentcloggedAnnouncements
 
     # - id: ionStorm # AI-controlled equipment are now weird, check their laws
     #  path: events/ion_storm.ogg

--- a/Resources/Prototypes/Announcers/tiktok.yml
+++ b/Resources/Prototypes/Announcers/tiktok.yml
@@ -108,6 +108,8 @@
       path: events/solar_flare-complete.ogg
     - id: ventClog # A random reagent is coming out of a scrubber
       path: events/vent_clog.ogg
+    - id: corpseEjectedFromVents # vent clog, kind of
+      path: events/vent_clog.ogg
     - id: slimesSpawn # Some simple slimes are appearing in vents
       path: events/vent_critters.ogg
     - id: spiderSpawn # Some simple spiders are appearing in vents

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -9,6 +9,7 @@
     - id: MouseMigration
     - id: LuggageMigration # imp special
     - id: SingleCritter # imp special
+    - id: CorpseEjectedFromVents # imp
 
 - type: entityTable
   id: SpicyPestEventsTable

--- a/Resources/Prototypes/_Impstation/GameRules/pests.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/pests.yml
@@ -144,3 +144,4 @@
   - type: VentCrittersRule
     specialEntries:
     - id: SalvageHumanCorpse
+      prob: 0

--- a/Resources/Prototypes/_Impstation/GameRules/pests.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/pests.yml
@@ -133,3 +133,14 @@
       prob: 0
     - id: MobButterfly
       prob: 0
+
+- type: entity
+  id: CorpseEjectedFromVents
+  parent: BaseStationEventShortDelay
+  components:
+  - type: StationEvent
+    reoccurrenceDelay: 10
+    weight: 3
+  - type: VentCrittersRule
+    specialEntries:
+    - id: SalvageHumanCorpse

--- a/Resources/Prototypes/_Impstation/GameRules/pests.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/pests.yml
@@ -139,9 +139,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    startAnnouncement: true
     reoccurrenceDelay: 10
     weight: 3
   - type: VentCrittersRule
+    announce: false
     specialEntries:
     - id: SalvageHumanCorpse
       prob: 0


### PR DESCRIPTION
adds the gamerule CorpseEjectedFromVents to the calm pest events table. you'll never guess what it does

https://github.com/user-attachments/assets/d0f186ee-8cfb-46d2-86e9-b6ae77298d65

**Changelog**
:cl:
- add: A body has been discovered.
