### PR TITLE
Gupdates

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/beeroboros.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/beeroboros.yml
@@ -28,8 +28,8 @@
     animation: WeaponArcBite
     damage:
       types:
-        Piercing: 3
-        Heat: 2
+        Piercing: 5
+        Heat: 3
   - type: InputMover
   - type: MobMover
   - type: HTN

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/flamethrower.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/flamethrower.yml
@@ -18,7 +18,7 @@
     damage:
       types:
         Blunt: 0
-        Heat: 10
+        Heat: 8
     soundHit:
       path: /Audio/Effects/lightburn.ogg
     forceSound: true

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/flamethrower.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/flamethrower.yml
@@ -18,11 +18,11 @@
     damage:
       types:
         Blunt: 0
-        Heat: 5
+        Heat: 10
     soundHit:
       path: /Audio/Effects/lightburn.ogg
     forceSound: true
   - type: IgniteOnCollide
-    fireStacks: 0.12
+    fireStacks: 0.15
   - type: IgnitionSource
     temperature: 700

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/flamers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/flamers.yml
@@ -25,7 +25,7 @@
     size: Ginormous
   - type: GunRequiresWield
   - type: Gun
-    projectileSpeed: 5
+    projectileSpeed: 8
     clumsyProof: false
     cameraRecoilScalar: 0
     fireRate: 8
@@ -61,3 +61,19 @@
       Steel: 400
   - type: IgnitionSource
     temperature: 700
+  - type: MeleeWeapon
+    attackRate: 0.4 #slower, but hits harder; bigger object to shove with
+    damage:
+      types:
+        Blunt: 8
+  - type: StaminaDamageOnHit
+    damage: 15 #slight stagger, but still like 7 hits to stun completely
+  - type: MeleeRequiresWield
+  - type: MeleeThrowOnHit
+    distance: 0.8
+    speed: 5
+  - type: DamageOtherOnHit #for throwing
+    staminaCost: 15
+    damage:
+      types:
+        Blunt: 12

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/ouroboros.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/ouroboros.yml
@@ -45,6 +45,12 @@
     fireCost: 3
   - type: FoodReagentExtractor
     solutionId: chamber
+    extractionReagents:
+    - Nutriment
+    - UncookedAnimalProteins
+    - Protein
+    - Vitamin
+    - Slime
     extractSound: /Audio/_Impstation/Weapons/Guns/Cock/beecharge.ogg
   - type: MagazineVisuals
     magState: mag

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/plasma.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/plasma.yml
@@ -61,6 +61,25 @@
     - EchionGun
   - type: StaticPrice
     price: 100
+  - type: MeleeWeapon
+    range: 0.8
+    attackRate: 0.8
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      path: /Audio/Effects/hit_kick.ogg
+    soundSwing:
+      path: /Audio/_Impstation/Weapons/Guns/Melee/shove_foley.ogg
+    resetOnHandSelected: false
+    wideAnimationRotation: -80
+  - type: AltFireMelee
+    attackType: Heavy
+  - type: DamageOtherOnHit #for throwing
+    staminaCost: 6
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   name: Akurra
@@ -116,3 +135,27 @@
     - EchionGun
   - type: StaticPrice
     price: 100
+  - type: MeleeWeapon
+    range: 0.8
+    attackRate: 0.6
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      path: /Audio/Effects/hit_kick.ogg
+    soundSwing:
+      path: /Audio/_Impstation/Weapons/Guns/Melee/shove_foley.ogg
+    resetOnHandSelected: false
+  - type: AltFireMelee
+    attackType: Heavy
+  - type: DamageOtherOnHit #for throwing
+    staminaCost: 10
+    damage:
+      types:
+        Blunt: 8
+  - type: StaminaDamageOnHit
+    damage: 10 #slight stagger, but still like 10 hits to stun completely
+  - type: MeleeRequiresWield
+  - type: MeleeThrowOnHit
+    distance: 0.8
+    speed: 5


### PR DESCRIPTION
Buffs across the board! Here are the changes to the recent guns I've added.

- Added melee attacks to the Xiuhcoatl, Adder, and Akurra (this was an oversight, they were intended to have it)
- Xiuhcoatl projectile speed increased from 5 to 8, increasing its effective range as well.
- Xiuhcoatl projectile damage boosted from 5 to 8, and firestacks from 0.12 to 0.15
- Ouroboros bee attack damage boosted from 3/2 to 5/3 (pierce/heat)
- Ouroboros can now use protein, uncooked animal protein, vitamins, and slime-- increasing its pool of useful food a lot.

**Changelog**
:cl:
- fix: the Xiuhcoatl, Adder, and Akurra have melee attacks now
- tweak: The Xiuhcoatl's projectiles are stronger and move faster now
- tweak: The Ouroboros bees are a bit more dangerous, and the gun is a lot less picky on what it wants to eat.
