### PR TITLE
Early merge Wizden #38041 Fix reinforced plasma window blocking laser shots

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -55,17 +55,6 @@
       sprite: Structures/Windows/cracks.rsi
   - type: StaticPrice
     price: 132
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.5,-0.5,0.5,0.5"
-        mask:
-        - FullTileMask
-        layer:
-        - WallLayer
-        density: 2000
 
 - type: entity
   id: PlasmaReinforcedWindowDirectional


### PR DESCRIPTION
Early merges https://github.com/space-wizards/space-station-14/pull/38041 to fix emitters not being able to fire through reinforced plasma windows. Simple yaml change

**Changelog**
:cl: ScarKy0
- fix: Reinforced plasma windows no longer block laser shots.

