### PR TITLE
Greencomms Removal (Kinda)

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -146,6 +146,10 @@ public sealed class RadioSystem : EntitySystem
             if (attemptEv.Cancelled)
                 continue;
 
+            // Imp original
+            if (channel.ReadOnly && HasComp<HeadsetComponent>(radioSource))
+                continue;
+
             // send the message
             RaiseLocalEvent(receiver, ref ev);
         }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -147,7 +147,7 @@ public sealed class RadioSystem : EntitySystem
                 continue;
 
             // Imp original
-            if (channel.ReadOnly && HasComp<HeadsetComponent>(radioSource))
+            if (channel.IntercomOnly && HasComp<HeadsetComponent>(radioSource))
                 continue;
 
             // send the message

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -40,6 +40,6 @@ public sealed partial class RadioChannelPrototype : IPrototype
     /// ImpStation original. If a channel is readOnly, then headsets cannot send messages through it.
     /// Intercomms still can.
     /// </summary>
-    [DataField("readOnly")]
-    public bool ReadOnly = false;
+    [DataField("intercomOnly")]
+    public bool IntercomOnly = false;
 }

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -35,4 +35,11 @@ public sealed partial class RadioChannelPrototype : IPrototype
     /// </summary>
     [DataField("longRange"), ViewVariables]
     public bool LongRange = false;
+
+    /// <summary>
+    /// ImpStation original. If a channel is readOnly, then headsets cannot send messages through it.
+    /// Intercomms still can.
+    /// </summary>
+    [DataField("readOnly")]
+    public bool ReadOnly = false;
 }

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -4,6 +4,7 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
+  readOnly: true # Imp Original
 
 - type: radioChannel
   id: CentCom

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -4,7 +4,7 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
-  readOnly: true # Imp Original
+  intercomOnly: true # Imp Original
 
 - type: radioChannel
   id: CentCom


### PR DESCRIPTION
https://github.com/user-attachments/assets/7cf81c3d-2625-4bbe-b501-edd19b41ffab

It has debated forever now, and I'm finally doing it.

Greencomms are now read-only from headsets. Intercoms are the only way to speak on Greencomms. This effectively limits commons access to people who aren't doing anything else and are in one of a few known locations, or the AI, who has mapped intercoms for everything already.

To pre-emptively address any concerns of us not being feature-ready to limit Greencomms like this, I would argue that it's impossible to decide if we're feature ready until we're in the world where we play without Greencomms. We'll find out what forms of communication we're missing in a trial by fire, and we'll _love_ it.

:cl:
Ecramox, TuttlePants
- tweak: You can no longer speak into Greencomms through a headset. Intercoms still work!
