### PR TITLE
miscellaneous heretic fixes blast

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Void.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Void.cs
@@ -73,7 +73,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
 
     private void OnVoidBlink(Entity<HereticComponent> ent, ref HereticVoidBlinkEvent args)
     {
-        if (!TryUseAbility(ent, args))
+        if (!TryUseAbility(ent, args) || !_interaction.InRangeUnobstructed(args.Performer, args.Target, range:1000F, collisionMask:CollisionGroup.Opaque, popup: true))
             return;
 
         _aud.PlayPvs(new SoundPathSpecifier("/Audio/Effects/tesla_consume.ogg"), ent);

--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chat.Systems;
 using Content.Server.DoAfter;
+using Content.Shared.Interaction;
 using Content.Server.Flash;
 using Content.Server.Hands.Systems;
 using Content.Server.Magic;
@@ -61,6 +62,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly ThrowingSystem _throw = default!;
     [Dependency] private readonly IPrototypeManager _prot = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
 
     private List<EntityUid> GetNearbyPeople(Entity<HereticComponent> ent, float range)
     {

--- a/Resources/Locale/en-US/_Goobstation/Heretic/game-ticking/game-presets/preset-heretic.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/game-ticking/game-presets/preset-heretic.ftl
@@ -42,6 +42,7 @@ ghostrole-ghoul-rules = You are a [color=red][bold]Team Antagonist[/bold][/color
 ghoul-notif-text =
     You have been resurrected as a ghoul!
 
+    You are now a [color=#6495ed][bold]Familiar[/bold][/color] of the one who summoned you.
     Protect your new master and follow their orders.
 ghoul-notif-title = Return to Flesh
 
@@ -51,4 +52,5 @@ hell-memory-text =
     Your mind has been harvested by a Heretic, driving you to madness!
 
     You have lost all memory of who did this to you and how.
+    [color=yellow][bold]Your allegiances have not changed![/bold][/color]
 hell-memory-confirm = Confirm

--- a/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_void.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_void.yml
@@ -12,6 +12,7 @@
       state: void_blast
   - type: TargetAction
     range: 0
+    checkCanAccess: false
   - type: WorldTargetAction
     event: !type:HereticVoidBlastEvent
   - type: HereticAction
@@ -32,6 +33,7 @@
       state: void_phase
   - type: TargetAction
     range: 0
+    checkCanAccess: false
   - type: WorldTargetAction
     event: !type:HereticVoidBlinkEvent
   - type: HereticAction

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
@@ -6,6 +6,11 @@
   components:
   - type: HereticBlade
   - type: Sharp
+  - type: Execution
+    doAfterDuration: 4.0
+  - type: Tool
+    qualities:
+      - Slicing
   - type: Sprite
     sprite: _Goobstation/Heretic/Blades/blade_blade.rsi
     state: icon


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

who knew all it took to motivate me to code heretic was being able to play heretic

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: the heretic's void blast can once again be aimed at non-visible targets.
- fix: the heretic's void teleport can go through lattices again.
- fix: heretic blades can now be used as cutting tools, and are able to do executions.
- tweak: changed up the ghoul and sacrifice notification screens for clarity.

