### PR TITLE
Better ingame hour count text

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -217,13 +217,21 @@ namespace Content.Client.Lobby
 
                 var hoursToday = Math.Round(minutesToday / 60f, 1);
 
-                var chosenString = minutesToday switch
+                // Imp edit begin
+                string chosenString = new Random().Next(9) switch
                 {
-                    < 180 => "lobby-state-playtime-comment-normal",
-                    < 360 => "lobby-state-playtime-comment-concerning",
-                    < 720 => "lobby-state-playtime-comment-grasstouchless",
-                    _ => "lobby-state-playtime-comment-selfdestructive"
+                    0 => "lobby-state-playtime-comment-normal",
+                    1 => "lobby-state-playtime-comment-aa",
+                    2 => "lobby-state-playtime-comment-lifespan",
+                    3 => "lobby-state-playtime-comment-itsfine",
+                    4 => "lobby-state-playtime-comment-entireday",
+                    5 => "lobby-state-playtime-comment-bros",
+                    6 => "lobby-state-playtime-comment-morallyneutral",
+                    7 => "lobby-state-playtime-comment-nottellingu",
+                    8 => "lobby-state-playtime-comment-nuke",
+                    _ => "lobby-state-playtime-comment-feettall"
                 };
+                // Imp edit end
 
                 Lobby.PlaytimeComment.SetMarkup(Loc.GetString(chosenString, ("hours", hoursToday)));
             }

--- a/Resources/Locale/en-US/_Impstation/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/_Impstation/lobby/lobby-state.ftl
@@ -1,0 +1,9 @@
+lobby-state-playtime-comment-aa = You've played {$hours} today, and none of it was as AA.
+lobby-state-playtime-comment-lifespan = {$hours} hours played today, which means {$hours} more hours added to your life span! Good job!
+lobby-state-playtime-comment-itsfine = You can spend {$hours} hours doing anything you want. It's fine.
+lobby-state-playtime-comment-entireday = If there were {$hours} hours in a day, you would have spent the entire day on station today.
+lobby-state-playtime-comment-bros = AAAAAAH! {$hours} GIANT BROS BEHIND YOU! Just kidding.
+lobby-state-playtime-comment-morallyneutral = You've spent {$hours} morally neutral hours playing today.
+lobby-state-playtime-comment-nottellingu = I'm not telling you how long you've played. Drink some water.
+lobby-state-playtime-comment-nuke = Next round, try entering {$hours} on the nuke to see what happens!
+lobby-state-playtime-comment-feettall = You're about {$hours} feet tall. Just kidding. Can you imagine?


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Upstream added a little line of text in the lobby stream that tells you how many hours you've played (total) in a given day. Which is great, because if you've played 6 hours or some shit in a day you should be aware of that. But once you cross a threshold the lobby text grows a tad condescending, and it remains condescending even if you get up and take a break and come back later. Because it works off total playtime, it doesn't respond to you actually continuing to take a break.
This PR just changes the reminder text to some lines written by Carousel (thanks!!) and makes it random instead of determined by playtime (to discourage a sense of achievement from reaching a certain playtime). I kept one upstream line ("Remember to take breaks!") because it's a good reminder to have.
Suggestions are welcome!

![Screenshot 2025-07-06 221535](https://github.com/user-attachments/assets/bece9332-04ee-4721-9b68-e01e940b10a4)
^^ fuuuck my life

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: CrocodileCarousel & Pinkbat5
- tweak: The lobby playtime text now has a little more personality.

