### PR TITLE
Makes foam grenades fast again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -462,8 +462,8 @@
   - type: OnUseTimerTrigger
     delay: 5
   - type: SmokeOnTrigger
-    duration: 10
-    spreadAmount: 20
+    duration: 2 # imp 10 -> 2
+    spreadAmount: 5 #imp 20 ->5
     smokePrototype: AluminiumMetalFoam
   - type: StaticPrice
     price: 350


### PR DESCRIPTION
either upstream un-changed these, or the numbers got changed unintentionally at some point, either way, they are fast again instead of being Slow
**Changelog**
:cl:
- tweak: Metal Foam grenades are now fast acting again! better for smaller breaches rather than a very large area