### PR TITLE
remove ninja from event table

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -29,7 +29,7 @@
     - id: ClosetSkeleton
     - id: DragonSpawn
     - id: KingRatMigration
-    - id: NinjaSpawn
+    - #id: NinjaSpawn # committed seppuku
     - id: ParadoxCloneSpawn
     - id: RevenantSpawn
     - id: SleeperAgents
@@ -55,7 +55,7 @@
     - id: ClosetSkeleton
     - id: DragonSpawn
     - id: KingRatMigration
-    - id: NinjaSpawn
+    - #id: NinjaSpawn # committed seppuku
     - id: RevenantSpawn
     - id: ZombieOutbreak
     - id: LoneOpsSpawn


### PR DESCRIPTION
Exactly as the title says, no more ninja spawning naturally.

Why: Because ninja gets more ahelps than any other antagonist and is a constant source of frustration, it especially does not work well with escalation rules. I've seen a lot of sentiment that it's a bad role in desperate need of a substantial rework and I agree. I do not think reducing its frequency or slightly tweaking its objectives will solve these problems. We have enough other midround antagonists that I think we can stand to be without ninja until a hero steps up to the challenge to rework it.

:cl:
- remove: ninja committed seppuku
