### PR TITLE
thaven ion storm functionality

### DIFF
--- a/Content.Server/Silicons/Laws/IonStormSystem.cs
+++ b/Content.Server/Silicons/Laws/IonStormSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events; // imp add
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Dataset;
@@ -59,13 +60,22 @@ public sealed class IonStormSystem : EntitySystem
     [ValidatePrototypeId<DatasetPrototype>]
     private const string Foods = "IonStormFoods";
 
+    // imp add start
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SiliconLawBoundComponent, IonStormEvent>(IonStormTarget);
+    }
+    // imp add end
+
     /// <summary>
     /// Randomly alters the laws of an individual silicon.
     /// </summary>
-    public void IonStormTarget(Entity<SiliconLawBoundComponent, IonStormTargetComponent> ent, bool adminlog = true)
+    public void IonStormTarget(Entity<SiliconLawBoundComponent> ent, ref IonStormEvent args) // imp edit, its an event subscription now
     {
-        var lawBound = ent.Comp1;
-        var target = ent.Comp2;
+        var lawBound = ent.Comp; // imp
+        EnsureComp<IonStormTargetComponent>(ent, out var target); // imp
         if (!_robustRandom.Prob(target.Chance))
             return;
 
@@ -152,7 +162,7 @@ public sealed class IonStormSystem : EntitySystem
         }
 
         // adminlog is used to prevent adminlog spam.
-        if (adminlog)
+        if (args.Adminlog) // imp edit
             _adminLogger.Add(LogType.Mind, LogImpact.High, $"{ToPrettyString(ent):silicon} had its laws changed by an ion storm to {laws.LoggingString()}");
 
         // laws unique to this silicon, dont use station laws anymore

--- a/Content.Server/Silicons/Laws/StartIonStormedSystem.cs
+++ b/Content.Server/Silicons/Laws/StartIonStormedSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.StationEvents.Events; // imp
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -28,7 +29,11 @@ public sealed class StartIonStormedSystem : EntitySystem
 
         for (int currentIonStorm = 0; currentIonStorm < ent.Comp.IonStormAmount; currentIonStorm++)
         {
-            _ionStorm.IonStormTarget((ent.Owner, lawBound, target), false);
+            // begin imp edit
+            // _ionStorm.IonStormTarget((ent.Owner, lawBound, target), false);
+            var ev = new IonStormEvent(false);
+            RaiseLocalEvent(ent, ref ev);
+            // end imp edit
         }
 
         var laws = _siliconLaw.GetLaws(ent.Owner, lawBound);

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -1,4 +1,4 @@
-using Content.Server.Silicons.Laws;
+// using Content.Server.Silicons.Laws; imp remove
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.Laws.Components;
@@ -8,7 +8,7 @@ namespace Content.Server.StationEvents.Events;
 
 public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 {
-    [Dependency] private readonly IonStormSystem _ionStorm = default!;
+    // [Dependency] private readonly IonStormSystem _ionStorm = default!; // imp remove
 
     protected override void Started(EntityUid uid, IonStormRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -17,14 +17,26 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
         if (!TryGetRandomStation(out var chosenStation))
             return;
 
-        var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
-        while (query.MoveNext(out var ent, out var lawBound, out var xform, out var target))
+        // begin imp edit, why tf wasnt this all just an event
+        // var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
+        var query = EntityQueryEnumerator<TransformComponent, IonStormTargetComponent>();
+        while (query.MoveNext(out var ent, out var xform, out _))
+        // end imp edit
         {
             // only affect law holders on the station
             if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station != chosenStation)
                 continue;
-
-            _ionStorm.IonStormTarget((ent, lawBound, target));
+            // begin imp edit again
+            var ev = new IonStormEvent();
+            RaiseLocalEvent(ent, ref ev);
+            //     _ionStorm.IonStormTarget((ent, lawBound, target));
         }
     }
 }
+
+// imp add
+/// <summary>
+/// Event raised on an entity with <see cref="IonStormTargetComponent"/> when an ion storm occurs on the attached station.
+/// </summary>
+[ByRefEvent]
+public record struct IonStormEvent(bool Adminlog = true);

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -19,8 +19,8 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 
         // begin imp edit, why tf wasnt this all just an event
         // var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
