### PR TITLE
Remove Brigmedic's SecLink

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -132,7 +132,7 @@
       - id: ClothingNeckCloakMoth #bzzz Moth-pocalypse
         prob: 0.15
       - id: TicketPad #imp special
-      - id: BaseSeclinkRadio #imp
+      - id: WeaponPocketDisabler #imp, replacement for seclink
 
 - type: entity
   id: LockerDetectiveFilled


### PR DESCRIPTION
small change to further reinforce that brigmedic shouldn't be going around arresting people unless it's a last resort thing.

:cl:
- tweak: Replaced the seclink in the brigmedic's locker with a pocket disabler.
