### PR TITLE
Plural stacks

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -214,8 +214,13 @@ public abstract partial class SharedHandsSystem : EntitySystem
     {
         var heldItemNames = EnumerateHeld(examinedUid, handsComp)
             .Where(entity => !HasComp<VirtualItemComponent>(entity))
-            .Select(item => FormattedMessage.EscapeText(Identity.Name(item, EntityManager)))
-            .Select(itemName => Loc.GetString("comp-hands-examine-wrapper", ("item", itemName)))
+            //.Select(item => FormattedMessage.EscapeText(Identity.Name(item, EntityManager))) // imp comment
+            // IMP EDIT - accounting for the cases in which entities have unique indefinite articles
+            .Select(item => Loc.GetString("comp-hands-examine-wrapper",
+                    ("itemName", FormattedMessage.EscapeText(Identity.Name(item, EntityManager))),
+                    ("item", Identity.Entity(item, EntityManager)))
+                    )
+            // END IMP EDIT
             .ToList();
 
         var locKey = heldItemNames.Count != 0 ? "comp-hands-examine" : "comp-hands-examine-empty";

--- a/Content.Shared/_Impstation/Examine/PluralNameComponent.cs
+++ b/Content.Shared/_Impstation/Examine/PluralNameComponent.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Impstation.Examine;
+
+/// <summary>
+/// Alters the way that this object is referred to by examination.
+/// For entities whose names on inspection should change slightly depending on how many there are.
+/// Also for those whose names don't quite make sense: i.e. "a glass", "a grapes", "a spesos"
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(PluralNameSystem))]
+public sealed partial class PluralNameComponent : Component
+{
+    /// <summary>
+    /// How to count one of these.
+    /// i.e. "a sheet of [glass]", "a pair of [glasses]".
+    /// Defaults to the indefinite article. Can be empty.
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
+    public LocId OneOf;
+
+    /// <summary>
+    /// How to count multiple of these.
+    /// Only necessary for stackable objects.
+    /// i.e. "some panes of [glass]", "some [spesos]".
+    /// defaults to "some".
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId SomeOf = "some";
+
+    /// <summary>
+    /// What this object's name is when by itself. Highlighted.
+    /// Compare it to what you'd say if you referred to "the" [object].
+    /// i.e. "[a pane of] glass", "[a pair of] glasses", "[a] speso".
+    /// defaults to "$name".
+    /// </summary>
+    //[DataField, AutoNetworkedField]
+    //public LocId The; // NYI
+
+    /// <summary>
+    /// What this object's name is when multiple stack together. Highlighted.
+    /// Compare it to what you'd call it if you referred to "these" [objects].
+    /// Only necessary for stackable objects.
+    /// i.e. "[some panes of] glass", "[some] spesos".
+    /// defaults to "$name".
+    /// </summary>
+    //[DataField, AutoNetworkedField]
+    //public LocId These; // NYI
+
+
+}

