### PR TITLE
no more alphabetization in loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -93,15 +93,15 @@
   minLimit: 0
   loadouts:
   - Glasses
-  # imp edit start - its in the middle for alphabetizing reasons sorry
+  # imp edit start
   - GlassesCheapSunglasses
+  - EyePatch
   - GlassesColorfulPink
   - GlassesColorfulRed
   - GlassesColorfulBlue
   - GlassesColorfulGreen
   - GlassesColorfulPurple
   - GlassesColorfulYellow
-  - EyePatch
   # imp edit end
   - GlassesJamjar
   - GlassesJensen
@@ -160,9 +160,9 @@
   name: loadout-group-captain-head
   minLimit: 0
   loadouts:
-  - CaptainBeret # imp
   - CaptainHead
   - CaptainCap
+  - CaptainBeret # imp
   - CaptainCrusherCap # imp
   - CaptainTricorne # imp
 
@@ -170,22 +170,22 @@
   id: CaptainJumpsuit
   name: loadout-group-captain-jumpsuit
   loadouts:
-  - CaptainEveningAttire #imp
   - CaptainJumpsuit
   - CaptainJumpskirt
   - CaptainFormalSuit
   - CaptainFormalSkirt
+  - CaptainEveningAttire #imp
 
 - type: loadoutGroup
   id: CaptainNeck
   name: loadout-group-captain-neck
   minLimit: 0
   loadouts:
-  - CaptainAdmiralCloak # imp
   - CaptainCloak
   - CaptainCloakFormal
-  - CaptainGreatcoat # imp
   - CaptainMantle
+  - CaptainGreatcoat # imp
+  - CaptainAdmiralCloak # imp
   - ScarfBlue # imp
 
 - type: loadoutGroup
@@ -197,8 +197,8 @@
   - CaptainDuffel
   # start imp
   - CommandVeteranBackpack
-  - CommandVeteranDuffel
   - CommandVeteranSatchel
+  - CommandVeteranDuffel
 
 - type: loadoutGroup
   id: CaptainOuterClothing
@@ -219,11 +219,11 @@
   id: HoPJumpsuit
   name: loadout-group-hop-jumpsuit
   loadouts:
-  - HoPBoatswain # DeltaV
   - HoPJumpsuit
   - HoPJumpskirt
-  - HoPMessSkirt # DeltaV
   - HoPMessSuit # DeltaV
+  - HoPMessSkirt # DeltaV
+  - HoPBoatswain # DeltaV
   - HoPPowerSuit # imp
 
 - type: loadoutGroup
@@ -240,11 +240,11 @@
   name: loadout-group-hop-backpack
   loadouts:
   - BackpackHoP # DeltaV
-  - CommandVeteranBackpack #imp
-  - CommandVeteranDuffel #imp
-  - CommandVeteranSatchel #imp
-  - HopDuffel # DeltaV
   - SatchelHoP # DeltaV
+  - HopDuffel # DeltaV
+  - CommandVeteranBackpack #imp
+  - CommandVeteranSatchel #imp
+  - CommandVeteranDuffel #imp
   # - CommonBackpack # DeltaV
   # - CommonDuffel # DeltaV
   # - CommonSatchel # DeltaV
@@ -256,20 +256,20 @@
   name: loadout-group-hop-outerclothing
   minLimit: 0
   loadouts:
-  - HoPFormalCoat # Delta-v
   - HoPWintercoat
+  - HoPFormalCoat # Delta-v
 
 # Civilian
 - type: loadoutGroup
   id: PassengerJumpsuit
   name: loadout-group-passenger-jumpsuit
   loadouts:
-  - GraytiderSpaceJumpsuit #imp
   - GreyJumpsuit
   - GreyJumpskirt
   - AncientJumpsuit
   - RainbowJumpsuit
   - RainbowJumpskirt
+  - GraytiderSpaceJumpsuit #imp
 
 - type: loadoutGroup
   id: PassengerFace
@@ -298,8 +298,8 @@
   name: loadout-group-passenger-neck
   minLimit: 0
   loadouts:
-  - GreyCloak #imp
   - Mantle
+  - GreyCloak #imp
   - WrappedScarfBlack #imp
   - WrappedScarfWhite #imp
 
@@ -308,9 +308,9 @@
   name: loadout-group-passenger-outerclothing
   minLimit: 0
   loadouts:
