### PR TITLE
Cluwne Cellular Damage Tweak

### DIFF
--- a/Content.Server/Cluwne/CluwneSystem.cs
+++ b/Content.Server/Cluwne/CluwneSystem.cs
@@ -53,7 +53,7 @@ public sealed class CluwneSystem : EntitySystem
             RemComp<CluwneComponent>(uid);
             RemComp<ClumsyComponent>(uid);
             RemComp<AutoEmoteComponent>(uid);
-            var damageSpec = new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Genetic"), 300);
+            var damageSpec = new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Genetic"), component.GeneticDamageOnDeath); // IMP
             _damageableSystem.TryChangeDamage(uid, damageSpec);
         }
     }

--- a/Content.Shared/Cluwne/CluwneComponent.cs
+++ b/Content.Shared/Cluwne/CluwneComponent.cs
@@ -38,4 +38,8 @@ public sealed partial class CluwneComponent : Component
 
     [DataField("knocksound")]
     public SoundSpecifier KnockSound = new SoundPathSpecifier("/Audio/Items/airhorn.ogg");
+
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int GeneticDamageOnDeath = 300; // IMP
 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -98,5 +98,6 @@
   description: A polymorphed unfortunate.
   components:
   - type: Cluwne
+    geneticDamageOnDeath: 0 # IMP
   - type: Speech
     speechVerb: Cluwne


### PR DESCRIPTION
Changed the cluwne component so the cluwne polymorph no longer does 300 cellular damage on death. This doesn't affect the smite.

:cl: Oberonics
- tweak: Dying as a Cluwne no longer unravels your DNA.