--- a/Content.Shared/_Impstation/Examine/PluralNameSystem.cs
+++ b/Content.Shared/_Impstation/Examine/PluralNameSystem.cs
@@ -1,0 +1,74 @@
+using Content.Shared.Examine;
+using Content.Shared.Stacks;
+using Content.Shared.IdentityManagement;
+using Robust.Shared.GameObjects.Components.Localization;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Administration.Logs;
+using Robust.Shared.Containers;
+
+namespace Content.Shared._Impstation.Examine;
+
+/// <summary>
+/// Alters the way that this object is referred to by interaction verbs, redefining its indefinite point of reference (typically "a" or "an").
+/// For entities whose names on inspection should change slightly depending on how many there are.
+/// Also for those whose names don't quite make sense: i.e. by default, "a glass", "a grapes", "a spesos".
+///
+/// NYI - Means of changing the actual (highlighted) name that appears on inspect are VERY hacky and probably touch WAY too much code. It's probably best to just leave that be.
+/// </summary>
+public sealed class PluralNameSystem : EntitySystem
+{
+
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PluralNameComponent, EntInsertedIntoContainerMessage>(OnPickup, before: new[] { typeof(SharedHandsSystem) });
+        SubscribeLocalEvent<PluralNameComponent, StackCountChangedEvent>(OnStackCountChanged);
+    }
+
+    private void UpdateToPlural(Entity<PluralNameComponent> uid)
+    {
+        var grammar = EnsureComp<GrammarComponent>(uid);
+        var someOf = Loc.GetString(uid.Comp.SomeOf);
+        grammar.Attributes["indefinite"] = someOf;
+        //if (!grammar.Attributes.ContainsValue(someOf))
+        //{
+        //    grammar.Attributes.Remove("indefinite");
+        //    grammar.Attributes.TryAdd("indefinite", someOf); // define the indefinite article
+        //}
+        Dirty(uid, grammar);
+    }
+
+    private void UpdateToSingular(Entity<PluralNameComponent> uid)
+    {
+        var grammar = EnsureComp<GrammarComponent>(uid);
+        var oneOf = Loc.GetString(uid.Comp.OneOf);
+        grammar.Attributes["indefinite"] = oneOf;
+        //if (!grammar.Attributes.ContainsValue(oneOf))
+        //{
+        //   grammar.Attributes.Remove("indefinite");
+        //    grammar.Attributes.TryAdd("indefinite", oneOf); // define the indefinite article
+        //}
+        Dirty(uid, grammar);
+    }
+
+    private void OnPickup(Entity<PluralNameComponent> uid, ref EntInsertedIntoContainerMessage args)
+    {
+        var grammar = EnsureComp<GrammarComponent>(uid);
+        if (TryComp<StackComponent>(uid, out var stack) && stack.Count != 1)
+            grammar.Attributes["indefinite"] = uid.Comp.SomeOf;
+        else
+            grammar.Attributes["indefinite"] = uid.Comp.OneOf;
+
+        Dirty(uid, grammar);
+    }
+
+    private void OnStackCountChanged(Entity<PluralNameComponent> uid, ref StackCountChangedEvent args)
+    {
+        if (args.NewCount == 1)
+            UpdateToSingular(uid);
+        else
+            UpdateToPlural(uid);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -13,6 +13,8 @@
     damage:
       types:
         Blunt: 10
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot] # BaseLensSlot from imp
@@ -32,6 +34,9 @@
     damage:
       types:
         Blunt: 10
+  - type: PluralName # imp
+    oneOf: a pair of
+
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot] # BaseLensSlot from imp
@@ -51,6 +56,9 @@
     damage:
       types:
         Blunt: 10
+  - type: PluralName # imp
+    oneOf: a pair of
+
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot, BaseEngineeringContraband] # BaseLensSlot from imp
@@ -72,6 +80,9 @@
     tags:
     - CorgiWearable
     - WhitelistChameleon
+  - type: PluralName # imp
+    oneOf: some
+
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot] # BaseLensSlot from imp
@@ -98,6 +109,8 @@
         whitelist:
           tags:
           - Lens
+  - type: PluralName
+    oneOf: a pair of
   # imp end
   - type: Tag
     tags:
@@ -117,6 +130,8 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   parent: ClothingEyesBase
@@ -134,6 +149,8 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot] # BaseLensSlot from imp
@@ -164,6 +181,8 @@
   # imp end
   - type: StaticPrice
     price: 500
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot] # BaseLensSlot from imp
@@ -182,6 +201,8 @@
     - WhitelistChameleon
   - type: IdentityBlocker
     coverage: EYES
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: ClothingEyesGlassesCheapSunglasses
@@ -198,6 +219,8 @@
     - CorgiWearable
     - HamsterWearable
     - WhitelistChameleon
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot, ShowSecurityIcons, BaseSecurityContraband] # BaseLensSlot from imp
@@ -227,6 +250,8 @@
     - Antagonists
   - type: IdentityBlocker
     coverage: EYES
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot, BaseCommandContraband] # BaseLensSlot from imp
@@ -250,6 +275,8 @@
   - type: IdentityBlocker
     coverage: EYES
   - type: ShowJobIcons
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot] # BaseLensSlot from imp
@@ -266,6 +293,8 @@
     protectionTime: 5
   - type: IdentityBlocker
     coverage: EYES
+  - type: PluralName # imp
+    oneOf: a pair of
 
 #Make a scanner category when these actually function and we get the trayson
 - type: entity
@@ -303,6 +332,8 @@
       tags:
       - CorgiWearable
       - WhitelistChameleon
+    - type: PluralName # imp
+      oneOf: some
 
 - type: entity
   parent: [ClothingEyesBase, BaseMajorContraband]
@@ -338,3 +369,5 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+  - type: PluralName # imp
+    oneOf: a pair of

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -99,6 +99,8 @@
     tags:
     - CorgiWearable
     - WhitelistChameleon
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
@@ -19,4 +19,3 @@
       interfaces:
         enum.ChameleonUiKey.Key:
           type: ChameleonBoundUserInterface
