### PR TITLE
Add intercoms and fix map bugs

### DIFF
--- a/Resources/Maps/_Impstation/barratry.yml
+++ b/Resources/Maps/_Impstation/barratry.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 261.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/30/2025 02:02:18
-  entityCount: 22729
+  time: 07/03/2025 02:00:34
+  entityCount: 22737
 maps:
 - 5005
 grids:
@@ -70305,6 +70305,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -48.5,75.5
       parent: 1
+  - uid: 20310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -60.5,34.5
+      parent: 1
   - uid: 20376
     components:
     - type: Transform
@@ -70490,6 +70496,24 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -62.5,34.5
+      parent: 1
+  - uid: 22594
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -59.5,34.5
+      parent: 1
+  - uid: 22732
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -58.5,34.5
+      parent: 1
+  - uid: 22733
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -57.5,14.5
       parent: 1
 - proto: DisposalPipeBroken
   entities:
@@ -73275,7 +73299,7 @@ entities:
       pos: -25.5,43.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -5853.7876
+      secondsUntilStateChange: -6331.6826
       state: Closing
   - uid: 9802
     components:
@@ -114495,23 +114519,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -35.5,22.5
       parent: 1
-  - uid: 8614
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -55.5,28.5
-      parent: 1
   - uid: 8615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -53.5,11.5
-      parent: 1
-  - uid: 8618
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -39.5,12.5
       parent: 1
   - uid: 8619
     components:
@@ -114547,6 +114559,18 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,51.5
+      parent: 1
+  - uid: 22735
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 22740
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -64.5,55.5
       parent: 1
 - proto: IntercomEngineering
   entities:
@@ -114599,6 +114623,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,31.5
       parent: 1
+  - uid: 15522
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,22.5
+      parent: 1
   - uid: 16246
     components:
     - type: Transform
@@ -114642,6 +114672,12 @@ entities:
     - type: Transform
       pos: -47.5,49.5
       parent: 1
+  - uid: 8614
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -59.5,59.5
+      parent: 1
   - uid: 13502
     components:
     - type: Transform
@@ -114652,6 +114688,12 @@ entities:
     components:
     - type: Transform
       pos: -76.5,12.5
+      parent: 1
+  - uid: 22739
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -55.5,67.5
       parent: 1
 - proto: IntercomService
   entities:
@@ -114671,6 +114713,17 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,40.5
+      parent: 1
+  - uid: 22736
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -29.5,39.5
+      parent: 1
+  - uid: 22737
+    components:
+    - type: Transform
+      pos: -54.5,0.5
       parent: 1
 - proto: IntercomSupply
   entities:
@@ -129260,14 +129313,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 19.5,48.5
       parent: 1
-- proto: ShelfChemistryChemistrySecure
-  entities:
-  - uid: 16633
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,22.5
-      parent: 1
 - proto: ShelfKitchen
   entities:
   - uid: 10080
@@ -133459,12 +133504,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,65.5
-      parent: 1
-  - uid: 20310
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -56.5,52.5
       parent: 1
   - uid: 20311
     components:
@@ -153178,6 +153217,11 @@ entities:
     components:
     - type: Transform
       pos: -61.5,53.5
+      parent: 1
+  - uid: 16633
+    components:
+    - type: Transform
+      pos: -56.5,52.5
       parent: 1
 - proto: WarningCO2
   entities:

--- a/Resources/Maps/_Impstation/core.yml
+++ b/Resources/Maps/_Impstation/core.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 261.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/29/2025 19:29:27
-  entityCount: 22290
+  time: 07/03/2025 02:03:04
+  entityCount: 22302
 maps:
 - 17546
 grids:
@@ -102670,6 +102670,12 @@ entities:
     - type: InsideEntityStorage
 - proto: IntercomAll
   entities:
+  - uid: 11880
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-30.5
+      parent: 2
   - uid: 19738
     components:
     - type: Transform
@@ -102696,16 +102702,53 @@ entities:
       parent: 2
 - proto: IntercomCommon
   entities:
-  - uid: 15174
+  - uid: 4551
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -42.5,-55.5
+      parent: 2
+  - uid: 4553
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -52.5,-55.5
+      parent: 2
+  - uid: 4554
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,18.5
+      pos: -18.5,-32.5
       parent: 2
-  - uid: 20452
+  - uid: 5086
     components:
     - type: Transform
