### PR TITLE
Revamped Box Atmos

### DIFF
--- a/Resources/Maps/_Impstation/box.yml
+++ b/Resources/Maps/_Impstation/box.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 261.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/27/2025 19:27:34
-  entityCount: 28169
+  time: 07/02/2025 00:45:25
+  entityCount: 28153
 maps:
 - 780
 grids:
@@ -290,7 +290,7 @@ entities:
           version: 7
         0,-4:
           ind: 0,-4
-          tiles: AQAAAAAAAFYAAAAAAQBWAAAAAAMAVgAAAAABAFYAAAAAAQBWAAAAAAAAVgAAAAAAAFYAAAAAAgBWAAAAAAIAVgAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABWAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAAAAFYAAAAAAABWAAAAAAAAVgAAAAAAAFYAAAAAAwABAAAAAAAAOgAAAAAAADoAAAAAAAA6AAAAAAAAOgAAAAAAADoAAAAAAAABAAAAAAAAVgAAAAAAAFYAAAAAAABWAAAAAAAAVgAAAAAAAFYAAAAAAQBWAAAAAAMAVgAAAAABAFYAAAAAAgBWAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFYAAAAAAwBWAAAAAAAAVgAAAAADAFYAAAAAAgBWAAAAAAEAVgAAAAABAFYAAAAAAwBWAAAAAAEAVgAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABWAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAACAFYAAAAAAwBWAAAAAAMAVgAAAAACAFYAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAVgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAQABAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAABAFYAAAAAAABWAAAAAAEAVgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAVgAAAAACAFYAAAAAAgBWAAAAAAAAVgAAAAACAFYAAAAAAwBWAAAAAAEAVgAAAAACAFYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAIAAAAAAAACAAEAAAAAAABWAAAAAAIAVgAAAAACAFYAAAAAAABWAAAAAAEAVgAAAAACAFYAAAAAAgBWAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAVgAAAAAAAFYAAAAAAQBWAAAAAAIAVgAAAAABAFYAAAAAAQBWAAAAAAMAVgAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAgABAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAABAFYAAAAAAQBWAAAAAAMAVgAAAAAAAFYAAAAAAgABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAEAAQAAAAAAAFYAAAAAAABWAAAAAAEAVgAAAAABAFYAAAAAAgBWAAAAAAEAVgAAAAABAFYAAAAAAQBWAAAAAAIAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAADAAEAAAAAAABWAAAAAAAAVgAAAAABAFYAAAAAAwBWAAAAAAMAVgAAAAABAFYAAAAAAwBWAAAAAAAAVgAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAwABAAAAAAAAAQAAAAAAAFYAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAACAAEAAAAAAAAAAAAAAAIAAQAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAABAAAAAAAAAgAVAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          tiles: AQAAAAAAAFYAAAAAAQBWAAAAAAMAVgAAAAABAFYAAAAAAQBWAAAAAAAAVgAAAAAAAFYAAAAAAgBWAAAAAAIAVgAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABWAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAAAAFYAAAAAAABWAAAAAAAAVgAAAAAAAFYAAAAAAwABAAAAAAAAOgAAAAAAADoAAAAAAAA6AAAAAAAAOgAAAAAAADoAAAAAAAABAAAAAAAAVgAAAAAAAFYAAAAAAABWAAAAAAAAVgAAAAAAAFYAAAAAAQBWAAAAAAMAVgAAAAABAFYAAAAAAgBWAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFYAAAAAAwBWAAAAAAAAVgAAAAADAFYAAAAAAgBWAAAAAAEAVgAAAAABAFYAAAAAAwBWAAAAAAEAVgAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABWAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAACAFYAAAAAAwBWAAAAAAMAVgAAAAACAFYAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAVgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAQABAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAABAFYAAAAAAABWAAAAAAEAVgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAVgAAAAACAFYAAAAAAgBWAAAAAAAAVgAAAAACAFYAAAAAAwBWAAAAAAEAVgAAAAACAFYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAIAAAAAAAACAAEAAAAAAABWAAAAAAIAVgAAAAACAFYAAAAAAABWAAAAAAEAVgAAAAACAFYAAAAAAgBWAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAVgAAAAAAAFYAAAAAAQBWAAAAAAIAVgAAAAABAFYAAAAAAQBWAAAAAAMAVgAAAAADAAEAAAAAAAA6AAAAAAAAOgAAAAAAADoAAAAAAAA6AAAAAAAAAQAAAAAAAAAAAAAAAgABAAAAAAAAVgAAAAACAFYAAAAAAgBWAAAAAAMAVgAAAAABAFYAAAAAAQBWAAAAAAMAVgAAAAAAAFYAAAAAAgABAAAAAAAAOgAAAAAAADoAAAAAAAA6AAAAAAAAOgAAAAAAAAEAAAAAAAAAAAAAAAEAAQAAAAAAAFYAAAAAAABWAAAAAAEAVgAAAAABAFYAAAAAAgBWAAAAAAEAVgAAAAABAFYAAAAAAQBWAAAAAAIAAQAAAAAAADoAAAAAAAA6AAAAAAAAOgAAAAAAADoAAAAAAAABAAAAAAAAAAAAAAADAAEAAAAAAABWAAAAAAAAVgAAAAABAFYAAAAAAwBWAAAAAAMAVgAAAAABAFYAAAAAAwBWAAAAAAAAVgAAAAABAAEAAAAAAAA6AAAAAAAAOgAAAAAAADoAAAAAAAA6AAAAAAAAAQAAAAAAAAAAAAAAAwABAAAAAAAAAQAAAAAAAFYAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAACAAEAAAAAAAAAAAAAAAIAAQAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAABAAAAAAAAAgAVAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
           version: 7
         2,-3:
           ind: 2,-3
@@ -730,21 +730,19 @@ entities:
             4154: -9,-73
             4159: 11,-78
             4162: -8,-73
-            4170: 15,-53
-            4171: 15,-52
             4172: -5,-77
             4173: -4,-77
             4174: 3,-77
             4175: 2,-77
-            4180: 15,-51
-            4181: 19,-51
-            4182: 19,-52
-            4183: 19,-53
             4214: -58,-11
             4215: -58,-10
             4216: -58,-9
             4945: -13,39
             4949: -8,56
+            4960: 16,-53
+            4962: 16,-54
+            4963: 18,-53
+            4964: 18,-54
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
@@ -2507,7 +2505,6 @@ entities:
             1052: -40,-31
             1053: -41,-30
             1054: -42,-25
-            1249: 11,-53
             1250: 6,-49
             1251: 7,-48
             1252: -1,-42
@@ -3910,7 +3907,6 @@ entities:
             4573: -6,37
             4574: -5,37
             4575: -4,37
-            4576: -4,38
             4577: -4,39
             4578: -4,40
             4579: -4,41
@@ -4740,7 +4736,6 @@ entities:
             4478: 17,21
             4479: 18,21
             4564: -4,37
-            4565: -4,38
             4566: -4,39
             4567: -4,40
             4568: -4,41
@@ -5719,9 +5714,6 @@ entities:
             4086: 21,-19
             4087: 21,-18
             4088: 21,-17
-            4184: 13,-53
-            4185: 13,-52
-            4186: 13,-51
             4198: 7,-85
             4199: 7,-84
             4200: 7,-83
@@ -6542,7 +6534,8 @@ entities:
           2,-10:
             0: 57584
           2,-13:
-            0: 63627
+            0: 63491
+            2: 8
           2,-11:
             0: 61166
           2,-9:
@@ -6554,7 +6547,8 @@ entities:
           3,-10:
             0: 45298
           3,-13:
-            0: 61883
+            0: 65280
+            2: 7
           4,-12:
             0: 65535
           4,-11:
@@ -6763,12 +6757,11 @@ entities:
             0: 29424
           -1,14:
             0: 41700
-            2: 16384
           0,15:
             0: 119
           -1,15:
             0: 186
-            2: 63044
+            2: 61440
           1,12:
             0: 1911
           1,13:
@@ -7606,7 +7599,8 @@ entities:
           2,-15:
             0: 48027
           2,-14:
-            0: 48059
+            0: 13107
+            2: 34944
           2,-17:
             0: 4915
           3,-16:
@@ -7615,7 +7609,7 @@ entities:
           3,-15:
             0: 65535
           3,-14:
-            0: 45567
+            2: 30576
           3,-17:
             6: 30576
           4,-16:
@@ -8238,7 +8232,7 @@ entities:
             2: 240
             0: 61440
           5,-15:
-            0: 30583
+            0: 32631
           5,-14:
             0: 30583
           6,-15:
@@ -9514,9 +9508,8 @@ entities:
       - 18754
       - 18753
       - 18752
-      - 22571
-      - 22951
-      - 22950
+      - 16651
+      - 22796
   - uid: 22589
     components:
     - type: Transform
@@ -12024,7 +12017,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -134246.5
+      secondsUntilStateChange: -138875.06
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13900,12 +13893,6 @@ entities:
     - type: Transform
       pos: -0.5,-39.5
       parent: 8364
-  - uid: 22571
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-47.5
-      parent: 8364
   - uid: 22572
     components:
     - type: Transform
@@ -15394,6 +15381,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -67.5,-9.5
       parent: 8364
+  - uid: 15504
+    components:
+    - type: Transform
+      pos: 13.5,-50.5
+      parent: 8364
   - uid: 16155
     components:
     - type: Transform
@@ -16765,6 +16757,11 @@ entities:
     - type: Transform
       pos: -10.5,41.5
       parent: 8364
+  - uid: 6312
+    components:
+    - type: Transform
+      pos: 13.5,-50.5
+      parent: 8364
   - uid: 7731
     components:
     - type: Transform
@@ -17508,6 +17505,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -16.5,49.5
       parent: 8364
