### PR TITLE
minor kodepiia pass

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
@@ -91,6 +91,8 @@
     damage:
       types:
         Blunt: 3
+  - type: Absorbable # imp edit
+    biomassRestored: 0.1
 
 - type: entity
   parent: BaseMobArgocyte

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -107,6 +107,8 @@
     successChance: 0.5
     interactSuccessString: petting-success-goliath
     interactFailureString: petting-failure-goliath
+  - type: Absorbable # imp edit
+    biomassRestored: 0.8
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -96,6 +96,8 @@
     color: "#50595C"
     activateSound: null
     deactivateSound: null
+  - type: Absorbable # imp edit
+    biomassRestored: 0.1
 
 - type: entity
   id: MobTickSalvage

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -426,6 +426,8 @@
     tags:
     - DoorBumpOpener
     - FootstepSound
+  - type: Absorbable # imp edit
+    biomassRestored: 0.2
 
 - type: entity
   name: space adder

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Boxes/emergency.yml
@@ -199,6 +199,20 @@
 
 - type: entity
   parent: BoxSurvivalKodepiia
+  id: BoxMimeKodepiia
+  suffix: Mime, Meat
+  components:
+  - type: StorageFill
+    contents:
+    - id: ClothingMaskBreath
+    - id: EmergencyOxygenTankFilled
+    - id: EmergencyMedipen
+    - id: Flare
+    - id: MobSnail
+    - id: Bloodpack
+
+- type: entity
+  parent: BoxSurvivalKodepiia
   id: BoxSurvivalSyndicateKodepiia
   name: extended-capacity survival box
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank. Something smells funny...

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/kodepiia.yml
@@ -100,6 +100,8 @@
     - HeadSide
     - Hair
     - Tail
+  - type: Hunger
+    baseDecayRate: 0.15 # 10x default. 6 minutes to hungry and 15.5 minutes to starving
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/survival.yml
@@ -203,7 +203,7 @@
     proto: Carnivorous
   storage:
     back:
-    - BoxMime
+    - BoxMimeKodepiia
 
 # Engineering / Extended
 - type: loadout


### PR DESCRIPTION
got asked to make a kodepiia mime survival box and took the time to do a few other minor changes i kept putting off

<img width="541" height="349" alt="SS14 Loader_i10fGYTi0M" src="https://github.com/user-attachments/assets/d447f57f-e09d-4990-93d9-dde5ca2c5697" />

it spawns a live snail that is a ghost role but i think its _probably_ fine given that this is a ghost role that shows up Only if a kodepiia mime is in the round


main things:

- severely cranked up kodepiia hunger. i timed it and it's approximately 16 minutes of idling until they starve. makes their diet more present and is feedback ive been receiving very often. im a little worried this is still a lot but i can always dial it back
- added absorbable to a few miscellaneous mobs, mostly vent spawns that went overlooked but also goliaths


**Changelog**
:cl:
- tweak: Kodepiia are hungrier.
