### PR TITLE
Make landmines spawn on debris again, make scrap now spawn on them

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -411,13 +411,16 @@
       children:
       - id: MobCarpSalvage
         weight: 2
-      - !type:AllSelector
+      # imp edit begin, remove scrap spawn trolling
+      - id: LandMineExplosive
         weight: 1
-        children:
-        #- id: LandMineExplosive #imp. die
-        - !type:NestedSelector # what's that thing underneath the scrap?
-          prob: 0.33
-          tableId: SalvageScrapSpawnerCommon
+      #- !type:AllSelector
+      #  weight: 1
+      #  children:
+      #  - id: LandMineExplosive
+      #  - !type:NestedSelector # what's that thing underneath the scrap?
+      #    prob: 0.33
+      #    tableId: SalvageScrapSpawnerCommon
     - !type:GroupSelector # scary monsters
       weight: 5
       children:


### PR DESCRIPTION
The PR for removing landmines was put out and merged in a rush with the main reason for removal being that they can spawn under debris, making them harder to notice. This PR removes the chance of scrap spawning on top of them. 

Salvage should be a dangerous job, and land mines add a threat that can't just be addressed by floating off grid to cheese mob AI. Landmines add a threat that can be avoided by being more deliberate with your movement and paying attention to your surroundings (right clicking on a pile of items shows you everything in that pile!) and further encourages salvage players actively working together so that they can help each other back to the station if they get hurt. There is a PR merged upstream to make is so the blinking light on their sprite is unshaded and will show up through darkness, so they will be more noticeable once we're updated to have that.

**Changelog**
:cl:
- add: Landmines once again spawn on debris, but scrap cannot spawn on top of them.

