### PR TITLE
Security EMP grenades

### DIFF
--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_armory.yml
@@ -67,3 +67,13 @@
   cost: 7500
   category: cargoproduct-category-name-armory
   group: market
+
+- type: cargoProduct
+  id: ArmoryEMP
+  icon:
+    sprite: Objects/Weapons/Grenades/empgrenade.rsi
+    state: icon
+  product: CrateArmoryEMP
+  cost: 6000
+  category: cargoproduct-category-name-armory
+  group: market

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/armory.yml
@@ -96,7 +96,6 @@
   description: Contains three electro-disruptor EMP grenades. Requires Armory access to open.
   components:
   - type: StorageFill
-    contents: 
+    contents:
     - id: EMPGrenadeSecurity
       amount: 3
-    

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/armory.yml
@@ -88,3 +88,15 @@
       amount: 2
     - id: MagazinePistolSubMachineGun
       amount: 4
+
+- type: entity
+  id: CrateArmoryEMP
+  parent: [ CrateWeaponSecure, BaseSecurityContraband ]
+  name: electro-disruptor EMP crate
+  description: Contains three electro-disruptor EMP grenades. Requires Armory access to open.
+  components:
+  - type: StorageFill
+    contents: 
+    - id: EMPGrenadeSecurity
+      amount: 3
+    

--- a/Resources/Prototypes/_Impstation/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Weapons/Throwable/grenades.yml
@@ -39,3 +39,20 @@
           params:
             volume: 5
       - type: ExplodeOnTrigger
+
+- type: entity
+  name: electro-disruptor
+  description: The official NT branded solution to robotic problems. Despite the fancy name it's actually just a cheap knock off of an EMP grenade.
+  parent: [GrenadeBase, BaseSecurityContraband]
+  id: EMPGrenadeSecurity
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Grenades/empgrenade.rsi
+  - type: EmpOnTrigger
+    range: 2.5
+    energyConsumption: 20000
+  - type: DeleteOnTrigger
+  - type: Appearance
+  - type: TimerTriggerVisuals
+    primingSound:
+      path: /Audio/Effects/countdown.ogg


### PR DESCRIPTION
Added the electro-disruptor, a fancy name for what is just a worse EMP grenade. It has less than half the radius and only drains 20000 power instead of 50000 so it doesn't fully deplete APCs. Currently the only way to obtain it is through cargo, 6000 for a crate of 3. It's also security contraband.

This was made specifically for replicators but it's still effective versus borgs. I can see it being an issue for assault borgs but crew has to actually buy and fetch the nades from the ATS so it's not always going to be available. Antagonists can also use it against security but I don't think it'll make that much of a difference, it isn't instant like the implant is and the small radius means security can scatter to avoid it. Spending the 6000 on a gun is almost always going to be a better idea in my opinion.

It doesn't have its own sprite because I'm terrible at sprite work and it inflicts psychic damage on me. I'd like to get one soon but for now I think a placeholder for something like this is okay. Also I'm half expecting this to be reverted in a week anyways.

**Changelog**
:cl:
- add: Added the electro-disruptor, an EMP grenade that can be purchased through cargo. It sucks, but it does the job! (custom sprite coming soon)