### PR TITLE
remove the minimum limit for security's outer clothing and belt loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1173,6 +1173,7 @@
 - type: loadoutGroup
   id: HeadofSecurityOuterClothing
   name: loadout-group-head-of-security-outerclothing
+  minLimit: 0 # imp edit
   loadouts:
   - HeadofSecurityCoat
   - HeadofSecurityEliteArmor #imp
@@ -1203,6 +1204,7 @@
 - type: loadoutGroup
   id: WardenOuterClothing
   name: loadout-group-warden-outerclothing
+  minLimit: 0 # imp edit
   loadouts:
   - WardenCoat
   - WardenArmoredWinterCoat
@@ -1243,6 +1245,7 @@
 - type: loadoutGroup
   id: SecurityBelt
   name: loadout-group-security-belt
+  minLimit: 0 # imp edit
   loadouts:
   - SecurityBelt
   - SecurityWebbing
@@ -1250,6 +1253,7 @@
 - type: loadoutGroup
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
+  minLimit: 0 # imp edit
   loadouts:
   - ArmorVest
   - ArmorVestCompact #imp
@@ -1310,6 +1314,7 @@
 - type: loadoutGroup
   id: DetectiveOuterClothing
   name: loadout-group-detective-outerclothing
+  minLimit: 0 # imp edit
   loadouts:
   - ClothingOuterCoatFieldJacket #imp
   - DetectiveArmorVest

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -946,6 +946,7 @@
 - type: loadoutGroup
   id: HeadofSecurityBelt
   name: loadout-group-head-of-security-belt
+  minLimit: 0
   loadouts:
   - SecurityBelt
   - SecurityWebbing


### PR DESCRIPTION
adding things to loadouts to make things easier for players is bad, but no one ever said anything about letting players make themselves worse

removes the limit for security's belt and outer clothing slots so people can start without armor or a belt if they really really want to, for the officer, detective, warden, and hos

:cl:
- tweak: Security is now allowed to start the shift without armor or a belt if they would like