-      pos: 49.5,-17.5
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-21.5
+      parent: 2
+  - uid: 11814
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,0.5
+      parent: 2
+  - uid: 11815
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,0.5
+      parent: 2
+  - uid: 11838
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -41.5,3.5
+      parent: 2
+  - uid: 11839
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,26.5
       parent: 2
   - uid: 20453
     components:
@@ -102750,6 +102793,18 @@ entities:
       parent: 2
 - proto: IntercomEngineering
   entities:
+  - uid: 2091
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-9.5
+      parent: 2
+  - uid: 4552
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-15.5
+      parent: 2
   - uid: 15409
     components:
     - type: Transform
@@ -102781,6 +102836,17 @@ entities:
       rot: 3.141592653589793 rad
       pos: 45.5,6.5
       parent: 2
+  - uid: 11842
+    components:
+    - type: Transform
+      pos: 41.5,14.5
+      parent: 2
+  - uid: 11843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 59.5,13.5
+      parent: 2
   - uid: 20480
     components:
     - type: Transform
@@ -102807,12 +102873,40 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 56.5,-16.5
       parent: 2
+  - uid: 11844
+    components:
+    - type: Transform
+      pos: 71.5,-15.5
+      parent: 2
+  - uid: 11845
+    components:
+    - type: Transform
+      pos: 69.5,-6.5
+      parent: 2
+  - uid: 11878
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 56.5,-14.5
+      parent: 2
+  - uid: 11879
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 67.5,-24.5
+      parent: 2
 - proto: IntercomSecurity
   entities:
   - uid: 5655
     components:
     - type: Transform
       pos: -0.5,26.5
+      parent: 2
+  - uid: 11840
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,34.5
       parent: 2
   - uid: 20477
     components:
@@ -102822,6 +102916,12 @@ entities:
       parent: 2
 - proto: IntercomService
   entities:
+  - uid: 8810
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -41.5,12.5
+      parent: 2
   - uid: 11609
     components:
     - type: Transform
@@ -102873,6 +102973,12 @@ entities:
     components:
     - type: Transform
       pos: 23.5,16.5
+      parent: 2
+  - uid: 11841
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,7.5
       parent: 2
   - uid: 20472
     components:
@@ -105943,26 +106049,6 @@ entities:
     components:
     - type: Transform
       pos: -17.319014,-23.365795
-      parent: 2
-  - uid: 4551
-    components:
-    - type: Transform
-      pos: 26.357937,-30.55413
-      parent: 2
-  - uid: 4552
-    components:
-    - type: Transform
-      pos: 26.468012,-30.64586
-      parent: 2
-  - uid: 4553
-    components:
-    - type: Transform
-      pos: 26.578089,-30.792627
-      parent: 2
-  - uid: 4554
-    components:
-    - type: Transform
-      pos: 26.724855,-30.92105
       parent: 2
 - proto: PaperWrittenAMEScribbles
   entities:
@@ -112683,12 +112769,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -51.5,9.5
       parent: 2
-  - uid: 8810
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,3.5
-      parent: 2
   - uid: 8811
     components:
     - type: Transform
@@ -118832,13 +118912,6 @@ entities:
     components:
     - type: Transform
       pos: 32.5,17.5
-      parent: 2
-- proto: SignRadiationMed
-  entities:
-  - uid: 2091
-    components:
-    - type: Transform
-      pos: -2.5,-15.5
       parent: 2
 - proto: SignReception
   entities:

--- a/Resources/Maps/_Impstation/elkridge.yml
+++ b/Resources/Maps/_Impstation/elkridge.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 261.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/29/2025 19:06:08
-  entityCount: 17594
+  time: 07/03/2025 02:04:05
+  entityCount: 17610
 maps:
 - 1
 grids:
@@ -14006,7 +14006,7 @@ entities:
       pos: 9.5,-20.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -3018.9204
+      secondsUntilStateChange: -3489.3862
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14416,7 +14416,7 @@ entities:
       pos: 47.5,5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -465022.9
+      secondsUntilStateChange: -465493.38
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -18141,11 +18141,6 @@ entities:
     - type: Transform
       pos: 10.5,-22.5
       parent: 2
-  - uid: 2045
-    components:
-    - type: Transform
-      pos: -12.5,-32.5
-      parent: 2
   - uid: 2786
     components:
     - type: Transform
@@ -18285,11 +18280,6 @@ entities:
     components:
     - type: Transform
       pos: -10.5,-33.5
-      parent: 2
-  - uid: 2490
-    components:
-    - type: Transform
-      pos: -12.5,-32.5
       parent: 2
   - uid: 2788
     components:
@@ -51571,12 +51561,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -9.5,-13.5
       parent: 2
