### PR TITLE
M-1 Recharge Change

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -982,11 +982,9 @@
   - type: Battery
     maxCharge: 1200
     startingCharge: 1200
-  - type: BatterySelfRecharger
+  - type: BatterySelfRecharger #imp removed the recharge pause but made the recharge even slower
     autoRecharge: true
-    autoRechargeRate: 24
-    autoRechargePause: true
-    autoRechargePauseTime: 30
+    autoRechargeRate: 18.5 #imp
 #imp edit begin; weapon melee
   - type: MeleeWeapon
     attackRate: 0.6

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -984,6 +984,9 @@
     startingCharge: 1200
   - type: BatterySelfRecharger #imp removed the recharge pause but made the recharge even slower
     autoRecharge: true
+   # autoRechargeRate: 24
+   # autoRechargePause: true
+   # autoRechargePauseTime: 30
     autoRechargeRate: 18.5 #imp
 #imp edit begin; weapon melee
   - type: MeleeWeapon


### PR DESCRIPTION
There's a pretty strong sentiment that the recharge on the M-1 just does not feel good. The 30 second wait is pretty extreme on top of already taking 50 seconds to get from empty to full-- compared to the Antique Laser that has no recharge delay and goes from 0 to full in 25 seconds, and after some discussion on the 'cord these were the numbers that were agreed upon-- but are still open to discussion. Removed the 30 second pause of the M-1's recharge but reduced the recharge rate from 24 to 18.5. Overall time to get from totally empty to full goes from 85 seconds to 65 seconds.

**Changelog**
:cl:
- tweak: The M-1 Energy Shotgun doesn't need to wait 30 seconds to recharge anymore, but recharges a bit slower.