+  - uid: 17052
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-50.5
+      parent: 8364
   - uid: 28167
     components:
     - type: Transform
@@ -17847,11 +17850,6 @@ entities:
     - type: Transform
       pos: -58.5,-11.5
       parent: 8364
-  - uid: 1301
-    components:
-    - type: Transform
-      pos: 25.5,-45.5
-      parent: 8364
   - uid: 1468
     components:
     - type: Transform
@@ -17861,6 +17859,11 @@ entities:
     components:
     - type: Transform
       pos: -38.5,-23.5
+      parent: 8364
+  - uid: 1477
+    components:
+    - type: Transform
+      pos: 22.5,-60.5
       parent: 8364
   - uid: 1488
     components:
@@ -17906,6 +17909,16 @@ entities:
     components:
     - type: Transform
       pos: -31.5,-28.5
+      parent: 8364
+  - uid: 1625
+    components:
+    - type: Transform
+      pos: 24.5,-56.5
+      parent: 8364
+  - uid: 1643
+    components:
+    - type: Transform
+      pos: 25.5,-42.5
       parent: 8364
   - uid: 1664
     components:
@@ -18307,10 +18320,25 @@ entities:
     - type: Transform
       pos: -20.5,-9.5
       parent: 8364
+  - uid: 3527
+    components:
+    - type: Transform
+      pos: 25.5,-43.5
+      parent: 8364
   - uid: 3681
     components:
     - type: Transform
       pos: 11.5,-74.5
+      parent: 8364
+  - uid: 3683
+    components:
+    - type: Transform
+      pos: 25.5,-44.5
+      parent: 8364
+  - uid: 3692
+    components:
+    - type: Transform
+      pos: 21.5,-60.5
       parent: 8364
   - uid: 3700
     components:
@@ -18320,12 +18348,12 @@ entities:
   - uid: 3702
     components:
     - type: Transform
-      pos: 25.5,-49.5
+      pos: 22.5,-45.5
       parent: 8364
   - uid: 3703
     components:
     - type: Transform
-      pos: 25.5,-53.5
+      pos: 23.5,-45.5
       parent: 8364
   - uid: 3705
     components:
@@ -18385,22 +18413,22 @@ entities:
   - uid: 3745
     components:
     - type: Transform
-      pos: 19.5,-41.5
+      pos: 17.5,-47.5
       parent: 8364
   - uid: 3746
     components:
     - type: Transform
-      pos: 18.5,-41.5
+      pos: 25.5,-49.5
       parent: 8364
   - uid: 3747
     components:
     - type: Transform
-      pos: 17.5,-41.5
+      pos: 16.5,-47.5
       parent: 8364
   - uid: 3748
     components:
     - type: Transform
-      pos: 17.5,-42.5
+      pos: 25.5,-47.5
       parent: 8364
   - uid: 3752
     components:
@@ -18582,10 +18610,30 @@ entities:
     - type: Transform
       pos: 2.5,-63.5
       parent: 8364
+  - uid: 4002
+    components:
+    - type: Transform
+      pos: 24.5,-45.5
+      parent: 8364
+  - uid: 4003
+    components:
+    - type: Transform
+      pos: 23.5,-56.5
+      parent: 8364
+  - uid: 4004
+    components:
+    - type: Transform
+      pos: 13.5,-59.5
+      parent: 8364
   - uid: 4005
     components:
     - type: Transform
       pos: 13.5,-77.5
+      parent: 8364
+  - uid: 4017
+    components:
+    - type: Transform
+      pos: 25.5,-48.5
       parent: 8364
   - uid: 4031
     components:
@@ -18637,15 +18685,60 @@ entities:
     - type: Transform
       pos: -7.5,-60.5
       parent: 8364
-  - uid: 4144
+  - uid: 4073
     components:
     - type: Transform
-      pos: 25.5,-43.5
+      pos: 17.5,-46.5
       parent: 8364
-  - uid: 4148
+  - uid: 4078
     components:
     - type: Transform
-      pos: 25.5,-51.5
+      pos: 21.5,-46.5
+      parent: 8364
+  - uid: 4079
+    components:
+    - type: Transform
+      pos: 17.5,-57.5
+      parent: 8364
+  - uid: 4080
+    components:
+    - type: Transform
+      pos: 17.5,-49.5
+      parent: 8364
+  - uid: 4140
+    components:
+    - type: Transform
+      pos: 17.5,-48.5
+      parent: 8364
+  - uid: 4164
+    components:
+    - type: Transform
+      pos: 20.5,-52.5
+      parent: 8364
+  - uid: 4165
+    components:
+    - type: Transform
+      pos: 26.5,-63.5
+      parent: 8364
+  - uid: 4166
+    components:
+    - type: Transform
+      pos: 26.5,-62.5
+      parent: 8364
+  - uid: 4168
+    components:
+    - type: Transform
+      pos: 26.5,-61.5
+      parent: 8364
+  - uid: 4169
+    components:
+    - type: Transform
+      pos: 17.5,-56.5
+      parent: 8364
+  - uid: 4170
+    components:
+    - type: Transform
+      pos: 17.5,-55.5
       parent: 8364
   - uid: 4212
     components:
@@ -19297,6 +19390,11 @@ entities:
     - type: Transform
       pos: -0.5,-26.5
       parent: 8364
+  - uid: 6313
+    components:
+    - type: Transform
+      pos: 17.5,-58.5
+      parent: 8364
   - uid: 6348
     components:
     - type: Transform
@@ -19852,6 +19950,11 @@ entities:
     - type: Transform
       pos: 28.5,-9.5
       parent: 8364
+  - uid: 7077
+    components:
+    - type: Transform
+      pos: 12.5,-60.5
+      parent: 8364
   - uid: 7088
     components:
     - type: Transform
@@ -19926,6 +20029,11 @@ entities:
     components:
     - type: Transform
       pos: 23.5,-0.5
+      parent: 8364
+  - uid: 7269
+    components:
+    - type: Transform
+      pos: 12.5,-61.5
       parent: 8364
   - uid: 7272
     components:
@@ -20237,10 +20345,20 @@ entities:
     - type: Transform
       pos: 27.5,-5.5
       parent: 8364
+  - uid: 8200
+    components:
+    - type: Transform
+      pos: 12.5,-62.5
+      parent: 8364
   - uid: 8201
     components:
     - type: Transform
       pos: 25.5,-0.5
+      parent: 8364
+  - uid: 8211
+    components:
+    - type: Transform
+      pos: 22.5,-62.5
       parent: 8364
   - uid: 8399
     components:
@@ -20561,6 +20679,11 @@ entities:
     components:
     - type: Transform
       pos: 3.5,26.5
+      parent: 8364
+  - uid: 8964
+    components:
+    - type: Transform
+      pos: 22.5,-61.5
       parent: 8364
   - uid: 8990
     components:
@@ -20996,6 +21119,11 @@ entities:
     components:
     - type: Transform
       pos: -14.5,55.5
+      parent: 8364
+  - uid: 9697
+    components:
+    - type: Transform
+      pos: 25.5,-56.5
       parent: 8364
   - uid: 9813
     components:
@@ -27722,6 +27850,11 @@ entities:
     - type: Transform
       pos: -53.5,5.5
       parent: 8364
+  - uid: 13813
+    components:
+    - type: Transform
+      pos: 25.5,-55.5
+      parent: 8364
   - uid: 13825
     components:
     - type: Transform
@@ -29575,7 +29708,7 @@ entities:
   - uid: 15130
     components:
     - type: Transform
-      pos: 13.5,-55.5
+      pos: 25.5,-54.5
       parent: 8364
   - uid: 15131
     components:
@@ -29600,7 +29733,7 @@ entities:
   - uid: 15135
     components:
     - type: Transform
-      pos: 14.5,-55.5
+      pos: 25.5,-53.5
       parent: 8364
   - uid: 15140
     components:
@@ -30385,17 +30518,17 @@ entities:
   - uid: 15305
     components:
     - type: Transform
-      pos: 21.5,-46.5
+      pos: 25.5,-52.5
       parent: 8364
   - uid: 15306
     components:
     - type: Transform
-      pos: 19.5,-47.5
+      pos: 25.5,-51.5
       parent: 8364
   - uid: 15308
     components:
     - type: Transform
-      pos: 16.5,-47.5
+      pos: 25.5,-46.5
       parent: 8364
   - uid: 15313
     components:
@@ -30415,17 +30548,12 @@ entities:
   - uid: 15458
     components:
     - type: Transform
-      pos: 17.5,-47.5
+      pos: 25.5,-45.5
       parent: 8364
   - uid: 15465
     components:
     - type: Transform
       pos: 14.5,-47.5
-      parent: 8364
-  - uid: 15466
-    components:
-    - type: Transform
-      pos: 20.5,-55.5
       parent: 8364
   - uid: 15481
     components:
@@ -30437,45 +30565,10 @@ entities:
     - type: Transform
       pos: -0.5,-21.5
       parent: 8364
-  - uid: 15496
-    components:
-    - type: Transform
-      pos: 15.5,-55.5
-      parent: 8364
-  - uid: 15499
-    components:
-    - type: Transform
-      pos: 17.5,-55.5
-      parent: 8364
-  - uid: 15500
-    components:
-    - type: Transform
-      pos: 18.5,-55.5
-      parent: 8364
   - uid: 15503
     components:
     - type: Transform
       pos: -33.5,-38.5
-      parent: 8364
-  - uid: 15504
-    components:
-    - type: Transform
-      pos: 16.5,-55.5
-      parent: 8364
-  - uid: 15518
-    components:
-    - type: Transform
-      pos: 20.5,-41.5
-      parent: 8364
-  - uid: 15520
-    components:
-    - type: Transform
-      pos: 20.5,-47.5
-      parent: 8364
-  - uid: 15528
-    components:
-    - type: Transform
-      pos: 18.5,-47.5
       parent: 8364
   - uid: 15575
     components:
