### PR TITLE
Invader Clause Rewrite

### DIFF
--- a/Resources/ServerInfo/_Impstation/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -12,9 +12,11 @@
 
   ### Exceptions
 
-  Sentencing is waived for [bold]foreign intruders[/bold] (such as nuclear operatives, ninjas, and other spacial aberrations), who are not governed by space law. Security should continue to follow standard alert procedure for such threats.
+  Sentencing may be waived at the discretion of the Head of Security (or whoever's in charge) for [bold]foreign invaders[/bold] that have shown clear intent to enact excessive destruction and sabotage. Certain gear can also mark individuals as invaders, such as syndicate pinpointers, or code names and military titles.
 
-  Traitors are [italic]not[/italic] considered foreign invaders, and should be treated in accordance with Space Law, like any member of the crew. 
+  [bold]All non-crew individuals should be treated as visitors until they are proven to be otherwise by their equipment and/or actions.[/bold]
+
+  Crew members, [italic]regardless of actions[/italic], are [bold]never[/bold] considered foreign invaders, and should always be treated in accordance with Space Law.
 
   ## Search and Seizure
   A [italic]personnel search[/italic] is a seizure of the objects in a person's backpack, hands, coat, belt, and pockets. If any [color=red]contraband items[/color] are found during a search, the officer may choose to either further the search into a detainment, or simply confiscate the restricted items. After the search is conducted, all legal items are to be returned to the person.
@@ -76,13 +78,13 @@
   [italic]Unreasonable failures of these crew members to ensure space law is followed, as determined by game admins, will be considered a [color=red]failure to follow server rules[/color].[/italic]
 
   ### Linked Crimes & Stacking Sentences
-  
+
   [bold]Suspects can not be charged for multiple instances of the same crime at once[/bold]. If upon release and completion of sentence, it is discovered that the suspect committed another instance of the same crime prior to being processed, they may be retroactively sentenced for previous instances of the crime committed.
-  
+
   For example...
   - A prisoner has been detained for three counts of assault. The maximum sentence would be equivalent to that of a prisoner detained for only a single count of assault.
-  - After this prisoner is released, it is discovered that prior to being arrested, they assaulted a fourth person. They may be arrested and charged with another count of assault for this fourth instance, despite having previously served a sentence for the initial three counts of assault. 
-  
+  - After this prisoner is released, it is discovered that prior to being arrested, they assaulted a fourth person. They may be arrested and charged with another count of assault for this fourth instance, despite having previously served a sentence for the initial three counts of assault.
+
   If you charge someone with two or more different crimes at the same time, you should [color=#a4885c]combine the sentences[/color] you would give them for each crime.
 
   Certain categories of crimes are considered [italic]linked crimes[/italic], shown in matching colors and suffixes on the [textlink="Crime Listing" link="SpaceLawCrimeList"]. These [color=red]can not be stacked[/color] and, instead, override each other. You should pick the highest crime that matches the case when considering sentencing.


### PR DESCRIPTION
Floated this change by the security channel a while back and never got around to pushing it out. I'm open to adjustments to the formatting. Goal with this rewrite is to cut down on metagaming with ghost roles, open up rp opportunities for security, and removing OOC terminology from space law.

:cl:
- tweak: The invader clause of Space law has been rewritten.
