### PR TITLE
she randomweight on my markingprototype till i randomhumanoidcharacterappearance

### DIFF
--- a/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
@@ -67,7 +67,6 @@ public sealed class RandomHumanoidAppearanceSystem : EntitySystem
             _metaData.SetEntityName(uid, profile.Name);
     }
 
-    // imp add
     private List<Marking> MarkingsToAdd(Dictionary<string, List<Color>> dict)
     {
         List<Marking> output = [];

--- a/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
@@ -29,8 +29,9 @@ public sealed class RandomHumanoidAppearanceSystem : EntitySystem
         }
 
         var profile = HumanoidCharacterProfile.RandomWithSpecies(humanoid.Species);
-        var appearance = profile.Appearance;
+        var appearance = profile.Appearance; // imp
 
+        // imp edits start
         List<Marking> markings;
         if (component.Markings != null)
             markings = MarkingsToAdd(component.Markings);
@@ -59,11 +60,14 @@ public sealed class RandomHumanoidAppearanceSystem : EntitySystem
         .WithGender(component.Gender ?? profile.Gender);
 
         _humanoid.LoadProfile(uid, finalProfile, humanoid);
+        // imp edits end
+
 
         if (component.RandomizeName)
             _metaData.SetEntityName(uid, profile.Name);
     }
 
+    // imp add
     private List<Marking> MarkingsToAdd(Dictionary<string, List<Color>> dict)
     {
         List<Marking> output = [];

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -1,10 +1,8 @@
 ﻿using System.Linq;
-using System.Text.RegularExpressions;
-using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Humanoid.Prototypes;
-using Content.Shared.Random;
-using Content.Shared.Random.Helpers;
+using Content.Shared.Random; // imp
+using Content.Shared.Random.Helpers; // imp
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -227,20 +227,18 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
             // if it's facial hair, there are entries in the category, and the character is not female, assign a random one. else bald
             if (category == MarkingCategories.FacialHair)
             {
-                newFacialHairStyle = markings.Keys.Any() || sex == Sex.Female ? HairStyles.DefaultFacialHairStyle : markingWeights.Pick(random);
+                newFacialHairStyle = markings.Count == 0 || sex == Sex.Female ? HairStyles.DefaultFacialHairStyle : markingWeights.Pick(random);
             }
 
             // if it's hair, and there are hair styles, roll one. else bald
             else if (category == MarkingCategories.Hair)
             {
-                newHairStyle = markings.Keys.Any() ? markingWeights.Pick(random) : HairStyles.DefaultHairStyle;
+                newHairStyle = markings.Count == 0 ? HairStyles.DefaultHairStyle : markingWeights.Pick(random);
             }
 
             // for every other category,
             else if (markings.Keys.Any())
             {
-                MarkingPrototype? lastMarking = null;
-
                 // get the amount of points available in the marking category.
                 var markingSet = new MarkingSet();
                 if (proto.TryIndex(species, out SpeciesPrototype? speciesProto))
@@ -255,14 +253,14 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                         continue;
 
                     // pick a random marking from the list
-                    if (!markings.TryGetValue(markingWeights.Pick(random), out var protoToAdd))
+                    var randomMarking = markingWeights.Pick(random);
+                    if (!markings.TryGetValue(randomMarking, out var protoToAdd))
                         continue;
                     var markingToAdd = protoToAdd.AsMarking();
                     Color markingColor;
 
-                    // prevent duplicates:
-                    if (lastMarking != null && lastMarking == protoToAdd)
-                        continue;
+                    // prevent duplicates
+                    markingWeights.Weights.Remove(randomMarking);
 
                     // set gauze to white.
                     // side note, I really hate that gauze isn't its own category. please fix that so that i can make this not suck as much.
@@ -271,7 +269,6 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                     {
                         markingToAdd.SetColor(Color.White);
                         newMarkings.Add(markingToAdd);
-                        lastMarking = protoToAdd;
                         continue;
                     }
 
@@ -287,7 +284,6 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
 
                     // otherwise, add it to the final list.
                     newMarkings.Add(markingToAdd);
-                    lastMarking = protoToAdd;
                 }
             }
         }

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -217,10 +217,11 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
             // grab a dictionary of markings in that category for that species,
             var markings = markingManager.MarkingsByCategoryAndSpecies(category, species);
 
-            // and make a new weightedrandomprototype that stores the string of the marking and the corresponding random weight.
+            // and make a new dictionary that stores the string of the marking and the corresponding random weight.
             var markingWeights = new Dictionary<string, float>();
             foreach (var marking in markings)
                 markingWeights.Add(marking.Key, marking.Value.RandomWeight);