@@ -31512,11 +31605,6 @@ entities:
     - type: Transform
       pos: 15.5,-45.5
       parent: 8364
-  - uid: 16578
-    components:
-    - type: Transform
-      pos: 16.5,-45.5
-      parent: 8364
   - uid: 16579
     components:
     - type: Transform
@@ -31542,70 +31630,10 @@ entities:
     - type: Transform
       pos: 21.5,-45.5
       parent: 8364
-  - uid: 16584
+  - uid: 16601
     components:
     - type: Transform
-      pos: 22.5,-45.5
-      parent: 8364
-  - uid: 16585
-    components:
-    - type: Transform
-      pos: 23.5,-45.5
-      parent: 8364
-  - uid: 16586
-    components:
-    - type: Transform
-      pos: 24.5,-45.5
-      parent: 8364
-  - uid: 16600
-    components:
-    - type: Transform
-      pos: 25.5,-42.5
-      parent: 8364
-  - uid: 16602
-    components:
-    - type: Transform
-      pos: 25.5,-44.5
-      parent: 8364
-  - uid: 16603
-    components:
-    - type: Transform
-      pos: 25.5,-46.5
-      parent: 8364
-  - uid: 16605
-    components:
-    - type: Transform
-      pos: 25.5,-48.5
-      parent: 8364
-  - uid: 16607
-    components:
-    - type: Transform
-      pos: 25.5,-50.5
-      parent: 8364
-  - uid: 16608
-    components:
-    - type: Transform
-      pos: 25.5,-47.5
-      parent: 8364
-  - uid: 16609
-    components:
-    - type: Transform
-      pos: 25.5,-52.5
-      parent: 8364
-  - uid: 16611
-    components:
-    - type: Transform
-      pos: 25.5,-54.5
-      parent: 8364
-  - uid: 16612
-    components:
-    - type: Transform
-      pos: 25.5,-55.5
-      parent: 8364
-  - uid: 16613
-    components:
-    - type: Transform
-      pos: 25.5,-56.5
+      pos: 22.5,-56.5
       parent: 8364
   - uid: 16623
     components:
@@ -31617,105 +31645,20 @@ entities:
     - type: Transform
       pos: 31.5,-117.5
       parent: 8364
-  - uid: 16636
-    components:
-    - type: Transform
-      pos: 23.5,-44.5
-      parent: 8364
-  - uid: 16637
-    components:
-    - type: Transform
-      pos: 23.5,-43.5
-      parent: 8364
-  - uid: 16638
-    components:
-    - type: Transform
-      pos: 23.5,-42.5
-      parent: 8364
-  - uid: 16639
-    components:
-    - type: Transform
-      pos: 23.5,-41.5
-      parent: 8364
-  - uid: 16640
-    components:
-    - type: Transform
-      pos: 23.5,-40.5
-      parent: 8364
-  - uid: 16641
-    components:
-    - type: Transform
-      pos: 23.5,-46.5
-      parent: 8364
-  - uid: 16642
-    components:
-    - type: Transform
-      pos: 23.5,-47.5
-      parent: 8364
-  - uid: 16643
-    components:
-    - type: Transform
-      pos: 23.5,-48.5
-      parent: 8364
-  - uid: 16644
-    components:
-    - type: Transform
-      pos: 23.5,-49.5
-      parent: 8364
-  - uid: 16645
-    components:
-    - type: Transform
-      pos: 23.5,-50.5
-      parent: 8364
-  - uid: 16646
-    components:
-    - type: Transform
-      pos: 23.5,-51.5
-      parent: 8364
   - uid: 16647
     components:
     - type: Transform
-      pos: 23.5,-52.5
-      parent: 8364
-  - uid: 16648
-    components:
-    - type: Transform
-      pos: 23.5,-53.5
-      parent: 8364
-  - uid: 16649
-    components:
-    - type: Transform
-      pos: 23.5,-54.5
-      parent: 8364
-  - uid: 16650
-    components:
-    - type: Transform
-      pos: 23.5,-55.5
-      parent: 8364
-  - uid: 16651
-    components:
-    - type: Transform
-      pos: 23.5,-56.5
-      parent: 8364
-  - uid: 16652
-    components:
-    - type: Transform
-      pos: 23.5,-57.5
+      pos: 19.5,-52.5
       parent: 8364
   - uid: 16653
     components:
     - type: Transform
       pos: 15.5,-44.5
       parent: 8364
-  - uid: 16655
-    components:
-    - type: Transform
-      pos: 17.5,-44.5
-      parent: 8364
   - uid: 16656
     components:
     - type: Transform
-      pos: 17.5,-43.5
+      pos: 17.5,-54.5
       parent: 8364
   - uid: 16661
     components:
@@ -31726,41 +31669,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-49.5
-      parent: 8364
-  - uid: 16663
-    components:
-    - type: Transform
-      pos: 12.5,-50.5
-      parent: 8364
-  - uid: 16664
-    components:
-    - type: Transform
-      pos: 12.5,-51.5
-      parent: 8364
-  - uid: 16665
-    components:
-    - type: Transform
-      pos: 12.5,-52.5
-      parent: 8364
-  - uid: 16666
-    components:
-    - type: Transform
-      pos: 12.5,-53.5
-      parent: 8364
-  - uid: 16667
-    components:
-    - type: Transform
-      pos: 12.5,-54.5
-      parent: 8364
-  - uid: 16668
-    components:
-    - type: Transform
-      pos: 12.5,-55.5
-      parent: 8364
-  - uid: 16669
-    components:
-    - type: Transform
-      pos: 12.5,-56.5
       parent: 8364
   - uid: 16670
     components:
@@ -31776,11 +31684,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-59.5
-      parent: 8364
-  - uid: 16673
-    components:
-    - type: Transform
-      pos: 13.5,-59.5
       parent: 8364
   - uid: 16674
     components:
@@ -31882,56 +31785,6 @@ entities:
     - type: Transform
       pos: 21.5,-47.5
       parent: 8364
-  - uid: 16699
-    components:
-    - type: Transform
-      pos: 13.5,-60.5
-      parent: 8364
-  - uid: 16700
-    components:
-    - type: Transform
-      pos: 13.5,-61.5
-      parent: 8364
-  - uid: 16701
-    components:
-    - type: Transform
-      pos: 14.5,-61.5
-      parent: 8364
-  - uid: 16702
-    components:
-    - type: Transform
-      pos: 15.5,-61.5
-      parent: 8364
-  - uid: 16703
-    components:
-    - type: Transform
-      pos: 16.5,-61.5
-      parent: 8364
-  - uid: 16704
-    components:
-    - type: Transform
-      pos: 17.5,-61.5
-      parent: 8364
-  - uid: 16705
-    components:
-    - type: Transform
-      pos: 18.5,-61.5
-      parent: 8364
-  - uid: 16706
-    components:
-    - type: Transform
-      pos: 19.5,-61.5
-      parent: 8364
-  - uid: 16707
-    components:
-    - type: Transform
-      pos: 20.5,-61.5
-      parent: 8364
-  - uid: 16708
-    components:
-    - type: Transform
-      pos: 21.5,-61.5
-      parent: 8364
   - uid: 16717
     components:
     - type: Transform
@@ -31975,7 +31828,7 @@ entities:
   - uid: 16766
     components:
     - type: Transform
-      pos: 13.5,-62.5
+      pos: 17.5,-52.5
       parent: 8364
   - uid: 16767
     components:
@@ -32056,6 +31909,11 @@ entities:
     components:
     - type: Transform
       pos: 17.5,-71.5
+      parent: 8364
+  - uid: 16850
+    components:
+    - type: Transform
+      pos: 17.5,-53.5
       parent: 8364
   - uid: 16902
     components:
@@ -32231,6 +32089,26 @@ entities:
     components:
     - type: Transform
       pos: 22.5,-21.5
+      parent: 8364
+  - uid: 17225
+    components:
+    - type: Transform
+      pos: 17.5,-51.5
+      parent: 8364
+  - uid: 17228
+    components:
+    - type: Transform
+      pos: 17.5,-50.5
+      parent: 8364
+  - uid: 17262
+    components:
+    - type: Transform
+      pos: 26.5,-60.5
+      parent: 8364
+  - uid: 17263
+    components:
+    - type: Transform
+      pos: 25.5,-60.5
       parent: 8364
   - uid: 17274
     components:
@@ -32706,6 +32584,11 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-71.5
+      parent: 8364
+  - uid: 17708
+    components:
+    - type: Transform
+      pos: 18.5,-52.5
       parent: 8364
   - uid: 17764
     components:
@@ -34886,16 +34769,6 @@ entities:
     components:
     - type: Transform
       pos: 23.5,-60.5
-      parent: 8364
-  - uid: 19124
-    components:
-    - type: Transform
-      pos: 22.5,-60.5
-      parent: 8364
-  - uid: 19125
-    components:
-    - type: Transform
-      pos: 21.5,-60.5
       parent: 8364
   - uid: 19310
     components:
@@ -38077,6 +37950,11 @@ entities:
     - type: Transform
       pos: -14.5,38.5
       parent: 8364
+  - uid: 22825
+    components:
+    - type: Transform
+      pos: 25.5,-50.5
+      parent: 8364
   - uid: 22855
     components:
     - type: Transform
@@ -38091,11 +37969,6 @@ entities:
     components:
     - type: Transform
       pos: 25.5,-71.5
-      parent: 8364
-  - uid: 22943
-    components:
-    - type: Transform
-      pos: 21.5,-41.5
       parent: 8364
   - uid: 22949
     components:
