### PR TITLE
Make heavyweight drunk slightly less strong

### DIFF
--- a/Content.Shared/_Impstation/Traits/Assorted/HeavyweightDrunkComponent.cs
+++ b/Content.Shared/_Impstation/Traits/Assorted/HeavyweightDrunkComponent.cs
@@ -11,5 +11,5 @@ namespace Content.Shared.Traits.Assorted;
 public sealed partial class HeavyweightDrunkComponent : Component
 {
     [DataField("boozeStrengthMultiplier"), ViewVariables(VVAccess.ReadWrite)]
-    public float BoozeStrengthMultiplier = 0.50f;
+    public float BoozeStrengthMultiplier = 0.80f;
 }

--- a/Resources/Locale/en-US/_Impstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Impstation/traits/traits.ftl
@@ -1,4 +1,4 @@
-trait-heavyweightdrunk-name = Heavyweight Drunk
+trait-heavyweightdrunk-name = Heavyweight drunk
 trait-heavyweightdrunk-desc = Alcohol has less of an effect on you.
 
 trait-hemophilia-name = Hemophilia


### PR DESCRIPTION
A few people pointed out that heavyweight drunk made getting drunk more or less impossible, which wasn't quite what I intended. Plus its current strength occasionally causes weird stuttering with the drunk shader which Sucks to look at.
Also fixes erronous capitalization in the trait name (whoops).

**Changelog**
:cl:
- tweak: Heavyweight drunks can get drunk slightly easier.