+
 
             // grab the markingset from our category..
             var markingSet = new Dictionary<MarkingCategories, MarkingPoints>();
@@ -252,6 +253,10 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                 // this will roll once for each point in the marking category.
                 for (var i = 0; i < categorySet.Points; i++)
                 {
+                    // just in case there are somehow more points than markings
+                    if (markingWeights.Count == 0)
+                        continue;
+
                     // category roll to see if we add anything
                     if (!random.Prob(categorySet.Weight))
                         continue;

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -235,14 +235,14 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
             // if it's facial hair, there are entries in the category, and the character is not female, roll & assign a random one. else bald
             if (category == MarkingCategories.FacialHair)
             {
-                newFacialHairStyle = markings.Count == 0 || sex == Sex.Female || random.Prob(categorySet.Weight) ?
+                newFacialHairStyle = markings.Count == 0 || sex == Sex.Female || !random.Prob(categorySet.Weight) ?
                     HairStyles.DefaultFacialHairStyle : random.Pick(markingWeights);
             }
 
             // if it's hair, and there are hair styles, roll one. else bald
             else if (category == MarkingCategories.Hair)
             {
-                newHairStyle = markings.Count == 0 || random.Prob(categorySet.Weight) ?
+                newHairStyle = markings.Count == 0 || !random.Prob(categorySet.Weight) ?
                     HairStyles.DefaultHairStyle : random.Pick(markingWeights);
             }
 

--- a/Content.Shared/Humanoid/Markings/MarkingPoints.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPoints.cs
@@ -47,7 +47,8 @@ public sealed partial class MarkingPoints
                 Points = points.Points,
                 Required = points.Required,
                 OnlyWhitelisted = points.OnlyWhitelisted,
-                DefaultMarkings = points.DefaultMarkings
+                DefaultMarkings = points.DefaultMarkings,
+                Weight = points.Weight // imp
             };
         }
 

--- a/Content.Shared/Humanoid/Markings/MarkingPoints.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPoints.cs
@@ -13,6 +13,17 @@ public sealed partial class MarkingPoints
     [DataField(required: true)]
     public bool Required;
 
+    // imp add
+    /// <summary>
+    /// Chance for a randomly generated entity to spawn with a marking in this category.
+    /// </summary>
+    /// <remarks>
+    /// Does one roll for each point- eg. at 2 points with a .6 weight,
+    /// you have a 16% chance of no marking, a 48% chance of one marking and a 36% chance of two markings.
+    /// </remarks>
+    [DataField]
+    public float Weight = 0.6f;
+
     /// <summary>
     ///     If the user of this marking point set is only allowed to
     ///     use whitelisted markings, and not globally usable markings.

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -80,8 +80,15 @@ namespace Content.Shared.Humanoid.Markings
             return new Marking(ID, Sprites.Count);
         }
 
+        // imp add
+        /// <summary>
+        /// Chance this marking will be added by appearance randomizer.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 1.
+        /// </remarks>
         [DataField]
-        public float RandomWeight = 0.2f;
+        public float RandomWeight = 1f;
 
     }
 }

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Humanoid.Markings
 {
-    [Prototype("marking")] // Floof
+    [Prototype] // Floof
     public sealed partial class MarkingPrototype : IPrototype
     {
         [IdDataField]
@@ -42,8 +42,8 @@ namespace Content.Shared.Humanoid.Markings
         [DataField("sprites", required: true)]
         public List<SpriteSpecifier> Sprites { get; private set; } = default!;
 
-        [DataField("shader")]
-        public string? Shader { get; private set; } = null;
+        [DataField]
+        public string? Shader { get; private set; } = null; // imp
 
         /// <summary>
         /// Allows specific images to be put into any arbitrary layer on the mob.
@@ -55,7 +55,7 @@ namespace Content.Shared.Humanoid.Markings
         /// e.g. "tail-cute-vulp" -> "tail-back", "tail-cute-vulp-oversuit" -> "tail-oversuit"
         /// also, FLOOF ADD =3
         /// </summary>
-        [DataField("layering")]
+        [DataField]
         public Dictionary<string, string>? Layering { get; private set; }
 
         /// <summary>
@@ -72,13 +72,17 @@ namespace Content.Shared.Humanoid.Markings
         /// cooltail-oversuit. Easy huh?
         /// also, FLOOF ADD =3
         /// </summary>
-        [DataField("colorLinks")]
+        [DataField]
         public Dictionary<string, string>? ColorLinks { get; private set; }
 
         public Marking AsMarking()
         {
             return new Marking(ID, Sprites.Count);
         }
+
+        [DataField]
+        public float RandomWeight = 0.2f;
+
     }
 }
 

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -52,7 +52,7 @@ public sealed partial class MarkingSet
     public Dictionary<MarkingCategories, MarkingPoints> Points = new();
 
     public MarkingSet()
