### PR TITLE
Add support for RoleTimeRequirement to use antag time trackers

### DIFF
--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -23,13 +23,7 @@ public sealed partial class AntagPrototype : IPrototype
     /// </summary>
     [DataField]
     public Color Color { get; private set; } = Color.Red;
-
-    /// <summary>
-    /// An icon used to represent the antag on UI elements, such as the lobby.
-    /// </summary>
-    [DataField]
-    public ProtoId<AntagIconPrototype> Icon { get; private set; }
-
+    // Imp edit end
 
     [ViewVariables]
     [IdDataField]

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Guidebook;
 using Content.Shared.Players.PlayTimeTracking; // imp
+using Content.Shared.StatusIcon; // imp
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype; // imp. iirc this is outdated but i dont care
@@ -13,8 +14,22 @@ namespace Content.Shared.Roles;
 [Serializable, NetSerializable]
 public sealed partial class AntagPrototype : IPrototype
 {
+    // Imp edit start
     [DataField("playTimeTracker", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<PlayTimeTrackerPrototype>))]
-    public string PlayTimeTracker { get; private set; } = string.Empty; // imp
+    public string PlayTimeTracker { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// A color representing this antag to use for text. Defaults to syndie blood red.
+    /// </summary>
+    [DataField]
+    public Color Color { get; private set; } = Color.Red;
+
+    /// <summary>
+    /// An icon used to represent the antag on UI elements, such as the lobby.
+    /// </summary>
+    [DataField]
+    public ProtoId<AntagIconPrototype> Icon { get; private set; }
+
 
     [ViewVariables]
     [IdDataField]

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Guidebook;
 using Content.Shared.Players.PlayTimeTracking; // imp
-using Content.Shared.StatusIcon; // imp
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype; // imp. iirc this is outdated but i dont care

--- a/Content.Shared/StatusIcon/StatusIconPrototype.cs
+++ b/Content.Shared/StatusIcon/StatusIconPrototype.cs
@@ -216,6 +216,23 @@ public sealed partial class SsdIconPrototype : StatusIconPrototype, IInheritingP
     public bool Abstract { get; private set; }
 }
 
+/// Imp addition
+/// <summary>
+/// StatusIcons to show next to antags in the lobby.
+/// </summary>
+[Prototype]
+public sealed partial class AntagIconPrototype : StatusIconPrototype, IInheritingPrototype
+{
+    /// <inheritdoc />
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<AntagIconPrototype>))]
+    public string[]? Parents { get; private set; }
+
+    /// <inheritdoc />
+    [NeverPushInheritance]
+    [AbstractDataField]
+    public bool Abstract { get; private set; }
+}
+
 [Serializable, NetSerializable]
 public enum StatusIconLocationPreference : byte
 {

--- a/Content.Shared/StatusIcon/StatusIconPrototype.cs
+++ b/Content.Shared/StatusIcon/StatusIconPrototype.cs
@@ -216,23 +216,6 @@ public sealed partial class SsdIconPrototype : StatusIconPrototype, IInheritingP
     public bool Abstract { get; private set; }
 }
 
-/// Imp addition
-/// <summary>
-/// StatusIcons to show next to antags in the lobby.
-/// </summary>
-[Prototype]
-public sealed partial class AntagIconPrototype : StatusIconPrototype, IInheritingPrototype
-{
-    /// <inheritdoc />
-    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<AntagIconPrototype>))]
-    public string[]? Parents { get; private set; }
-
-    /// <inheritdoc />
-    [NeverPushInheritance]
-    [AbstractDataField]
-    public bool Abstract { get; private set; }
-}
-
 [Serializable, NetSerializable]
 public enum StatusIconLocationPreference : byte
 {

--- a/Resources/Prototypes/_Impstation/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_Impstation/Roles/play_time_trackers.yml
@@ -7,6 +7,7 @@
 
 # imp - upstream antag trackers
 # placeholder trackers for building blocks - there's too much to rework otherwise so i'm doing this instead. they literally do nothing.
+# TODO: implement these as antagGroups instead
 - type: playTimeTracker
   id: AntagGeneric
 


### PR DESCRIPTION
Lets RoleTimeRequirement be able to take a time tracker linked to an antag, allowing roles to require playtime as specific antags to unlock. Previously the system would only check to see if a given playtime tracker corresponded to a valid job prototype, this adds a second check to see if the tracker corresponds to an antag prototype instead. This also adds a new Color datafield to antag prototypes (defaulting to red), which is used for coloring the name of the antag in the lobby playtime requirement UI. I wanted to work a bit more on this to have most antags have a unique color and also work on giving antags their own icons to display next to their names in the lobby, but I wanted to focus on implementing the RoleTimeRequirement first and work on that other stuff later on.

https://github.com/user-attachments/assets/78d7782d-d185-4565-acec-2049b19a0291

no cl, not player facing.
