### PR TITLE
thaven are now affected by gas

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -86,9 +86,6 @@
         - !type:OrganType
           type: Vox
           shouldHave: false
-        - !type:OrganType #imp, thaven lungs don't do chemical reactions
-          type: Thaven
-          shouldHave: false
         ratios:
           CarbonDioxide: 1.0
           Oxygen: -1.0
@@ -144,10 +141,6 @@
           types:
             Poison:
               1
-        conditions: #imp
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
       - !type:Oxygenate #imp, thaven can breathe all gases safely
         conditions:
         - !type:OrganType
@@ -158,9 +151,6 @@
         conditions:
           - !type:ReagentThreshold
             min: 1.5
-          - !type:OrganType #imp, thaven can breathe all gases safely
-            type: Thaven
-            shouldHave: false
         clear: True
         time: 5
   reactiveEffects:
@@ -201,10 +191,6 @@
           types:
             Radiation:
               1
-        conditions: #imp
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
       - !type:Oxygenate #imp, thaven can breathe all gases safely
         conditions:
         - !type:OrganType
@@ -215,9 +201,6 @@
         conditions:
           - !type:ReagentThreshold
             min: 1.5
-          - !type:OrganType #imp, thaven can breathe all gases safely
-            type: Thaven
-            shouldHave: false
         clear: True
         time: 5
 
@@ -267,9 +250,6 @@
           type: Thaven
       - !type:HealthChange
         conditions:
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
         - !type:OrganType
           type: Plant
           shouldHave: false
@@ -290,9 +270,6 @@
         conditions:
         - !type:OrganType
           type: Plant
-          shouldHave: false
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
           shouldHave: false
         factor: -4
       # We need a metabolism effect on reagent removal
@@ -375,9 +352,6 @@
         - !type:OrganType
           type: Slime
           shouldHave: false
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
         emote: Laugh
         showInChat: true
         probability: 0.1
@@ -389,9 +363,6 @@
         - !type:OrganType
           type: Slime
           shouldHave: false
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
         emote: Scream
         showInChat: true
         probability: 0.01
@@ -402,9 +373,6 @@
           min: 0.5
         - !type:OrganType
           type: Slime
-          shouldHave: false
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
           shouldHave: false
         type: Local
         visualType: Medium
@@ -418,9 +386,6 @@
         - !type:OrganType
           type: Slime
           shouldHave: false
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
       - !type:GenericStatusEffect
@@ -430,9 +395,6 @@
           min: 1.8
         - !type:OrganType
           type: Slime
-          shouldHave: false
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
           shouldHave: false
         key: ForcedSleep
         component: ForcedSleeping
@@ -445,9 +407,6 @@
           min: 3.5
         - !type:OrganType
           type: Slime
-          shouldHave: false
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
           shouldHave: false
         ignoreResistances: true
         damage:
@@ -508,9 +467,6 @@
         - !type:ReagentThreshold
           reagent: Frezon
           min: 0.5
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -540,9 +496,6 @@
         - !type:ReagentThreshold
           reagent: Frezon
           min: 0.5
-        - !type:OrganType #imp, thaven can breathe all gases safely
-          type: Thaven
-          shouldHave: false
       - !type:PopupMessage
         type: Local
         visualType: Medium

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -36,10 +36,18 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions: #imp, thaven are immune to carpotoxin because it's naturally in their bodies
+        - !type:OrganType
+          type: Thaven
+          shouldHave: false
         damage:
           types:
             Poison: 4
       - !type:PopupMessage
+        conditions: #imp, thaven are immune to carpotoxin because it's naturally in their bodies
+        - !type:OrganType
+          type: Thaven
+          shouldHave: false
         type: Local
         visualType: MediumCaution
         messages: [ "generic-reagent-effect-burning-insides" ]

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -36,18 +36,10 @@
     Poison:
       effects:
       - !type:HealthChange
-        conditions: #imp, thaven are immune to carpotoxin because it's naturally in their bodies
-        - !type:OrganType
-          type: Thaven
-          shouldHave: false
         damage:
           types:
             Poison: 4
       - !type:PopupMessage
-        conditions: #imp, thaven are immune to carpotoxin because it's naturally in their bodies
-        - !type:OrganType
-          type: Thaven
-          shouldHave: false
         type: Local
         visualType: MediumCaution
         messages: [ "generic-reagent-effect-burning-insides" ]

--- a/Resources/ServerInfo/_Impstation/Guidebook/Mobs/Thaven.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/Mobs/Thaven.xml
@@ -22,7 +22,7 @@
   Thaven hand-to-hand martial arts have a focus on inflicting non-permanent damage. As a result, [color=#ffa500]their unarmed attacks are slow, and deal no damage,[/color] but [color=#1e90ff]cause a fair amount of stun buildup.[/color]
 
 ## Breathing
-   Due to sharing a common ancestor with space carp, Thaven lungs are strange, resilient organs that generate energy from the motion of respiration alone. As such, [color=#1e90ff]Thaven can safely breathe any kind of atmosphere,[/color] though unlike their genetic lineage, [color=#ffa500]they're still vulnerable to asphyxiation and barotrauma.[/color]
+   Due to sharing a common ancestor with space carp, Thaven lungs are strange, resilient organs that generate energy from the motion of respiration alone. As such, [color=#1e90ff]Thaven are immune to asphyxiation,[/color] so long as there is something to breathe.
 
 ## Damage
   Due to their relatively fragile bone structure and unique nervous system, they take [color=#ffa500]10% more damage from blunt, slash, pierce, and genetic, and 20% more damage from radiation,[/color] but their unique ancestry allows them to take [color=#1e90ff]10% less damage from heat, cold, and poison.[/color]


### PR DESCRIPTION
this pr removes thaven immunity to carpotoxin, and modifies how their lungs interact with harmful gases. the basic intention is to bring the gameplay balance of thaven more in line with the rest of our species. here is my reasoning

- this is an all upsides species, with the primary intended downside being the rp-oriented moods mechanic. moods in practice have not really functioned as a downside and act more as player prompts. in line with that reasoning this pr removes one minor upside and nerfs one major upside.
- the original pitch for thaven lungs was that they need to be in _a_ pressurized environment, with the details of the gasses pressurizing it being less strict than other species. this pr brings the mechanic in line with the original intent. this means you can still have your thaven stink room, and can additionally hang out in water vapor and nitrogen break rooms without negative consequences, but can no longer frezon bomb a room without also getting hit with it (rip eorg)
- no other species is immune to the reagents in their own organs, except kodepiia, who i intentionally coded that way because it matches their cannibalistic identity. grays famously have radioactive blood and are not immune to radiation. species that cannot digest uncooked proteins (humans, dwarves, snails, vox) cannot eat their own organs. notably there is [an extensively documented real life disease that comes from cannibalism](https://en.wikipedia.org/wiki/Kuru_(disease)).

**Changelog**
:cl:
- tweak: Thaven can get high on nitrous, but it still doesn't choke them.
