### PR TITLE
Add a delay to equipping/unequipping hardsuits.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -119,6 +119,9 @@
   - type: HeldSpeedModifier
   - type: Item
     size: Ginormous
+  - type: Clothing #imp edit
+    equipDelay: 2
+    unequipDelay: 2
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -120,6 +120,8 @@
   - type: Item
     size: Ginormous
   - type: Clothing #imp edit
+    equipSound: /Audio/Mecha/mechmove03.ogg
+    unequipSound: /Audio/Mecha/mechmove03.ogg
     equipDelay: 2
     unequipDelay: 2
   - type: Armor

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -649,6 +649,8 @@
     sprite: _Impstation/Clothing/OuterClothing/Hardsuits/syndicate_juggernaut.rsi #imp edit
   - type: Clothing
     sprite: _Impstation/Clothing/OuterClothing/Hardsuits/syndicate_juggernaut.rsi #imp edit
+    equipDelay: 5 #imp edit
+    unequipDelay: 5 #imp edit
   - type: PressureProtection
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -649,8 +649,10 @@
     sprite: _Impstation/Clothing/OuterClothing/Hardsuits/syndicate_juggernaut.rsi #imp edit
   - type: Clothing
     sprite: _Impstation/Clothing/OuterClothing/Hardsuits/syndicate_juggernaut.rsi #imp edit
-    equipDelay: 5 #imp edit
-    unequipDelay: 5 #imp edit
+    equipSound: /Audio/Mecha/mechmove03.ogg #imp edit start
+    unequipSound: /Audio/Mecha/mechmove03.ogg
+    equipDelay: 5
+    unequipDelay: 5 #imp edit end
   - type: PressureProtection
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000


### PR DESCRIPTION
Inspired by a conversation in suggestions, this adds a small delay to equipping and unequipping hardsuits. They're big and bulky, it only makes sense! for now, basic hardsuits take 2 seconds to put on, and the juggernaut takes 5 seconds. I didn't get any granular than that because I didn't want to.
![dotnet_20Eqh4vGEm](https://github.com/user-attachments/assets/333190ab-e5cb-4157-98bc-501bb3738f80)
right now, they use the same sound that helmets make when you equip them. if anyone has a better sound please let me know!

:cl:
- tweak: Hardsuits now have a delay when equipping and unequipping them.