+  - PassengerWintercoat
   - BomberBlack #imp
   - BomberWhite #imp
-  - PassengerWintercoat
 
 - type: loadoutGroup
   id: PassengerShoes
@@ -348,8 +348,8 @@
   - BartenderVest
   - BartenderApron
   - BartenderCuteApron # imp
-  - BartenderWintercoat
   - ServiceClownApron # imp
+  - BartenderWintercoat
 
 - type: loadoutGroup
   id: ChefHead
@@ -381,30 +381,26 @@
   loadouts:
   - ChefApron
   - ChefCuteApron # imp
+  - ServiceClownApron # imp
   - ChefJacket
   - ChefWintercoat
-  - ServiceClownApron # imp
 
 - type: loadoutGroup
   id: LibrarianJumpsuit
   name: loadout-group-librarian-jumpsuit
   loadouts:
+  - LibrarianJumpsuit
+  - LibrarianJumpskirt
+  - CuratorJumpsuit
+  - CuratorJumpskirt
   - ClothingUniformBrownSuit #imp
   - ClothingUniformBrownSuitSkirt #imp
-  - LibrarianJumpskirt
-  - LibrarianJumpsuit
-  - CuratorJumpskirt
-  - CuratorJumpsuit
   - LibrarianSpaceDress #imp
 
 - type: loadoutGroup
   id: LawyerJumpsuit
   name: loadout-group-lawyer-jumpsuit
   loadouts:
-  - ClerkJumpskirt # DeltaV
-  - ClerkJumpsuit # DeltaV
-  - ClothingUniformCreamSuit #imp
-  - ClothingUniformCreamSuitSkirt #imp
   - LawyerJumpsuit
   - LawyerJumpskirt
   - LawyerJumpsuitBlue
@@ -415,20 +411,24 @@
   - LawyerJumpskirtRed
   - LawyerJumpsuitGood
   - LawyerJumpskirtGood
-  - ProsecutorJumpskirt # DeltaV
+  - ClerkJumpsuit # DeltaV
+  - ClerkJumpskirt # DeltaV
+  - ClothingUniformCreamSuit #imp
+  - ClothingUniformCreamSuitSkirt #imp
   - ProsecutorJumpsuit # DeltaV
+  - ProsecutorJumpskirt # DeltaV
 
 - type: loadoutGroup
   id: LawyerNeck
   name: loadout-group-lawyer-neck
   minLimit: 0
   loadouts:
-  - DefenseAttorneyArmband #imp
-  - DefenseAttorneyNeck # imp
-  - LawyerArmband #imp
   - LawyerNeck
-  - ProsecutorArmband #imp
+  - LawyerArmband #imp
   - ProsecutorNeck # DeltaV
+  - ProsecutorArmband #imp
+  - DefenseAttorneyNeck # imp
+  - DefenseAttorneyArmband #imp
 
 - type: loadoutGroup
   id: ChaplainHead
@@ -451,10 +451,10 @@
   name: loadout-group-chaplain-mask
   minLimit: 0
   loadouts:
-  - ChaplainClown # imp
   - ChaplainMask
   - ChaplainMaskClayshaper # imp
   - ChaplainMaskFire # imp
+  - ChaplainClown # imp
 
 - type: loadoutGroup
   id: ChaplainJumpsuit
@@ -574,20 +574,20 @@
   name: loadout-group-clown-head
   minLimit: 0
   loadouts:
-  - CircusClownHat #imp
   - JesterHat
   - JesterAltHat
+  - CircusClownHat #imp
 
 - type: loadoutGroup
   id: ClownJumpsuit
   name: loadout-group-clown-jumpsuit
   loadouts:
-  - CircusClownSuit #imp
   - ClownSuit
   - ClownSkirt
   - JesterSuit
   - JesterAltSuit
   - JokesterSuit #imp
+  - CircusClownSuit #imp
 
 - type: loadoutGroup
   id: ClownBackpack
@@ -610,10 +610,10 @@
   id: ClownShoes
   name: loadout-group-clown-shoes
   loadouts:
-  - CircusClownShoes # imp
   - ClownShoes
   - JesterShoes
   - JokesterShoes # imp
+  - CircusClownShoes # imp
 
 - type: loadoutGroup
   id: SurvivalClown
@@ -621,11 +621,11 @@
   minLimit: 2
   hidden: true
   loadouts:
