### PR TITLE
Event Table Weight Adjustments

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -21,54 +21,53 @@
     - id: GoblinKnightEvent # imp
 
 - type: entityTable
-  id: BasicAntagEventsTable
+  id: GreaterAntagEventsTable #imp: higher impact antags
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-    - !type:NestedSelector # DV
-      tableId: BasicAntagEventsTableDV
-    - id: ClosetSkeleton
     - id: DragonSpawn
     - id: KingRatMigration
     - id: NinjaSpawn
-    - id: ParadoxCloneSpawn
     - id: RevenantSpawn
     - id: SleeperAgents
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
-    - id: DerelictCyborgSpawn
     - id: WizardSpawn
     - id: ChangelingAwakening
-    - id: GoblinStowawaysEvent # imp
-    - id: GoblinCastawaysEvent # imp
     - id: BountyHunterSpawn # imp
     - id: ReplicatorSpawn # imp
+
+- type: entityTable
+  id: LesserAntagEventsTable # imp: lower impact antags
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector # DV
+      tableId: BasicAntagEventsTableDV
+    - id: ClosetSkeleton
+    - id: ParadoxCloneSpawn
+    - id: DerelictCyborgSpawn
+    - id: GoblinStowawaysEvent #imp
+    - id: GoblinCastawaysEvent #imp
     - id: OppaSpawnLight #imp
     - id: OppaSpawnNight #imp
     - id: SyndicateInfiltratorSpawn # imp
 
 - type: entityTable
-  id: SleeperlessAntagEventsTable
+  id: SleeperlessGreaterAntagEventsTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - !type:NestedSelector # DV
       tableId: BasicAntagEventsTableDV
-    - id: ClosetSkeleton
     - id: DragonSpawn
     - id: KingRatMigration
     - id: NinjaSpawn
     - id: RevenantSpawn
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
-    - id: DerelictCyborgSpawn
     - id: WizardSpawn
     - id: ChangelingAwakening
-    - id: GoblinStowawaysEvent # imp
-    - id: GoblinCastawaysEvent # imp
     - id: BountyHunterSpawn # imp
     - id: ReplicatorSpawn # imp
-    - id: OppaSpawnLight #imp
-    - id: OppaSpawnLight #imp
-    - id: SyndicateInfiltratorSpawn # imp
+
 
 - type: entity
   id: BaseStationEvent

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -17,7 +17,6 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: BrosSpawn #imp
-    - id: KingRatMigration
     - id: SnailMigration
     - id: SnakeSpawn #imp
     - id: SlimesSpawn #imp

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -379,19 +379,22 @@
     children:
       - !type:NestedSelector
         tableId: BasicCalmEventsTable
-        weight: 20
+        weight: 30
       - !type:NestedSelector
-        tableId: BasicAntagEventsTable
-        weight: 10
+        tableId: GreaterAntagEventsTable #imp
+        weight: 7
+      - !type:NestedSelector
+        tableId: LesserAntagEventsTable #imp
+        weight: 15
       - !type:NestedSelector
         tableId: CargoGiftsTable
-        weight: 7.5
+        weight: 16
       - !type:NestedSelector
         tableId: CalmPestEventsTable
-        weight: 5
+        weight: 17
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
-        weight: 7.5
+        weight: 15
 
 - type: entityTable
   id: SleeperlessGameRulesTable # imp: changed from AllSelector to GroupSelector
@@ -399,19 +402,22 @@
     children:
       - !type:NestedSelector
         tableId: BasicCalmEventsTable
-        weight: 20
+        weight: 30
       - !type:NestedSelector
-        tableId: SleeperlessAntagEventsTable
-        weight: 10
+        tableId: SleeperlessGreaterAntagEventsTable #imp
+        weight: 7
+      - !type:NestedSelector
+        tableId: LesserAntagEventsTable #imp
+        weight: 15
       - !type:NestedSelector
         tableId: CargoGiftsTable
-        weight: 7.5
+        weight: 16
       - !type:NestedSelector
         tableId: CalmPestEventsTable
-        weight: 5
+        weight: 17
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
-        weight: 7.5
+        weight: 15
 
 - type: entityTable
   id: SpaceTrafficControlTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -375,33 +375,43 @@
 
 - type: entityTable
   id: BasicGameRulesTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+  table: !type:GroupSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
       - !type:NestedSelector
         tableId: BasicCalmEventsTable
+        weight: 20
       - !type:NestedSelector
         tableId: BasicAntagEventsTable
+        weight: 10
       - !type:NestedSelector
         tableId: CargoGiftsTable
+        weight: 7.5
       - !type:NestedSelector
         tableId: CalmPestEventsTable
+        weight: 5
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
+        weight: 7.5
 
 - type: entityTable
   id: SleeperlessGameRulesTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+  table: !type:GroupSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
       - !type:NestedSelector
         tableId: BasicCalmEventsTable
+        weight: 20
       - !type:NestedSelector
         tableId: SleeperlessAntagEventsTable
+        weight: 10
       - !type:NestedSelector
         tableId: CargoGiftsTable
+        weight: 7.5
       - !type:NestedSelector
         tableId: CalmPestEventsTable
+        weight: 5
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
+        weight: 7.5
 
 - type: entityTable
   id: SpaceTrafficControlTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -374,7 +374,7 @@
 # event schedulers
 
 - type: entityTable
-  id: BasicGameRulesTable
+  id: BasicGameRulesTable # imp: changed from AllSelector to GroupSelector
   table: !type:GroupSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
       - !type:NestedSelector
@@ -394,7 +394,7 @@
         weight: 7.5
 
 - type: entityTable
-  id: SleeperlessGameRulesTable
+  id: SleeperlessGameRulesTable # imp: changed from AllSelector to GroupSelector
   table: !type:GroupSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
       - !type:NestedSelector


### PR DESCRIPTION
Draft for now while I make sure that this actually functions. 

Changes the basic event tables to use weights in an attempt to solve the problems discussed in this thread: https://discord.com/channels/1327800873660842097/1398361004127162579

The short summary is that, in current implementation, the event tables use AllSelectors to determine the next event, meaning that as we add more things to each individual table that table becomes more likely to be rolled. This changes it to use GroupSelectors and assign weights to each table, so they always roll at set rates, then roll events within based on their weights.

No changelog