### PR TITLE
Remove playtime requirement from Cargo Technician, limit Supply Assistants

### DIFF
--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_amber.yml
         - type: StationJobs
-          availableJobs: # total of 54 jobs roundstart, max of 64 inc. latejoins and trainees.
+          availableJobs: # total of 54 jobs roundstart, max of 63 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -60,10 +60,10 @@
             SecurityCadet: [ 2, 2 ]
             SecurityOfficer: [ 3, 3 ]
             Warden: [ 1, 1 ]
-            # supply - 6-8
+            # supply - 6-7
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -14,7 +14,7 @@
             !type:NanotrasenNameGenerator
             prefixCreator: 'R4' # R4407/Goon. GS isn't as cool sounding.
         - type: StationJobs
-          availableJobs: # total of 43 jobs roundstart, max of 57 inc. latejoins and trainees.
+          availableJobs: # total of 43 jobs roundstart, max of 56 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -55,10 +55,10 @@
             SecurityCadet: [ 3, 3 ]
             SecurityOfficer: [ 3, 3 ]
             Warden: [ 1, 1 ]
-            # supply - 5-7
+            # supply - 5-6
             CargoTechnician: [ 2, 2 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
         - type: StationJobs
-          availableJobs: # Total of 63 jobs roundstart, max of 80 inc. latejoins and trainees.
+          availableJobs: # Total of 63 jobs roundstart, max of 79 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -60,10 +60,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 4, 4 ]
             Warden: [ 1, 1 ]
-            # supply - 7-9
+            # supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
         - type: StationJobs
-          availableJobs: # Total of 66 jobs roundstart, max of 85 inc. latejoins and trainees.
+          availableJobs: # Total of 66 jobs roundstart, max of 83 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -60,10 +60,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 5, 5 ]
             Warden: [ 1, 1 ]
-            #supply - 7-10
+            #supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 3, 3 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -16,7 +16,7 @@
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
         - type: StationJobs
-          availableJobs: # Total of 45 jobs roundstart, max of 55 inc. latejoins and trainees.
+          availableJobs: # Total of 45 jobs roundstart, max of 54 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -57,10 +57,10 @@
             SecurityCadet: [ 2, 2 ]
             SecurityOfficer: [ 3, 3 ]
             Warden: [ 1, 1 ]
-            # supply - 5-7
+            # supply - 5-6
             CargoTechnician: [ 2, 2 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ]
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_wode.yml
         - type: StationJobs
-          availableJobs: # Total of 72 jobs roundstart, max of 88 inc. latejoins and trainees.
+          availableJobs: # Total of 72 jobs roundstart, max of 86 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -62,10 +62,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 4, 4 ]
             Warden: [ 1, 1 ]
-            # supply - 7-10
+            # supply - 7-8
             CargoTechnician: [ 4, 4 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 3, 3 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             Courier: [ 1, 1 ] #imp
-            SupplyAssistant: [ 3, 3 ] #imp
+            SupplyAssistant: [ 1, 1 ] #imp
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_core.yml # imp
         - type: StationJobs
-          availableJobs: # Total of 62 jobs roundstart, max of 74 inc. latejoins and trainees.
+          availableJobs: # Total of 62 jobs roundstart, max of 72 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -66,6 +66,6 @@
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 3, 3 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_elkridge.yml # imp
         - type: StationJobs
-          availableJobs: # Total of 52 jobs roundstart, max of 62 inc. latejoins and trainees.
+          availableJobs: # Total of 52 jobs roundstart, max of 61 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -66,6 +66,6 @@
             CargoTechnician: [ 2, 2 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -15,7 +15,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
         - type: StationJobs
-          availableJobs: # Total of 69 nice jobs roundstart, max of 85 inc. latejoins and trainees.
+          availableJobs: # Total of 69 nice jobs roundstart, max of 83 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -64,6 +64,6 @@
             CargoTechnician: [ 6, 6 ]
             Courier: [ 2, 2 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 3, 3 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
         - type: StationJobs
-          availableJobs: # Total of 62 jobs roundstart, max of 77 inc. latejoins and trainees.
+          availableJobs: # Total of 62 jobs roundstart, max of 76 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -60,10 +60,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 4, 4 ]
             Warden: [ 1, 1 ]
-            # supply - 7-9
+            # supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_meta.yml
         - type: StationJobs
-          availableJobs: # Total of 71 jobs roundstart, max of 91 inc. latejoins and trainees. she's normal now.
+          availableJobs: # Total of 71 jobs roundstart, max of 89 inc. latejoins and trainees. she's normal now.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -59,10 +59,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 6, 6 ]
             Warden: [ 1, 1 ]
-            # supply - 8-11
+            # supply - 8-9
             CargoTechnician: [ 4, 4 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 3, 3 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -15,7 +15,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_accordia.yml
         - type: StationJobs
-          availableJobs: # Total of 79 jobs roundstart, max of 97 inc. latejoins and trainees.
+          availableJobs: # Total of 79 jobs roundstart, max of 95 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -59,10 +59,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 7, 7 ]
             Warden: [ 1, 1 ]
-            # supply - 8-11
+            # supply - 8-9
             CargoTechnician: [ 4, 4 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 3, 3 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_omega.yml
         - type: StationJobs
-          availableJobs: # Total of 52 jobs roundstart, max of 62 inc. latejoins and trainees.
+          availableJobs: # Total of 52 jobs roundstart, max of 61 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -60,10 +60,10 @@
             SecurityCadet: [ 2, 2 ]
             SecurityOfficer: [ 3, 3 ]
             Warden: [ 1, 1 ]
-            # supply - 5-7
+            # supply - 5-6
             CargoTechnician: [ 2, 2 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_crimson.yml
         - type: StationJobs
-          availableJobs: # Total of 50 jobs roundstart, max of 61 inc. latejoins and trainees.
+          availableJobs: # Total of 50 jobs roundstart, max of 60 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -58,10 +58,10 @@
             SecurityCadet: [ 2, 2 ]
             SecurityOfficer: [ 3, 3 ]
             Warden: [ 1, 1 ]
-            # supply - 5-7
+            # supply - 5-6
             CargoTechnician: [ 2, 2 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_plasma.yml
         - type: StationJobs
-          availableJobs: #Total of 71 jobs roundstart, max of 92 inc. latejoins and trainees.
+          availableJobs: #Total of 71 jobs roundstart, max of 90 inc. latejoins and trainees.
             #command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -62,10 +62,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 6, 6 ]
             Warden: [ 1, 1 ]
-            # supply - 9-12
+            # supply - 9-10
             CargoTechnician: [ 4, 4 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 4, 4 ]
-            SupplyAssistant: [ 3, 3 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian - the tiders yearn for the mines
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -15,7 +15,7 @@
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
         - type: StationJobs
-          availableJobs: # Total of 52 jobs roundstart, max of 67 inc. latejoins and trainees.
+          availableJobs: # Total of 52 jobs roundstart, max of 66 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -56,10 +56,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 4, 4 ]
             Warden: [ 1, 1 ]
-            # supply - 5-7
+            # supply - 5-6
             CargoTechnician: [ 2, 2 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -18,7 +18,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_omega.yml # TODO - add railway station
         - type: StationJobs
-          availableJobs: # Total of 61 jobs roundstart, max of 75 inc. latejoins and trainees.
+          availableJobs: # Total of 61 jobs roundstart, max of 74 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -62,10 +62,10 @@
             SecurityCadet: [ 3, 3 ]
             SecurityOfficer: [ 5, 5 ]
             Warden: [ 1, 1 ]
-            # supply - 7-9
+            # supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/xeno.yml
+++ b/Resources/Prototypes/Maps/xeno.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_xeno.yml
         - type: StationJobs
-          availableJobs: # Total of 61 jobs roundstart, max of 79 inc. latejoins and trainees.
+          availableJobs: # Total of 61 jobs roundstart, max of 77 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -61,10 +61,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 4, 4 ]
             Warden: [ 1, 1 ]
-            # supply - 7-10
+            # supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # Imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 3, 3 ] # Imp
+            SupplyAssistant: [ 1, 1 ] # Imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -3,12 +3,6 @@
   name: job-name-cargotech
   description: job-description-cargotech
   playTimeTracker: JobCargoTechnician
-  # Begin DeltaV modifications - Add time requirement to cargo tech
-  requirements:
-  - !type:DepartmentTimeRequirement
-    department: Cargo
-    time: 7200 # IMP 2 hrs ~2 shifts, down from 6h
-  # End DeltaV modifications
   startingGear: CargoTechGear
   icon: "JobIconCargoTechnician"
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/_DV/Maps/submarine.yml
+++ b/Resources/Prototypes/_DV/Maps/submarine.yml
@@ -61,10 +61,10 @@
             SecurityCadet: [ 3, 3 ]
             SecurityOfficer: [ 6, 6 ]
             Warden: [ 1, 1 ]
-            # supply - 14
+            # supply - 10
             CargoTechnician: [ 4, 4 ]
             Courier: [ 2, 2 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Cargo/cargo_assistant.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Cargo
-    time: 18000 #IMP 5 hrs, down from 15h
+    time: 14400 #IMP 4 hrs, ~3 shifts, down from 15h
     inverted: true # stop playing intern if you're good at cargo!
   icon: "JobIconSupplyAssistant"
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/_Harmony/Maps/Eclipse.yml
+++ b/Resources/Prototypes/_Harmony/Maps/Eclipse.yml
@@ -63,7 +63,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 5, 5 ]
             Courier: [ 2, 2 ]
-            SupplyAssistant: [ 3, 3 ]
+            SupplyAssistant: [ 1, 1 ]
             #civilian
             Passenger: [ -1, -1 ]
             #silicon

--- a/Resources/Prototypes/_Harmony/Maps/barratry.yml
+++ b/Resources/Prototypes/_Harmony/Maps/barratry.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/_Harmony/Shuttles/cargo_barratry.yml
         - type: StationJobs
-          availableJobs: # Total of 64 jobs roundstart, max of 82 inc. latejoins and trainees.
+          availableJobs: # Total of 64 jobs roundstart, max of 81 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -61,10 +61,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 5, 5 ]
             Warden: [ 1, 1 ]
-            # supply - 7-9
+            # supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Impstation/Maps/boat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/boat.yml
@@ -19,7 +19,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_fland.yml
         - type: StationJobs
-          availableJobs: # Total of 62 jobs roundstart, max of 76 inc. latejoins and trainees.
+          availableJobs: # Total of 62 jobs roundstart, max of 74 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -63,10 +63,10 @@
             SecurityCadet: [ 3, 3 ]
             SecurityOfficer: [ 3, 3 ]
             Warden: [ 1, 1 ]
-            # supply - 8-11
+            # supply - 8-9
             CargoTechnician: [ 4, 4 ]
             SalvageSpecialist: [ 3, 3 ]
             Courier: [ 1, 1 ]
-            SupplyAssistant: [ 3, 3 ]
+            SupplyAssistant: [ 1, 1 ]
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Impstation/Maps/hash.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hash.yml
@@ -64,6 +64,6 @@
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ] # imp
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ] # imp
+            SupplyAssistant: [ 1, 1 ] # imp
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/_Impstation/Shuttles/emergency_courser_hummingbird.yml
         - type: StationJobs
-          availableJobs: # Total of 69 nice jobs roundstart, max of 83 inc. latejoins and trainees.
+          availableJobs: # Total of 69 nice jobs roundstart, max of 82 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -61,10 +61,10 @@
             SecurityCadet: [ 3, 3 ]
             SecurityOfficer: [ 4, 4 ]
             Warden: [ 1, 1 ]
-            # supply - 7-9
+            # supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 2, 2 ]
+            SupplyAssistant: [ 1, 1 ]
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Impstation/Maps/luna.yml
+++ b/Resources/Prototypes/_Impstation/Maps/luna.yml
@@ -67,6 +67,6 @@
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]
-            SupplyAssistant: [ 2, 2 ]
+            SupplyAssistant: [ 1, 1 ]
             # civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Impstation/Maps/union.yml
+++ b/Resources/Prototypes/_Impstation/Maps/union.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
         - type: StationJobs
-          availableJobs: # Total of 67 jobs roundstart, max of 82 inc. latejoins and trainees.
+          availableJobs: # Total of 67 jobs roundstart, max of 80 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -61,10 +61,10 @@
             SecurityCadet: [ 4, 4 ]
             SecurityOfficer: [ 4, 4 ]
             Warden: [ 1, 1 ]
-            # supply - 7-10
+            # supply - 7-8
             CargoTechnician: [ 3, 3 ]
             Courier: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
-            SupplyAssistant: [ 3, 3 ]
+            SupplyAssistant: [ 1, 1 ]
             # civilian
             Passenger: [ -1, -1 ]


### PR DESCRIPTION
Once again removes the playtime requirement from Cargo Technician, lowers Supply Assistant lockout to 4 hours, limits Supply Assistant job slots to one across all maps.

Cargo Technician is the easiest departmental job to learn with arguably the least amount of pressure on them (discounting Service), anybody can easily jump into playing Cargo Technician without having too high expectations put on them. Additionally, an excess of players in the Cargo department doesn't help station efficiency the same way that an excess of medical or engineering staff would. With that said, I do think there is value in having an intern role slot dedicated for those who want to signal that they are still very new to the department. This PR tries to strike a middle ground without outright removing Supply Assistant.

**Changelog**
:cl:
- tweak: Cargo Technician no longer has a playtime requirement (again).
- tweak: Supply Assistant has been limited to 1 per map and locks out after 4 hours of Cargo playtime.

