### PR TITLE
Fx secret reinforced door recipe name

### DIFF
--- a/Resources/Locale/en-US/_Impstation/recipes/recipes.ftl
+++ b/Resources/Locale/en-US/_Impstation/recipes/recipes.ftl
@@ -1,0 +1,2 @@
+recipes-reinforced-secret-door-name = secret door (reinforced)
+recipes-reinforced-secret-door-desc = A secret door disguised as a reinforced wall. The perfect solution for hiding your shady dealings.

--- a/Resources/Prototypes/_Impstation/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Construction/structures.yml
@@ -38,6 +38,8 @@
 
 - type: construction
   id: SecretReinf
+  name: recipes-reinforced-secret-door-name
+  description: recipes-reinforced-secret-door-desc
   graph: SecretReinf
   startNode: start
   targetNode: reinfSecretDoor


### PR DESCRIPTION
Adds two locale strings so secret reinforced doors appear distinct from the reinforced wall in the construction menu.

![xK9m2mv](https://github.com/user-attachments/assets/861f55fa-e1d5-49f0-ad01-d2334c64fcbd)

**Changelog**
:cl:
- fix: Fixed reinforced secret doors not appearing in the construction menu properly.