-

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/random_suit.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/random_suit.yml
@@ -145,6 +145,8 @@
           base_leg_short: Sixteen
           base_leg_skirt: Sixteen
           base_leg_skirt_long: Sixteen
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: ClothingUniformRandom

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -407,6 +407,10 @@
           Quantity: 5
         - ReagentId: EggCooked
           Quantity: 6
+  - type: PluralName # imp
+    oneOf: a
+    someOf: a stack of
+
 
 - type: entity
   name: blueberry pancake

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1977,6 +1977,8 @@
     entries:
       Taco: Soybeans
       Burger: SoybeansBurger
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   name: spaceman's trumpet
@@ -2285,6 +2287,8 @@
   - type: Tag
     tags:
     - Fruit
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   name: berries
@@ -2322,6 +2326,8 @@
     entries:
       Taco: Berries
       Burger: BerriesBurger
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   name: bungo fruit

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -50,6 +50,9 @@
       glass:
         canReact: false
   - type: NonMobStatusIcon #imp edit. for the salvohud
+  - type: PluralName # imp
+    oneOf: a sheet of
+    someOf: some sheets of
 
 - type: entity
   parent: SheetGlassBase

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -35,6 +35,9 @@
     guides:
     - ExpandingRepairingStation
   - type: NonMobStatusIcon #imp edit. for the salvohud
+  - type: PluralName # imp
+    oneOf: a sheet of
+    someOf: some sheets of
 
 - type: entity
   parent: SheetMetalBase

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -28,6 +28,9 @@
       paper:
         canReact: false
   - type: NonMobStatusIcon #imp edit. for the salvohud
+  - type: PluralName # imp
+    oneOf: a sheet of
+    some: some sheets of
 
 - type: entity
   parent: SheetOtherBase

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -27,8 +27,7 @@
         acts: [ "Destruction" ]
   - type: NonMobStatusIcon #imp edit. for the salvohud
   - type: PluralName # imp
-    oneOf: a bar of
-    someOf: some bars of
+    oneOf: a
 
 - type: entity
   parent: IngotBase

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -26,6 +26,9 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: NonMobStatusIcon #imp edit. for the salvohud
+  - type: PluralName # imp
+    oneOf: a bar of
+    someOf: some bars of
 
 - type: entity
   parent: IngotBase

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -23,6 +23,8 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: PluralName # imp
+    oneOf: a piece of
 
 - type: entity
   parent: MaterialBase
@@ -176,6 +178,8 @@
     node: cloth
   - type: Item
     heldPrefix: cloth
+  - type: PluralName # imp
+    oneOf: a bolt of # the more you know https://english.stackexchange.com/questions/430790/what-do-you-call-a-of-cloth
 
 - type: entity
   parent: MaterialCloth
@@ -240,6 +244,8 @@
       - RawMaterial
   - type: Item
     heldPrefix: durathread
+  - type: PluralName # imp
+    oneOf: a bolt of
 
 - type: entity
   parent: MaterialDurathread
@@ -334,6 +340,9 @@
     - TileWoodParquetLight
     - TileWoodParquetRed
     - TileWoodRed
+  - type: PluralName
+    oneOf: a plank of
+    someOf: some planks of
 
 - type: entity
   parent: MaterialWoodPlank
@@ -372,6 +381,9 @@
   - type: GuideHelp
     guides:
     - Cloning
+  - type: PluralName # imp
+    oneOf: a scrap of # will probably never be seen in-game
+    someOf: a cube of
 
 - type: entity
   parent: MaterialBiomass
@@ -411,6 +423,8 @@
   - type: Tag
     tags:
       - BearHide
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   parent: MaterialBase
@@ -431,6 +445,8 @@
   - type: Tag
     tags:
     - HideCorgi
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   parent: MaterialBase
@@ -471,6 +487,9 @@
     - RawMaterial
     - Diamond
   - type: NonMobStatusIcon #imp edit. for the salvohud
+  - type: PluralName # imp
+    oneOf: a gem of
+    someOf: gems of
 
 - type: entity
   parent: MaterialDiamond
@@ -747,6 +766,9 @@
   - type: Tag
     tags:
     - ToothSpaceCarp
+  - type: PluralName # imp
+    oneOf: a singular
+    someOf: a collection of
 
 - type: entity
   parent: MaterialToothSpaceCarp
@@ -790,6 +812,9 @@
     tags:
     - Knife
     - ToothSharkminnow
+  - type: PluralName # imp
+    oneOf: a singular
+    someOf: a collection of
 
 - type: entity
   parent: MaterialToothSharkminnow
@@ -835,6 +860,9 @@
     - DroneUsable
     - RawMaterial
     - KodeEdible
