### PR TITLE
Give the service request computer board to the HD

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -141,7 +141,7 @@
     - id: HoPIDCard
     - id: IDComputerCircuitboard
     - id: FundingAllocationComputerCircuitboard
-    - id: CargoRequestServiceComputerCircuitboard
+    # - id: CargoRequestServiceComputerCircuitboard imp edit
     - id: RubberStampApproved
     - id: RubberStampDenied
     - id: RubberStampHop

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Lockers/heads.yml
@@ -12,6 +12,7 @@
     - id: RubberStampHD
     - id: ServiceTechFabCircuitboard
     - id: PersonalAILearnerService
+    - id: CargoRequestServiceComputerCircuitboard
 
 - type: entity
   id: LockerHospitalityDirectorFilled


### PR DESCRIPTION
It's currently in the HoP locker, since that's still the service department head upstream. Two line change to move it.

:cl:
- tweak: Moved the service request computer board to the HD locker, where it belongs.