### PR TITLE
rename air scrubbers, air injectors, and air vents to use "gas"

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -163,7 +163,7 @@
 - type: entity
   parent: GasBinaryBase
   id: GasPassiveGate
-  name: passive gate
+  name: passive gas gate # imp - renamed
   description: A one-way air valve that does not require power.
   placement:
     mode: SnapgridCenter
@@ -203,7 +203,7 @@
 - type: entity
   parent: GasBinaryBase
   id: GasValve
-  name: manual valve
+  name: manual gas valve # imp - renamed
   description: A pipe with a valve that can be used to disable the flow of gas through it.
   placement:
     mode: SnapgridCenter
@@ -263,7 +263,7 @@
 - type: entity
   parent: GasBinaryBase
   id: SignalControlledValve
-  name: signal valve
+  name: signal gas valve # imp - renamed
   description: A pipe with a valve that can be controlled with signals.
   placement:
     mode: SnapgridCenter
@@ -334,7 +334,7 @@
 - type: entity
   parent: GasBinaryBase
   id: GasPort
-  name: connector port
+  name: gas connector port # imp - renamed
   description: For connecting portable devices related to atmospherics control.
   placement:
     mode: SnapgridCenter
@@ -377,7 +377,7 @@
 - type: entity
   parent: GasVentPump
   id: GasDualPortVentPump
-  name: dual-port air vent
+  name: dual-port gas vent # imp - renamed
   description: Has a valve and a pump attached to it. There are two ports, one is an input for releasing air, the other is an output when siphoning.
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -23,7 +23,7 @@
 - type: entity
   parent: [GasUnaryBase, AirSensorBase]
   id: GasVentPump
-  name: gas vent
+  name: gas vent # imp - renamed
   description: Has a valve and a pump attached to it.
   placement:
     mode: SnapgridCenter
@@ -84,7 +84,7 @@
 - type: entity
   parent: GasUnaryBase
   id: GasPassiveVent
-  name: passive gas vent
+  name: passive gas vent # imp - renamed
   description: It's an open vent.
   placement:
     mode: SnapgridCenter
@@ -119,7 +119,7 @@
 - type: entity
   parent: [GasUnaryBase, AirSensorBase]
   id: GasVentScrubber
-  name: gas scrubber
+  name: gas scrubber # imp - renamed
   description: Has a valve and pump attached to it.
   placement:
     mode: SnapgridCenter
@@ -180,7 +180,7 @@
 - type: entity
   parent: GasUnaryBase
   id: GasOutletInjector
-  name: gas injector
+  name: gas injector # imp - renamed
   description: Has a valve and pump attached to it.
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -23,7 +23,7 @@
 - type: entity
   parent: [GasUnaryBase, AirSensorBase]
   id: GasVentPump
-  name: air vent
+  name: gas vent
   description: Has a valve and a pump attached to it.
   placement:
     mode: SnapgridCenter
@@ -84,7 +84,7 @@
 - type: entity
   parent: GasUnaryBase
   id: GasPassiveVent
-  name: passive vent
+  name: passive gas vent
   description: It's an open vent.
   placement:
     mode: SnapgridCenter
@@ -119,7 +119,7 @@
 - type: entity
   parent: [GasUnaryBase, AirSensorBase]
   id: GasVentScrubber
-  name: air scrubber
+  name: gas scrubber
   description: Has a valve and pump attached to it.
   placement:
     mode: SnapgridCenter
@@ -180,7 +180,7 @@
 - type: entity
   parent: GasUnaryBase
   id: GasOutletInjector
-  name: air injector
+  name: gas injector
   description: Has a valve and pump attached to it.
   placement:
     mode: SnapgridCenter
@@ -512,4 +512,3 @@
   - type: GuideHelp
     guides:
     - GasCondensing
-


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Renamed air scrubbers, air injectors, and air vents to use "gas," in order to make the G menu slightly less annoying.
