### PR TITLE
Anaconda and Damage on Shoot changes

### DIFF
--- a/Content.Shared/_Impstation/Weapons/Ranged/DamageOnShootSystem.cs
+++ b/Content.Shared/_Impstation/Weapons/Ranged/DamageOnShootSystem.cs
@@ -59,7 +59,7 @@ public sealed class DamageOnShootSystem : EntitySystem
             }
         }
 
-        totalDamage = _damageableSystem.TryChangeDamage(args.User, totalDamage);
+        totalDamage = _damageableSystem.TryChangeDamage(args.User, totalDamage, entity.Comp.IgnoreResistances);
 
         if (totalDamage != null && totalDamage.AnyPositive())
         {

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Revolvers/anaconda.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Revolvers/anaconda.yml
@@ -2,7 +2,7 @@
   name: Anaconda
   parent: [BaseWeaponRevolver, Tier3Contraband]
   id: WeaponAnaconda
-  description: A junior designer at Waffle Corp. swears they submitted this as a joke. Kicks like a blood-red horse if used without a hardsuit. Uses .60 anti-materiel ammo.
+  description: A junior designer at Waffle Corp. swears they submitted this as a joke. Kicks like a blood-red horse when fired. Uses .60 anti-materiel ammo.
   components:
   - type: Sprite
     sprite: _Impstation/Objects/Weapons/Guns/Revolvers/anaconda.rsi
@@ -48,6 +48,7 @@
       types:
         Blunt: 10
     popupText: null
+    ignoreResistances: true
     damageSound: /Audio/Weapons/boxingpunch3.ogg
   - type: MeleeWeapon
     range: 0.8


### PR DESCRIPTION
Ignore Resistances now properly works on Damage on Shoot and you can't escape the Anaconda's recoil-- wrists everywhere beware!

**Changelog**
:cl:
- tweak: The Anaconda now hurts your wrist regardless of what you're wearing. Be careful!