@@ -69365,12 +69238,6 @@ entities:
           - ArtifactAnalyzerReceiver
 - proto: ComputerAtmosMonitoring
   entities:
-  - uid: 8211
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-48.5
-      parent: 8364
   - uid: 22048
     components:
     - type: Transform
@@ -69914,15 +69781,15 @@ entities:
     - type: Transform
       pos: 17.5,28.5
       parent: 8364
-  - uid: 8964
+- proto: ComputerSurveillanceWirelessCameraMonitor
+  entities:
+  - uid: 16602
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,29.5
       parent: 8364
-- proto: ComputerSurveillanceWirelessCameraMonitor
-  entities:
-  - uid: 9697
+  - uid: 16603
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -71472,7 +71339,7 @@ entities:
       pos: 35.5,-0.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -49656.938
+      secondsUntilStateChange: -54285.508
       state: Closing
   - uid: 8917
     components:
@@ -71669,13 +71536,6 @@ entities:
     components:
     - type: Transform
       pos: 73.5,-44.5
-      parent: 8364
-- proto: DefaultStationBeaconAtmospherics
-  entities:
-  - uid: 28423
-    components:
-    - type: Transform
-      pos: 12.5,-48.5
       parent: 8364
 - proto: DefaultStationBeaconBar
   entities:
@@ -80012,6 +79872,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -6.5,-65.5
       parent: 8364
+  - uid: 23165
+    components:
+    - type: Transform
+      pos: -50.5,-10.5
+      parent: 8364
   - uid: 23483
     components:
     - type: Transform
@@ -83066,7 +82931,6 @@ entities:
       devices:
       - 22687
       - 19161
-      - 22571
       - 18757
       - 18756
       - 18755
@@ -85384,7 +85248,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -128435.055
+      secondsUntilStateChange: -133063.62
       state: Closing
   - uid: 15010
     components:
@@ -87230,56 +87094,54 @@ entities:
       parent: 8364
 - proto: GasFilter
   entities:
-  - uid: 17247
+  - uid: 15516
     components:
-    - type: MetaData
-      name: n2 filter
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 12.5,-59.5
+      pos: 12.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 17248
+      color: '#FF0000FF'
+  - uid: 15517
     components:
-    - type: MetaData
-      name: o2 filter
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 16.5,-59.5
+      pos: 16.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17260
+      color: '#FF0000FF'
+  - uid: 15520
     components:
-    - type: MetaData
-      name: waste filter
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 21.5,-48.5
+      pos: 22.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 17263
+      color: '#FF0000FF'
+  - uid: 15528
     components:
-    - type: MetaData
-      name: h2o filter
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 21.5,-52.5
+      pos: 22.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17264
+      color: '#FF0000FF'
+  - uid: 16578
     components:
-    - type: MetaData
-      name: co2 filter
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 21.5,-56.5
+      pos: 22.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
+  - uid: 16584
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-44.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
 - proto: GasFilterFlipped
   entities:
   - uid: 6982
@@ -87377,14 +87239,6 @@ entities:
       parent: 8364
 - proto: GasMixer
   entities:
-  - uid: 17052
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-57.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 24988
     components:
     - type: Transform
@@ -87413,42 +87267,54 @@ entities:
       parent: 8364
 - proto: GasOutletInjector
   entities:
-  - uid: 15511
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,-44.5
-      parent: 8364
-  - uid: 15512
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,-48.5
-      parent: 8364
-  - uid: 15513
+  - uid: 16649
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-52.5
       parent: 8364
-  - uid: 15514
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,-56.5
-      parent: 8364
-  - uid: 15515
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-64.5
-      parent: 8364
-  - uid: 15516
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-64.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16989
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17086
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-44.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-48.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17253
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-64.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 17757
     components:
     - type: Transform
@@ -87457,14 +87323,24 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 23110
+  - uid: 21370
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-64.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
+  - uid: 26173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-83.5
       parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#FF6B9FFF'
   - uid: 28553
     components:
     - type: Transform
@@ -87493,13 +87369,16 @@ entities:
     - type: Transform
       pos: -14.5,-79.5
       parent: 8364
-  - uid: 21381
+  - uid: 26160
     components:
     - type: Transform
-      pos: 20.5,-60.5
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-71.5
       parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#FF6B9FFF'
   - uid: 28630
     components:
     - type: Transform
@@ -87575,12 +87454,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 72.5,-39.5
       parent: 8364
-  - uid: 15517
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-64.5
-      parent: 8364
   - uid: 16540
     components:
     - type: Transform
@@ -87589,30 +87462,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 16760
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-64.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 16764
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-64.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 16765
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-64.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 17031
     components:
     - type: Transform
@@ -87627,46 +87476,64 @@ entities:
       rot: 3.141592653589793 rad
       pos: 82.5,-28.5
       parent: 8364
-  - uid: 17222
+  - uid: 22735
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-42.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 17224
+  - uid: 22740
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-46.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 17225
+  - uid: 22744
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,-50.5
+      rot: 3.141592653589793 rad
+      pos: 18.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 17226
+      color: '#03FCD2FF'
+  - uid: 22754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-54.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22844
+  - uid: 22755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 25.5,-40.5
+      pos: 26.5,-50.5
+      parent: 8364
+  - uid: 22762
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#03FCD2FF'
+  - uid: 22793
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-40.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 22844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-64.5
+      parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 27182
     components:
     - type: Transform
@@ -87721,30 +87588,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3527
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-48.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 3683
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 3692
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 3821
     components:
     - type: Transform
@@ -87753,14 +87596,14 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 4140
+  - uid: 3996
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-47.5
+      rot: 3.141592653589793 rad
+      pos: 11.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 4508
     components:
     - type: Transform
@@ -88464,6 +88307,56 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
+  - uid: 16586
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16609
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,-40.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16637
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16640
+    components:
+    - type: Transform
+      pos: 16.5,-49.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16700
+    components:
+    - type: Transform
+      pos: 17.5,-51.5
+      parent: 8364
+  - uid: 16701
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-54.5
+      parent: 8364
   - uid: 16837
     components:
     - type: Transform
@@ -88484,21 +88377,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,-75.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 16988
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-57.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 16989
-    components:
-    - type: Transform
-      pos: 20.5,-57.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
@@ -88594,14 +88472,14 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 17246
+  - uid: 17236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 11.5,-59.5
+      pos: 11.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17255
     components:
     - type: Transform
@@ -88625,36 +88503,12 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 17265
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-59.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17314
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 17341
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,15.5
       parent: 8364
-  - uid: 17384
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,-40.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 17565
     components:
     - type: Transform
@@ -88727,6 +88581,14 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 19124
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-46.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 19332
     components:
     - type: Transform
@@ -88735,14 +88597,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 20067
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-81.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 20202
     components:
     - type: Transform
@@ -88811,37 +88665,22 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 22744
+  - uid: 22794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 19.5,-81.5
+      pos: 16.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 22780
+      color: '#0055CCFF'
+  - uid: 22822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 22.5,-58.5
+      pos: 14.5,-58.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22781
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-58.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22799
-    components:
-    - type: Transform
-      pos: 23.5,-41.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD2FF'
   - uid: 22830
     components:
     - type: Transform
@@ -88858,6 +88697,13 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
+  - uid: 22922
+    components:
+    - type: Transform
+      pos: 20.5,-58.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
   - uid: 23008
     components:
     - type: Transform
@@ -89532,14 +89378,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 27244
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-48.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 27366
     components:
     - type: Transform
@@ -89637,6 +89475,94 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
+- proto: GasPipeBendAlt1
+  entities:
+  - uid: 16664
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 16755
+    components:
+    - type: Transform
+      pos: 26.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17569
+    components:
+    - type: Transform
+      pos: 24.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 20214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-72.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 22771
+    components:
+    - type: Transform
+      pos: 22.5,-48.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 22790
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-72.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26155
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26157
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 17815
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-41.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22837
+    components:
+    - type: Transform
+      pos: 22.5,-41.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeFourway
   entities:
   - uid: 7720
@@ -89667,6 +89593,16 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 16703
+    components:
+    - type: Transform
+      pos: 17.5,-53.5
+      parent: 8364
+  - uid: 16704
+    components:
+    - type: Transform
+      pos: 17.5,-52.5
+      parent: 8364
   - uid: 20264
     components:
     - type: Transform
@@ -89877,20 +89813,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 28280
-    components:
-    - type: Transform
-      pos: 18.5,-48.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28327
-    components:
-    - type: Transform
-      pos: 18.5,-54.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 28582
     components:
     - type: Transform
@@ -89898,6 +89820,15 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
+- proto: GasPipeManifold
+  entities:
+  - uid: 16673
+    components:
+    - type: Transform
+      pos: 16.5,-45.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeSensor
   entities:
   - uid: 22813
@@ -89926,25 +89857,34 @@ entities:
       baseName: gas pipe sensor
 - proto: GasPipeSensorDistribution
   entities:
-  - uid: 24428
+  - uid: 17252
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-46.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeSensorWaste
   entities:
-  - uid: 22809
+  - uid: 16756
     components:
     - type: Transform
-      pos: 11.5,-51.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
 - proto: GasPipeStraight
   entities:
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-61.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 750
     components:
     - type: Transform
@@ -90197,44 +90137,14 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3996
-    components:
-    - type: Transform
-      pos: 16.5,-43.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 3997
     components:
     - type: Transform
-      pos: 16.5,-42.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 3999
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,-41.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 4002
-    components:
-    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 17.5,-45.5
+      pos: 12.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 4004
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 4062
     components:
     - type: Transform
@@ -90243,37 +90153,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 4073
-    components:
-    - type: Transform
-      pos: 16.5,-44.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 4078
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 22.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 4079
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 4080
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 4107
     components:
     - type: Transform