-  - EmergencyMeatClown # imp
   - EmergencyNitrogenClown
   - EmergencyOxygenClown
-  - LoadoutSpeciesAquaticFullTank # Imp
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyMeatClown # imp
+  - LoadoutSpeciesAquaticFullTank # Imp
 
 - type: loadoutGroup
   id: MimeHead
@@ -649,8 +649,8 @@
   name: loadout-group-mime-jumpsuit
   loadouts:
   - MimeJumpsuit
-  - MimeJumpsuitCropped #imp
   - MimeJumpskirt
+  - MimeJumpsuitCropped #imp
   - MimeJumpskirtCropped #imp
 
 - type: loadoutGroup
@@ -683,21 +683,21 @@
   minLimit: 2
   hidden: true
   loadouts:
-  - EmergencyMeatMime # imp
   - EmergencyNitrogenMime
   - EmergencyOxygenMime
   - EmergencySpeciesMothMime
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyMeatMime # imp
   - LoadoutSpeciesAquaticFullTank # Imp
 
 - type: loadoutGroup
   id: MusicianJumpsuit
   name: loadout-group-musician-jumpsuit
   loadouts:
-  - ClothingUniformMrSpaceWide #imp
-  - ClothingUniformMrSpaceWideSkirt #imp
   - MusicianJumpsuit
   - MusicianJumpskirt
+  - ClothingUniformMrSpaceWide #imp
+  - ClothingUniformMrSpaceWideSkirt #imp
   - MusicianMarchingBand #imp
   - MusicianSingerDress #imp
 
@@ -769,8 +769,8 @@
   minLimit: 0
   loadouts:
   - QuartermasterCloak
-  - QuartermasterGreatcoat # imp
   - QuartermasterMantle
+  - QuartermasterGreatcoat # imp
   - ScarfBrown # imp
 
 - type: loadoutGroup
@@ -778,9 +778,9 @@
   name: loadout-group-quartermaster-outerclothing
   minLimit: 0
   loadouts:
-  - QuartermasterPoncho #imp
   - QuartermasterWintercoat
   - QuartermasterWintercoatXXXL #imp
+  - QuartermasterPoncho #imp
 
 - type: loadoutGroup
   id: QuartermasterShoes
@@ -819,16 +819,16 @@
   name: loadout-group-cargo-technician-outerclothing
   minLimit: 0
   loadouts:
-  - BomberCargo #imp
   - CargoTechnicianWintercoat
+  - BomberCargo #imp
 
 - type: loadoutGroup
   id: CargoTechnicianShoes
   name: loadout-group-cargo-technician-shoes
   loadouts:
   - BlackShoes
-  - CargoClownShoes # imp
   - CargoWinterBoots
+  - CargoClownShoes # imp
 
 - type: loadoutGroup
   id: SalvageSpecialistBackpack
@@ -843,9 +843,9 @@
   name: loadout-group-salvage-specialist-outerclothing
   minLimit: 0
   loadouts:
-  - BomberCargo #imp
-  - SalvageSpecialistDecapoidCoat #imp
   - SalvageSpecialistWintercoat
+  - SalvageSpecialistDecapoidCoat #imp
+  - BomberCargo #imp
 
 - type: loadoutGroup
   id: SalvageSpecialistShoes
@@ -871,7 +871,7 @@
   - ChiefEngineerJumpskirt
   - ChiefEngineerTurtleneck
   - ChiefEngineerTurtleneckSkirt
-  - ChiefEngineerJumpsuitForeman # imp; will appear alphabetical in-game
+  - ChiefEngineerJumpsuitForeman # imp
 
 - type: loadoutGroup
   id: ChiefEngineerNeck
@@ -894,8 +894,8 @@
   name: loadout-group-chief-engineer-shoes
   loadouts:
   - BrownShoes
-  - EngineeringWinterBoots
   - WorkBoots # imp
+  - EngineeringWinterBoots
 
 - type: loadoutGroup
   id: TechnicalAssistantJumpsuit
@@ -938,17 +938,17 @@
   name: loadout-group-station-engineer-outerclothing
   minLimit: 0
   loadouts:
-  - BomberEngineering #imp
   - StationEngineerOuterVest
   - StationEngineerWintercoat
+  - BomberEngineering #imp
 
 - type: loadoutGroup
   id: StationEngineerShoes
   name: loadout-group-station-engineer-shoes
   loadouts:
   - WorkBoots
