### PR TITLE
MTLB consistency pass

### DIFF
--- a/Resources/Locale/en-US/_Impstation/bountyhunter/bountyhunter.ftl
+++ b/Resources/Locale/en-US/_Impstation/bountyhunter/bountyhunter.ftl
@@ -57,7 +57,7 @@ bounty-hunter-category-syndie-description =
 
 bounty-hunter-category-captain-name = Rogue Captain
 bounty-hunter-category-captain-description =
-    You were previously a member of NanoTrasen command.
+    You were previously a member of Nanotrasen command.
     You didn't leave on good terms.
     Includes: An armored carapace, a command encryption key,
     a cerimonial sabre, and a laser pistol.

--- a/Resources/Locale/en-US/_Impstation/datasets/mugs.ftl
+++ b/Resources/Locale/en-US/_Impstation/datasets/mugs.ftl
@@ -36,4 +36,4 @@ novelty-mugs-dataset-35 = It says: "Hardly working!".
 novelty-mugs-dataset-36 = It says: "This and some Yuri".
 novelty-mugs-dataset-37 = It says: "This and some Yaoi".
 novelty-mugs-dataset-38 = It says: "HoS: head of Sass".
-novelty-mugs-dataset-39 = It says: "Forcefem survivor".
+novelty-mugs-dataset-39 = It says: "It's pronounced Nanotrasen".

--- a/Resources/Locale/en-US/_Impstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Impstation/store/uplink-catalog.ftl
@@ -47,7 +47,7 @@ uplink-poison-injector-name = Lethal Poison Auto-Injector
 uplink-poison-injector-desc = A single dose of a lethal toxin mix, courtesy of Gorlex's Stealth Operations department, induces gradual organ failure and esophagus inflammation which eliminates a subject within one to two minutes of injection.
 
 uplink-mascot-cindy-suit-bundle-name = Cindy, the Red Chaos Cat bundle
-uplink-mascot-cindy-suit-bundle-desc = A suit in the image of Cindy, The Red Carnage Cat! Space-safe, and equipped with minimal armor to wreak maximum morale damage against those NanoTrasen dogs!
+uplink-mascot-cindy-suit-bundle-desc = A suit in the image of Cindy, The Red Carnage Cat! Space-safe, and equipped with minimal armor to wreak maximum morale damage against those Nanotrasen dogs!
 
 uplink-nullrod-upgrade-name = Profane Censer
 uplink-nullrod-upgrade-desc = A vile incense burner used to transform nullrod items into more sinister forms.

--- a/Resources/Locale/en-US/paper/paper-misc.ftl
+++ b/Resources/Locale/en-US/paper/paper-misc.ftl
@@ -52,7 +52,7 @@ book-text-agrichemkit-manual = Thank you for choosing the safe-for-all-ages Nano
       Unstable mutagen can have a wide variety of effects on plant life, including drastic changes to all sorts of growth parameters, produce full of helpful pharmaceuticals, plants that glow in the dark, or creating entirely new species.
 
       Each individual plant responds to unstable mutagen differently, so you may want to use small doses on multiple crops and try to crossbreed the best traits from each of those. Applying multiple doses to one plant can stack multiple changes and make it harder to single out desirable traits.
-      Unstable mutagen is entirely safe when used as a fertilizer, and NanoTrasen takes no responsibility for dead crops, excessive water bills, newly sentient plants asking existential questions, or flora-strangled farmhands that may coincidentally occur while using it.
+      Unstable mutagen is entirely safe when used as a fertilizer, and Nanotrasen takes no responsibility for dead crops, excessive water bills, newly sentient plants asking existential questions, or flora-strangled farmhands that may coincidentally occur while using it.
       Do not drink unstable mutagen. Wash your hands thoroughly after handling. Wash your eyes if you have looked at unstable mutagen for over 30 minutes in a 24 hour period. Store in a dark room between 293–295K. Do not use on corporate holidays. If you begin hearing voices telling you to drink unstable mutagen, please contact your doctor, head of personnel, or exorcist.
 
 

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ClothingNeckBase
   id: ClothingNeckCloakCentcom
