### PR TITLE
grey sec jumpskirt trim mistake finally rectified

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -714,9 +714,9 @@
   description: A tactical relic of years past before Nanotrasen decided it was cheaper to dye the suits red instead of washing out the blood.
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpskirt/security_grey.rsi
+    sprite: _Impstation/Clothing/Uniforms/Jumpskirt/security_grey.rsi #imp
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpskirt/security_grey.rsi
+    sprite: _Impstation/Clothing/Uniforms/Jumpskirt/security_grey.rsi #imp
 
 - type: entity
   parent: ClothingUniformSkirtBase


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
![image](https://github.com/user-attachments/assets/e0f047ab-2b7c-480a-80a2-7d82479487bf)
it just makes the jskirt trim match the rest of the jumpskirt's trim.
this fucking sprite change has been in the game since May 16th. i just forgot to change the yaml because i got so caught up in changing other security jumpsuits. jesus christ

**Changelog**
i'm not writing a changelong i got my ass beat
