### PR TITLE
monkey's squeaky clean delight

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meal.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meal.yml
@@ -119,4 +119,5 @@
       - FoodMealBreakfastBagelPoppy
       - FoodMothCottonSoup
       - FoodMothCottonSalad
+      - FoodSoupMonkeySanitized
     rareChance: 0.05

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/soup.yml
@@ -83,3 +83,15 @@
           Quantity: 10
         - ReagentId: ChloralHydrate
           Quantity: 5
+
+- type: entity
+  name: monkey's squeaky clean delight
+  parent: FoodSoupMonkey
+  id: FoodSoupMonkeySanitized
+  description: A delicious soup with hunks of monkey meat simmered to perfection, in a broth that tastes faintly of bananas. There's a strange chemical aftertaste...
+  components:
+  - type: FlavorProfile
+    flavors:
+    - jungle
+    - banana
+    - metallic

--- a/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
@@ -553,3 +553,20 @@
     FoodBagel: 1
     FoodCreamCheese: 1
   recipeType: Assembler
+
+#added recipe alternate to account for monkeycube changes
+- type: microwaveMealRecipe
+  id: RecipeMonkeysDelightSoupSanitized
+  name: monkeys squeaky clean delight recipe
+  result: FoodSoupMonkeySanitized
+  time: 10
+  group: Soup
+  reagents:
+    Flour: 5
+    TableSalt: 1
+    Blackpepper: 1
+  solids:
+    FoodBowlBig: 1
+    FoodBanana: 1
+    MonkeyCubeSanitized: 1
+  recipeType: Oven # Frontier


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<img width="370" height="147" alt="image" src="https://github.com/user-attachments/assets/97ead62d-adef-4589-a1eb-6d32233186b4" />

i forgot to get a screenshot of the fucking guidebook
<img width="229" height="155" alt="image" src="https://github.com/user-attachments/assets/4f27492d-6a7c-43cd-a9f0-ae6fe9a580d8" />

adds a variant to the existing recipe monkey's delight that uses sanitized monkey cubes that were added in pr #2777 . so sorry chefs for making you gamble with your box for meal of monkey.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: monkey's delight is now able to be made with sanitized monkey cubes