-  name: central commander's cloak
+  name: Central Commander's cloak # imp; preferring to capitalize this for the pomp and circumstance of it
   description: A pompous and elite green cloak with a nice gold trim, tailored specifically to the Central Commander. It's so heavy, the gold trim might be real.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -132,8 +132,8 @@
 - type: entity
   parent: [ClothingOuterArmorBaseCarapace, BaseCentcommContraband]
   id: ClothingOuterArmorCentcommCarapace
-  name: centcomm carapace
-  description: An armored chestpiece that provides protection whilst still offering maximum mobility and flexibility. Issued only to centcomm officials and agents.
+  name: CentComm carapace # imp caps fix
+  description: An armored chestpiece that provides protection whilst still offering maximum mobility and flexibility. Issued only to CentComm officials and agents. # imp caps fix
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Armor/centcomm_carapace.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -304,7 +304,7 @@
     - type: Implanter
       implant: MindShieldImplant
 
-# Centcomm implanters
+# CentComm implanters # imp i'm fixing this comment so it doesn't appear on text fix passes
 
 - type: entity
   id: RadioImplanterCentcomm

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -166,7 +166,7 @@
   # end imp edits #
 
 - type: entity
-  name: hop's fountain pen
+  name: HoP's fountain pen # imp; emphasizing this is an acronym and not for some guy named hop
   parent: PenEmbeddable
   id: PenHop
   description: A luxurious fountain pen for the head of personnel of the station. Perfect for signing all those employee safety waivers. # imp edit

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -361,7 +361,7 @@
    - type: SubdermalImplant
    - type: MindShieldImplant
 
-# Centcomm implants
+# CentComm implants # imp i'm fixing this comment so it doesn't appear on text fix passes
 
 - type: entity
   parent: BaseSubdermalImplant
@@ -378,8 +378,8 @@
 - type: entity
   parent: DeathRattleImplant
   id: DeathRattleImplantCentcomm
-  name: centcomm death rattle implant
-  description: This implant will inform the Centcomm radio channel should the user fall into critical condition or die.
+  name: CentComm death rattle implant # imp caps fix
+  description: This implant will inform the CentComm radio channel should the user fall into critical condition or die. # imp caps fix
   categories: [ HideSpawnMenu ]
   components:
   - type: Rattle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -303,7 +303,7 @@
   - BaseItem
   - PowerCellSlotMediumItem
   id: WeaponTetherGun
-  description: Manipulates gravity around objects to fling them at high velocities.
+  description: You can call it the Zero-Point Energy Field Manipulator if you really want to. # imp; this thing isn't for flinging
   components:
     - type: Item
       storedRotation: -90
@@ -365,7 +365,7 @@
     - BaseItem
     - PowerCellSlotMediumItem
   id: WeaponForceGun
-  description: Manipulates gravity around objects to fling them at high velocities.
+  description: Pulls stuff, then throws stuff, probably hitting someone. # imp
   components:
     - type: Item
       storedRotation: -90
@@ -431,6 +431,7 @@
   name: grappling gun
   parent: BaseItem
   id: WeaponGrapplingGun
+  description: A gun that pulls its user towards its target. Useful for getting around while off-grid, or doing some anime shit. # imp; it seriously didn't have a description before
   components:
     - type: AmmoCounter
     - type: GrapplingGun
@@ -465,7 +466,7 @@
   parent: BaseItem
   id: WeaponTetherGunAdmin
   suffix: Admeme
-  description: Manipulates gravity around objects to fling them at high velocities.
+  description: Counter-resonant singularity device. # imp edit
   components:
     - type: TetherGun
       canTetherAlive: true
@@ -527,7 +528,7 @@
   parent: BaseItem
   id: WeaponForceGunAdmin
   suffix: Admeme
-  description: Manipulates gravity around objects to fling them at high velocities.
+  description: A gun for the admin who'll ban you forever. # imp edit
   components:
     - type: ForceGun
       canTetherAlive: true

--- a/Resources/Prototypes/Entities/Structures/Furniture/altar.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/altar.yml
@@ -31,7 +31,7 @@
 - type: entity
   id: AltarNanotrasen
   parent: AltarBase
-  name: Nanotrasen altar # imp edit; preferential to capitalizing company names
+  name: Nanotrasen altar # imp; it's Nanotrasen not Trasen
   components:
   - type: Sprite
     sprite: Structures/Furniture/Altars/Gods/nanotrasen.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/mascotcindysuit.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/mascotcindysuit.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: cindy suit