-  - EngineerClownShoes # imp
   - EngineeringWinterBoots
+  - EngineerClownShoes # imp
 
 - type: loadoutGroup
   id: StationEngineerID
@@ -970,10 +970,10 @@
   name: loadout-group-atmospheric-technician-outerclothing
   minLimit: 0
   loadouts:
+  - AtmosphericTechnicianWintercoat
   - BomberAtmos #imp
   - BomberAtmosHolo #imp
   - BomberEngineering #imp
-  - AtmosphericTechnicianWintercoat
 
 - type: loadoutGroup
   id: AtmosphericTechnicianBackpack
@@ -997,11 +997,11 @@
   minLimit: 2
   hidden: true
   loadouts:
-  - EmergencyMeatExtended # imp
   - EmergencyNitrogenExtended
   - EmergencyOxygenExtended
-  - LoadoutSpeciesAquaticFullTank # Imp
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyMeatExtended # imp
+  - LoadoutSpeciesAquaticFullTank # Imp
 
 # Science
 - type: loadoutGroup
@@ -1017,9 +1017,9 @@
   name: loadout-group-research-director-neck
   minLimit: 0
   loadouts:
-  - MystagogueCloak # DeltaV
   - ResearchDirectorMantle
   - ResearchDirectorCloak
+  - MystagogueCloak # DeltaV
   - ScarfPurple # imp
 
 - type: loadoutGroup
@@ -1043,12 +1043,12 @@
   name: loadout-group-research-director-shoes
   loadouts:
   - BrownShoes
+  - WhiteShoes # imp
+  - WhiteDressShoes #imp
   - LacedShoes #imp
-  - LeatherShoes
+  - LeatherShoes # imp
   - ScienceWinterBoots
   - RoboticistWinterBoots # imp
-  - WhiteDressShoes #imp
-  - WhiteShoes # imp
 
 - type: loadoutGroup
   id: ScientistHead
@@ -1073,11 +1073,11 @@
   name: loadout-group-scientist-jumpsuit
   loadouts:
   - ScientistJumpsuit
-  - ScientistJumpsuitFormal # imp
   - ScientistJumpskirt
-  - SpaceScienceJumpsuit # imp
+  - ScientistJumpsuitFormal # imp
   - RoboticistJumpsuit
   - RoboticistJumpskirt
+  - SpaceScienceJumpsuit # imp
   - SeniorResearcherJumpsuit
   - SeniorResearcherJumpskirt
 
@@ -1094,13 +1094,13 @@
   name: loadout-group-scientist-outerclothing
   minLimit: 0
   loadouts:
-  - BomberScience #imp
   - RegularLabCoat
   - ScienceLabCoat
   - ScienceWintercoat
   - RoboticistLabCoat
   - RoboticistWintercoat
   - SeniorResearcherLabCoat
+  - BomberScience #imp
 
 - type: loadoutGroup
   id: ScientistShoes
@@ -1108,9 +1108,9 @@
   loadouts:
   - WhiteShoes
   - BlackShoes
+  - ScienceWinterBoots
   - RoboticistWinterBoots # imp
   - ScientistClownShoes # imp
-  - ScienceWinterBoots
 
 - type: loadoutGroup
   id: ScientistGloves
@@ -1143,8 +1143,8 @@
   minLimit: 0
   loadouts:
   - HeadofSecurityHead
-  - HeadofSecurityHeadDV # DeltaV
   - HeadofSecurityBeret
+  - HeadofSecurityHeadDV # DeltaV
   - HeadofSecurityPatrolCap # imp
 
 - type: loadoutGroup
@@ -1153,14 +1153,14 @@
   loadouts:
   - HeadofSecurityJumpsuit
   - HeadofSecurityJumpskirt
-  - HeadofSecurityJumpsuitGrey #imp
-  - HeadofSecurityJumpskirtGrey #imp
   - HeadofSecurityTurtleneck
   - HeadofSecurityTurtleneckSkirt
-  - HeadofSecurityProfessionalJumpsuit # imp
-  - HeadofSecurityProfessionalJumpskirt # imp
   - HeadofSecurityFormalSuit
   - HeadofSecurityFormalSkirt
