### PR TITLE
I may be neurodivergent

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -148,6 +148,11 @@
     sprite: Clothing/OuterClothing/Armor/centcomm_carapace.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/centcomm_carapace.rsi
+  - type: DamageOnShootProtection #imp
+    slots: OUTERCLOTHING
+    damageProtection:
+      flatReductions:
+        Blunt: 10
 
 #Web vest
 - type: entity
@@ -248,6 +253,11 @@
         Piercing: 0.35
         Heat: 0.35
         Caustic: 0.5
+  - type: DamageOnShootProtection #imp
+    slots: OUTERCLOTHING
+    damageProtection:
+      flatReductions:
+        Blunt: 10
   - type: ExplosionResistance
     damageCoefficient: 0.35
   #- type: StaminaResistance

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/LightPistols/Lpistols.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/LightPistols/Lpistols.yml
@@ -19,6 +19,7 @@
     angleIncrease: 3
     angleDecay: 10
     fireRate: 6
+    selectedMode: FullAuto
     availableModes:
     - SemiAuto
     - FullAuto
@@ -68,6 +69,7 @@
     angleIncrease: 1.5
     angleDecay: 10
     fireRate: 5
+    selectedMode: Burst
     burstFireRate: 16
     availableModes:
     - Burst


### PR DESCRIPTION
I always get annoyed I forgot to add their respective special firing modes as their default for these two pistols and then I keep forgetting to make this change so I'm finally making this change. Also the raid suit isn't tripped by the Leviathan now.

**Changelog**
:cl:
- tweak: The Syndicate Raid Suit will now protect you from being knocked over by the Leviathan firing.
- tweak: The Mk 93 + 92HB both will now default to their respective signature firing modes.
