### PR TITLE
Add Hospitality Director access to Command access group

### DIFF
--- a/Resources/Prototypes/Access/command.yml
+++ b/Resources/Prototypes/Access/command.yml
@@ -22,6 +22,7 @@
   - HeadOfSecurity
   - Quartermaster
   - ResearchDirector
+  - HospitalityDirector #imp edit
   
 - type: accessLevel
   id: EmergencyShuttleRepealAll


### PR DESCRIPTION
Oversight when adding HD, somehow hasn't come up until now.

**Changelog**
:cl:
- fix: Fixed command door remote not being able to interact with Hospitality Director locked doors.

