### PR TITLE
Anti-tamper lockboxes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -498,6 +498,9 @@
         - CrateMask #this is so they can go under plastic flaps
         layer:
         - MachineLayer
+  - type: AntiTamper # imp edit
+    containers:
+      - entity_storage
 
 - type: entity
   id: CrateLockBoxEngineering


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Makes all departmental lockboxes anti-tamper, so Cargo can't PKA them open to get the goods inside (and then re-crate and sell them). Interdepartmental friction is normally fun, but right now it's too easy to Cargo to simply bypass the new lockbox system.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Department lockboxes are now equipped with anti-tamper acidifiers.