+  - HeadofSecurityJumpsuitGrey #imp
+  - HeadofSecurityJumpskirtGrey #imp
+  - HeadofSecurityProfessionalJumpsuit # imp
+  - HeadofSecurityProfessionalJumpskirt # imp
 
 - type: loadoutGroup
   id: HeadofSecurityNeck
@@ -1194,14 +1194,14 @@
   id: WardenJumpsuit
   name: loadout-group-warden-jumpsuit
   loadouts:
-  - ChiefJusticeFormalJumpsuit # DeltaV
-  - ChiefJusticeFormalJumpskirt # DeltaV
-  - ChiefJusticeWhiteJumpsuit # DeltaV
-  - SecurityJumpsuitBlue # imp
   - WardenJumpsuit
   - WardenJumpskirt
-  - WardenTurtleskirt # DeltaV
   - WardenTurtlesuit # DeltaV
+  - WardenTurtleskirt # DeltaV
+  - SecurityJumpsuitBlue # imp
+  - ChiefJusticeWhiteJumpsuit # DeltaV
+  - ChiefJusticeFormalJumpsuit # DeltaV
+  - ChiefJusticeFormalJumpskirt # DeltaV
 
 - type: loadoutGroup
   id: WardenOuterClothing
@@ -1226,14 +1226,14 @@
   name: loadout-group-security-jumpsuit
   loadouts:
   - SecurityJumpsuit
-  - SecurityJumpsuitBlue # imp
   - SecurityJumpskirt
   - SecurityJumpsuitGrey
   - SecurityJumpskirtGrey
-  - SecuritySpaceJumpsuit # imp
   - SeniorOfficerJumpsuit
   - SeniorOfficerJumpskirt
   - TrooperUniform
+  - SecurityJumpsuitBlue # imp
+  - SecuritySpaceJumpsuit # imp
 
 - type: loadoutGroup
   id: SecurityBackpack
@@ -1257,10 +1257,10 @@
   - ArmorVest
   - ArmorVestCompact #imp
   - ArmorVestSlim
-  - BomberSecurity #imp
   - DuraVest # DeltaV
   - PlateCarrier # DeltaV
   - SecurityOfficerWintercoat
+  - BomberSecurity #imp
   - StasecSweater # DeltaV
 
 - type: loadoutGroup
@@ -1268,8 +1268,8 @@
   name: loadout-group-security-shoes
   loadouts:
   - JackBoots
-  - SecurityClownShoes # imp
   - SecurityWinterBoots
+  - SecurityClownShoes # imp
 
 - type: loadoutGroup
   id: SecurityPDA
@@ -1283,9 +1283,9 @@
   name: loadout-group-detective-head
   minLimit: 0
   loadouts:
-  - ClothingHeadDeerstalker #imp
   - DetectiveFedora
   - DetectiveFedoraGrey
+  - ClothingHeadDeerstalker #imp
 
 - type: loadoutGroup
   id: DetectiveNeck
@@ -1299,25 +1299,25 @@
   id: DetectiveJumpsuit
   name: loadout-group-detective-jumpsuit
   loadouts:
+  - DetectiveJumpsuit
+  - DetectiveJumpskirt
+  - NoirJumpsuit
+  - NoirJumpskirt
+  - ForensicSpecTurtlesuit # DeltaV
+  - ForensicSpecTurtleskirt # DeltaV
   - ClothingUniformMiamiVice #imp
   - ClothingUniformMiamiViceSkirt #imp
   - ClothingUniformDetectiveSuit #imp
   - ClothingUniformDetectiveSuitSkirt #imp
-  - DetectiveJumpsuit
-  - DetectiveJumpskirt
-  - ForensicSpecTurtleskirt # DeltaV
-  - ForensicSpecTurtlesuit # DeltaV
-  - NoirJumpsuit
-  - NoirJumpskirt
 
 - type: loadoutGroup
   id: DetectiveOuterClothing
   name: loadout-group-detective-outerclothing
   loadouts:
-  - ClothingOuterCoatFieldJacket #imp
   - DetectiveArmorVest
   - DetectiveCoat
   - DetectiveCoatGrey
+  - ClothingOuterCoatFieldJacket #imp
 
 - type: loadoutGroup
   id: SecurityCadetJumpsuit
@@ -1332,11 +1332,11 @@
   minLimit: 2
   hidden: true
   loadouts:
-  - EmergencyMeatSecurity # imp
   - EmergencyNitrogenSecurity
   - EmergencyOxygenSecurity