@@ -90300,74 +90179,11 @@ entities:
   - uid: 4147
     components:
     - type: Transform
-      pos: 11.5,-49.5
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 4149
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-62.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 4164
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-61.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 4165
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-62.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 4166
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-63.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 4168
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-61.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 4169
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-62.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 4170
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-63.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 4174
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-61.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF0000FF'
   - uid: 4228
     components:
     - type: Transform
@@ -90479,14 +90295,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 4537
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-73.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 4538
     components:
     - type: Transform
@@ -93727,6 +93535,37 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
+  - uid: 15513
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 15514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 15515
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 15518
+    components:
+    - type: Transform
+      pos: 11.5,-59.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 15543
     components:
     - type: Transform
@@ -93841,14 +93680,44 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 16601
+  - uid: 16521
+    components:
+    - type: Transform
+      pos: 11.5,-58.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16585
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16600
+    components:
+    - type: Transform
+      pos: 11.5,-57.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16604
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-62.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16608
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 10.5,-48.5
+      pos: 25.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 16620
     components:
     - type: Transform
@@ -93857,6 +93726,88 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
+  - uid: 16641
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-51.5
+      parent: 8364
+  - uid: 16650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16652
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-52.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16655
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-46.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-54.5
+      parent: 8364
+  - uid: 16666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-54.5
+      parent: 8364
+  - uid: 16667
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-62.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
+  - uid: 16668
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-46.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16669
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16706
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 16707
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 16720
     components:
     - type: Transform
@@ -93865,90 +93816,48 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 16733
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-54.5
+      parent: 8364
   - uid: 16741
     components:
     - type: Transform
-      pos: 16.5,-63.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 16742
-    components:
-    - type: Transform
-      pos: 16.5,-60.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 16743
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-59.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 16755
-    components:
-    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 20.5,-59.5
+      pos: 14.5,-51.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 16756
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-59.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 16757
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-59.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 16758
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-59.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
   - uid: 16759
     components:
     - type: Transform
-      pos: 16.5,-61.5
+      pos: 16.5,-54.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 16761
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-59.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
   - uid: 16762
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-59.5
+      pos: 16.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
   - uid: 16763
     components:
     - type: Transform
-      pos: 16.5,-62.5
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
+  - uid: 16765
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-49.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 16825
     components:
     - type: Transform
@@ -94117,10 +94026,10 @@ entities:
   - uid: 17023
     components:
     - type: Transform
-      pos: 21.5,-42.5
+      pos: 16.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17028
     components:
     - type: Transform
@@ -94143,45 +94052,36 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 17047
-    components:
-    - type: Transform
-      pos: 20.5,-58.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 17050
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-57.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#FF0000FF'
   - uid: 17053
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-57.5
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#FF0000FF'
   - uid: 17054
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-59.5
+      pos: 22.5,-58.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#FF0000FF'
   - uid: 17055
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-58.5
+      pos: 22.5,-59.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#FF0000FF'
   - uid: 17057
     components:
     - type: Transform
@@ -94189,21 +94089,35 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 17083
+  - uid: 17062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,-57.5
+      pos: 21.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 17086
+      color: '#FF0000FF'
+  - uid: 17064
     components:
     - type: Transform
-      pos: 21.5,-41.5
+      pos: 22.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
+  - uid: 17083
+    components:
+    - type: Transform
+      pos: 22.5,-51.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17084
+    components:
+    - type: Transform
+      pos: 22.5,-53.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 17094
     components:
     - type: Transform
@@ -94410,17 +94324,19 @@ entities:
   - uid: 17210
     components:
     - type: Transform
-      pos: 11.5,-57.5
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17211
     components:
     - type: Transform
-      pos: 11.5,-58.5
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17212
     components:
     - type: Transform
@@ -94431,212 +94347,152 @@ entities:
   - uid: 17213
     components:
     - type: Transform
-      pos: 11.5,-53.5
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17214
     components:
     - type: Transform
-      pos: 11.5,-52.5
+      pos: 16.5,-53.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17216
     components:
     - type: Transform
-      pos: 11.5,-50.5
+      pos: 16.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17217
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-63.5
+      pos: 16.5,-51.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 17228
+      color: '#FF0000FF'
+  - uid: 17218
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,-56.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17231
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-56.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17232
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-56.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17233
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,-56.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17234
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17235
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17236
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17237
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17238
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,-48.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17239
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: 24.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
+  - uid: 17219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-52.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-52.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17234
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17235
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-61.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-54.5
+      parent: 8364
   - uid: 17240
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 23.5,-48.5
+      pos: 18.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
   - uid: 17241
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 22.5,-48.5
+      pos: 20.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
   - uid: 17242
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-50.5
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
   - uid: 17243
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-51.5
+      pos: 22.5,-57.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
   - uid: 17244
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-53.5
+      pos: 22.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#FF0000FF'
   - uid: 17245
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-54.5
+      pos: 22.5,-54.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17252
+      color: '#FF0000FF'
+  - uid: 17246
     components:
     - type: Transform
-      pos: 12.5,-61.5
+      pos: 22.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17253
+      color: '#FF0000FF'
+  - uid: 17247
     components:
     - type: Transform
-      pos: 12.5,-62.5
+      pos: 22.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17254
+      color: '#FF0000FF'
+  - uid: 17248
     components:
     - type: Transform
-      pos: 12.5,-63.5
+      pos: 22.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17259
+      color: '#FF0000FF'
+  - uid: 17260
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-55.5
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17262
-    components:
-    - type: Transform
-      pos: 12.5,-60.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17266
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-57.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 17267
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-58.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
+      color: '#0055CCFF'
   - uid: 17305
     components:
     - type: Transform
@@ -94669,6 +94525,13 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
+  - uid: 17314
+    components:
+    - type: Transform
+      pos: 22.5,-42.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 17320
     components:
     - type: Transform
@@ -94688,10 +94551,10 @@ entities:
   - uid: 17333
     components:
     - type: Transform
-      pos: 11.5,-54.5
+      pos: 22.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 17336
     components:
     - type: Transform
@@ -94708,6 +94571,13 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 17339
+    components:
+    - type: Transform
+      pos: 22.5,-45.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 17381
     components:
     - type: Transform
@@ -94729,6 +94599,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-68.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
@@ -94771,14 +94649,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 17569
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-41.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 17578
     components:
     - type: Transform
@@ -94795,13 +94665,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 17595
-    components:
-    - type: Transform
-      pos: 21.5,-43.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 17600
     components:
     - type: Transform
@@ -94858,46 +94721,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 17812
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-44.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 17813
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 17814
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 17815
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-47.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 17816
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-49.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
   - uid: 17833
     components:
     - type: Transform
@@ -95092,14 +94915,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 20151
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 20153
     components:
     - type: Transform
@@ -95123,14 +94938,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 20633
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 20855
     components:
     - type: Transform
@@ -95147,6 +94954,14 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
+  - uid: 21381
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-63.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 21382
     components:
     - type: Transform
@@ -95263,49 +95078,30 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 22735
-    components:
-    - type: Transform
-      pos: 14.5,-59.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 22739
     components:
     - type: Transform
-      pos: 20.5,-63.5
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-46.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 22740
-    components:
-    - type: Transform
-      pos: 20.5,-62.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 22741
     components:
     - type: Transform
-      pos: 20.5,-61.5
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-54.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 22743
     components:
     - type: Transform
-      pos: 20.5,-59.5
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-42.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 22749
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-76.5
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-42.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 22751
     components:
     - type: Transform
@@ -95317,75 +95113,21 @@ entities:
   - uid: 22760
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,-54.5
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-46.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
   - uid: 22761
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-54.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22762
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-54.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22767
-    components:
-    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 25.5,-50.5
+      pos: 23.5,-42.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22768
+  - uid: 22767
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-50.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22769
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-50.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22771
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22772
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
-  - uid: 22773
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#B3A234FF'
   - uid: 22777
     components:
     - type: Transform
@@ -95397,154 +95139,68 @@ entities:
   - uid: 22779
     components:
     - type: Transform
-      pos: 22.5,-59.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22782
+      color: '#03FCD2FF'
+  - uid: 22781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 23.5,-57.5
+      pos: 16.5,-62.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 22783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 23.5,-56.5
+      pos: 20.5,-61.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD2FF'
   - uid: 22784
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-55.5
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-50.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 22785
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-54.5
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-46.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 22786
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-53.5
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-50.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22787
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 22788
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-51.5
+      pos: 18.5,-59.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD2FF'
   - uid: 22789
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-50.5
+      pos: 20.5,-59.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22790
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-49.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD2FF'
   - uid: 22791
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-48.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22792
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-47.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22793
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22795
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-44.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22796
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-43.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22797
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-42.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22798
-    components:
-    - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 11.5,-46.5
+      pos: 14.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22803
-    components:
-    - type: Transform
-      pos: 11.5,-56.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 22804
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-62.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22810
+      color: '#947507FF'
+  - uid: 22795
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -95552,19 +95208,11 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 22811
+  - uid: 22804
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22812
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-46.5
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-62.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -95576,62 +95224,22 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 22820
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-44.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 22821
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-44.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
-  - uid: 22822
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,-44.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#3AB334FF'
   - uid: 22823
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,-41.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD2FF'
   - uid: 22824
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-41.5
+      rot: 3.141592653589793 rad
+      pos: 16.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22825
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-41.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22826
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,-41.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF0000FF'
   - uid: 22833
     components:
     - type: Transform
@@ -95640,30 +95248,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 22836
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,-42.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 22837
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-42.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 22838
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-42.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 22840
     components:
     - type: Transform
@@ -95687,7 +95271,7 @@ entities:
       pos: 23.5,-40.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF0000FF'
   - uid: 22846
     components:
     - type: Transform
