### PR TITLE
Split migrations into separate files

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1,3 +1,4 @@
+# IMP NOTE: Add new additions should be added to migration_imp.yml
 # This is a basic dictionary that maps old entity prototype ids to new ids. This only works for entity prototypes, and
 # is intended to allow maps to load without having to manually edit them. An empty or "null" string results in the
 # entity getting deleted.
@@ -679,64 +680,3 @@ BarSignEmprahAlignTile: BarSignEmprah
 BarSignSpacebucksAlignTile: BarSignSpacebucks
 BarSignMaltroachAlignTile: BarSignMaltroach
 BarSignWhiskeyEchoesAlignTile: BarSignWhiskeyEchoes
-
-# IMPSTATION SPECIFIC MIGRATIONS BELOW
-# ====================================
-
-# 2024-11-25
-#impstation change
-ToolboxArtistic: ToolboxArtisticFilled
-
-# 2024-11-25
-# impstation: Removal of seperate borg parts
-LeftArmBorgCargo: LeftArmBorg
-RightArmBorgCargo: RightArmBorg
-LeftLegBorgCargo: LeftLegBorg
-RightLegBorgCargo: RightLegBorg
-HeadBorgCargo: LightHeadBorg
-TorsoBorgCargo: TorsoBorg
-
-# 2025-01-16
-# impstation: Removal of duplicate holopad Entity, oopsies
-HolopadCargoMailroomCourier: HolopadCargoMailroom
-
-# 2025-01-20
-# impstation: Make sure the templar helmet doesn't slink back in and break new maps
-ClothingHeadHelmetTemplar: null
-
-# 2025-02-18
-# impstation: Replace Walter spawns with the Walter/Dolby spawner
-SpawnMobWalter: SpawnMobChemDog
-
-# 2025-03-13
-# impstation: make the courier hardsuit non-roundstart
-SuitStorageCourier: null
-LockerCourierFilledHardsuit: LockerCourierFilled
-
-# 2025-03-25
-# impstation: swap mail systems
-MailTeleporter: CargoMailTeleporter
-
-# 2025-03-12
-SmartFridge: DVSmartFridge
-
-# 2025-05-14
-# impstation: remove fishing rods until the system is done
-FishingRodBase: null
-FishingRodPlasma: null
-
-# 2025-05-31
-# impstation: remove DV stock cartridge
-StockTradingCartridge: null
-
-# 2025-06-09 (nice)
-# imp borg module swaps
-BorgModulePaper: BorgModuleService
-
-# 2025-06-09
-# impstation: migrate our cleanade crate to upstream implementation
-CrateServiceCleanades: CrateServiceCleanerGrenades
-
-# impstation: replace custodial closets with secure janitor lockers
-ClosetJanitor: LockerJanitor
-ClosetJanitorFilled: LockerJanitorFilled

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1,4 +1,4 @@
-# IMP NOTE: Add new additions should be added to migration_imp.yml
+# IMP NOTE: New imp migrations should be added to migration_imp.yml
 # This is a basic dictionary that maps old entity prototype ids to new ids. This only works for entity prototypes, and
 # is intended to allow maps to load without having to manually edit them. An empty or "null" string results in the
 # entity getting deleted.

--- a/Resources/migration_imp.yml
+++ b/Resources/migration_imp.yml
@@ -1,0 +1,67 @@
+# This is a basic dictionary that maps old entity prototype ids to new ids. This only works for entity prototypes, and
+# is intended to allow maps to load without having to manually edit them. An empty or "null" string results in the
+# entity getting deleted.
+
+# e.g., you can swap all walls with windows and delete all tables by adding lines like:
+#
+# Window: WallSolid
+# WallSolid: Window
+# Table: null
+
+# 2024-11-25
+#impstation change
+ToolboxArtistic: ToolboxArtisticFilled
+
+# 2024-11-25
+# impstation: Removal of seperate borg parts
+LeftArmBorgCargo: LeftArmBorg
+RightArmBorgCargo: RightArmBorg
+LeftLegBorgCargo: LeftLegBorg
+RightLegBorgCargo: RightLegBorg
+HeadBorgCargo: LightHeadBorg
+TorsoBorgCargo: TorsoBorg
+
+# 2025-01-16
+# impstation: Removal of duplicate holopad Entity, oopsies
+HolopadCargoMailroomCourier: HolopadCargoMailroom
+
+# 2025-01-20
+# impstation: Make sure the templar helmet doesn't slink back in and break new maps
+ClothingHeadHelmetTemplar: null
+
+# 2025-02-18
+# impstation: Replace Walter spawns with the Walter/Dolby spawner
+SpawnMobWalter: SpawnMobChemDog
+
+# 2025-03-13
+# impstation: make the courier hardsuit non-roundstart
+SuitStorageCourier: null
+LockerCourierFilledHardsuit: LockerCourierFilled
+
+# 2025-03-25
+# impstation: swap mail systems
+MailTeleporter: CargoMailTeleporter
+
+# 2025-03-12
+SmartFridge: DVSmartFridge
+
+# 2025-05-14
+# impstation: remove fishing rods until the system is done
+FishingRodBase: null
+FishingRodPlasma: null
+
+# 2025-05-31
+# impstation: remove DV stock cartridge
+StockTradingCartridge: null
+
+# 2025-06-09 (nice)
+# imp borg module swaps
+BorgModulePaper: BorgModuleService
+
+# 2025-06-09
+# impstation: migrate our cleanade crate to upstream implementation
+CrateServiceCleanades: CrateServiceCleanerGrenades
+
+# impstation: replace custodial closets with secure janitor lockers
+ClosetJanitor: LockerJanitor
+ClosetJanitorFilled: LockerJanitorFilled


### PR DESCRIPTION
Splits Imp specific migrations into its own migrations file, based off of Frontier's implementation: https://github.com/new-frontiers-14/frontier-station-14/blob/fc9549eb52983c6f5c507ea1d56600cf2288edae/Content.Server/Maps/MapMigrationSystem.cs#L18 (which is based off of DeltaV's implementation. DeltaV moved migrations to their own directory which *probably* causes extra work in maintaining migrations.yml, so I went with Frontier's implementation). Tested this loading an unmodified upstream version of Reach and it replaced the SmartFridge and custodial closet as expected.