-        var query = EntityQueryEnumerator<TransformComponent, IonStormTargetComponent>();
-        while (query.MoveNext(out var ent, out var xform, out _))
+        var query = EntityQueryEnumerator<IonStormTargetComponent, TransformComponent>();
+        while (query.MoveNext(out var ent, out _, out var xform))
         // end imp edit
         {
             // only affect law holders on the station

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -2,9 +2,9 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using Content.Server.Chat.Systems;
-using Content.Server.Ghost;
 using Content.Server.Light.Components;
 using Content.Server.Singularity.Components;
+using Content.Server.StationEvents.Events;
 using Content.Shared._EE.CCVar;
 using Content.Shared._EE.Supermatter.Components;
 using Content.Shared._Impstation.Thaven.Components;
@@ -710,21 +710,22 @@ public sealed partial class SupermatterSystem
 
         foreach (var mob in mobLookup)
         {
+            // Scramble thaven moods
+            if (TryComp<ThavenMoodsComponent>(mob, out var moods))
+                _moods.RefreshMoods((mob, moods));
+
             // Scramble laws for silicons, then ignore other effects
             if (TryComp<SiliconLawBoundComponent>(mob, out var law))
             {
                 var target = EnsureComp<IonStormTargetComponent>(mob); // they hit the fucking ai
                 var oldChance = target.Chance;
                 target.Chance = 1f;
-                _ionStorm.IonStormTarget((mob.Owner, law, target));
+                var ev = new IonStormEvent();
+                RaiseLocalEvent(mob, ref ev);
                 target.Chance = oldChance; // hacky fucking code. whatever. don't look at me
 
                 continue;
             }
-
-            // Scramble thaven moods
-            if (TryComp<ThavenMoodsComponent>(mob, out var moods))
-                _moods.RefreshMoods((mob, moods));
 
             // Add effects to all mobs
             // TODO: change paracusia to actual hallucinations whenever those are real

--- a/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
+++ b/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Shared._Impstation.CCVar;
 using Robust.Shared.Audio.Systems;
+using Content.Server.StationEvents.Events;
 
 namespace Content.Server._Impstation.Thaven;
 
@@ -58,6 +59,7 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
         SubscribeLocalEvent<ThavenMoodsComponent, ComponentShutdown>(OnThavenMoodShutdown);
         SubscribeLocalEvent<ThavenMoodsComponent, ToggleMoodsScreenEvent>(OnToggleMoodsScreen);
         SubscribeLocalEvent<ThavenMoodsComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
+        SubscribeLocalEvent<ThavenMoodsComponent, IonStormEvent>(OnIonStorm);
         SubscribeLocalEvent<RoundRestartCleanupEvent>((_) => NewSharedMoods());
     }
 
@@ -393,8 +395,14 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
         AddWildcardMood(ent);
     }
 
-    public void ThavenIonStorm(Entity<ThavenMoodsComponent> ent)
+    public void OnIonStorm(Entity<ThavenMoodsComponent> ent, ref IonStormEvent args)
     {
-        return;
+        if (!ent.Comp.IonStormable)
+            return;
+
+        if (_random.Prob(ent.Comp.IonStormWildcardChance))
+            AddWildcardMood(ent);
+        else
+            TryAddRandomMood(ent);
     }
 }

--- a/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
+++ b/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
@@ -94,7 +94,7 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
 
     private bool SharedMoodConflicts(ThavenMood mood)
     {
-        return mood.ProtoId is {} id &&
+        return mood.ProtoId is { } id &&
             (GetConflicts(_sharedMoods).Contains(id) ||
             GetMoodProtoSet(_sharedMoods).Overlaps(mood.Conflicts));
     }
@@ -323,7 +323,7 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
 
         foreach (var mood in moods)
         {
-            if (mood.ProtoId is {} id)
+            if (mood.ProtoId is { } id)
                 conflicts.Add(id); // Specific moods shouldn't be added twice
             conflicts.UnionWith(mood.Conflicts);
         }
@@ -349,7 +349,7 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
         _moodProtos.Clear();
         foreach (var mood in moods)
         {
-            if (mood.ProtoId is {} id)
+            if (mood.ProtoId is { } id)
                 _moodProtos.Add(id);
         }
 
@@ -391,5 +391,10 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
             return;
 
         AddWildcardMood(ent);
+    }
+
+    public void ThavenIonStorm(Entity<ThavenMoodsComponent> ent)
+    {
+        return;
     }
 }

--- a/Content.Shared/_Impstation/Thaven/ThavenMoodsComponent.cs
+++ b/Content.Shared/_Impstation/Thaven/ThavenMoodsComponent.cs
@@ -28,6 +28,18 @@ public sealed partial class ThavenMoodsComponent : Component
     public bool CanBeEmagged = true;
 
     /// <summary>
+    /// Whether to allow ion storms to add a random mood.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool IonStormable = true;
+
+    /// <summary>
+    /// The probability that an ion storm will pull a mood from the wildcard dataset.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float IonStormWildcardChance = 0.2f;
+
+    /// <summary>
     /// Notification sound played if your moods change.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
@@ -12,6 +12,7 @@
     sprite: _Impstation/Mobs/Species/Thaven/parts.rsi # Unlike dwarves elves are NOT made of slime
     state: full
   - type: ThavenMoods
+  - type: IonStormTarget
   - type: Respirator
     damage:
       types:


### PR DESCRIPTION
recent conversations around thaven moods reminded me that on their conception they were planned to have ion storm functionality and that just never happened. so when i coded it :>

currently theres an arbitrary 20% chance to pull a wildcard / emag mood, i just made this number up arbitrarily. otherwise it'll just pull a normal mood. it also doesnt have a maximum so hypothetically you could just keep getting new moods forever, but i dont think ion storms roll naturally enough for that to be an issue.

https://github.com/user-attachments/assets/780aad4e-a675-4c84-9c05-cde6e6dc43bd

pulled the implementation outta my ass, as always feel free to suggest different ways this could work

this also includes a minor }soap refactor to how ion storms work to allow them to apply to ANY entity, not just silicons. already shot a pr for this upstream, so this might end up being an early merge if that goes through. but i talked to beck t from wizden and they said doing this seemed fine so yay!

**Changelog**
:cl:
- add: Thaven are now vulnerable to Ion Storms.
