### PR TITLE
oppas and dragons have expressions for real this time it's real it's real

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -205,6 +205,9 @@
         type: StrippableBoundUserInterface
   - type: Hands # imp. don't worry, they don't actually have hands.
   - type: ComplexInteraction # imp. necessary for them to be able to use the pinpointer. This doesn't do much else for them, except I think they can now open crates.
+  - type: Emoting #imp. Let them emote
+  - type: BodyEmotes #imp
+    soundsId: GeneralBodyEmotes #imp
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/oppa.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/oppa.yml
@@ -164,6 +164,9 @@
     radius: 1.1
     energy: 2
 #fixing vocal
+  - type: Emoting
+  - type: BodyEmotes
+    soundsId: GeneralBodyEmotes
   - type: Speech
     speechSounds: Squeak
     speechVerb: SmallMob


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
![image](https://github.com/user-attachments/assets/77601fd6-ab34-4de0-a04d-bc49457b4692)
![image](https://github.com/user-attachments/assets/19c4cf94-94fe-4dec-93f8-a1307114f0c6)
my previous oppa fix was a lie, because it turns out spawning an entity is different than ghostrolling an entity emoteswise. this gives oppas and dragons the ability to emote.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: oppas and dragons can now make hand signals