-  - LoadoutSpeciesAquaticFullTank # Imp
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyMeatSecurity # imp
+  - LoadoutSpeciesAquaticFullTank # Imp
 
 - type: loadoutGroup
   id: SecurityStar
@@ -1352,8 +1352,8 @@
   minLimit: 0
   loadouts:
   - ChiefMedicalOfficerBeret
-  - CMOClip # imp
   - CMOMedicalHeadMirror
+  - CMOClip # imp
 
 - type: loadoutGroup
   id: ChiefMedicalOfficerJumpsuit
@@ -1363,10 +1363,10 @@
   - ChiefMedicalOfficerJumpskirt
   - ChiefMedicalOfficerTurtleneckJumpsuit
   - ChiefMedicalOfficerTurtleneckJumpskirt
-  - CMOCasualSkirt # imp
   - CMOCasualSuit # imp
-  - CMOFormalDress # imp
+  - CMOCasualSkirt # imp
   - CMOFormalSuit # imp
+  - CMOFormalDress # imp
   - CMOScrubs # imp
 
 - type: loadoutGroup
@@ -1394,10 +1394,10 @@
   name: loadout-group-chief-medical-officer-shoes
   loadouts:
   - BrownShoes
+  - WhiteShoes # imp
   - LacedShoes #imp
   - LeatherShoes #imp
   - MedicalWinterBoots
-  - WhiteShoes # imp
 
 - type: loadoutGroup
   id: MedicalDoctorHead
@@ -1416,30 +1416,30 @@
   id: MedicalDoctorJumpsuit
   name: loadout-group-medical-doctor-jumpsuit
   loadouts:
-  - GeneticsJumpskirt # imp
-  - GeneticsJumpsuit # imp
   - MedicalDoctorJumpsuit
   - MedicalDoctorJumpskirt
+  - SpaceMedicalJumpsuit # imp
   - SeniorPhysicianJumpsuit
   - SeniorPhysicianJumpskirt
   - MedicalBlueScrubs
   - MedicalGreenScrubs
   - MedicalPurpleScrubs
-  - SpaceMedicalJumpsuit # imp
-  - VirologyJumpskirt # imp
   - VirologyJumpsuit # imp
+  - VirologyJumpskirt # imp
+  - GeneticsJumpsuit # imp
+  - GeneticsJumpskirt # imp
 
 - type: loadoutGroup
   id: MedicalDoctorOuterClothing
   name: loadout-group-medical-doctor-outerclothing
   minLimit: 0
   loadouts:
-  - BomberMedical #imp
-  - GeneticsWinterCoat # imp
   - RegularLabCoat
   - MedicalDoctorWintercoat
-  - SeniorPhysicianLabCoat
   - VirologyWinterCoat # imp
+  - GeneticsWinterCoat # imp
+  - BomberMedical #imp
+  - SeniorPhysicianLabCoat
 
 - type: loadoutGroup
   id: MedicalBackpack
@@ -1453,9 +1453,9 @@
   id: MedicalShoes
   name: loadout-group-medical-doctor-shoes
   loadouts:
-  - DoctorClownShoes # imp
   - WhiteShoes
   - MedicalWinterBoots
+  - DoctorClownShoes # imp
 
 - type: loadoutGroup
   id: MedicalDoctorPDA
@@ -1477,8 +1477,8 @@
   name: loadout-group-medical-mask
   minLimit: 0
   loadouts:
-  - DoctorClown # imp
   - SterileMask
+  - DoctorClown # imp
 
 - type: loadoutGroup
   id: MedicalInternJumpsuit
@@ -1491,9 +1491,9 @@
   id: ChemistJumpsuit
   name: loadout-group-chemist-jumpsuit
   loadouts:
-  - ChemistFormalSuit # imp
   - ChemistJumpsuit
   - ChemistJumpskirt
+  - ChemistFormalSuit # imp
   - SpaceChemistJumpsuit # imp
 
 - type: loadoutGroup
@@ -1501,12 +1501,12 @@
   name: loadout-group-chemist-outerclothing
   minLimit: 0
   loadouts:
-  - BomberMedical #imp
-  - ChemistryApron # imp
   - RegularLabCoat
   - ChemistLabCoat
-  - ChemistWintercoat
   - SeniorPhysicianLabCoat # imp
