### PR TITLE
make ninja spawn less

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -212,7 +212,7 @@
   id: NinjaSpawn
   components:
   - type: StationEvent
-    weight: 6
+    weight: 1
     duration: null
     earliestStart: 30
     reoccurrenceDelay: 20


### PR DESCRIPTION
Make ninja spawn less frequently. currently many people find ninja to be a bad antag, Mira will commission a programmer to tweak them so for now I'm just lowering their spawn rate
**Changelog**

:cl:
- tweak: The spider clan has seen a sharp decrease in recruits.

