### PR TITLE
Caseless Availability

### DIFF
--- a/Resources/Locale/en-US/_Impstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Impstation/store/uplink-catalog.ftl
@@ -34,6 +34,9 @@ uplink-bloodredrosekit-desc = A set of roses for the romantic killer to get clos
 uplink-saw-ammo-name = Ammunition box (.20 rifle)
 uplink-saw-ammo-desc = A box of 50 cartridges compatible with the L6 Nidhogg light machine gun. Doesn't come with any ammo boxes, load it yourself!
 
+uplink-caseless-ammo-name = Ammunition box (.25 caseless)
+uplink-caseless-ammo-desc = A box of 50 cartridges compatible with the Basilisk-11 and the Cobra. Doesn't come with any magazines, load it yourself!
+
 uplink-mixed-rejects-name = Dan's Soaked Smokes Rejects
 uplink-mixed-rejects-desc = Dan worked with Interdyne chemistry to dispose of excess chemicals, ENJOY CAUTIOUSLY.
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
@@ -3,7 +3,7 @@
   parent: BaseItem
   id: BaseMagazineBoxCaselessRifle
   name: ammunition box (.25 caseless)
-  description: A box made for 60 rounds of .25 caseless ammunition. #imp
+  description: A box made for 50 rounds of .25 caseless ammunition. #imp
   components:
   - type: BallisticAmmoProvider
     mayTransfer: true
@@ -11,7 +11,7 @@
       tags:
         - CartridgeCaselessRifle
     proto: CartridgeCaselessRifle
-    capacity: 60
+    capacity: 50 #imp
   - type: Item
     size: Small
   - type: ContainerContainer
@@ -72,7 +72,7 @@
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifle
   name: ammunition box (.25 caseless)
-  description: A box made for 60 rounds of .25 caseless ammunition, labeled as live-fire bullets. #imp
+  description: A box made for 50 rounds of .25 caseless ammunition, labeled as live-fire bullets. #imp
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifle
@@ -87,7 +87,7 @@
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRiflePractice
   name: ammunition box (.25 caseless practice)
-  description: A box made for 60 rounds of .25 caseless ammunition, labeled as practice bullets. #imp
+  description: A box made for 50 rounds of .25 caseless ammunition, labeled as practice bullets. #imp
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRiflePractice

--- a/Resources/Prototypes/_Impstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/uplink_catalog.yml
@@ -58,6 +58,16 @@
   - UplinkAmmo
 
 - type: listing
+  id: UplinkCaselessAmmo
+  name: uplink-caseless-ammo-name
+  description: uplink-caseless-ammo-desc
+  productEntity: MagazineBoxCaselessRifle
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkAmmo
+
+- type: listing
   id: UplinkBulletcatcher
   name: uplink-bulletcatcher-name
   description: uplink-bulletcatcher-desc

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless.yml
@@ -1,0 +1,25 @@
+- type: entity
+  id: MagazinePistolCaselessRifleEmpty
+  name: "pistol magazine (.25 caseless any)"
+  description: A 10-round .25 caseless pistol magazine with no apparent markings.
+  parent: BaseMagazinePistolCaselessRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: null
+    capacity: 10
+  - type: MagazineVisuals
+    magState: mag
+    steps: 6
+    zeroVisible: false
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left-mag
+      right:
+      - state: inhand-right-mag

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/dmr.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/dmr.yml
@@ -132,3 +132,17 @@
     magState: mag
     steps: 7
     zeroVisible: false
+
+- type: entity
+  id: MagazineBREmpty
+  name: "magazine (.25 caseless any)"
+  description: A 24-round .25 caseless battle rifle magazine, with no apparent markings.
+  parent: MagazineBR
+  components:
+  - type: BallisticAmmoProvider
+    proto: null
+    capacity: 24
+  - type: MagazineVisuals
+    magState: mag
+    steps: 7
+    zeroVisible: false

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
@@ -20,3 +20,8 @@
   recipes:
   - CombatKnife
   - RiotShield
+  - MagazineCobraEmpty
+  - MagazineCobra
+  - MagazineBasiliskEmpty
+  - MagazineBasilisk
+  - MagazineBoxCaseless

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/ammo.yml
@@ -1,0 +1,34 @@
+- type: latheRecipe
+  parent: BaseEmptyAmmoRecipe
+  id: MagazineCobraEmpty
+  result: MagazinePistolCaselessRifleEmpty
+  materials:
+    Steel: 25
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineCobra
+  result: MagazinePistolCaselessRifle
+  materials:
+    Steel: 185
+
+- type: latheRecipe
+  parent: BaseEmptyAmmoRecipe
+  id: MagazineBasiliskEmpty
+  result: MagazineBREmpty
+  materials:
+    Steel: 25
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineBasilisk
+  result: MagazineBR
+  materials:
+    Steel: 409
+
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBoxCaseless
+  result: MagazineBoxCaselessRifle
+  materials:
+    Steel: 800


### PR DESCRIPTION
One of the most frequent complaints I will hear regarding syndicate guns is that the Basilisk just runs out of ammo too quickly. I also wasn't a big fan of the ability to buy a Basilisk magazine for 2 telecrystals for the better ammo-economy to transfer to the Cobra magazines. So I took a page from the L6 SAW's playbook and added a box of .25 caseless to the uplink catalogue. I've also added .25 caseless stuffs to the list of items that can be printed from an emagged autolathe. This should help ease the burden of a gun that otherwise will just run out of ammo and stay out of ammo if you don't have any TC-- a pretty dramatic downside that's had no compensating upside to it.

**Changelog**
:cl:
- add: You can now purchase a box of .25 Caseless bullets for 2 telecrystals.
- add: You can now print .25 Caseless magazines and bullets from emagged autolathes.
