### PR TITLE
Muted people can now scream

### DIFF
--- a/Content.Server/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Server/Abilities/Mime/MimePowersSystem.cs
@@ -55,7 +55,9 @@ namespace Content.Server.Abilities.Mime
 
         private void OnComponentInit(EntityUid uid, MimePowersComponent component, ComponentInit args)
         {
-            EnsureComp<MutedComponent>(uid);
+            var mutedComponent = EnsureComp<MutedComponent>(uid); // IMP
+            mutedComponent.MutedScream = false; // IMP
+
             if (component.PreventWriting)
             {
                 EnsureComp<BlockWritingComponent>(uid, out var illiterateComponent);

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -62,6 +62,9 @@
       - BorgChassis
   components:
     - type: Muted
+      mutedEmotes: true # IMP
+      mutedScream: false # IMP
+      mutedSpeech: true # IMP
 
 - type: trait
   id: Paracusia


### PR DESCRIPTION
Used the changes I made to the muted component to allow people with the muted trait and mimes to hit the scream button. It still doesn't make sound like the other emotes so it's just them pretending to scream.

:cl: Oberonics
- tweak: Mute people can now express their fear.