+  - ChemistWintercoat
+  - BomberMedical #imp
+  - ChemistryApron # imp
 
 - type: loadoutGroup
   id: ChemistBackpack
@@ -1535,9 +1535,9 @@
   name: loadout-group-paramedic-outerclothing
   minLimit: 0
   loadouts:
-  - BomberMedical #imp
   - ParamedicWindbreaker
   - ParamedicWintercoat
+  - BomberMedical #imp
 
 - type: loadoutGroup
   id: ParamedicShoes
@@ -1552,13 +1552,13 @@
   name: loadout-group-medical-glasses
   minLimit: 0
   loadouts:
-  - EyePatch # imp
   - MedicalHud
   - MedicalEyePatchHud
   - MedicalGlassesHud #imp
   - Glasses
   # imp edit start - its in the middle for alphabetizing reasons sorry
   - GlassesCheapSunglasses
+  - EyePatch
   - GlassesColorfulPink
   - GlassesColorfulRed
   - GlassesColorfulBlue
@@ -1575,11 +1575,11 @@
   minLimit: 2
   hidden: true
   loadouts:
-  - EmergencyMeatMedical # imp
   - EmergencyNitrogenMedical
   - EmergencyOxygenMedical
-  - LoadoutSpeciesAquaticFullTank # Imp
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyMeatMedical # imp
+  - LoadoutSpeciesAquaticFullTank # Imp
 
 # Wildcards
 - type: loadoutGroup
@@ -1621,11 +1621,11 @@
   minLimit: 2
   hidden: true
   loadouts:
-  - EmergencyMeatSyndicate # imp
   - EmergencyNitrogenSyndicate
   - EmergencyOxygenSyndicate
-  - LoadoutSpeciesAquaticFullTank # Imp
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyMeatSyndicate # imp
+  - LoadoutSpeciesAquaticFullTank # Imp
 
 - type: loadoutGroup
   id: GroupSpeciesBreathTool

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/courier.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Cargo/courier.yml
@@ -6,12 +6,12 @@
 
 # Jumpsuit
 - type: loadout
-  id: CourierJumpsuit
+  id: CourierJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtCourier
 
 - type: loadout
-  id: CourierJumpskirt
+  id: CourierJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitCourier
 

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -503,6 +503,7 @@
   minLimit: 0
   loadouts:
   - ScarfGreen
+  - ScarfBrown
 
 - type: loadoutGroup
   id: LibrarianShoes
@@ -715,6 +716,7 @@
   - LeatherShoes
   - BlackHeels
   - ClownShoesExpert
+
 # supply
 
 - type: loadoutGroup
@@ -770,10 +772,10 @@
   minLimit: 0
   loadouts:
 #  - MinerCloak # upstream removed it :(
-  - DrillerCape
   - SaMantle
   - ScarfBrown
   - RainCape
+  - DrillerCape
 
 - type: loadoutGroup
   id: SalvageSpecialistJumpsuit
@@ -791,6 +793,7 @@
   loadouts:
   - Glasses
   - GlassesCheapSunglasses
+  - EyePatch
   - GlassesColorfulBlue
   - GlassesColorfulGreen
   - GlassesColorfulPink
@@ -1089,12 +1092,12 @@
   loadouts:
   - BrigmedicArmoredWinterCoat
   - BrigmedicWinterCoat
+  - BrigmedicBomber
   - ArmorVest
   - ArmorVestSlim
   - ArmorVestCompact
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
-  - BrigmedicBomber
 
 - type: loadoutGroup
   id: BrigmedicShoes
@@ -1246,4 +1249,3 @@
   - LeatherShoes
   - BlackHeels
   - ClownShoesExpert
-


### PR DESCRIPTION
Loadouts will have default/upstream stuff first again instead of alphabetically.
Also loadout courier jumpsuit was straight up named wrong and unfortunately people will have to make sure they're wearing the right one since I fixed it. Sorry.
bad:
<img width="690" height="781" alt="image" src="https://github.com/user-attachments/assets/958432c9-fcd2-4acc-82bd-d827cd176598" />
good:
<img width="433" height="472" alt="image" src="https://github.com/user-attachments/assets/9e936ec2-6354-48de-9b91-b37b7f898264" />

**Changelog**
:cl:
- fix: Doctors won't be pressured to wear clown shoes by default, and other similar cases.