### PR TITLE
Free Agent Text Edit

### DIFF
--- a/Resources/Locale/en-US/_Impstation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Impstation/ghost/roles/ghost-role-component.ftl
@@ -1,4 +1,4 @@
-ghost-role-information-freeagent-rat-king-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
+ghost-role-information-freeagent-rat-king-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You must still follow escalation, but are not bound to the same restrictions as crew-aligned characters.
                                          Your primary goal is getting food. Killing should be used as a last resort. You are still subject to Mass Chaos RDM rules unless declared an enemy of the ship.
 
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
@@ -32,7 +32,7 @@ ghost-role-information-cargorilla-description = A "well" trained gorilla, assist
 ghost-role-information-goblin-stowaway-name = Goblin Stowaway
 ghost-role-information-goblin-stowaway-description = You are Goblin. Your fellow Goblin is Goblin. Goblin must construct Goblinhome.
 
-ghost-role-information-nonantagonist-freeagent-goblin-stowaway = You are a [color=yellow][bold]Team Free Agent[/bold][/color] with all other Goblins. You are free to act as either antagonists or non-antagonists.
+ghost-role-information-nonantagonist-freeagent-goblin-stowaway = You are a [color=yellow][bold]Team Free Agent[/bold][/color] with all other Goblins. You must still follow escalation, but are not bound to the same restrictions as crew-aligned characters.
                                          Your primary goal is to construct Goblinhome, a home for yourself and your people. [color=red]Harming the station would likely put that goal at risk.[/color]
 
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
@@ -142,7 +142,7 @@ ghost-role-information-antagonistchance-rules = You are a [color=green][bold]Non
                                              You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
 
 ghost-role-information-infiltrator-name = Syndicate Infiltrator
-ghost-role-information-infiltrator-description = You are an elite espionage agent sent to sabotage the station and its crew. 
+ghost-role-information-infiltrator-description = You are an elite espionage agent sent to sabotage the station and its crew.
 ghost-role-information-infiltrator-rules = You are a [color=red][bold]Solo Antagonist[/bold][/color]. Your intentions are clear, and harmful to the station and its crew.
 
                                           You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
@@ -152,7 +152,7 @@ ghost-role-information-whiteboy-description = You are a ghoulish white boy. Do w
 
 ghost-role-information-partygray-name = Partying Gray
 ghost-role-information-partygray-description = It's time for a celebration and this station looks like the perfect place to throw a party!
-ghost-role-information-nonantagonist-freeagent-partygeay-rules = You are a [color=yellow][bold]Team Free Agent[/bold][/color] with the other Partying Grays. You are a delinquent who is only here to party. You are not seeking to cause damage to the station or its crew, but your rowdiness may lead to it.
-                                                                 Your goal is to throw a party; what you are celebrating is up to you. 
+ghost-role-information-nonantagonist-freeagent-partygeay-rules = You are a [color=yellow][bold]Team Free Agent[/bold][/color] with the other Partying Grays. You must still follow escalation, but are not bound to the same restrictions as crew-aligned characters. You are a delinquent who is only here to party. You are not seeking to cause damage to the station or its crew, but your rowdiness may lead to it.
+                                                                 Your goal is to throw a party; what you are celebrating is up to you.
 
                                                                  You don't remember any of your previous life, and you don't remember anything you learned as a ghost.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -5,7 +5,8 @@ ghost-role-component-default-rules = All normal rules apply unless an administra
 ghost-role-information-nonantagonist-rules = You are a [color=green][bold]Non-antagonist[/bold][/color]. You should generally not seek to harm the station and its crew.
 
                                              You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
-ghost-role-information-freeagent-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
+#imp edit
+ghost-role-information-freeagent-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You must still follow escalation, but are not bound to the same restrictions as crew-aligned characters.
                                          You are still required to follow rules against excessive destruction. [color=red]Do not seek to sabotage critical infrastructure without proper escalation.[/color]
 
                                          You don't remember any of your previous life, and you don't remember anything you learned as a ghost.

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
@@ -10,8 +10,9 @@
   ## Team Antagonist
   Team antagonists are like solo antagonists but they have other antagonists who they are expected to not hinder, and who they may be expected to help. You are only a team antagonist if the game clearly and explicitly tells you that you are a team antagonist.
 
+<!--imp edit I'm not sure if we still use this, but I'm changing it for completion's sake-->
   ## Free Agent
-  Certain roles are free to choose if they want to behave as an antagonist or as a non-antagonist, and may change their mind whenever they'd like. You are only free agent if the game clearly and explicitly tells you that you are a free agent.
+  Free agents exist in the middle ground between antagonist and non-antagonist. They are not requried to work toward a net positive effect on the round, but may choose to do so. They are, however, still required to follow escaltation. You are only free agent if the game clearly and explicitly tells you that you are a free agent.
 
   ## Familiar
   Familiars are considered non-antagonists, but have instructions to obey someone. They must obey this person even if it causes them to violate roleplay rules or die. You are only a familiar if the game clearly and explicitly tells you that you are a familiar. You are only the familiar of the person the game tells you.


### PR DESCRIPTION
Quick pass to change the free agent ghost role text from "You are free to act as either an antagonist or a non-antagonist." to "You must still follow escalation, but are not bound to the same restrictions as crew-aligned characters." as the former doesn't really work with how our rules are written and the latter offers some helpful clarification on how they're expected to be played.

:cl:
- tweak: Free agent ghost role text edited for clarification.
