### PR TITLE
Un-nerf space cleaner dispenser

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -58,7 +58,7 @@
       tank:
         reagents:
         - ReagentId: SpaceCleaner
-          Quantity: 1000 #imp edit, was 5000
+          Quantity: 5000
   - type: DrainableSolution
     solution: tank
   - type: ReagentTank


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Reverts the imp-side nerf of space cleaner from 5000 to 1000u.

My reasoning: following playing with the nerf in place, I've ran into these issues:

- When chemists are willing to make space cleaner for you, they usually only make one jug, or two or three if you tell them you're going to need as many jugs as they're willing to make. This is not enough; 1000u is equivalent to _five_ jugs of space cleaner, and I can single-handedly use up that amount no more than 15 minutes into the round.
- The nerf removes 4000u of cleaner from the dispenser; to compensate for this, a chemist would need to make _twenty_ jugs. When was the last time a chemist mixed twenty jugs of anything?!
- Chemists are often not willing to make space cleaner at all, not even one jug. If they're alone and tasked with making all medicines themselves, they'll just tell you no. Medicine is always going to be considered more important.
- With all this in mind, it becomes extremely tempting to simply ask for nitrogen and hydrogen jugs and do the mixing yourself, which defeats the entire purpose of the nerf.
And:
- We have bleach now, an even more powerful cleaning chem that isn't available roundstart. So janitors still have a reason to go to chemistry, only now they aren't fucked over if the chemist tells them no.

In essence, promoting interaction with chemistry only works if the chemist is willing to engage in those interactions; and they usually aren't. Chemistry is already an extremely busy job and giving them even more work to do is only a good idea if that work is optional.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Space cleaner dispensers start with more cleaner in them. If you'd like something stronger, consider asking the chemist for a few jugs of bleach!