-  - uid: 15876
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-17.5
-      parent: 2
 - proto: DisposalPipe
   entities:
   - uid: 141
@@ -51697,8 +51681,8 @@ entities:
   - uid: 2083
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-17.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,-17.5
       parent: 2
   - uid: 2183
     components:
@@ -51777,12 +51761,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
-      parent: 2
-  - uid: 5522
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-17.5
       parent: 2
   - uid: 5528
     components:
@@ -53775,18 +53753,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -19.5,-21.5
       parent: 2
-  - uid: 15754
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-17.5
-      parent: 2
-  - uid: 15755
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-17.5
-      parent: 2
   - uid: 15797
     components:
     - type: Transform
@@ -54899,14 +54865,6 @@ entities:
       parent: 2
     - type: DisposalTagger
       tag: waste
-  - uid: 16453
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-17.5
-      parent: 2
-    - type: DisposalTagger
-      tag: waste
   - uid: 16858
     components:
     - type: Transform
@@ -55116,12 +55074,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -21.5,-21.5
       parent: 2
-  - uid: 15756
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-17.5
-      parent: 2
   - uid: 15798
     components:
     - type: Transform
@@ -55284,11 +55236,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,4.5
-      parent: 2
-  - uid: 5599
-    components:
-    - type: Transform
-      pos: -9.5,-17.5
       parent: 2
   - uid: 6564
     components:
@@ -84171,11 +84118,70 @@ entities:
       parent: 2
 - proto: IntercomCommon
   entities:
+  - uid: 12769
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-27.5
+      parent: 2
   - uid: 14477
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-15.5
+      parent: 2
+  - uid: 15379
+    components:
+    - type: Transform
+      pos: -17.5,2.5
+      parent: 2
+  - uid: 15514
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -51.5,-32.5
+      parent: 2
+  - uid: 15515
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-40.5
+      parent: 2
+  - uid: 15516
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-20.5
+      parent: 2
+  - uid: 15558
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,4.5
+      parent: 2
+  - uid: 15560
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,15.5
+      parent: 2
+  - uid: 15754
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,47.5
+      parent: 2
+  - uid: 15755
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,38.5
+      parent: 2
+  - uid: 16952
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,18.5
       parent: 2
 - proto: IntercomEngineering
   entities:
@@ -84185,6 +84191,35 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 25.5,-8.5
       parent: 2
+  - uid: 14941
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,-41.5
+      parent: 2
+  - uid: 15250
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-26.5
+      parent: 2
+  - uid: 16199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-16.5
+      parent: 2
+  - uid: 16283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-4.5
+      parent: 2
+  - uid: 16437
+    components:
+    - type: Transform
+      pos: 44.5,-7.5
+      parent: 2
 - proto: IntercomMedical
   entities:
   - uid: 4076
@@ -84193,6 +84228,22 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 29.5,6.5
       parent: 2
+  - uid: 16438
+    components:
+    - type: Transform
+      pos: 24.5,17.5
+      parent: 2
+  - uid: 16453
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,17.5
+      parent: 2
+  - uid: 16911
+    components:
+    - type: Transform
+      pos: 33.5,12.5
+      parent: 2
 - proto: IntercomScience
   entities:
   - uid: 11181
@@ -84200,6 +84251,24 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,18.5
+      parent: 2
+  - uid: 15756
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -31.5,21.5
+      parent: 2
+  - uid: 15876
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,13.5
+      parent: 2
+  - uid: 15968
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,23.5
       parent: 2
 - proto: IntercomSecurity
   entities:
@@ -84214,19 +84283,47 @@ entities:
     - type: Transform
       pos: -2.5,31.5
       parent: 2
+  - uid: 14833
+    components:
+    - type: Transform
+      pos: 0.5,-23.5
+      parent: 2
   - uid: 15299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-15.5
       parent: 2
+  - uid: 16985
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-32.5
+      parent: 2
 - proto: IntercomService
   entities:
+  - uid: 5522
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,-24.5
+      parent: 2
+  - uid: 5599
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
   - uid: 15899
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
+      parent: 2
+  - uid: 16823
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,4.5
       parent: 2
 - proto: IntercomSupply
   entities:
@@ -84235,6 +84332,23 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,26.5
+      parent: 2
+  - uid: 16913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,26.5
+      parent: 2
+  - uid: 16937
+    components:
+    - type: Transform
+      pos: 12.5,40.5
+      parent: 2
+  - uid: 16939
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,38.5
       parent: 2
 - proto: JanitorialTrolley
   entities:
