### PR TITLE
SpeciesId For Dummies

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/decapoid.yml
@@ -246,6 +246,7 @@
       state: "creampie_human" # default
       visible: false
   - type: Inventory
+    speciesId: decapoid
     templateId: decapoid
     displacements:
       jumpsuit:

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/gastropoid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/gastropoid.yml
@@ -180,6 +180,7 @@
     prototype: Gastropoid
   - type: Inventory
     templateId: gastropoid
+    speciesId: gastropoid
     displacements:
       jumpsuit:
         sizeMaps:

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/gray.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/gray.yml
@@ -132,6 +132,7 @@
   - type: Body
     prototype: Gray
   - type: Inventory
+    speciesId: gray
     templateId: gray
     displacements:
       jumpsuit:

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
@@ -115,6 +115,7 @@
   - type: Sprite
     scale: 1, 1
   - type: Inventory
+    speciesId: thaven
     templateId: thaven
     displacements:
       jumpsuit:


### PR DESCRIPTION
most imp original species _(decapoid, gastropoid, thaven, gray)_ didn't have SpeciesId on their dummies so species-specific sprites for stuff _(like equipped-OUTERCLOTHING-gastropoid for example)_ would not show up in the loadout screen.
i fixd   it    i think           by     putting them   on theere                                    ok
<img width="306" height="238" alt="OK THANKS" src="https://github.com/user-attachments/assets/8f09397f-cb22-418a-84a1-5cc714499be3" />


**Changelog**
:cl:
- fix: Species-specific equipment sprites for Decapoids, Gastropoids, Thaven and Grays should now show up on the loadout screen.
