### PR TITLE
imp species mimes get survival boxes again

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -80,6 +80,11 @@
     - Dwarf
     - Human
     - Reptilian
+    # imp below
+    - Decapoid
+    - Gray
+    - Gastropoid
+    - Thaven
 
 - type: loadoutEffectGroup
   id: OxygenBreatherMimeMoth


### PR DESCRIPTION
decas probably should get a different survival box but wyci

**Changelog**
:cl:
- fix: Thaven mimes get their starting baguette back. No response from the crowd.