### PR TITLE
Update migration_imp.yml for tabletop computers

### DIFF
--- a/Resources/migration_imp.yml
+++ b/Resources/migration_imp.yml
@@ -62,6 +62,11 @@ BorgModulePaper: BorgModuleService
 # impstation: migrate our cleanade crate to upstream implementation
 CrateServiceCleanades: CrateServiceCleanerGrenades
 
+# 2025-06-17
 # impstation: replace custodial closets with secure janitor lockers
 ClosetJanitor: LockerJanitor
 ClosetJanitorFilled: LockerJanitorFilled
+
+# 2025-07-17
+# removed redundant prototype from DV tabletop computer port
+MobileComputerTabletopComms: ComputerTabletopComms


### PR DESCRIPTION
Migrates out a tabletop prototype that was removed, fixes date attribution on janitor locker change. Required before https://github.com/impstation/imp-station-14/pull/3048 can be merged.
