### PR TITLE
Reduce Decapoid Movement Speed by 0.9

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -9,6 +9,8 @@
     damage:
       types:
         blunt: 0 # immune to space
+  - type: SnailSpeed
+    snailSlowdownModifier: 0.9
   - type: Absorbable
   - type: Hunger # removed thirst
   - type: Icon


### PR DESCRIPTION
Change requested by Beck. Throwing up the PR as a favor so they can go to bed.

:cl:
- tweak: Decapoids are now slower than they were, but not quite as slow as they used to be.