### PR TITLE
medHUD implant for CMO

### DIFF
--- a/Content.Server/_Impstation/Implants/MedHUDImplantSystem.cs
+++ b/Content.Server/_Impstation/Implants/MedHUDImplantSystem.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Implants;
+using Content.Shared.Implants.Components;
+using Content.Shared.Overlays;
+using Robust.Shared.Containers;
+
+namespace Content.Server.Implants;
+
+public sealed class MedHUDImplantSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MedHUDImplantComponent, ImplantImplantedEvent>(OnImplantImplanted);
+        SubscribeLocalEvent<MedHUDImplantComponent, EntGotRemovedFromContainerMessage>(OnRemove);
+    }
+
+    /// <summary>
+    /// If implanted with a medHUD implant, installs the necessary intrinsic medHUD components
+    /// </summary>
+    private void OnImplantImplanted(Entity<MedHUDImplantComponent> ent, ref ImplantImplantedEvent args)
+    {
+        if (args.Implanted == null)
+            return;
+
+        EnsureComp<ShowHealthBarsComponent>(args.Implanted.Value);
+        EnsureComp<ShowHealthIconsComponent>(args.Implanted.Value);
+    }
+
+    /// <summary>
+    /// Removes intrinsic medHUD components once the MedHUD implant is removed
+    /// </summary>
+    private void OnRemove(Entity<MedHUDImplantComponent> ent, ref EntGotRemovedFromContainerMessage args)
+    {
+        if (TryComp<ShowHealthBarsComponent>(args.Container.Owner, out var showHealthBarsComponent))
+        {
+            RemCompDeferred<ShowHealthBarsComponent>(args.Container.Owner);
+        }
+        if (TryComp<ShowHealthIconsComponent>(args.Container.Owner, out var showHealthIconsComponent))
+        {
+            RemCompDeferred<ShowHealthIconsComponent>(args.Container.Owner);
+        }
+    }
+}

--- a/Content.Shared/_Impstation/Implants/Components/MedHUDImplantComponent.cs
+++ b/Content.Shared/_Impstation/Implants/Components/MedHUDImplantComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.Implants.Components;
+
+/// <summary>
+/// Gives the user medical HUD vision without eyewear.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MedHUDImplantComponent : Component
+{ }

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -225,6 +225,8 @@
     - id: ClothingBackpackDuffelSurgeryFilled
     - id: ClothingCloakCmo
     - id: ClothingEyesHudMedical
+    - id: MedHUDImplanter # impspecial
+    - id: ClothingEyesGlassesChemical # imp
     - id: ClothingHandsGlovesNitrile
     - id: ClothingHeadHatBeretCmo
     - id: ClothingHeadsetAltMedical

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -44,6 +44,7 @@
       - DeathAcidifierImplant
       - DeathRattleImplant
       - MindShieldImplant
+      - MedHUDImplant # imp
       #deimplantFailureDamage: # imp - this is addressing an issue we like. dont have. lol
       #  types:
       #    Cellular: 50

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/implanters.yml
@@ -5,3 +5,11 @@
   components:
   - type: Implanter
     implant: GayStorageImplant
+
+- type: entity
+  id: MedHUDImplanter
+  name: medical HUD implanter
+  parent: BaseImplantOnlyImplanter
+  components:
+  - type: Implanter
+    implant: MedHUDImplant

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/subdermal_implants.yml
@@ -31,3 +31,12 @@
     interfaces:
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
+
+- type: entity
+  id: MedHUDImplant
+  name: medical HUD implant
+  parent: BaseSubdermalImplant
+  description: A rare and expensive implant letting you see people's medical status without any glasses. Reserved for CMO use only.
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: MedHUDImplant


### PR DESCRIPTION
Adds a medical HUD implant for the CMO as an extra toy. Directly inspired by a similar item CMO gets on /tg/, a medHUD autosurgeon. Chem goggles are just in there because it's something I see frequently complained about.

:cl:
- add: The CMO now gets a medHUD implant in their locker!
- add: CMO also gets a roundstart pair of chem goggles. They need it.
