### PR TITLE
alphabetize CE's foreman jumpsuit in loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -865,10 +865,10 @@
   name: loadout-group-chief-engineer-jumpsuit
   loadouts:
   - ChiefEngineerJumpsuit
-  - ChiefEngineerJumpsuitForeman # imp
   - ChiefEngineerJumpskirt
   - ChiefEngineerTurtleneck
   - ChiefEngineerTurtleneckSkirt
+  - ChiefEngineerJumpsuitForeman # imp; will appear alphabetical in-game
 
 - type: loadoutGroup
   id: ChiefEngineerNeck


### PR DESCRIPTION
puts foreman's jumpsuit at the bottom of the list, preserving grouping and is alphabetical

<img width="747" height="754" alt="image" src="https://github.com/user-attachments/assets/d0748ce3-af34-40a5-b1a8-d4931601befa" />

so small I don't it needs a CL