### PR TITLE
Make cards embeddable

### DIFF
--- a/Resources/Prototypes/_EstacaoPirata/Entities/Objects/Misc/cards.yml
+++ b/Resources/Prototypes/_EstacaoPirata/Entities/Objects/Misc/cards.yml
@@ -171,6 +171,9 @@
   - type: EmitSoundOnLand
     sound:
       collection: cardShove
+  - type: EmbeddableProjectile
+    removalTime: 0
+    sound: /Audio/Weapons/star_hit.ogg
   - type: Sprite
     sprite: _EstacaoPirata/Objects/Misc/cards.rsi
     state: singlecard_down_black

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/cards.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/cards.yml
@@ -121,6 +121,9 @@
   - type: EmitSoundOnLand
     sound:
       collection: cardShove
+  - type: EmbeddableProjectile
+    removalTime: 0
+    sound: /Audio/Weapons/star_hit.ogg
   - type: Sprite
     sprite: _EstacaoPirata/Objects/Misc/cards.rsi
     state: singlecard_down_tarot


### PR DESCRIPTION
Cards now embed in people and walls, for when you need to do a surprise tarot reading or get really mad at a dealer.

<sub>fumbled the audio on the video i'm srory</sub>

https://github.com/user-attachments/assets/69e1c3dc-4838-4d7b-ac15-5410a2cca844

**Changelog**
:cl:
- tweak: Playing cards and tarot cards now embed.