### PR TITLE
let (most) command roll antags

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -238,6 +238,9 @@
     - prefRoles: [ HeadRev ]
       max: 3
       playerRatio: 15
+      blacklist:
+        components:
+        - CommandStaff # imp edit to prevent command rolling headrev, while other antags are still available
       briefing:
         text: head-rev-role-greeting
         color: CornflowerBlue

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -19,7 +19,7 @@
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
   supervisors: job-supervisors-hop-captain #imp
-  canBeAntag: false
+  canBeAntag: true # imp
   access:
   - Cargo
   - Courier #Imp

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -26,7 +26,7 @@
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
   supervisors: job-supervisors-captain #imp
-  canBeAntag: false
+  canBeAntag: true # imp
   access:
   - Command
   - HeadOfPersonnel

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -19,7 +19,7 @@
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"
   supervisors: job-supervisors-hop-captain #imp
-  canBeAntag: false
+  canBeAntag: true # imp
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -21,7 +21,7 @@
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-hop-captain #imp
-  canBeAntag: false
+  canBeAntag: true # imp
   access:
   - Medical
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -13,7 +13,7 @@
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"
   supervisors: job-supervisors-hop-captain #imp
-  canBeAntag: false
+  canBeAntag: true # imp
   access:
   - Research
   - Command

--- a/Resources/Prototypes/_Impstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/roundstart.yml
@@ -34,6 +34,7 @@
       blacklist:
         components:
         - AntagImmune
+        - CommandStaff
       lateJoinAdditional: true
       forceAllPossible: true
       mindRoles:
@@ -64,6 +65,7 @@
       blacklist:
         components:
         - AntagImmune
+        - CommandStaff
       lateJoinAdditional: true
       forceAllPossible: true
       mindRoles:
@@ -94,6 +96,7 @@
       blacklist:
         components:
         - AntagImmune
+        - CommandStaff
       lateJoinAdditional: true
       forceAllPossible: true
       mindRoles:

--- a/Resources/Prototypes/_Impstation/Roles/Jobs/Service/hospitality_director.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Jobs/Service/hospitality_director.yml
@@ -22,7 +22,7 @@
   startingGear: HospitalityDirectorGear
   icon: JobIconHospitalityDirector
   supervisors: job-supervisors-hop-captain
-  canBeAntag: false
+  canBeAntag: true
   accessGroups:
   - Service #why don't other heads have their accesses set up this way?
   access:


### PR DESCRIPTION
As the title reads. I thiiiiiink this also prevents all command from rolling headrev, but I could be wrong.

Primarily posting this to get discussion on it in a more visible/recordable format, I know it's controversial. Happy to try and do cs to try and implement any changes that get landed on, also happy if we end up deciding not to.

:cl:
- tweak: All command except the HoS and Captain can roll antag now.