### PR TITLE
New Musician Items Fixed

### DIFF
--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Civilian/musician.yml
@@ -39,13 +39,13 @@
 - type: loadout
   id: FeatherBoa
   equipment:
-    head: ClothingNeckFeatherBoa
+    neck: ClothingNeckFeatherBoa
 
 # Gloves
 - type: loadout
   id: MusicianSingerGloves
   equipment:
-    head: ClothingHandsMusicianSingerGloves
+    gloves: ClothingHandsMusicianSingerGloves
 
 # Outerclothing
 - type: loadout


### PR DESCRIPTION
gloves and boa weren't showing up in loadout screen because they were equipping to the head
they werent supposed to do that
gloves dont go on your head they're for hand.
they dont do that anymore
okay thanks
:cl:
- fix: You will no longer wear fancy gloves on your head.