### PR TITLE
Laying down forces you to drop what you're carrying

### DIFF
--- a/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
@@ -141,7 +141,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         return true;
     }
 
-    public bool TryLieDown(EntityUid uid, LayingDownComponent? layingDown = null, StandingStateComponent? standingState = null, DropHeldItemsBehavior behavior = DropHeldItemsBehavior.AlwaysDrop, bool isIntentional = false)
+    public bool TryLieDown(EntityUid uid, LayingDownComponent? layingDown = null, StandingStateComponent? standingState = null, DropHeldItemsBehavior behavior = DropHeldItemsBehavior.AlwaysDrop, bool isIntentional = false) //Imp edit, NoDrop -> AlwaysDrop
     {
         if (!Resolve(uid, ref standingState, false) ||
             !Resolve(uid, ref layingDown, false) ||

--- a/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_Goobstation/Standing/SharedLayingDownSystem.cs
@@ -141,7 +141,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         return true;
     }
 
-    public bool TryLieDown(EntityUid uid, LayingDownComponent? layingDown = null, StandingStateComponent? standingState = null, DropHeldItemsBehavior behavior = DropHeldItemsBehavior.NoDrop, bool isIntentional = false)
+    public bool TryLieDown(EntityUid uid, LayingDownComponent? layingDown = null, StandingStateComponent? standingState = null, DropHeldItemsBehavior behavior = DropHeldItemsBehavior.AlwaysDrop, bool isIntentional = false)
     {
         if (!Resolve(uid, ref standingState, false) ||
             !Resolve(uid, ref layingDown, false) ||


### PR DESCRIPTION
very small change, and this PR is mostly just to get a discussion going. my ideal would be that you can't hold anything at all while laying down, but I don't know how to do that (i'm a lowly yaml warrior). my reasoning is basically that I think it's lame that gunfights can be determined by whoever chooses to press R first, it doesn't feel like an actual cool skillful thing, it's just pressing a button to stop bullets from hitting you. I'm aware that bullets CAN hit people that are laying down, but I've noticed this doesn't always work, and when it doesn't work it feels bad. I'm open to hearing people's thoughts, maybe people really like this! It's just something I personally do not enjoy.
![dotnet_0ggUvzGCp7](https://github.com/user-attachments/assets/eaef57c0-13a0-4b2d-b452-33783cfa4a16)


- tweak: Laying down makes you drop what you're carrying now.