@@ -91297,11 +91411,6 @@ entities:
     - type: Transform
       pos: 12.5,-11.5
       parent: 2
-  - uid: 14833
-    components:
-    - type: Transform
-      pos: -21.5,-25.5
-      parent: 2
   - uid: 14834
     components:
     - type: Transform
@@ -91601,11 +91710,6 @@ entities:
     components:
     - type: Transform
       pos: 11.5,-4.5
-      parent: 2
-  - uid: 14941
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
       parent: 2
   - uid: 14942
     components:
@@ -91932,11 +92036,6 @@ entities:
     - type: Transform
       pos: -13.5,-22.5
       parent: 2
-  - uid: 17549
-    components:
-    - type: Transform
-      pos: -13.5,-27.5
-      parent: 2
   - uid: 17550
     components:
     - type: Transform
@@ -91951,11 +92050,6 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-31.5
-      parent: 2
-  - uid: 17553
-    components:
-    - type: Transform
-      pos: 0.5,-23.5
       parent: 2
   - uid: 17554
     components:
@@ -95913,20 +96007,10 @@ entities:
       parent: 2
 - proto: SignNosmoking
   entities:
-  - uid: 12769
-    components:
-    - type: Transform
-      pos: 34.5,-41.5
-      parent: 2
   - uid: 12772
     components:
     - type: Transform
       pos: 27.5,17.5
-      parent: 2
-  - uid: 15250
-    components:
-    - type: Transform
-      pos: 16.5,-26.5
       parent: 2
 - proto: SignPlaque
   entities:
@@ -116807,6 +116891,18 @@ entities:
     components:
     - type: Transform
       pos: -8.5,36.5
+      parent: 2
+- proto: WardrobePrisonFilled
+  entities:
+  - uid: 2045
+    components:
+    - type: Transform
+      pos: -12.5,-32.5
+      parent: 2
+  - uid: 2490
+    components:
+    - type: Transform
+      pos: -9.5,-17.5
       parent: 2
 - proto: WarningCO2
   entities:

--- a/Resources/Maps/_Impstation/packed.yml
+++ b/Resources/Maps/_Impstation/packed.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 261.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/29/2025 19:35:32
-  entityCount: 15234
+  time: 07/03/2025 02:05:19
+  entityCount: 15261
 maps:
 - 126
 grids:
@@ -7893,7 +7893,7 @@ entities:
       pos: 101.5,-19.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -28484.984
+      secondsUntilStateChange: -28798.65
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -67367,6 +67367,12 @@ entities:
     - type: Transform
       pos: 17.5,-2.5
       parent: 2
+  - uid: 13761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 30.5,43.5
+      parent: 2
 - proto: IntercomCommon
   entities:
   - uid: 4989
@@ -67378,6 +67384,70 @@ entities:
     components:
     - type: Transform
       pos: 32.5,16.5
+      parent: 2
+  - uid: 13655
+    components:
+    - type: Transform
+      pos: 64.5,-14.5
+      parent: 2
+  - uid: 13758
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 36.5,33.5
+      parent: 2
+  - uid: 13915
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,34.5
+      parent: 2
+  - uid: 14084
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,8.5
+      parent: 2
+  - uid: 14085
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-2.5
+      parent: 2
+  - uid: 14131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-15.5
+      parent: 2
+  - uid: 14238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 2
+  - uid: 14240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 14250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-1.5
+      parent: 2
+  - uid: 14263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,4.5
+      parent: 2
+  - uid: 14522
+    components:
+    - type: Transform
+      pos: 21.5,19.5
       parent: 2
 - proto: IntercomEngineering
   entities:
@@ -67392,6 +67462,29 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 24.5,-25.5
       parent: 2
+  - uid: 13744
+    components:
+    - type: Transform
+      pos: 34.5,-21.5
+      parent: 2
+  - uid: 13745
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.5,-37.5
+      parent: 2
+  - uid: 13752
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-25.5
+      parent: 2
+  - uid: 13753
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 38.5,-49.5
+      parent: 2
 - proto: IntercomMedical
   entities:
   - uid: 11407
@@ -67399,12 +67492,89 @@ entities:
     - type: Transform
       pos: 48.5,1.5
       parent: 2
