### PR TITLE
Add a disclaimer to the records tab in character creation

### DIFF
--- a/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
+++ b/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
@@ -3,6 +3,10 @@
     <BoxContainer Orientation="Vertical">
          <ScrollContainer VerticalExpand="True">
              <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="10">
+                 <!-- RP disclaimer, imp edit -->
+                 <BoxContainer Orientation="Vertical">
+                     <Label Name="RecordsDisclaimer" Text="{Loc 'humanoid-profile-editor-cd-records-disclaimer'}" Align="Center" VAlign="Center" HorizontalExpand="True" FontColorOverride="Yellow"/>
+                 </BoxContainer>
                  <!-- Height, Weight -->
                  <GridContainer Columns="2">
                      <BoxContainer HorizontalExpand="True" SeparationOverride="2">

--- a/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
+++ b/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
@@ -4,9 +4,7 @@
          <ScrollContainer VerticalExpand="True">
              <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="10">
                  <!-- RP disclaimer, imp edit -->
-                 <BoxContainer Orientation="Vertical">
-                     <Label Name="RecordsDisclaimer" Text="{Loc 'humanoid-profile-editor-cd-records-disclaimer'}" Align="Center" VAlign="Center" HorizontalExpand="True" FontColorOverride="Yellow"/>
-                 </BoxContainer>
+                 <RichTextLabel Name="RecordsDisclaimer" Text="{Loc 'humanoid-profile-editor-cd-records-disclaimer'}" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalExpand="True"/>
                  <!-- Height, Weight -->
                  <GridContainer Columns="2">
                      <BoxContainer HorizontalExpand="True" SeparationOverride="2">

--- a/Resources/Locale/en-US/_CD/records/editor.ftl
+++ b/Resources/Locale/en-US/_CD/records/editor.ftl
@@ -1,6 +1,9 @@
 # Records editor
 humanoid-profile-editor-cd-records-tab = Records
 
+#imp edit, disclaimer
+humanoid-profile-editor-cd-records-disclaimer = Character records are optional, both writing and reading them. Their usage is a fun RP treat, and not a game mechanic.
+
 # General
 humanoid-profile-editor-cd-records-height = Height (cm):
 humanoid-profile-editor-cd-records-weight = Weight (kg):

--- a/Resources/Locale/en-US/_CD/records/editor.ftl
+++ b/Resources/Locale/en-US/_CD/records/editor.ftl
@@ -2,7 +2,7 @@
 humanoid-profile-editor-cd-records-tab = Records
 
 #imp edit, disclaimer
-humanoid-profile-editor-cd-records-disclaimer = Character records are optional, both writing and reading them. Their usage is a fun RP treat, and not a game mechanic.
+humanoid-profile-editor-cd-records-disclaimer = [color=yellow]Character records are optional, both writing and reading them. Their usage is a fun RP treat, and not a game mechanic.[/color]
 
 # General
 humanoid-profile-editor-cd-records-height = Height (cm):


### PR DESCRIPTION
adds a disclaimer at the top of the records tab to clarify that they're for RP use only. this is my first time messing with UI stuff so please tell me if i did this in a weird way. also open to rewriting the disclaimer, but i want to make it clear that reading records is completely optional.

![image](https://github.com/user-attachments/assets/aa7f3fd5-af3e-4c9d-ac5c-587600790557)


:cl:
- tweak: Added a disclaimer to the character records menu.

