### PR TITLE
Allow carpets to be deconstructed using wirecutters

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
@@ -69,6 +69,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_red
+  # imp edit start
+  - type: Construction
+    graph: Carpet
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetBlack
@@ -102,6 +107,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_black
+  # imp edit start
+  - type: Construction
+    graph: CarpetBlack
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetPink
@@ -135,6 +145,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_pink
+  # imp edit start
+  - type: Construction
+    graph: CarpetPink
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetBlue
@@ -168,6 +183,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_blue
+  # imp edit start
+  - type: Construction
+    graph: CarpetBlue
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetGreen
@@ -201,6 +221,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_green
+  # imp edit start
+  - type: Construction
+    graph: CarpetGreen
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetOrange
@@ -234,6 +259,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_orange
+  # imp edit start
+  - type: Construction
+    graph: CarpetOrange
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetSBlue
@@ -267,6 +297,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_skyblue
+  # imp edit start
+  - type: Construction
+    graph: CarpetSBlue
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetPurple
@@ -300,6 +335,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_purple
+  # imp edit start
+  - type: Construction
+    graph: CarpetPurple
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetCyan
@@ -333,6 +373,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_cyan
+  # imp edit start
+  - type: Construction
+    graph: CarpetCyan
+    node: carpet
+  # imp edit end
 
 - type: entity
   id: CarpetWhite
@@ -366,6 +411,11 @@
                 max: 1
   - type: IconSmooth #imp edit, make carpets not smooth with each other
     key: full_white
+  # imp edit start
+  - type: Construction
+    graph: CarpetWhite
+    node: carpet
+  # imp edit end
 
 # TODO nuke this once tiles support rotating sprites
 # IMP NOTE they added support to rotating tiles, but seemingly only in the tile placer menu

--- a/Resources/Prototypes/_Impstation/Recipes/Construction/Graphs/furniture/carpets.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Construction/Graphs/furniture/carpets.yml
@@ -1,0 +1,179 @@
+﻿- type: constructionGraph
+  id: Carpet
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+      - to: start
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemRed
+          amount: 1
+        - !type:DeleteEntity {}
+        steps:
+        - tool: Cutting
+          doAfter: 1
+
+- type: constructionGraph
+  id: CarpetBlack
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemBlack
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetPink
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemPink
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetBlue
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemBlue
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetGreen
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemGreen
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetOrange
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemOrange
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetSBlue
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemSkyBlue
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetPurple
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemPurple
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetCyan
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemCyan
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1
+
+- type: constructionGraph
+  id: CarpetWhite
+  start: start
+  graph:
+    - node: start
+
+    - node: carpet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemWhite
+              amount: 1
+            - !type:DeleteEntity {}
+          steps:
+          - tool: Cutting
+            doAfter: 1


### PR DESCRIPTION
I thought it was silly that you could only remove carpets by going caveman on them with a weapon, so I've added a simple construction graph to all carpets to let you cut carpets of the floor using wirecutters.

https://github.com/user-attachments/assets/5ab4cd2f-9192-4460-962b-a60eb6c82105

**Changelog**
:cl:
- add: Carpets can now be cut off the floor by using a wirecutter on them.
