### PR TITLE
Revert "remove the minimum limit for security's outer clothing and belt loadouts"

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1173,7 +1173,6 @@
 - type: loadoutGroup
   id: HeadofSecurityOuterClothing
   name: loadout-group-head-of-security-outerclothing
-  minLimit: 0 # imp edit
   loadouts:
   - HeadofSecurityCoat
   - HeadofSecurityEliteArmor #imp
@@ -1204,7 +1203,6 @@
 - type: loadoutGroup
   id: WardenOuterClothing
   name: loadout-group-warden-outerclothing
-  minLimit: 0 # imp edit
   loadouts:
   - WardenCoat
   - WardenArmoredWinterCoat
@@ -1245,7 +1243,6 @@
 - type: loadoutGroup
   id: SecurityBelt
   name: loadout-group-security-belt
-  minLimit: 0 # imp edit
   loadouts:
   - SecurityBelt
   - SecurityWebbing
@@ -1253,7 +1250,6 @@
 - type: loadoutGroup
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
-  minLimit: 0 # imp edit
   loadouts:
   - ArmorVest
   - ArmorVestCompact #imp
@@ -1314,7 +1310,6 @@
 - type: loadoutGroup
   id: DetectiveOuterClothing
   name: loadout-group-detective-outerclothing
-  minLimit: 0 # imp edit
   loadouts:
   - ClothingOuterCoatFieldJacket #imp
   - DetectiveArmorVest

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -946,7 +946,6 @@
 - type: loadoutGroup
   id: HeadofSecurityBelt
   name: loadout-group-head-of-security-belt
-  minLimit: 0
   loadouts:
   - SecurityBelt
   - SecurityWebbing


### PR DESCRIPTION
Reverts impstation/imp-station-14#3103

this. probably wasnt a good idea on my part since by default they start without anything in these slots, making it bad for new players. if there was a way for loadouts to by default have something selected without there being a minimum then maybe this can happen again but for now its a bit pusk