### PR TITLE
Aghost default tool tweaks

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -145,13 +145,13 @@
     - AccessConfiguratorUniversal
     - Multitool
     # imp edit start
-    - PowerDrill
-    - JawsOfLife
+    - Omnitool
     - WelderExperimental
     - GeigerCounter
     - SprayPainter
     - CrayonRainbowInfinite
     - ClothingEyesHudOmni
+    - RCDExperimental
     # imp edit end
 
 #Gladiator with spear


### PR DESCRIPTION
Replaces the aghost's drill and jaws of life with an omnitool, and gives them an Experimental RCD in their bag.
Largely because I have to spawn in an experimental RCD pretty frequently and it's annoying. 
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
