### PR TITLE
Generic and Science Chassis Changes

### DIFF
--- a/Resources/Locale/en-US/borg/borg.ftl
+++ b/Resources/Locale/en-US/borg/borg.ftl
@@ -38,8 +38,12 @@ borg-select-type-menu-guidebook = Guidebook
 ## Borg type information
 
 borg-type-generic-name = Generic
-borg-type-generic-desc = Jack of all trades, master of none. Do various random station tasks, or maybe help out the science department that built you.
+borg-type-generic-desc = Jack of all trades, master of none. Do various random station tasks.
 borg-type-generic-transponder = generic cyborg
+
+borg-type-science-name = Science
+borg-type-science-desc = Team up with the science department in the pursue of research. Help the crew unlock tools, weapons, toys, and more.
+borg-type-science-transponder = science cyborg
 
 borg-type-engineering-name = Engineering
 borg-type-engineering-desc = Assist the engineering team in station construction, repairing damage, or fixing electrical and atmospheric issues.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -89,6 +89,14 @@
   - type: BorgSwitchableType
     selectedBorgType: cargo
 
+- type: entity # Imp
+  id: BorgChassisScience
+  parent: BorgChassisSelectable
+  name: science cyborg
+  components:
+  - type: BorgSwitchableType
+    selectedBorgType: science
+
 - type: entity
   id: BorgChassisSyndicateAssault
   parent: BaseBorgChassisSyndicate

--- a/Resources/Prototypes/_Impstation/borg_types.yml
+++ b/Resources/Prototypes/_Impstation/borg_types.yml
@@ -26,3 +26,31 @@
   spriteHasMindState: cargo_e
   spriteNoMindState: cargo_e_r
   spriteToggleLightState: cargo_l
+
+- type: borgType
+  id: science
+
+  # Description
+  dummyPrototype: BorgChassisScience
+
+  # Functional
+  extraModuleCount: 3
+  moduleWhitelist:
+    tags:
+    - BorgModuleGeneric
+    - BorgModuleScience
+
+  defaultModules:
+  - BorgModuleArtifact
+  - BorgModuleAnomaly
+  - BorgModuleTool
+
+  radioChannels:
+  - Science
+
+  inventoryTemplateId: borgTall
+  spriteBodyState: peace
+  spriteBodyMovementState: peace
+  spriteHasMindState: peace_e
+  spriteNoMindState: peace_e_r
+  spriteToggleLightState: peace_l

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -10,12 +10,12 @@
   moduleWhitelist:
     tags:
     - BorgModuleGeneric
-    - BorgModuleScience #until sciborgs are added
+  #  - BorgModuleScience # Imp
 
   defaultModules:
   - BorgModuleTool
-  - BorgModuleArtifact
-  - BorgModuleAnomaly
+  #- BorgModuleArtifact # Imp
+  #- BorgModuleAnomaly # Imp
   radioChannels:
   - Science
 

--- a/Resources/ServerInfo/_Impstation/Guidebook/Science/Cyborgs.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/Science/Cyborgs.xml
@@ -26,6 +26,7 @@
   Once created, a cyborg needs to specialize its chassis to a duty on the station. This determines what modules it starts with, which additional modules can be installed, and what [color=#a4885c]departmental radio channel[/color] it has access to. All cyborgs have access to the [color=#D381C9]Science[/color] and [color=green]station-wide[/color] radio channels. All cyborg types have [color=#a4885c]all-access[/color]: as long as they have battery power, they can be asked to open any door on the station.
   <Box>
     <GuideEntityEmbed Entity="BorgChassisGeneric" Caption="Generic"/>
+    <GuideEntityEmbed Entity="BorgChassisScience" Caption="Science"/>
     <GuideEntityEmbed Entity="BorgChassisEngineer" Caption="Engineering"/>
     <GuideEntityEmbed Entity="BorgChassisMining" Caption="Salvage"/>
     <GuideEntityEmbed Entity="BorgChassisJanitor" Caption="Janitor"/>


### PR DESCRIPTION
:cl:
- add: Added a new Science Borg Chassis. It comes with a tool, anomaly, and artifact module. "You will be baked and there will be cake!"
- add: Added the Science Borg Chassis to the cyborg section of the Guidebook.
- remove: Removed science modules from the Generic Chassis. You are now a generic and very good at it!
- tweak: Updated the Generic Chassis entry in the Guidebook.