+  - uid: 13649
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 63.5,-1.5
+      parent: 2
+  - uid: 13650
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,-6.5
+      parent: 2
+  - uid: 13651
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 75.5,6.5
+      parent: 2
+  - uid: 13652
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 75.5,-7.5
+      parent: 2
 - proto: IntercomScience
   entities:
   - uid: 5107
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 61.5,17.5
+      parent: 2
+  - uid: 8398
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 48.5,20.5
+      parent: 2
+  - uid: 12293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 48.5,16.5
+      parent: 2
+  - uid: 13648
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 69.5,12.5
+      parent: 2
+- proto: IntercomSecurity
+  entities:
+  - uid: 13754
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 13755
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,21.5
+      parent: 2
+  - uid: 13757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,20.5
+      parent: 2
+  - uid: 14521
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,27.5
+      parent: 2
+- proto: IntercomService
+  entities:
+  - uid: 14367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 48.5,-5.5
       parent: 2
 - proto: IntercomSupply
   entities:
@@ -67419,6 +67589,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,20.5
+      parent: 2
+  - uid: 13759
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,36.5
       parent: 2
 - proto: JanitorialTrolley
   entities:
@@ -69359,11 +69535,6 @@ entities:
     components:
     - type: Transform
       pos: 44.5,26.5
-      parent: 2
-  - uid: 8398
-    components:
-    - type: Transform
-      pos: 51.5,22.5
       parent: 2
 - proto: PortableGeneratorJrPacman
   entities:
@@ -77617,12 +77788,6 @@ entities:
     components:
     - type: Transform
       pos: 57.499714,16.503765
-      parent: 2
-  - uid: 12293
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,16.5
       parent: 2
 - proto: SignRobo
   entities:

--- a/Resources/Maps/_Impstation/reach.yml
+++ b/Resources/Maps/_Impstation/reach.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 260.2.0
+  engineVersion: 261.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/16/2025 09:53:57
-  entityCount: 2643
+  time: 07/03/2025 01:53:38
+  entityCount: 2652
 maps:
 - 1
 grids:
@@ -6487,26 +6487,6 @@ entities:
     - type: Transform
       pos: 12.5,12.5
       parent: 2
-- proto: ClosetJanitorFilled
-  entities:
-  - uid: 886
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 2
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 887
-          - 889
-          - 888
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ClosetRadiationSuitFilled
   entities:
   - uid: 891
@@ -12050,6 +12030,26 @@ entities:
     - type: Transform
       pos: 6.506955,-8.404718
       parent: 2
+- proto: IntercomCommon
+  entities:
+  - uid: 1709
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-1.5
+      parent: 2
+  - uid: 2651
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 2
+  - uid: 2652
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-9.5
+      parent: 2
 - proto: IntercomEngineering
   entities:
   - uid: 1632
@@ -12057,6 +12057,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-0.5
+      parent: 2
+  - uid: 2644
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-16.5
       parent: 2
 - proto: IntercomMedical
   entities:
@@ -12066,12 +12072,58 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 2
+  - uid: 2645
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 2646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 2
+- proto: IntercomScience
+  entities:
+  - uid: 2648
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 2
 - proto: IntercomSecurity
   entities:
   - uid: 2554
     components:
     - type: Transform
       pos: 12.5,11.5
+      parent: 2
+  - uid: 2650
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,2.5
+      parent: 2
+- proto: IntercomService
+  entities:
+  - uid: 2649
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 2
+- proto: IntercomSupply
+  entities:
+  - uid: 1960
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 2647
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,14.5
       parent: 2
 - proto: JanitorialTrolley
   entities:
@@ -12251,6 +12303,26 @@ entities:
     - type: Transform
       pos: 21.5,3.5
       parent: 2
+- proto: LockerJanitorFilled
+  entities:
+  - uid: 886
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 887
+          - 889
+          - 888
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: LockerMedicalFilled
   entities:
   - uid: 1654
@@ -12661,11 +12733,6 @@ entities:
       parent: 2
 - proto: PosterLegitNanotrasenLogo
   entities:
-  - uid: 1709
-    components:
-    - type: Transform
-      pos: -11.5,-1.5
-      parent: 2
   - uid: 1710
     components:
     - type: Transform
@@ -14325,13 +14392,6 @@ entities:
     components:
     - type: Transform
       pos: 24.5,-1.5
-      parent: 2
-- proto: SignScience
-  entities:
-  - uid: 1960
-    components:
-    - type: Transform
-      pos: -0.5,6.5
       parent: 2
 - proto: SignSecureMed
   entities:


### PR DESCRIPTION
Adds some intercoms to arrivals, evac, cryo, chemistry, botany, and the warden's office.
Fixes some bugs with Elkridge, Barratry and Packed.

**Changelog**
no player-facing changelog