### PR TITLE
Make experimental welding tools as fast as advanced industrial welding tools

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -200,6 +200,8 @@
   - type: RequiresEyeProtection
     statusEffectTime: 5 # less harmful; sunglasses can block it
   # imp edit start
+  - type: Tool
+    speedModifier: 1.3
   - type: SolutionPurge
     solution: Welder
     preserve:


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
All of the roundstart sci-researchable Chief Engineer tools are slightly (or not slightly) faster than their normal counterparts, with the exception of the experimental welding tool. Which is strange, because advanced industrial welding tools (which aren't sci-researchable) _are_ faster.
The majority of maps start with an advanced industrial welding tool laying around for the normal engineers to fight over. This means that one normal engineer is getting a faster roundstart welding tool than the CE. This strikes me as an oversight, and I think it makes the most sense from a game design perspective if the command toy and sci unlock is just as fast as a round-start available tool.
Yes, unlimited fuel is nothing to scoff at! But it's the only advantage the experimental welding tool has. The power drill has two advantages: being two tools in one, and drilling faster. And the jaws have three: being two tools in one, free all access (!!), and prying faster. I just think this is more consistent.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Experimental welding tools now weld slightly faster.

