### PR TITLE
Learner pAI Playtime Tweaks

### DIFF
--- a/Resources/Locale/en-US/_Impstation/pai/pai-system.ftl
+++ b/Resources/Locale/en-US/_Impstation/pai/pai-system.ftl
@@ -16,8 +16,11 @@ pai-system-role-description-learner-service = Ask questions and learn your way a
 pai-system-role-name-learner-science = research director's personal learner ai
 pai-system-role-description-learner-science = Ask questions and learn your way around the science department, all as a special electronic pal!
 
-pai-system-role-name-learner-command = captain's personal learner ai
+pai-system-role-name-learner-command = head of personal's personal learner ai
 pai-system-role-description-learner-command = Ask questions and learn your way around command, all as a special electronic pal!
 
 pai-system-role-name-learner-cargo = quartermaster's personal learner ai
 pai-system-role-description-learner-cargo = Ask questions and learn your way around the cargo department, all as a special electronic pal!
+
+pai-system-role-name-learner-captain = captain's personal learner ai
+pai-system-role-description-learner-captain = Ask questions and learn your way around being a captain, all as a special electronic pal!

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -61,7 +61,7 @@
       - !type:PlayerCountCondition
         max: 15
     - id: TicketPad #imp special
-    - id: PersonalAILearnerCommand #impspecial
+    - id: PersonalAILearnerCaptain # imp
 
 # No laser table + Laser table
 - type: entityTable
@@ -147,6 +147,7 @@
     - id: RubberStampHop
     - id: WeaponDisabler
     - id: ClothingEyesHudCommand
+    - id: PersonalAILearnerCommand #impspecial
 
 - type: entity
   id: LockerHeadOfPersonnelFilled

--- a/Resources/Prototypes/_Impstation/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Fun/pai.yml
@@ -15,9 +15,9 @@
       map: ["screen"]
   - type: ToggleableGhostRole
     requirements:
-    - !type:DepartmentTimeRequirement
-      department: Science
-      time: 54000 #15 hrs
+    - !type:RoleTimeRequirement
+      role: JobResearchDirector
+      time: 36000 #15 hrs
       inverted: true
     roleName: pai-system-role-name-learner-science
     roleDescription: pai-system-role-description-learner-science
@@ -51,9 +51,9 @@
       map: ["screen"]
   - type: ToggleableGhostRole
     requirements:
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 54000 #15 hrs
+    - !type:RoleTimeRequirement
+      role: JobChiefEngineer
+      time: 36000 #10 hrs
       inverted: true
     roleName: pai-system-role-name-learner-engineering
     roleDescription: pai-system-role-description-learner-engineering
@@ -87,9 +87,9 @@
       map: ["screen"]
   - type: ToggleableGhostRole
     requirements:
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 54000 #15 hrs
+    - !type:RoleTimeRequirement
+      role: JobHeadOfSecurity
+      time: 36000 #10 hrs
       inverted: true
     roleName: pai-system-role-name-learner-security
     roleDescription: pai-system-role-description-learner-security
@@ -123,9 +123,9 @@
       map: ["screen"]
   - type: ToggleableGhostRole
     requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 54000 #15 hrs
+    - !type:RoleTimeRequirement
+      role: JobChiefMedicalOfficer
+      time: 36000 #10 hrs
       inverted: true
     roleName: pai-system-role-name-learner-medical
     roleDescription: pai-system-role-description-learner-medical
@@ -159,9 +159,9 @@
       map: ["screen"]
   - type: ToggleableGhostRole
     requirements:
-    - !type:DepartmentTimeRequirement
-      department: Cargo
-      time: 18000 #5 hrs
+    - !type:RoleTimeRequirement
+      role: JobQuartermaster
+      time: 36000 #10 hrs
       inverted: true
     roleName: pai-system-role-name-learner-cargo
     roleDescription: pai-system-role-description-learner-cargo
@@ -195,9 +195,9 @@
       map: ["screen"]
   - type: ToggleableGhostRole
     requirements:
-    - !type:DepartmentTimeRequirement
-      department: Service
-      time: 54000 #15 hrs
+    - !type:RoleTimeRequirement
+      role: JobHospitalityDirector
+      time: 36000 #10 hrs
       inverted: true
     roleName: pai-system-role-name-learner-service
     roleDescription: pai-system-role-description-learner-service
@@ -215,11 +215,11 @@
           Off: { state: service-pai-off-overlay }
           Searching: { state: service-pai-searching-overlay }
           On: { state: service-pai-on-overlay }
-      
+
 - type: entity
   parent: PersonalAI
   id: PersonalAILearnerCommand
-  name: captain's personal learner device
+  name: head of personal's personal learner device
   description: Your electronic pal, who is itching to learn!
   components:
   - type: Sprite
@@ -233,10 +233,46 @@
     requirements:
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 54000 #15 hrs
+      time: 90000 #25 hrs
       inverted: true
     roleName: pai-system-role-name-learner-command
     roleDescription: pai-system-role-description-learner-command
+    roleRules: ghost-role-information-familiar-rules
+    mindRoles:
+    - MindRoleGhostRoleFamiliar
+  - type: ActiveRadio
+    channels:
+    - Command
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.ToggleableGhostRoleVisuals.Status:
+        screen:
+          Off: { state: command-pai-off-overlay }
+          Searching: { state: command-pai-searching-overlay }
+          On: { state: command-pai-on-overlay }
+
+- type: entity
+  parent: PersonalAI
+  id: PersonalAILearnerCaptain
+  name: captain's personal learner device
+  description: Your electronic pal, who is itching to learn!
+  components:
+  - type: Sprite
+    sprite: _Impstation/Objects/Fun/pai.rsi
+    layers:
+    - state: command-pai-base
+    - state: command-pai-off-overlay
+      shader: unshaded
+      map: ["screen"]
+  - type: ToggleableGhostRole
+    requirements:
+    - !type:RoleTimeRequirement
+      role: JobCaptain
+      time: 36000 #10 hrs
+      inverted: true
+    roleName: pai-system-role-name-learner-captain
+    roleDescription: pai-system-role-description-learner-captain
     roleRules: ghost-role-information-familiar-rules
     mindRoles:
     - MindRoleGhostRoleFamiliar


### PR DESCRIPTION
Increased the playtime allowed for joining the learner pAI of each department head.
Changed all learner pAI, except the command learner pAI, to use role time instead of department time. 
Added a new learner pAI for specifically learning how to be a captain.

:cl:
- add: The captain now has a learner pAI for those wanting to learn how to be a captain.
- tweak: Changed the learner pAI's to use role playtime rather than department playtime, except the command learner pAI
- tweak: Increased the playtime allowed for the learner pAI
- tweak: The command learner pAI has been moved to the HOP's locker, while the new captain learner pAI can be found in the captain's locker.