### PR TITLE
red glowsticks are craftable

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
@@ -5,6 +5,7 @@
   recipes:
     - UvLightTube
     - LightReplacer
+    - GlowstickRed
 
 - type: latheRecipePack
   id: ImpServiceStatic


### PR DESCRIPTION
adds red glowsticks to the service techfab and autolathe. this is an existing upstream lathe recipe that was just not accessible anywhere. i only added red glowsticks because they were the only ones that already had a recipe implemented

**Changelog**
:cl:
- tweak: Glowsticks are craftable.
