### PR TITLE
Allow shutters and firelocks to close over SmartFridges

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/smartfridge.yml
@@ -55,7 +55,7 @@
           !type:PhysShapeAabb
           bounds: "-0.45,-0.45,0.45,0.45"
         mask:
-        - MachineMask
+        - Impassable #imp edit from MachineMask, allows shutters and firelocks to close over them
         layer:
         - MachineLayer
         density: 200


### PR DESCRIPTION
SmartFridges tend to be built into the walls, however shutters and firelocks cannot close over them, making them a spacing hazard. Thin firelocks could be mapped on the tiles adjacent to them, but changing their collision mask seemed like a less cumbersome solution.

**Changelog**
:cl:
- tweak: Firelocks and shutters can now close over SmartFridges.