-    {}
+    { }
 
     /// <summary>
     ///     Construct a MarkingSet using a list of markings, and a points
@@ -557,6 +557,26 @@ public sealed partial class MarkingSet
                 marking = m;
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    // imp add
+    /// <summary>
+    /// Finds the random weight of a marking category
+    /// </summary>
+    /// <param name="category">The category to search.</param>
+    /// <param name="weight">The float weight of the category.</param>
+    /// <returns></returns>
+    public bool TryGetWeight(MarkingCategories category, out float weight)
+    {
+        weight = 0f;
+
+        if (Points.TryGetValue(category, out var points))
+        {
+            weight = points.Weight;
+            return true;
         }
 
         return false;

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -52,7 +52,7 @@ public sealed partial class MarkingSet
     public Dictionary<MarkingCategories, MarkingPoints> Points = new();
 
     public MarkingSet()
-    { }
+    {}
 
     /// <summary>
     ///     Construct a MarkingSet using a list of markings, and a points

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -562,26 +562,6 @@ public sealed partial class MarkingSet
         return false;
     }
 
-    // imp add
-    /// <summary>
-    /// Finds the random weight of a marking category
-    /// </summary>
-    /// <param name="category">The category to search.</param>
-    /// <param name="weight">The float weight of the category.</param>
-    /// <returns></returns>
-    public bool TryGetWeight(MarkingCategories category, out float weight)
-    {
-        weight = 0f;
-
-        if (Points.TryGetValue(category, out var points))
-        {
-            weight = points.Weight;
-            return true;
-        }
-
-        return false;
-    }
-
     /// <summary>
     ///     Shifts a marking's rank towards the front of the list
     /// </summary>

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -52,6 +52,7 @@
     Hair:
       points: 1
       required: false
+      weight: 1 # imp
     FacialHair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -52,6 +52,7 @@
     Hair:
       points: 1
       required: false
+      weight: 1 # imp
     FacialHair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -53,6 +53,7 @@
     Hair:
       points: 1
       required: false
+      weight: 1 # imp
     FacialHair:
       points: 1
       required: false

--- a/Resources/Prototypes/_Impstation/Species/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Species/kodepiia.yml
@@ -63,6 +63,7 @@
     Arms:
       points: 1
       required: true
+      weight: 1
       defaultMarkings: [ KodeWingsBlade ]
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_Impstation/Species/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Species/kodepiia.yml
@@ -45,6 +45,7 @@
     Hair:
       points: 1
       required: false
+      weight: 0.3
     Tail:
       points: 2
       required: false

--- a/Resources/Prototypes/_Impstation/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Species/thaven.yml
@@ -48,6 +48,7 @@
     Hair:
       points: 1
       required: false
+      weight: 1
     HeadTop:
       points: 4
       required: false

--- a/Resources/Prototypes/_NF/Species/goblin_species.yml
+++ b/Resources/Prototypes/_NF/Species/goblin_species.yml
@@ -39,6 +39,7 @@
     Hair:
       points: 1
       required: false
+      weight: 1 # imp
     HeadTop:
       points: 1
       required: true


### PR DESCRIPTION
if i go too many months without touching up randomhumanoidcharacterappearance i start turning into one of the gremlins from gremlins.

this pr adds optional marking weights to randomhumanoidcharacterappearance, for both individual markings and for categories.
what you can do with this:
- make ultra-rare ghost role markings
- make super-common ghost role markings
- thats about it tbh but listen. the randomize appearance button is my beautiful baby. i love her

i know doop was keen to use ghostrole marking rarities for reapers, so with this pr that'll be possible.

as part of this, i also edited the kodepiia marking yaml to guarantee that the randomizer would always roll arms, since previously there was a 2/3 chance they would get stuck with the default marking. heres a video proof of concept to demonstrate.

current randomizer:

https://github.com/user-attachments/assets/699ab389-1ea2-47fc-9d39-316466a36248

new randomizer (i also set square eyes weight to 10 to demonstrate individual marking weights):

https://github.com/user-attachments/assets/1c0e73ae-a3fc-46e3-9597-f8170b22888b

:cl:
- tweak: Random character appearances have gotten even zanier.