@@ -95696,21 +95280,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 22916
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-75.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 22922
-    components:
-    - type: Transform
-      pos: 18.5,-82.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 22929
     components:
     - type: Transform
@@ -95731,26 +95300,65 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-55.5
+      pos: 15.5,-58.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#03FCD2FF'
+  - uid: 22933
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-62.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
   - uid: 22941
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,-77.5
+      pos: 18.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 22944
+      color: '#03FCD2FF'
+  - uid: 22943
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,-78.5
+      pos: 14.5,-62.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#03FCD2FF'
+  - uid: 22944
+    components:
+    - type: Transform
+      pos: 14.5,-59.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
+  - uid: 22950
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-61.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
+  - uid: 22951
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-63.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
+  - uid: 22952
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-61.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
   - uid: 22981
     components:
     - type: Transform
@@ -96332,14 +95940,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 23111
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-79.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 23113
     components:
     - type: Transform
@@ -96558,14 +96158,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 23165
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 23167
     components:
     - type: Transform
@@ -107979,14 +107571,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -15.5,19.5
       parent: 8364
-  - uid: 25966
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-80.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 26015
     components:
     - type: Transform
@@ -108026,14 +107610,54 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#3AB334FF'
-  - uid: 26118
+  - uid: 26175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 19.5,-57.5
+      pos: 20.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#947507FF'
+  - uid: 26176
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#947507FF'
+  - uid: 26177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#947507FF'
+  - uid: 26178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#947507FF'
+  - uid: 26179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#947507FF'
+  - uid: 26180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#947507FF'
   - uid: 26621
     components:
     - type: Transform
@@ -108204,14 +107828,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 26896
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 26921
     components:
     - type: Transform
@@ -108616,14 +108232,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 27548
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-74.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 27549
     components:
     - type: Transform
@@ -108784,21 +108392,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 28399
-    components:
-    - type: Transform
-      pos: 14.5,-58.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 28400
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 28418
     components:
     - type: Transform
@@ -108931,6 +108524,509 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
+- proto: GasPipeStraightAlt1
+  entities:
+  - uid: 16638
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-53.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 16663
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-55.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17085
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-49.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17226
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-51.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17384
+    components:
+    - type: Transform
+      pos: 24.5,-59.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17441
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-54.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17563
+    components:
+    - type: Transform
+      pos: 24.5,-58.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17568
+    components:
+    - type: Transform
+      pos: 24.5,-57.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17703
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 17812
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 19125
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-72.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 22772
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-50.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 22792
+    components:
+    - type: Transform
+      pos: 26.5,-61.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 22821
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-52.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 24428
+    components:
+    - type: Transform
+      pos: 26.5,-62.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 25689
+    components:
+    - type: Transform
+      pos: 26.5,-63.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 25691
+    components:
+    - type: Transform
+      pos: 26.5,-64.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 25692
+    components:
+    - type: Transform
+      pos: 26.5,-65.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 25966
+    components:
+    - type: Transform
+      pos: 26.5,-66.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26117
+    components:
+    - type: Transform
+      pos: 26.5,-67.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26118
+    components:
+    - type: Transform
+      pos: 26.5,-68.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26153
+    components:
+    - type: Transform
+      pos: 26.5,-69.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26154
+    components:
+    - type: Transform
+      pos: 26.5,-70.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26156
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26159
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26161
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26163
+    components:
+    - type: Transform
+      pos: 18.5,-73.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26164
+    components:
+    - type: Transform
+      pos: 18.5,-74.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26165
+    components:
+    - type: Transform
+      pos: 18.5,-75.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26166
+    components:
+    - type: Transform
+      pos: 18.5,-76.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26167
+    components:
+    - type: Transform
+      pos: 18.5,-77.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26168
+    components:
+    - type: Transform
+      pos: 18.5,-78.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26169
+    components:
+    - type: Transform
+      pos: 18.5,-79.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26170
+    components:
+    - type: Transform
+      pos: 18.5,-80.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26171
+    components:
+    - type: Transform
+      pos: 18.5,-81.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 26172
+    components:
+    - type: Transform
+      pos: 18.5,-82.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 540
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-52.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 3685
+    components:
+    - type: Transform
+      pos: 22.5,-63.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 4537
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-54.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15496
+    components:
+    - type: Transform
+      pos: 22.5,-62.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15500
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-53.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16605
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-41.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16648
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-56.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16699
+    components:
+    - type: Transform
+      pos: 16.5,-42.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16702
+    components:
+    - type: Transform
+      pos: 16.5,-43.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16743
+    components:
+    - type: Transform
+      pos: 22.5,-61.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16992
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-55.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 17231
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-41.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 17232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-41.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 17814
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-58.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 17816
+    components:
+    - type: Transform
+      pos: 16.5,-44.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22571
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-57.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22787
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-59.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22803
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-47.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22809
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-44.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22820
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-49.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22826
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-42.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22834
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-43.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22836
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-41.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22838
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-41.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-48.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22850
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-50.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 22916
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-51.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 23110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-46.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 23111
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-45.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeTJunction
   entities:
   - uid: 1148
@@ -108941,14 +109037,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1625
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-54.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 2556
     components:
     - type: Transform
@@ -108981,29 +109069,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3998
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-41.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 4003
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 4145
-    components:
-    - type: Transform
-      pos: 10.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 4173
     components:
     - type: Transform
@@ -109525,22 +109590,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 16521
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-71.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 16604
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-48.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 16725
     components:
     - type: Transform
@@ -109563,14 +109612,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -12.5,-81.5
       parent: 8364
-  - uid: 16992
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-71.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 17025
     components:
     - type: Transform
@@ -109606,13 +109647,6 @@ entities:
     components:
     - type: Transform
       pos: 15.5,-79.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 17064
-    components:
-    - type: Transform
-      pos: 19.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
@@ -109655,6 +109689,21 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
+  - uid: 17254
+    components:
+    - type: Transform
+      pos: 11.5,-48.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 17259
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-47.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 17261
     components:
     - type: Transform
@@ -109692,14 +109741,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 17563
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,-71.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 17570
     components:
     - type: Transform
@@ -109887,22 +109928,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 22754
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 22794
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-45.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 22805
     components:
     - type: Transform
@@ -109918,14 +109943,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 22834
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-50.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 22847
     components:
     - type: Transform
@@ -111702,14 +111719,6 @@ entities:
     - type: Transform
       pos: 8.5,-78.5
       parent: 8364
-  - uid: 26697
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-71.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 26917
     components:
     - type: Transform
@@ -111756,14 +111765,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,-81.5
       parent: 8364
-  - uid: 27553
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-53.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 27941
     components:
     - type: Transform
@@ -111772,54 +111773,39 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 28180
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-51.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28182
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28210
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28332
+- proto: GasPipeTJunctionAlt1
+  entities:
+  - uid: 20151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,-48.5
+      pos: 17.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28339
+      color: '#FF6B9FFF'
+  - uid: 20633
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-50.5
+      rot: 3.141592653589793 rad
+      pos: 18.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28411
+      color: '#FF6B9FFF'
+  - uid: 22469
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-51.5
+      rot: 3.141592653589793 rad
+      pos: 16.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF00FFFF'
+      color: '#FF6B9FFF'
+  - uid: 26162
+    components:
+    - type: Transform
+      pos: 20.5,-71.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
 - proto: GasPort
   entities:
   - uid: 409
@@ -111867,8 +111853,10 @@ entities:
     - type: Transform
       pos: 15.5,-70.5
       parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#FF6B9FFF'
   - uid: 6665
     components:
     - type: Transform
@@ -111937,8 +111925,10 @@ entities:
     - type: Transform
       pos: 18.5,-70.5
       parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#FF6B9FFF'
   - uid: 16131
     components:
     - type: Transform
@@ -111976,8 +111966,10 @@ entities:
     - type: Transform
       pos: 16.5,-70.5
       parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#FF6B9FFF'
   - uid: 17116
     components:
     - type: Transform
@@ -111989,6 +111981,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-73.5
+      parent: 8364
+  - uid: 17813
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-52.5
       parent: 8364
   - uid: 18298
     components:
@@ -112005,8 +112003,10 @@ entities:
     - type: Transform
       pos: 17.5,-70.5
       parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#FF6B9FFF'
   - uid: 19386
     components:
     - type: Transform
@@ -112051,14 +112051,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 23.5,-73.5
       parent: 8364
-  - uid: 20214
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-51.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 20802
     components:
     - type: Transform
@@ -112075,14 +112067,12 @@ entities:
     - type: Transform
       pos: 80.5,-23.5
       parent: 8364
-  - uid: 22933
+  - uid: 22780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 19.5,-52.5
+      pos: 18.5,-53.5
       parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 23127
     components:
     - type: Transform
@@ -112170,14 +112160,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-76.5
       parent: 8364
-  - uid: 26765
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-51.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 27178
     components:
     - type: Transform
@@ -112189,30 +112171,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-76.5
       parent: 8364
-  - uid: 28178
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-52.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28181
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-50.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28270
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-50.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 28335
     components:
     - type: Transform
@@ -112232,11 +112190,6 @@ entities:
       parent: 8364
 - proto: GasPressurePump
   entities:
-  - uid: 3685
-    components:
-    - type: Transform
-      pos: 18.5,-47.5
-      parent: 8364
   - uid: 3993
     components:
     - type: Transform
@@ -112317,14 +112270,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,-81.5
       parent: 8364
-  - uid: 13813
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,-40.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 16146
     components:
     - type: Transform
@@ -112333,29 +112278,71 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 17000
+  - uid: 16607
+    components:
+    - type: MetaData
+      name: teg input
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-48.5
+      parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
+  - uid: 16636
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-54.5
+      parent: 8364
+  - uid: 16639
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-60.5
+      parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 16757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 22.5,-42.5
+      pos: 16.5,-51.5
       parent: 8364