+  - type: PluralName # imp
+    oneOf: some
+    someOf: a bundle of
 
 - type: entity
   parent: MaterialBones
@@ -862,6 +890,8 @@
       Gunpowder: 100
   - type: Item
     size: Tiny
+  - type: PluralName # imp
+    oneOf: a pinch of
 
 - type: entity
   parent: MaterialBase
@@ -896,6 +926,8 @@
   - type: Tag
     tags:
     - GoliathPlate
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   parent: MaterialGoliathHide

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -23,6 +23,8 @@
           - ItemMask
         restitution: 0.3
         friction: 0.2
+  - type: PluralName # imp
+    oneOf: a piece of
 
 - type: entity
   parent: OreBase

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -85,6 +85,9 @@
     prototypes:
     - Grille
     - Table
+  - type: PluralName # imp
+    oneOf: a
+    someOf: a bundle of
 
 - type: entity
   parent: PartRodMetal

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -52,6 +52,8 @@
         mask:
         - ItemMask
   - type: Appearance
+  - type: PluralName # imp
+    oneOf: some
 
 - type: material
   id: Credit

--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -49,6 +49,9 @@
   - type: GuideHelp
     guides:
     - ExpandingRepairingStation
+  - type: PluralName # imp
+    oneOf: a tile of
+    someOf: some tiles of
 
 - type: entity
   name: steel dark checker tile

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
@@ -21,6 +21,8 @@
     entries:
       Burger: LeavesCannabisBurger
       Taco: LeavesCannabis
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   name: green marijuana leaves
@@ -43,6 +45,8 @@
     entries:
       Burger: LeavesCannabisBurger
       Taco: LeavesCannabis
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   name: dried cannabis leaves
@@ -67,6 +71,8 @@
     entries:
       Burger: LeavesCannabisBurger
       Taco: LeavesCannabis
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   name: ground cannabis
@@ -96,6 +102,8 @@
       - Smokable
   - type: Item
     size: Tiny
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   name: rainbow cannabis leaves

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -51,6 +51,9 @@
     count: 10
   - type: StackPrice
     price: 5
+  - type: PluralName # imp
+    oneOf: a tube of
+    someOf: some tubes of
 
 - type: entity
   id: Ointment1
@@ -110,6 +113,10 @@
     count: 10
   - type: StackPrice
     price: 20
+  - type: PluralName # imp
+    oneOf: a piece of
+    someOf: some pieces of
+
 
 - type: entity
   id: OintmentAdvanced1
@@ -164,6 +171,9 @@
     count: 10
   - type: StackPrice
     price: 5
+  - type: PluralName # imp
+    oneOf: a
+    someOf: a handful of
 
 - type: entity
   id: Brutepack1
@@ -220,6 +230,9 @@
     count: 10
   - type: StackPrice
     price: 20
+  - type: PluralName # imp
+    oneOf: a spindle of
+    someOf: some spindles of
 
 - type: entity
   id: BrutepackAdvanced1

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -22,6 +22,9 @@
   - type: Currency
     price:
       Telecrystal: 1
+  - type: PluralName # imp
+    oneOf: a
+    someOf: a handful of
 
 - type: entity
   parent: Telecrystal

--- a/Resources/Prototypes/Entities/Objects/Tools/inflatable_wall.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/inflatable_wall.yml
@@ -23,6 +23,9 @@
     - type: Tag
       tags:
         - DroneUsable
+    - type: PluralName # imp
+      oneOf: an
+      someOf: an armful of
 # TODO: Add stack sprites + visuals.
 
 - type: entity
@@ -50,6 +53,9 @@
     - type: Tag
       tags:
         - DroneUsable
+    - type: PluralName # imp
+      oneOf: an
+      someOf: an armful of
 # TODO: Add stack sprites + visuals.
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
@@ -12,6 +12,8 @@
     modifiers:
       coefficients:
         Caustic: 0.85
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingEyesGlassesChemical, ShowMedicalIcons, Tier1Contraband]
@@ -23,3 +25,5 @@
     sprite: _DV/Clothing/Eyes/Glasses/interdynechemgoogles.rsi
   - type: Clothing
     sprite: _DV/Clothing/Eyes/Glasses/interdynechemgoogles.rsi
+  - type: PluralName # imp
+    oneOf: a pair of

