### PR TITLE
Air Alarms Auto Mode only scrubs waste gasses

### DIFF
--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -18,12 +18,8 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public static HashSet<Gas> DefaultFilterGases = new()
         {
             Gas.CarbonDioxide,
-            Gas.Plasma,
-            Gas.Tritium,
-            Gas.WaterVapor,
             Gas.Ammonia,
             Gas.NitrousOxide,
-            Gas.Frezon
         };
 
         // Presets for 'dumb' air alarm modes

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -17,6 +17,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
 
         public static HashSet<Gas> DefaultFilterGases = new()
         {
+            // Imp, removed all non-player-waste gases
             Gas.CarbonDioxide,
             Gas.Ammonia,
             Gas.NitrousOxide,


### PR DESCRIPTION
This PR was made after some discussion in the Discord suggestions channel. The goal of this PR is to give Atmos a bit more to do, since it's entirely possible to ignore some gas leaks as scrubbers will take care of them. Feels bad for the Atmos Tech to get called over and by the time they reach it, Scrubbers have gotten most of it anyways.

:cl:
- tweak: Auto Mode on Air Alarms now only scrubs waste gasses. That's CO2, NO2, and Ammonia!
