### PR TITLE
Thief invisible crate buff

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -919,6 +919,7 @@
   components:
   - type: Stealth
     hadOutline: true
+    useAltShader: true # imp
   - type: StealthOnMove
     passiveVisibilityRate: -0.10
     movementVisibilityRate: 0.10


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Changes the invisible thief crate to the new shader we have. It is now perfectly invisible when at rest.
Before:
![thief_crate_old_shader](https://github.com/user-attachments/assets/2a63ec39-9229-4bcc-966c-bddd7cac6097)

After:
![thief_crate_new_shader](https://github.com/user-attachments/assets/07400e8a-651f-4df5-bcd3-49b385dda8ec)

My reasoning: I hate spotting an invisible thing the second I walk into the room and having to pretend that I didn't see it. Because sometimes that invisible thing is still REALLY obvious, and it makes me genuinely unsure if my character would notice it or not. I'd rather the thing be invisible to ME as well!
So if the crate is actually, genuinely invisible, and you still notice it (because its been anchored down in the middle of a hallway or something) then you can safely say that the thief that bought it didn't do a good enough job hiding it, and interact with it guilt-free.

Worth noting that the crate remains perfectly invisible when being dragged around, unlike ninjas/changelings using the new shader. I think this is hilarious so I'm keeping it that way. You still run the risk of accidentally shoving people around with this thing, which outs you and your crate.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The invisible thief crate is now actually fully invisible.