--- a/Resources/Prototypes/_EE/Clothing/Eyes/goggles.yml
+++ b/Resources/Prototypes/_EE/Clothing/Eyes/goggles.yml
@@ -14,6 +14,8 @@
     isEquipment: true
   - type: IdentityBlocker
     coverage: EYES
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   parent: [ClothingEyesNightVisionGoggles, ShowSecurityIcons]
@@ -88,6 +90,8 @@
     toggleAction: PulseThermalVision
   - type: IdentityBlocker
     coverage: EYES
+  - type: PluralName # imp
+    oneOf: some
 
 - type: entity
   parent: ClothingEyesThermalVisionGoggles
@@ -99,6 +103,8 @@
     sprite: _EE/Clothing/Eyes/Goggles/monocle_thermal.rsi
   - type: Clothing
     sprite: _EE/Clothing/Eyes/Goggles/monocle_thermal.rsi
+  - type: PluralName # imp
+    oneOf: a # lol
 
 - type: entity
   parent: ClothingEyesThermalVisionGoggles

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/glasses.yml
@@ -51,6 +51,8 @@
       tags:
       - WhitelistChameleon
       - DroneUsable
+    - type: PluralName
+      oneOf: a pair of
 
 - type: entity
   parent: ClothingEyesGlassesColorfulBase

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Hands/base_clothinghands.yml
@@ -18,3 +18,5 @@
     damageProtection:
       flatReductions:
         Heat: 5 # the average lightbulb only does around four damage!
+  - type: PluralName # imp
+    oneOf: a pair of

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/random_simple.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/random_simple.yml
@@ -265,6 +265,8 @@
     spawned:
     - id: ClothingUniformRandomSimpleShorts
       amount: 1
+  - type: PluralName
+    oneOf: a pair of
 
 # Just the shorts
 - type: entity
@@ -294,6 +296,8 @@
           decor_leg_simple_belt: SimpleBeltbuckle
         leg:
           base_leg_simple_shorts: SimpleBottom
+  - type: PluralName # imp
+    oneOf: a pair of
 
 - type: entity
   parent: [ClothingUniformRandom]

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Materials/materials.yml
@@ -59,6 +59,8 @@
   - type: Construction
     graph: HempObjects
     node: hempcloth
+  - type: PluralName
+    oneOf: a bolt of
 
 - type: entity
   parent: MaterialHempCloth

--- a/Resources/Prototypes/_Impstation/Objects/Specific/Bounty Hunter/bounty_hunter_items.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Specific/Bounty Hunter/bounty_hunter_items.yml
@@ -37,6 +37,8 @@
   - type: FlashImmunity
   - type: EyeProtection
     protectionTime: 5
+  - type: PluralName # imp
+    oneOf: a pair of
 
 # Companion Cyborg Reinforcement Radio, borgdisabler, and nonlethal module
 - type: entity

--- a/Resources/Prototypes/_Impstation/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Specific/Medical/healing.yml
@@ -30,6 +30,9 @@
     count: 10
   - type: StackPrice
     price: 5
+  - type: PluralName # imp
+    oneOf: a spindle of
+    someOf: some spindles of
 
 - type: entity
   id: SimpleSuture1
@@ -70,6 +73,9 @@
     count: 10
   - type: StackPrice
     price: 5
+  - type: PluralName # imp
+    oneOf: a tube of
+    someOf: some tubes of
 
 - type: entity
   id: ShockGel1
@@ -171,6 +177,9 @@
             volume: -4
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: PluralName # imp
+    oneOf: a bottle of
+    someOf: some bottles of
 
 - type: entity
   id: Tincture1


### PR DESCRIPTION
A `make text less bad` PR which, following on from #2447, continues to account for pluralization of item descriptions.

This adds a new component `PluralName` which updates the way an item is described on holder-examine, especially for when its stack-size changes. For example, instead of seeing "They are holding a **sun glasses**", you now see "They are holding a pair of **sun glasses**". This is done through redefining the indefinite article. It also respects stacked items, for example holding 2+ sheets of steel appears as "They are holding some sheets of steel" but holding 1 sheet only says "They are holding a sheet of steel".

The really critical NYI of this whole PR is that there isn't a way (that I can tell; that isn't hacky as all fuck) for me to make the names of items responsive on stack, i.e. updating "gold bar" to "gold bars" when stacked. This PR as a result is slightly limited in scope (and potentially introduces grammatical mistakes!!) for items where it was entirely unfeasible to create a means of referring to them plurally. This feature will be another PR later on.

**Changelog**
:cl:
- add: Items whose quantities were not clear when in someone's hands (i.e. "a grapes", "a gloves", "a steel") now should be grammatically correct (i.e. "some grapes", "a pair of gloves", "a sheet / some sheets of steel").
