### PR TITLE
Allow reagent tanks to be refillable

### DIFF
--- a/Resources/Locale/en-US/_Impstation/fluids/dumpablesolution-component.ftl
+++ b/Resources/Locale/en-US/_Impstation/fluids/dumpablesolution-component.ftl
@@ -1,0 +1,1 @@
+﻿dumpablesolution-component-fill-verb-inhand = Fill with {$object}

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -185,3 +185,7 @@
     transferAmount: 100
   - type: StaticPrice
     price: 5000 # That's a pretty fancy keg you got there.
+  # imp edit start, allows refilling with verb or click-and-dragging
+  - type: DumpableSolution
+    solution: tank
+  # imp edit end

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
@@ -67,6 +67,10 @@
   - type: ReagentTank
   - type: Transform
     noRot: true
+  # imp edit start, allows refilling with verb or click-and-dragging
+  - type: DumpableSolution
+    solution: tank
+  # imp edit end
 
 # For highcap tanks
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -90,7 +90,3 @@
     weldingDamage:
       types:
         Heat: 20
-  # imp edit start, allows refilling with verb or click-and-dragging
-  - type: DumpableSolution
-    solution: tank
-  # imp edit end

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -64,6 +64,10 @@
   - type: ReagentTank
   - type: ExaminableSolution
     solution: tank
+  # imp edit start, allows refilling with verb or click-and-dragging
+  - type: DumpableSolution
+    solution: tank
+  # imp edit end
 
 - type: entity
   parent: CleanerDispenser
@@ -86,3 +90,7 @@
     weldingDamage:
       types:
         Heat: 20
+  # imp edit start, allows refilling with verb or click-and-dragging
+  - type: DumpableSolution
+    solution: tank
+  # imp edit end


### PR DESCRIPTION
This PR was originally done with the intention of letting players refill space cleaner dispensers, since borgs can only refill their spray bottles by using it on entities with the DrainableSolution component, but I figured it would make sense to extend this to all reagent tanks. Water tanks, fuel tanks, water coolers, wall dispensers, the nuke keg can now all be refilled by click-and-dragging a solution container on to them or by using a new right-click verb. Incidentally, the ChemMaster can now also be refilled by using the same right-click verb.

![HgXtani](https://github.com/user-attachments/assets/480db928-0dae-4ff4-84b5-7edb8011b2cc)

**Changelog**
:cl:
- add: Water tanks, fuel tanks, water coolers, wall dispensers, and the nuke keg can now be refilled by either click and dragging a reagent container on to them or by using a right-click verb.
- add: Reagents can now be added to ChemMasters using a right-click verb.
