### PR TITLE
PSA changes

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/security.yml
@@ -39,6 +39,7 @@
   recipes:
   - PRIbarPlusConversionKit
   - ClothingEyesNightVisionSecurityGoggles
+  - PortableSensorArray
 
 - type: latheRecipePack
   id: SecurityAmmoImp

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/devices.yml
@@ -5,5 +5,5 @@
   materials:
     Steel: 500
     Glass: 100
-    Plasma: 050
+    Silver: 010
     Gold: 010


### PR DESCRIPTION
Nobody's really used this thing since I added it, with availability being probably the biggest. I considered buffing the stats but in the end I decided adjusting how easy it is to make and get one to use should be tested first. I've adjusted the crafting price, still requiring gold and now silver too, though not much, and definitely by the point that this is considered there should be plenty of both anyways. It only uses 1/10th of a bar of each. I also added the recipe to the security lathe pack, but kept it in the science one because... let's be honest, until Ninjas get better objectives that have them going into other departments more scientists will probably want this little device to warn them.

**Changelog**
:cl:
- tweak: The Portable Sensor Array can be manufactured at the Security Techfab alongside the protolathe with a cost adjustment.