-  - uid: 17001
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 22.5,-50.5
-      parent: 8364
-  - uid: 17084
+  - uid: 16758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-54.5
       parent: 8364
-  - uid: 17085
+  - uid: 16760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-46.5
+      parent: 8364
+  - uid: 16761
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-42.5
+      parent: 8364
+  - uid: 16764
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-60.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD2FF'
+  - uid: 17000
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-50.5
       parent: 8364
   - uid: 17104
     components:
@@ -112372,50 +112359,24 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 17218
+  - uid: 17222
     components:
-    - type: MetaData
-      name: air to distro
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-60.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 17219
-    components:
-    - type: MetaData
-      name: o2 pump
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 17220
+      color: '#03FCD2FF'
+  - uid: 17595
     components:
     - type: MetaData
-      name: n2 pump
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-60.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 17472
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-54.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 17568
-    components:
+      name: supermatter input
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 22.5,-44.5
+      pos: 21.5,-55.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#947507FF'
   - uid: 19114
     components:
     - type: Transform
@@ -112438,14 +112399,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 22755
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 22928
     components:
     - type: Transform
@@ -112508,45 +112461,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-76.5
       parent: 8364
-  - uid: 27230
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-55.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 27500
-    components:
-    - type: Transform
-      pos: 16.5,-53.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 27677
-    components:
-    - type: Transform
-      pos: 19.5,-47.5
-      parent: 8364
-  - uid: 28255
-    components:
-    - type: Transform
-      pos: 16.5,-49.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
-  - uid: 28275
-    components:
-    - type: Transform
-      pos: 17.5,-47.5
-      parent: 8364
-  - uid: 28410
-    components:
-    - type: Transform
-      pos: 18.5,-49.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
 - proto: GasThermoMachineFreezer
   entities:
   - uid: 3805
@@ -112563,19 +112477,23 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 6312
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-53.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
   - uid: 8808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-80.5
+      parent: 8364
+  - uid: 17266
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-53.5
+      parent: 8364
+  - uid: 17267
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-52.5
       parent: 8364
   - uid: 20859
     components:
@@ -112599,14 +112517,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 9.5,-81.5
       parent: 8364
-  - uid: 28318
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-54.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF00FFFF'
 - proto: GasThermoMachineFreezerEnabled
   entities:
   - uid: 10485
@@ -112647,31 +112557,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -17.5,49.5
       parent: 8364
-  - uid: 17062
+  - uid: 16643
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-71.5
+      pos: 22.5,-41.5
       parent: 8364
-    - type: GasValve
-      open: False
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#FF0000FF'
   - uid: 17707
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-78.5
-      parent: 8364
-    - type: GasValve
-      open: False
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 17708
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-71.5
       parent: 8364
     - type: GasValve
       open: False
@@ -112735,16 +112632,6 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 21370
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-72.5
-      parent: 8364
-    - type: GasValve
-      open: False
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 22565
     components:
     - type: Transform
@@ -112765,16 +112652,6 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 22843
-    components:
-    - type: MetaData
-      name: waste valve 2
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-40.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 25002
     components:
     - type: Transform
@@ -112787,6 +112664,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 77.5,-39.5
       parent: 8364
+  - uid: 26174
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-71.5
+      parent: 8364
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#FF6B9FFF'
 - proto: GasVentPump
   entities:
   - uid: 1204
@@ -113109,6 +112996,17 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 16651
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-47.5
+      parent: 8364
+    - type: DeviceNetwork
+      deviceLists:
+      - 22568
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 17123
     components:
     - type: Transform
@@ -113208,21 +113106,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 79.5,-12.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22950
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-46.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 22952
-    components:
-    - type: Transform
-      pos: 16.5,-40.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -114736,6 +114619,17 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
+  - uid: 22796
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-48.5
+      parent: 8364
+    - type: DeviceNetwork
+      deviceLists:
+      - 22568
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 22800
     components:
     - type: Transform
@@ -114752,13 +114646,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 22951
-    components:
-    - type: Transform
-      pos: 11.5,-47.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 23010
     components:
     - type: Transform
@@ -121223,10 +121110,25 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -7.5,34.5
       parent: 8364
+  - uid: 16612
+    components:
+    - type: Transform
+      pos: 15.5,-53.5
+      parent: 8364
+  - uid: 16646
+    components:
+    - type: Transform
+      pos: 15.5,-54.5
+      parent: 8364
   - uid: 16659
     components:
     - type: Transform
       pos: 0.5,-61.5
+      parent: 8364
+  - uid: 16705
+    components:
+    - type: Transform
+      pos: 15.5,-52.5
       parent: 8364
   - uid: 16721
     components:
@@ -121317,6 +121219,11 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-100.5
+      parent: 8364
+  - uid: 17001
+    components:
+    - type: Transform
+      pos: 15.5,-51.5
       parent: 8364
   - uid: 17036
     components:
@@ -122083,6 +121990,24 @@ entities:
     components:
     - type: Transform
       pos: 42.5,-1.5
+      parent: 8364
+  - uid: 22797
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,62.5
+      parent: 8364
+  - uid: 22798
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,61.5
+      parent: 8364
+  - uid: 22799
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,60.5
       parent: 8364
   - uid: 22832
     components:
@@ -123129,27 +123054,10 @@ entities:
     - type: Transform
       pos: -0.5,64.5
       parent: 8364
-  - uid: 25689
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,62.5
-      parent: 8364
   - uid: 25690
     components:
     - type: Transform
       pos: -14.5,64.5
-      parent: 8364
-  - uid: 25691
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,60.5
-      parent: 8364
-  - uid: 25692
-    components:
-    - type: Transform
-      pos: -14.5,60.5
       parent: 8364
   - uid: 26616
     components:
@@ -123359,6 +123267,40 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
+  - uid: 15466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-51.5
+      parent: 8364
+  - uid: 15499
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-51.5
+      parent: 8364
+  - uid: 16642
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-54.5
+      parent: 8364
+  - uid: 16734
+    components:
+    - type: Transform
+      pos: 11.5,-53.5
+      parent: 8364
+  - uid: 16742
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-54.5
+      parent: 8364
+  - uid: 17237
+    components:
+    - type: Transform
+      pos: 11.5,-52.5
+      parent: 8364
   - uid: 17607
     components:
     - type: Transform
@@ -123401,6 +123343,20 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-80.5
+      parent: 8364
+- proto: HeatExchangerBend
+  entities:
+  - uid: 4148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-54.5
+      parent: 8364
+  - uid: 16708
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-51.5
       parent: 8364
 - proto: Hemostat
   entities:
@@ -123466,11 +123422,6 @@ entities:
       parent: 8364
 - proto: HolofanProjector
   entities:
-  - uid: 8200
-    components:
-    - type: Transform
-      pos: 13.588713,-48.57287
-      parent: 8364
   - uid: 14217
     components:
     - type: Transform
@@ -123846,7 +123797,7 @@ entities:
       pos: 28.5,-34.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -108205.4
+      secondsUntilStateChange: -112833.97
       state: Closing
 - proto: hydroponicsSoil
   entities:
@@ -125550,11 +125501,6 @@ entities:
       parent: 8364
 - proto: LockerWeldingSuppliesFilled
   entities:
-  - uid: 1477
-    components:
-    - type: Transform
-      pos: 13.5,-54.5
-      parent: 8364
   - uid: 3637
     components:
     - type: Transform
@@ -129376,6 +129322,50 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 8.5,53.5
       parent: 8364
+- proto: PoweredFloorLight
+  entities:
+  - uid: 17264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-46.5
+      parent: 8364
+  - uid: 17265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-59.5
+      parent: 8364
+  - uid: 22768
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-63.5
+      parent: 8364
+  - uid: 22769
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-68.5
+      parent: 8364
+  - uid: 22810
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-54.5
+      parent: 8364
+  - uid: 22811
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-59.5
+      parent: 8364
+  - uid: 22812
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-41.5
+      parent: 8364
 - proto: Poweredlight
   entities:
   - uid: 70
@@ -129682,12 +129672,6 @@ entities:
     components:
     - type: Transform
       pos: 39.5,0.5
-      parent: 8364
-  - uid: 7077
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-53.5
       parent: 8364
   - uid: 7282
     components:
@@ -130793,20 +130777,6 @@ entities:
       parent: 8364
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 16733
-    components:
-    - type: Transform
-      pos: 17.5,-40.5
-      parent: 8364
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 16734
-    components:
-    - type: Transform
-      pos: 21.5,-40.5
-      parent: 8364
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 17079
     components:
     - type: Transform
@@ -130823,6 +130793,12 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-78.5
+      parent: 8364
+  - uid: 17224
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-49.5
       parent: 8364
   - uid: 17315
     components:
@@ -130877,12 +130853,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-41.5
-      parent: 8364
-  - uid: 17703
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-46.5
       parent: 8364
   - uid: 17771
     components:
@@ -131216,6 +131186,12 @@ entities:
       parent: 8364
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 20067
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-49.5
+      parent: 8364
   - uid: 20137
     components:
     - type: Transform
@@ -131865,12 +131841,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -41.5,-21.5
       parent: 8364
-  - uid: 27679
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-53.5
-      parent: 8364
   - uid: 27882
     components:
     - type: Transform
@@ -131893,24 +131863,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-76.5
-      parent: 8364
-  - uid: 28254
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,-59.5
-      parent: 8364
-  - uid: 28279
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-49.5
-      parent: 8364
-  - uid: 28317
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-49.5
       parent: 8364
   - uid: 28336
     components:
@@ -134000,11 +133952,6 @@ entities:
     - type: Transform
       pos: -5.5,-45.5
       parent: 8364
