### PR TITLE
Replicator Bugfixes + Balance

### DIFF
--- a/Content.Shared/_Impstation/Replicator/ReplicatorComponent.cs
+++ b/Content.Shared/_Impstation/Replicator/ReplicatorComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class ReplicatorComponent : Component
     /// The duration for which a replicator of this type will be stunned upon recieving an EMP effect.
     /// </summary>
     [DataField]
-    public TimeSpan EmpStunTime = TimeSpan.FromSeconds(10);
+    public TimeSpan EmpStunTime = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// If a replicator is Queen, it will spawn a nest when it spawns.

--- a/Content.Shared/_Impstation/Replicator/ReplicatorNestComponent.cs
+++ b/Content.Shared/_Impstation/Replicator/ReplicatorNestComponent.cs
@@ -57,7 +57,7 @@ public sealed partial class ReplicatorNestComponent : Component
     /// Is multiplied by the current level.
     /// </summary>
     [DataField]
-    public int BonusPointsHumanoid = 20;
+    public int BonusPointsHumanoid = 0; // currently trying out setting this to 0, to discourage violence outside of self defense
     /// <summary>
     /// The number of points required to spawn a new replicator.
     /// Increases linearly with the number of unclaimed ghostroles.

--- a/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
+++ b/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
@@ -143,6 +143,7 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
         if (TryComp<StackComponent>(tripper, out var stackComp))
         {
             ent.Comp.TotalPoints += stackComp.Count;
+            ent.Comp.SpawningProgress += stackComp.Count;
         }
 
         // you get a bonus point if the item is Large, 2 bonus points if it's Huge, and 3 bonus points if it's above that.
@@ -155,7 +156,7 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
             else if (_item.GetSizePrototype(itemComp.Size) >= _item.GetSizePrototype("Ginormous"))
                 ent.Comp.TotalPoints += 30;
             // regardless, items only net 1 spawning progress.
-            ent.Comp.SpawningProgress++;
+            ent.Comp.SpawningProgress += 10;
         }
 
         // if it wasn't an item and was anchorable, you get 3 bonus points.

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-loadout.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-loadout.yml
@@ -133,7 +133,8 @@
     animation: WeaponArcSlash
     damage:
       types:
-        Blunt: 30
+        Blunt: 22
+        Shock: 8 # split up damage groups to make them a little more effective against armored/blunt resistant targets
         Structural: 45
   - type: Unremoveable
   - type: Prying

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
@@ -188,9 +188,6 @@
     - ActionReplicatorUpgrade2
     - ActionReplicatorUpgrade2Alt
   - type: CombatMode
-  - type: Puller
-    needsHands: false
-    applySpeedModifier: false
   - type: StaminaDamageOnHit
     damage: 20
     sound: /Audio/Weapons/egloves.ogg
@@ -249,9 +246,6 @@
     upgradeActions:
     - ActionReplicatorUpgrade3
     readyToUpgradeMessage: replicator-upgrade-t2
-  - type: Puller
-    needsHands: false
-    applySpeedModifier: false
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
     baseSprintSpeed: 4.2
@@ -301,9 +295,6 @@
     upgradeActions:
     - ActionReplicatorUpgrade3
     readyToUpgradeMessage: replicator-upgrade-t2
-  - type: Puller
-    needsHands: false
-    applySpeedModifier: false
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
     baseSprintSpeed: 4.2
@@ -351,9 +342,6 @@
   - type: CombatMode
   - type: Replicator
     upgradeStage: 2
-  - type: Puller
-    needsHands: false
-    applySpeedModifier: false
   - type: MovementAlwaysTouching
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
@@ -8,6 +8,9 @@
   abstract: true
   parent: PlayerSiliconBase
   components:
+  - type: Puller
+    needsHands: false
+    applySpeedModifier: false
   - type: ZombieImmune
   - type: Replicator
   - type: NameIdentifier
@@ -153,7 +156,7 @@
       path: /Audio/Items/crowbar.ogg
   - type: NpcFactionMember
     factions:
-    - SimpleHostile
+    - Replicator
   - type: Inventory
     templateId: replicator
   - type: InventorySlots
@@ -248,6 +251,7 @@
     readyToUpgradeMessage: replicator-upgrade-t2
   - type: Puller
     needsHands: false
+    applySpeedModifier: false
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
     baseSprintSpeed: 4.2
@@ -299,6 +303,7 @@
     readyToUpgradeMessage: replicator-upgrade-t2
   - type: Puller
     needsHands: false
+    applySpeedModifier: false
   - type: MovementSpeedModifier
     baseWalkSpeed: 2 # same as slime
     baseSprintSpeed: 4.2

--- a/Resources/Prototypes/_Impstation/GameRules/replicator_event.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/replicator_event.yml
@@ -7,9 +7,9 @@
   components:
   - type: StationEvent
     earliestStart: 20
-    weight: 6.5
+    weight: 5.5
     duration: null
-    minimumPlayers: 25
+    minimumPlayers: 30
     maxOccurrences: 1
   - type: RandomSpawnRule
     prototype: SpawnPointGhostReplicatorQueen

--- a/Resources/Prototypes/_Impstation/ai_factions.yml
+++ b/Resources/Prototypes/_Impstation/ai_factions.yml
@@ -24,3 +24,24 @@
 # Initial infected should be ignored by zombies
 - type: npcFaction
   id: InitialInfectedIgnore
+
+- type: npcFaction
+  id: Replicator
+  hostile:
+  - NanoTrasen
+  - Dragon
+  - Mouse
+  - Passive
+  - PetsNT
+  - SimpleHostile
+  - SimpleNeutral
+  - Syndicate
+  - Xeno
+  - Zombie
+  - Revolutionary
+  - Wizard
+  - Xenoborg
+  - Changeling
+  - Heretic
+  - Dino
+  - Penguin


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Replicators no longer get points or levelup progress from humanoids. They still provide enough spawning progress for a new ghostrole, however. 
- tweak: Reduced the amount of time Replicators are stunned by EMPs.
- tweak: Gave Replicators their own faction, meaning they should now be counted as hostile by carp and rats.
- tweak: Adjusted Replicator Tier 2 pulling speeds.
- tweak: Adjusted Replicator Tier 3 damage.
- tweak: Increased minimum playercount and decreased event weight for the ReplicatorSpawn event.
- fix: Fixed Replicator Nests incorrectly assigning spawning progress to certain items. Stacked items should now contribute to spawning more ghostroles.
