### PR TITLE
Replicator Minor Update

### DIFF
--- a/Content.Server/_Impstation/Replicator/ReplicatorNestSystem.cs
+++ b/Content.Server/_Impstation/Replicator/ReplicatorNestSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Destructible;
 using Content.Shared.Explosion.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
+using Content.Shared.Mech.Components;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
@@ -77,6 +78,7 @@ public sealed class ReplicatorNestSystem : SharedReplicatorNestSystem
                 !HasComp<HumanoidAppearanceComponent>(uid) && // Store people
                 !HasComp<OnUseTimerTriggerComponent>(uid) && // Store grenades
                 !HasComp<StealTargetComponent>(uid) && // Store steal targets
+                !HasComp<MechComponent>(uid) && // Store mechs like Ripley
                 !TryComp<MindContainerComponent>(uid, out var mind) | (mind != null && !mind!.HasMind)) // Store anything else that has a mind
             {
                 toDel.Add(uid);
@@ -251,7 +253,7 @@ public sealed class ReplicatorNestSystem : SharedReplicatorNestSystem
             else
                 locationsList = string.Concat(locationsList, $"[/color]and [color=#d70aa0]{location}[/color].");
 
-            totalPoints += pointsStorage.TotalPoints;
+            totalPoints += pointsStorage.TotalPoints / 10; // dividing by ten gives us a slightly more manageable number + keeps it consistent with pre-stackcount point calculation.
 
             totalSpawned += pointsStorage.TotalReplicators;
 

--- a/Content.Shared/_Impstation/Replicator/ReplicatorNestComponent.cs
+++ b/Content.Shared/_Impstation/Replicator/ReplicatorNestComponent.cs
@@ -51,32 +51,32 @@ public sealed partial class ReplicatorNestComponent : Component
     /// The number of additional points given for living targets.
     /// </summary>
     [DataField]
-    public int BonusPointsAlive = 1;
+    public int BonusPointsAlive = 10;
     /// <summary>
     /// The number of additional points given for incapacitated humanoid targets.
     /// Is multiplied by the current level.
     /// </summary>
     [DataField]
-    public int BonusPointsHumanoid = 2;
+    public int BonusPointsHumanoid = 20;
     /// <summary>
     /// The number of points required to spawn a new replicator. 
     /// Increases linearly with the number of unclaimed ghostroles. 
     /// </summary>
     [DataField]
-    public int SpawnNewAt = 30;
+    public int SpawnNewAt = 300;
     /// <summary>
     /// The number of points required to upgrade existing replicators & the nest itself.
     /// Multiplied by current nest level.
     /// </summary>
     [DataField]
-    public int UpgradeAt = 40;
+    public int UpgradeAt = 400;
 
     /// <summary>
     /// The level at which the nest stops growing. It will still produce and upgrade replicators, 
     /// but the upgrade thresholds will not increase, and the nest will start ignoring weightlessness.
     /// </summary>
     [DataField]
-    public int EndgameLevel = 3;
+    public int EndgameLevel = 30;
 
     /// <summary>
     /// Entity to be spawned when reaching spawn point thresholds.

--- a/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
+++ b/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Content.Shared.Throwing;
 using Robust.Shared.Prototypes;
+using Content.Shared.Stacks;
 
 namespace Content.Shared._Impstation.Replicator;
 
@@ -131,19 +132,28 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
 
     private void HandlePoints(Entity<ReplicatorNestComponent> ent, EntityUid tripper) // this is its own method because I think it reads cleaner. also the way goobcode handled this sucked.
     {
-        // regardless of what falls in, you get at least one point.
-        ent.Comp.TotalPoints++;
-        ent.Comp.SpawningProgress++;
+        // regardless of what falls in, you get at least one point
+        if (!HasComp<StackComponent>(tripper)) // as long as it's not a stack.
+        {
+            ent.Comp.TotalPoints += 10;
+            ent.Comp.SpawningProgress += 10;
+        }
+
+        // if the item is in a stack, you get points depending on how many items are in that stack. 
+        if (TryComp<StackComponent>(tripper, out var stackComp))
+        {
+            ent.Comp.TotalPoints += stackComp.Count;
+        }
 
         // you get a bonus point if the item is Large, 2 bonus points if it's Huge, and 3 bonus points if it's above that.
-        if (TryComp<ItemComponent>(tripper, out var itemComp))
+        else if (TryComp<ItemComponent>(tripper, out var itemComp))
         {
             if (_item.GetSizePrototype(itemComp.Size) == _item.GetSizePrototype("Large"))
-                ent.Comp.TotalPoints++;
+                ent.Comp.TotalPoints += 10;
             else if (_item.GetSizePrototype(itemComp.Size) == _item.GetSizePrototype("Huge"))
-                ent.Comp.TotalPoints += 2;
+                ent.Comp.TotalPoints += 20;
             else if (_item.GetSizePrototype(itemComp.Size) >= _item.GetSizePrototype("Ginormous"))
-                ent.Comp.TotalPoints += 3;
+                ent.Comp.TotalPoints += 30;
             // regardless, items only net 1 spawning progress.
             ent.Comp.SpawningProgress++;
         }
@@ -151,9 +161,9 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
         // if it wasn't an item and was anchorable, you get 3 bonus points.
         else if (TryComp<AnchorableComponent>(tripper, out _))
         {
-            ent.Comp.TotalPoints += 3;
+            ent.Comp.TotalPoints += 30;
             // structures give a lot more spawning progress than items
-            ent.Comp.SpawningProgress += 3;
+            ent.Comp.SpawningProgress += 30;
         }
 
         // recycling four dead replicators nets you one new replicator, but no progress towards leveling up.

--- a/Resources/Locale/en-US/_Impstation/replicators/replicators.ftl
+++ b/Resources/Locale/en-US/_Impstation/replicators/replicators.ftl
@@ -43,10 +43,36 @@ replicator-levelup-confirm = Are you sure? Use the action again to confirm.
 terror-replicators = Attention crew, it appears that someone on your station has made an unexpected communication with a distributed machine intelligence in nearby space.
 
 # AAC phrases
-repli-phrase-species-organic = Organic
-repli-phrase-species-silicon = Silicon
-phrase-we = We
-phrase-we-are = We are
-phrase-this-unit = This unit
-phrase-that-unit = That unit
-phrase-is = Is
+
+rep-phrase-query = Query:
+rep-phrase-affirmative = Affirmative
+rep-phrase-negative = Negative
+rep-phrase-questionmark = ?
+
+rep-phrase-hostile = Hostile
+rep-phrase-combatant = Combatant
+rep-phrase-noncombatant = Noncombatant
+rep-phrase-ally = Ally
+rep-phrase-hazardous = Hazardous
+
+rep-phrase-unit = Unit
+rep-phrase-units = Units
+rep-phrase-i = This unit
+rep-phrase-you = You
+rep-phrase-we = We
+
+rep-phrase-are = Are
+rep-phrase-is = Is
+rep-phrase-will = Will
+rep-phrase-not = Not
+
+rep-phrase-leave = Leave
+rep-phrase-attack = Attack
+rep-phrase-dismantle = Dismantle
+rep-phrase-consume = Consume
+rep-phrase-endanger = Endanger
+rep-phrase-cease = Cease
+rep-phrase-suspend = Suspend
+
+rep-phrase-the-nest = The Nest
+rep-phrase-the-hive = The Hive

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-AAC-phrases.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-AAC-phrases.yml
@@ -1,30 +1,6 @@
 - type: quickPhraseGroup
   id: ReplicatorPhrases
   prototypes:
-# Safety
-    - SafetyInDangerPhrase
-    - SafetyInjuredPhrase
-    - SafetyEscapePhrase
-    - SafetyHazardousPhrase
-    - SafetyNotPhrase
-    - SafetyYouArePhrase
-    - SafetyIAmPhrase
-# Species
-    - ReplicatorOrganicPhrase
-    - ReplicatorSiliconPhrase
-# Actions
-    - ShowMePhrase
-    - HelpPhrase
-    - AttackPhrase
-    - BreakPhrase
-    - RunPhrase
-# Tools
-    - WrenchPhrase
-    - CrowbarPhrase
-    - ScrewdriverPhrase
-    - WirecutterPhrase
-    - WeldingToolPhrase
-    - MultitoolPhrase
 # Laws
     - ReplicatorLaw1Phrase
     - ReplicatorLaw2Phrase
@@ -32,55 +8,47 @@
 # Directions
     - LocationNearPhrase
     - LocationFarPhrase
-    - LocationInsidePhrase
-    - LocationOutsidePhrase
     - LocationNorthPhrase
     - LocationEastPhrase
     - LocationSouthPhrase
     - LocationWestPhrase
-    - LocationNorthEastPhrase
-    - LocationSouthEastPhrase
-    - LocationSouthWestPhrase
-    - LocationNorthWestPhrase
-# Pronouns
-    - ItPhrase
-    - WePhrase
-    - WeArePhrase
-# Hostiles
-    - HostileLifeformPhrase
-    - HostileEntityPhrase
-    - HostileWeaponPhrase
-# Manners
-    - YesPhrase
-    - NoPhrase
-# Commands
-    - GoAwayPhrase
-    - GoToPhrase
-    - DoNotPhrase
-    - ThisPhrase
-    - TakePhrase
-    - LeavePhrase
-    - StopPhrase
-    - WaitPhrase
+# Nouns
+    - RepYouPhrase
+    - RepWePhrase
+    - RepUnitPhrase
+    - RepUnitsPhrase
+    - RepThisUnitPhrase
+    - RepTheNestPhrase
+    - RepTheHivePhrase
+# Verbs
+    - RepArePhrase
+    - RepIsPhrase
+    - RepWillPhrase
+    - RepNotPhrase
+    - RepLeavePhrase
+    - RepAttackPhrase
+    - RepDismantlePhrase
+    - RepConsumePhrase
+    - RepEndangerPhrase
+    - RepCeasePhrase
+    - RepSuspendPhrase
+# Alignment
+    - RepHostilePhrase
+    - RepCombatantPhrase
+    - RepNoncombatantPhrase
+    - RepAllyPhrase
+    - RepHazardousPhrase
+# Confirmation
+    - RepAffirmativePhrase
+    - RepNegativePhrase
+    - RepQueryPhrase
+    - RepQuestionMarkPhrase
 # Questions
     - WherePhrase
-    - WhoPhrase
     - WhatPhrase
     - WhyPhrase
     - HowPhrase
     - WhenPhrase
-    - WhichPhrase
-
-# Species
-- type: quickPhrase
-  id: ReplicatorOrganicPhrase
-  parent: BaseSpeciesPhrase
-  text: repli-phrase-species-organic
-
-- type: quickPhrase
-  id: ReplicatorSiliconPhrase
-  parent: BaseSpeciesPhrase
-  text: repli-phrase-species-silicon
 
 # Laws
 - type: quickPhrase
@@ -98,13 +66,141 @@
   tab: Laws
   text: law-replicator-3
 
-# Pronouns
+# Nouns
 - type: quickPhrase
-  id: WePhrase
-  parent: BaseNounsPhrase
-  text: phrase-we
+  id: RepYouPhrase
+  tab: Nouns
+  text: rep-phrase-you
 
 - type: quickPhrase
-  id: WeArePhrase
-  parent: BaseNounsPhrase
-  text: phrase-we-are
+  id: RepWePhrase
+  tab: Nouns
+  text: rep-phrase-we
+
+- type: quickPhrase
+  id: RepUnitPhrase
+  tab: Nouns
+  text: rep-phrase-unit
+
+- type: quickPhrase
+  id: RepUnitsPhrase
+  tab: Nouns
+  text: rep-phrase-units
+
+- type: quickPhrase
+  id: RepThisUnitPhrase
+  tab: Nouns
+  text: rep-phrase-i
+
+- type: quickPhrase
+  id: RepTheNestPhrase
+  tab: Nouns
+  text: rep-phrase-the-nest
+
+- type: quickPhrase
+  id: RepTheHivePhrase
+  tab: Nouns
+  text: rep-phrase-the-hive
+
+# Verbs
+- type: quickPhrase
+  id: RepArePhrase
+  tab: Verbs
+  text: rep-phrase-are
+
+- type: quickPhrase
+  id: RepIsPhrase
+  tab: Verbs
+  text: rep-phrase-is
+
+- type: quickPhrase
+  id: RepWillPhrase
+  tab: Verbs
+  text: rep-phrase-will
+
+- type: quickPhrase
+  id: RepNotPhrase
+  tab: Verbs
+  text: rep-phrase-not
+
+- type: quickPhrase
+  id: RepLeavePhrase
+  tab: Verbs
+  text: rep-phrase-leave
+
+- type: quickPhrase
+  id: RepAttackPhrase
+  tab: Verbs
+  text: rep-phrase-attack
+
+- type: quickPhrase
+  id: RepDismantlePhrase
+  tab: Verbs
+  text: rep-phrase-dismantle
+
+- type: quickPhrase
+  id: RepConsumePhrase
+  tab: Verbs
+  text: rep-phrase-consume
+
+- type: quickPhrase
+  id: RepEndangerPhrase
+  tab: Verbs
+  text: rep-phrase-endanger
+
+- type: quickPhrase
+  id: RepCeasePhrase
+  tab: Verbs
+  text: rep-phrase-cease
+
+- type: quickPhrase
+  id: RepSuspendPhrase
+  tab: Verbs
+  text: rep-phrase-suspend
+
+# Confirmation
+- type: quickPhrase
+  id: RepAffirmativePhrase
+  tab: Confirmation
+  text: rep-phrase-affirmative
+
+- type: quickPhrase
+  id: RepNegativePhrase
+  tab: Confirmation
+  text: rep-phrase-negative
+
+- type: quickPhrase
+  id: RepQueryPhrase
+  tab: Confirmation
+  text: rep-phrase-query
+
+- type: quickPhrase
+  id: RepQuestionMarkPhrase
+  tab: Confirmation
+  text: rep-phrase-questionmark
+
+# Alignment
+- type: quickPhrase
+  id: RepHostilePhrase
+  tab: Alignment
+  text: rep-phrase-hostile
+
+- type: quickPhrase
+  id: RepCombatantPhrase
+  tab: Alignment
+  text: rep-phrase-combatant
+
+- type: quickPhrase
+  id: RepNoncombatantPhrase
+  tab: Alignment
+  text: rep-phrase-noncombatant
+
+- type: quickPhrase
+  id: RepAllyPhrase
+  tab: Alignment
+  text: rep-phrase-ally
+
+- type: quickPhrase
+  id: RepHazardousPhrase
+  tab: Alignment
+  text: rep-phrase-hazardous


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Replicator nests now count items in stacks properly. One stack of 30 is worth (equivalent to) 3 points. 
- tweak: It is now harder for Replicators to make sexual innuendo. Sorry, folks.
- tweak: Replicator Nests now preserve mechs. 