-  description: The body of Cindy, the Red Carnage Cat! Comes with armored plating to defend against Gorlex live-round birthday parties and ballpit shivs. 
+  description: The body of Cindy, the Red Carnage Cat! Comes with armored plating to defend against Gorlex live-round birthday parties and ballpit shivs.
   id: MascotCindySuit
   parent: [ ClothingOuterEVASuitBase, Tier1Contraband ]
   components:
@@ -104,8 +104,8 @@
       ░██░░░░░░░██░██░|[/head][color=gray][italic]Copies NOT available by[/color][/italic]
       [head=3]░░░░░██████░░░░░|[/color][/head][color=gray][italic]mail order.[/color][/italic]
       ===================================================
-      Hello, and congratulations! If you are reading this, you have purchased a [color=red]Cindy, the Red Carnage Cat[/color]™ Costume Kit!                                    
-      
+      Hello, and congratulations! If you are reading this, you have purchased a [color=red]Cindy, the Red Carnage Cat[/color]™ Costume Kit!
+
       Only the best and bravest of the [color=#A32D26]Gorlex Marauders[/color] are considered worthy to represent the beloved character, so take:
 
       ([color=gray][italic] A moment.[/color][/italic]                       )
@@ -114,28 +114,28 @@
       [bold]--------------------------------------------------------------------------[/bold]
       [bold]--------------------------------------------------------------------------[/bold]
       [head=3]Contents:[/head]
-      
+
       [bold][bullet/][/bold] ([italic][color=gray]1x[/italic][/color]) [color=red]Cindy, the Red Carnage Cat[/color]™ Costume Head.
-      
+
       [bold][bullet/][/bold] ([italic][color=gray]1x[/italic][/color]) [color=red]Cindy, the Red Carnage Cat[/color]™ Costume Body.
-      
+
       [bold][bullet/][/bold] ([italic][color=gray]1x[/italic][/color]) Rocket Assisted Sledgehammer.
-      
+
       [head=3]The Three [bold][head=2][color=#A32D26]DON'T[/head][/color][/bold]s of [color=red]Cindy, the Red Carnage Cat[/color]™[/head]
       [bold]--------------------------------------------------------------------------[/bold]
-      [italic][color=gray]The following guidelines dictate what Cybersun Industries customers will avoid when using [color=red]Cindy, the Red Carnage Cat[/color]™ under penalty of death.[/italic][/color] 
-      
-      [bold][head=3]1. [color=#A32D26]DON'T[/color][/bold] allow Syndicate-aligned civilians to see Cindy unless the actor is in full costume -[/head] We want to create the illusion that [color=red]Cindy, the Red Carnage Cat[/color]™ is real. 
-      
-      [bold][head=3]2. [color=#A32D26]DON'T[/color][/bold] endorse things that [color=red]Cindy, the Red Carnage Cat[/color]™ wouldn't -[/bold] Cindy is a good kitty. She wouldn't support capitalism, sobriety, NanoTrasen, the monarchy, etc. Remember - [bold][color=red]Cindy, the Red Carnage Cat[/color]™ is real.[/bold]
-      
+      [italic][color=gray]The following guidelines dictate what Cybersun Industries customers will avoid when using [color=red]Cindy, the Red Carnage Cat[/color]™ under penalty of death.[/italic][/color]
+
+      [bold][head=3]1. [color=#A32D26]DON'T[/color][/bold] allow Syndicate-aligned civilians to see Cindy unless the actor is in full costume -[/head] We want to create the illusion that [color=red]Cindy, the Red Carnage Cat[/color]™ is real.
+
+      [bold][head=3]2. [color=#A32D26]DON'T[/color][/bold] endorse things that [color=red]Cindy, the Red Carnage Cat[/color]™ wouldn't -[/bold] Cindy is a good kitty. She wouldn't support capitalism, sobriety, Nanotrasen, the monarchy, etc. Remember - [bold][color=red]Cindy, the Red Carnage Cat[/color]™ is real.[/bold]
+
       [bold][head=3]3. [color=#A32D26]DON'T[/color][/bold] allow the [color=red]Cindy, the Red Carnage Cat[/color]™ costume to fall into the wrong hands -[/bold] In the event that your station falls to enemy forces, use the included Rocket Assisted Sledgehammer to render the [color=red]Cindy, the Red Carnage Cat[/color]™ costume completely unrecognizable. [bold]Failure to do so will result in [color=#A32D26]your demise[/color][/bold].
       [bold]--------------------------------------------------------------------------[/bold]
-      [italic][color=gray]If any parts of the Cindy, the Red Carnage Cat™ Costume Kit are faulty or missing, please contact the Cybersun Mascot & Party Division using the following hyperphone number: 
+      [italic][color=gray]If any parts of the Cindy, the Red Carnage Cat™ Costume Kit are faulty or missing, please contact the Cybersun Mascot & Party Division using the following hyperphone number:
       89054378908-8568094234546-93489734786673
-      
+
       Cybersun is not liable in the event of shipment errors or wrongful death.[/italic][/color]
-      
+
               ════░░░░════
         ═════▒▒▒▒▒▒═════
         ════░░░░░░░░════
@@ -152,13 +152,13 @@
                  │░░░░░X░░░░░│
                     │░───────░│
                      │░░░│  │░░│
-                   |░░░░│  │░░░|       
+                   |░░░░│  │░░░|
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateFilledMascotCindy
   name: Cindy, the Red Carnage Cat bundle
-  description: "A suit in the image of Cindy, The Red Carnage Cat! Space safe with minimal armor to wreck maximum morale damage against the dogs of NanoTrasen!"
+  description: "A suit in the image of Cindy, The Red Carnage Cat! Space safe with minimal armor to wreck maximum morale damage against the dogs of Nanotrasen!"
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/mascotgriffysuit.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/OuterClothing/mascotgriffysuit.yml
@@ -76,9 +76,9 @@
       ░░░░██░░██░██░██░|[/head][color=gray][italic]Copies available by mail order.[/color][/italic]
       [head=3]░░░░██░░░████░███|[/color][/head]
       ===================================================
-      Hello, and congratulations! If you are reading this then your station has been selected for a [color=red]Griffy, the Sec Safety Dog[/color]™ Costume Kit!                                    
-      
-      Only the best and bravest of the [color=#A32D26]NanoTrasen Security Forces[/color] are considered worthy to represent the beloved character, so take:
+      Hello, and congratulations! If you are reading this then your station has been selected for a [color=red]Griffy, the Sec Safety Dog[/color]™ Costume Kit!
+
+      Only the best and bravest of the [color=#A32D26]Nanotrasen Security Forces[/color] are considered worthy to represent the beloved character, so take:
 
       ([color=gray][italic] Five to ten seconds at most.[/color][/italic]    )
        [bold]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/bold]
@@ -86,30 +86,30 @@
       [bold]--------------------------------------------------------------------------[/bold]
       [bold]--------------------------------------------------------------------------[/bold]
       [head=3]Contents:[/head]
-      
+
       [bold][bullet/][/bold] ([italic][color=gray]1x[/italic][/color]) [color=red]Griffy, the Sec Safety Dog[/color]™ Costume Head.
-      
+
       [bold][bullet/][/bold] ([italic][color=gray]1x[/italic][/color]) [color=red]Griffy, the Sec Safety Dog[/color]™ Costume Body.
-      
+
       [bold][bullet/][/bold] ([italic][color=gray]1x[/italic][/color]) [color=red]Griffy, the Sec Safety Dog[/color]™ PDA Device.
-      
+
       [bold][bullet/][/bold] ([italic][color=gray]1x[/italic][/color]) Rocket Assisted Sledgehammer.
-      
+
       [head=3]The Three [bold][head=2][color=#A32D26]DON'T[/head][/color][/bold]s of [color=red]Griffy, the Sec Safety Dog[/color]™[/head]
       [bold]--------------------------------------------------------------------------[/bold]
-      [italic][color=gray]The following guidelines dictate what Nanotrasen employees will avoid when using [color=red]Griffy, the Sec Safety Dog[/color]™ under penalty of law.[/italic][/color] 
-      
-      [bold][head=3]1. [color=#A32D26]DON'T[/color][/bold] allow civilians to see Griffy unless the actor is in full costume -[/head] We want to create the illusion that [color=red]Griffy, the Sec Safety Dog[/color]™ is real. 
-      
+      [italic][color=gray]The following guidelines dictate what Nanotrasen employees will avoid when using [color=red]Griffy, the Sec Safety Dog[/color]™ under penalty of law.[/italic][/color]
+
+      [bold][head=3]1. [color=#A32D26]DON'T[/color][/bold] allow civilians to see Griffy unless the actor is in full costume -[/head] We want to create the illusion that [color=red]Griffy, the Sec Safety Dog[/color]™ is real.
+
       [bold][head=3]2. [color=#A32D26]DON'T[/color][/bold] endorse things that [color=red]Griffy, the Sec Safety Dog[/color]™ wouldn't -[/bold] Griffy is a good boy. He wouldn't support crime, drugs, the Syndicate, unionization, etc. Remember - [bold][color=red]Griffy, the Sec Safety Dog[/color]™ is real.[/bold]
-      
+
       [bold][head=3]3. [color=#A32D26]DON'T[/color][/bold] allow the [color=red]Griffy, the Sec Safety Dog[/color]™ costume to fall into the wrong hands -[/bold] In the event that your station falls to enemy forces, use the included Rocket Assisted Sledgehammer to render the [color=red]Griffy, the Sec Safety Dog[/color]™ costume completely unrecognizable. [bold]Failure to do so may result in disciplinary action up to and including [color=#A32D26]capital punishment[/color][/bold].
       [bold]--------------------------------------------------------------------------[/bold]
-      [italic][color=gray]If any parts of the Griffy, the Sec Safety Dog™ Costume Kit are faulty or missing, please contact the NT Mascot & Party Division using the following hyperphone number: 
+      [italic][color=gray]If any parts of the Griffy, the Sec Safety Dog™ Costume Kit are faulty or missing, please contact the NT Mascot & Party Division using the following hyperphone number:
       89054378908-8568094234546-93489734786673
-      
-      NanoTrasen is not liable in the event of shipment errors or wrongful death.[/italic][/color]
-      
+
+      Nanotrasen is not liable in the event of shipment errors or wrongful death.[/italic][/color]
+
               ════░░░░════
         ═════▒▒▒▒▒▒═════
         ════░░░░░░░░════
@@ -126,4 +126,4 @@
                  │░░░░░X░░░░░│
                     │░───────░│
                      │░░░│  │░░│
-                   |░░░░│  │░░░|       
+                   |░░░░│  │░░░|

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/hoptart.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/hoptart.yml
@@ -140,7 +140,7 @@
 - type: entity
   parent: HopTartCookedBase
   id: HopTartCookedCentcomm
-  suffix: Centcomm
+  suffix: CentComm
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Chapel/holy_texts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Chapel/holy_texts.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: quran
-  description: Printed in both original Arabic and Nanotrasen Standard English.
+  description: Printed in both original Arabic and Galactic Common.
   parent: Bible
   id: HolyTextQuran
   components:
@@ -158,7 +158,7 @@
     sprite: _Impstation/Objects/Specific/Chapel/holytexts.rsi
     state: bibble
 
-- type: entityTable 
+- type: entityTable
   id: HolyTextEntityTable
   table: !type:GroupSelector
     children:

--- a/Resources/Prototypes/_Impstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/traitor.yml
@@ -13,7 +13,7 @@
 - type: entity
   parent: [BaseTraitorObjective, BaseKillObjective]
   id: KillRandomTraitorSvSObjective # Used for rounds when basically every valid person will be a traitor.
-  description: Do it however you like, just make sure they don't make it to centcom.
+  description: Do it however you like, just make sure they don't make it to CentComm.
   components:
   - type: Objective
     issuer: objective-issuer-syndicate


### PR DESCRIPTION
A minor update for `make text less bad`.
- Fixes some new instances of inconsistent with prior MTLB PRs.
- Gives the tether gun and force gun unique descriptions: the latter was the one that ACTUALLY flung shit, so now it's easier to tell what it's used for. (does the same for the admeme versions)
- Gives the grappling gun a description
- Fixes anglocentric flavor text on the quran; it's fairly well-established in server culture that the Nanotrasen standard language in game is "Galactic Common", not "English"
- Removes a reference to forced-feminization (per [discord discussion](https://discord.com/channels/1327800873660842097/1361301707015065800/1384892692596654100))

**Changelog**
:cl:
- tweak: Gave some non-bullet guns proper descriptions.
- fix: Nanotrasen is still spelled Nanotrasen, we just made sure.