-  - uid: 16850
-    components:
-    - type: Transform
-      pos: 13.5,-48.5
-      parent: 8364
   - uid: 17632
     components:
     - type: Transform
@@ -135170,11 +135117,6 @@ entities:
     components:
     - type: Transform
       pos: 17.5,-8.5
-      parent: 8364
-  - uid: 28424
-    components:
-    - type: Transform
-      pos: 14.5,-51.5
       parent: 8364
 - proto: RandomSnacks
   entities:
@@ -138218,6 +138160,11 @@ entities:
     - type: Transform
       pos: -37.5,-42.5
       parent: 8364
+  - uid: 3999
+    components:
+    - type: Transform
+      pos: 15.5,-53.5
+      parent: 8364
   - uid: 4000
     components:
     - type: Transform
@@ -138277,11 +138224,6 @@ entities:
     components:
     - type: Transform
       pos: 23.5,-56.5
-      parent: 8364
-  - uid: 4017
-    components:
-    - type: Transform
-      pos: 23.5,-57.5
       parent: 8364
   - uid: 4018
     components:
@@ -138372,6 +138314,11 @@ entities:
     components:
     - type: Transform
       pos: -34.5,-29.5
+      parent: 8364
+  - uid: 4144
+    components:
+    - type: Transform
+      pos: 15.5,-54.5
       parent: 8364
   - uid: 4177
     components:
@@ -139747,6 +139694,11 @@ entities:
     - type: Transform
       pos: 9.5,-58.5
       parent: 8364
+  - uid: 16613
+    components:
+    - type: Transform
+      pos: 15.5,-51.5
+      parent: 8364
   - uid: 16617
     components:
     - type: Transform
@@ -139763,6 +139715,11 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-41.5
+      parent: 8364
+  - uid: 17047
+    components:
+    - type: Transform
+      pos: 15.5,-52.5
       parent: 8364
   - uid: 17088
     components:
@@ -142215,6 +142172,17 @@ entities:
         21764:
         - - Pressed
           - Toggle
+  - uid: 22773
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-50.5
+      parent: 8364
+    - type: DeviceLinkSource
+      linkedPorts:
+        6312:
+        - - Pressed
+          - Toggle
   - uid: 27608
     components:
     - type: Transform
@@ -142523,6 +142491,14 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-71.5
+      parent: 8364
+- proto: SignDetective
+  entities:
+  - uid: 22782
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,22.5
       parent: 8364
 - proto: SignDirectionalBridge
   entities:
@@ -145228,18 +145204,6 @@ entities:
     - type: Transform
       pos: -57.5,-61.5
       parent: 8364
-- proto: SpaceHeater
-  entities:
-  - uid: 17441
-    components:
-    - type: Transform
-      pos: 15.5,-54.5
-      parent: 8364
-  - uid: 28273
-    components:
-    - type: Transform
-      pos: 14.5,-54.5
-      parent: 8364
 - proto: SpaceVillainArcadeComputerCircuitboard
   entities:
   - uid: 21709
@@ -145455,13 +145419,6 @@ entities:
     components:
     - type: Transform
       pos: 73.5,-45.5
-      parent: 8364
-- proto: SpawnMobSpaceSpider
-  entities:
-  - uid: 22469
-    components:
-    - type: Transform
-      pos: -6.5,14.5
       parent: 8364
 - proto: SpawnPointAdminAssistant
   entities:
@@ -146831,21 +146788,6 @@ entities:
     - type: Transform
       pos: 62.5,-33.5
       parent: 8364
-  - uid: 28319
-    components:
-    - type: Transform
-      pos: 15.5,-50.5
-      parent: 8364
-  - uid: 28334
-    components:
-    - type: Transform
-      pos: 15.5,-51.5
-      parent: 8364
-  - uid: 28408
-    components:
-    - type: Transform
-      pos: 15.5,-52.5
-      parent: 8364
   - uid: 28434
     components:
     - type: Transform
@@ -146992,23 +146934,6 @@ entities:
     components:
     - type: Transform
       pos: -67.42753,12.306509
-      parent: 8364
-- proto: SuitStorageAtmos
-  entities:
-  - uid: 17339
-    components:
-    - type: Transform
-      pos: 13.5,-52.5
-      parent: 8364
-  - uid: 22850
-    components:
-    - type: Transform
-      pos: 13.5,-51.5
-      parent: 8364
-  - uid: 27242
-    components:
-    - type: Transform
-      pos: 13.5,-50.5
       parent: 8364
 - proto: SuitStorageCaptain
   entities:
@@ -147562,28 +147487,6 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: SMES Bank
-  - uid: 122
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-45.5
-      parent: 8364
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraEngineering
-      nameSet: True
-      id: North Atmos
-  - uid: 1643
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-53.5
-      parent: 8364
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraEngineering
-      nameSet: True
-      id: Atmos
   - uid: 3722
     components:
     - type: Transform
@@ -154771,11 +154674,6 @@ entities:
     - type: Transform
       pos: -7.5,20.5
       parent: 8364
-  - uid: 540
-    components:
-    - type: Transform
-      pos: 14.5,-53.5
-      parent: 8364
   - uid: 543
     components:
     - type: Transform
@@ -155507,6 +155405,12 @@ entities:
     components:
     - type: Transform
       pos: -45.5,-19.5
+      parent: 8364
+  - uid: 1301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-50.5
       parent: 8364
   - uid: 1302
     components:
@@ -159159,6 +159063,11 @@ entities:
     - type: Transform
       pos: 67.5,-70.5
       parent: 8364
+  - uid: 3998
+    components:
+    - type: Transform
+      pos: 15.5,-55.5
+      parent: 8364
   - uid: 4028
     components:
     - type: Transform
@@ -159342,10 +159251,21 @@ entities:
     - type: Transform
       pos: 23.5,-67.5
       parent: 8364
+  - uid: 4145
+    components:
+    - type: Transform
+      pos: 12.5,-50.5
+      parent: 8364
   - uid: 4146
     components:
     - type: Transform
       pos: 19.5,-63.5
+      parent: 8364
+  - uid: 4149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-50.5
       parent: 8364
   - uid: 4150
     components:
@@ -159421,6 +159341,12 @@ entities:
     components:
     - type: Transform
       pos: 29.5,-45.5
+      parent: 8364
+  - uid: 4174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-55.5
       parent: 8364
   - uid: 4175
     components:
@@ -161632,12 +161558,6 @@ entities:
     components:
     - type: Transform
       pos: 81.5,-55.5
-      parent: 8364
-  - uid: 7269
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-53.5
       parent: 8364
   - uid: 7275
     components:
@@ -164328,6 +164248,16 @@ entities:
     - type: Transform
       pos: -33.5,-23.5
       parent: 8364
+  - uid: 15511
+    components:
+    - type: Transform
+      pos: 14.5,-55.5
+      parent: 8364
+  - uid: 15512
+    components:
+    - type: Transform
+      pos: 15.5,-50.5
+      parent: 8364
   - uid: 15551
     components:
     - type: Transform
@@ -164373,6 +164303,12 @@ entities:
     - type: Transform
       pos: -12.5,-86.5
       parent: 8364
+  - uid: 16611
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-55.5
+      parent: 8364
   - uid: 16615
     components:
     - type: Transform
@@ -164383,6 +164319,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,47.5
+      parent: 8364
+  - uid: 16645
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-55.5
       parent: 8364
   - uid: 16697
     components:
@@ -165490,11 +165432,6 @@ entities:
     - type: Transform
       pos: 1.5,-50.5
       parent: 8364
-  - uid: 26117
-    components:
-    - type: Transform
-      pos: 14.5,-49.5
-      parent: 8364
   - uid: 26581
     components:
     - type: Transform
@@ -165746,11 +165683,6 @@ entities:
     - type: Transform
       pos: 3.5,-88.5
       parent: 8364
-  - uid: 27262
-    components:
-    - type: Transform
-      pos: 13.5,-49.5
-      parent: 8364
   - uid: 27360
     components:
     - type: Transform
@@ -165819,11 +165751,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-77.5
       parent: 8364
-  - uid: 27551
-    components:
-    - type: Transform
-      pos: 14.5,-51.5
-      parent: 8364
   - uid: 27678
     components:
     - type: Transform
@@ -165890,22 +165817,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -9.5,-71.5
       parent: 8364
-  - uid: 28147
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-53.5
-      parent: 8364
-  - uid: 28179
-    components:
-    - type: Transform
-      pos: 15.5,-49.5
-      parent: 8364
-  - uid: 28263
-    components:
-    - type: Transform
-      pos: 14.5,-52.5
-      parent: 8364
   - uid: 28265
     components:
     - type: Transform
@@ -165916,11 +165827,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-79.5
-      parent: 8364
-  - uid: 28316
-    components:
-    - type: Transform
-      pos: 14.5,-50.5
       parent: 8364
   - uid: 28324
     components:
@@ -175073,13 +174979,6 @@ entities:
     - type: Transform
       pos: 61.5,-19.5
       parent: 8364
-- proto: WelderIndustrial
-  entities:
-  - uid: 6313
-    components:
-    - type: Transform
-      pos: 13.53663,-48.458206
-      parent: 8364
 - proto: WelderMini
   entities:
   - uid: 9035
@@ -175194,11 +175093,6 @@ entities:
     components:
     - type: Transform
       pos: -12.5,7.5
-      parent: 8364
-  - uid: 28059
-    components:
-    - type: Transform
-      pos: 15.5,-48.5
       parent: 8364
   - uid: 28617
     components:


### PR DESCRIPTION
Revamps box atmos, and fixes some mix mapping errors such as missing disposals pipes and incorrect camera monitors
![image](https://github.com/user-attachments/assets/a5901ed3-68b2-483e-b6f9-10dbb2d73f17)

**Changelog**
:cl:
- tweak: Major revamp to Box's atmos
