### PR TITLE
Change lawyer secoff playtime requirement to security playtime requirement, adjust secoff requirements and sec cadet lockout to be more in-line with other roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -6,9 +6,14 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 36000 # 10 hrs, imp
-    - !type:RoleTimeRequirement # imp
-      role: JobSecurityOfficer
-      time: 7200 #2 hrs
+    #imp edit start, substitute secoff playtime with sec playtime, better match upstream intent
+    #- !type:RoleTimeRequirement
+    #  role: JobSecurityOfficer
+    #  time: 7200 #2 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hrs
+    #imp edit end,
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -8,7 +8,7 @@
       time: 36000 #10 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 108000 #30 hrs
+      time: 54000 #15 hrs, imp
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 36000 #10 hrs, imp
+      time: 14400 #4 hrs, imp
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
Upstream recently added a 2.5 hour Security Office playtime requirement to Lawyer as a means of ensuring players have a familiarity with space law before they can start being a gadfly to Security about it. I thought this was fine, until I looked a little further into it and realized our Secoff and Cadet requirements and lockouts are *drastically* different than on Wizden. This PR changes the 2 hours of Secoff playtime requirement to 5 hours of Security playtime requirement (essentially 5 hours of Sec Cadet) to better match the expected playtime investment from upstream.

Additionally, adjusts Secoff requirements and Cadet lockout to be more like other departmental jobs. Currently, Sec Cadet locks out after **30 hours** of playtime, which is frankly absurd and double the playtime lockout of any other intern role of 15 hours (which... is still pretty high). Intern roles are meant to signify that someone is still new to a department and offer a dedicated role slot to give them an opportunity to learn, 15 hours is ample time for this. 

To go with this, the Secoff playtime requirement has been reduced to 4 hours of Security playtime to match other baseline departmental jobs. Currently it is 10 hours, but an upstream change reduced it to 2.5 as a part of an initiative to reduce playtime requirements across the board so people feel less of a compulsion to grind out playtimes and play the game to an unhealthy degree. Broadly, this is a position I agree with, but I feel like an appropriate compromise would be to make the requirement more consistent with other jobs.

For reference, here are playtime requirements upstream compared to ours:

Cadet:
10 hours overall -> 10 hours overall (unchanged)
5 hours Security lockout -> 15 hours Security lockout

Officer:
2.5 hours Security -> 4 hours Security

Lawyer:
2.5 hours Security Officer -> 5 hours Security


**Changelog**
:cl:
- tweak: Lawyer's Security Officer playtime requirement has been modified to be 5 hours of departmental Security playtime
- tweak: Security Cadet lockout and Security Officer playtime requirements have been adjusted to be more in-line with other departmental jobs.
