### PR TITLE
gay implant

### DIFF
--- a/Resources/Locale/en-US/_Impstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Impstation/store/uplink-catalog.ftl
@@ -51,3 +51,6 @@ uplink-mascot-cindy-suit-bundle-desc = A suit in the image of Cindy, The Red Car
 
 uplink-nullrod-upgrade-name = Profane Censer
 uplink-nullrod-upgrade-desc = A vile incense burner used to transform nullrod items into more sinister forms.
+
+uplink-gay-implanter-name = Gay implanter
+uplink-gay-implanter-desc = Huh??? Why is this in here??? Is my uplink hacked??

--- a/Resources/Prototypes/_Impstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/uplink_catalog.yml
@@ -271,3 +271,21 @@
   - !type:BuyerJobCondition
     whitelist:
     - Chaplain
+
+# implanters
+
+- type: listing
+  id: UplinkGayImplanter
+  name: uplink-gay-implanter-name
+  description: uplink-gay-implanter-desc
+  icon: { sprite: /Textures/Clothing/Back/Backpacks/backpack.rsi, state: icon }
+  productEntity: GayImplanter
+  cost:
+    Telecrystal: 50
+  categories:
+  - UplinkImplants
+  conditions: # i want this to only show up in surplus crates
+  - !type:BuyerWhitelistCondition
+    whitelist:
+      components:
+      - SurplusBundle

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/implanters.yml
@@ -1,0 +1,7 @@
+﻿- type: entity
+  id: GayStorageImplanter
+  name: gay implanter
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+  - type: Implanter
+    implant: GayStorageImplant

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,33 @@
+﻿- type: entity
+  parent: BaseSubdermalImplant
+  id: GayStorageImplant
+  name: gay implant
+  description: Huh? What? Do you want us to make, like, gay implanters?
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    implantAction: ActionOpenStorageImplant
+    whitelist:
+      components:
+      - Hands # no use giving a mouse a storage implant, but a monkey is another story...
+  - type: Storage
+    grid:
+    - 0,0,0,3
+    - 0,0,2,0
+    - 0,3,2,3
+    - 2,2,2,2
+    - 4,1,4,3
+    - 6,1,6,3
+    - 5,2,5,2
+    - 5,0,5,0
+    - 9,2,9,3
+    - 8,0,8,1
+    - 10,0,10,1
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: [ ]
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface


### PR DESCRIPTION
![interdyne](https://github.com/user-attachments/assets/180ee3bf-b9e9-4bb3-9211-7fd076515978)

adds the gay implant, a storage implant with a massively extended but borderline useless grid.

![SS14 Loader_aDNAMif3oy](https://github.com/user-attachments/assets/17daf955-72cf-48ab-b089-fbf0eea55dfd) ![SS14 Loader_VQIjIJBZHe](https://github.com/user-attachments/assets/b0eace8d-5e76-4450-9fc2-a7068ce851df) 
![SS14 Loader_Dnhhfswu0n](https://github.com/user-attachments/assets/70cca1c7-5c56-41aa-94e3-49291e8bc1b0)

this is HYPOTHETICALLY only player accessible via surplus crates. however i spawned 50 super surpluses and didn't get one so either i got unlucky or i don't understand how the surplus whitelist works. either way it's a spectre haunting uplinks and is otherwise only realistically admin accessible

**Changelog**
:cl:
- add: Happy pride month from Interdyne Pharmaceuticals!
