### PR TITLE
Cargo Borg Inner Storage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -472,7 +472,7 @@
 
 # cargo modules
 - type: entity
-  id: BorgModuleAppraisal
+  id: BorgModuleAppraisal # imp special and modified
   parent: [ BaseBorgModuleCargo, BaseProviderBorgModule ]
   name: appraisal cyborg module
   components:
@@ -481,13 +481,14 @@
     - state: cargo
     - state: icon-appraisal
   - type: ItemBorgModule
-    items:
+    items: # imp rearranged the items in this module
+    - BorgDuffel # imp allows the cargo borg to have a form of interior storage for logistics
     - AppraisalTool
-    - Pen
     - HandLabeler
+    - RadioHandheld
     - RubberStampApproved
     - RubberStampDenied
-    - RadioHandheld
+    - Pen
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: appraisal-module }
 

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/tools.yml
@@ -144,3 +144,14 @@
     - ClothingHeadHatCone
     - PowerCellSmall
     - Decalamp
+
+- type: entity
+  parent: ClothingBackpackDuffelCargo
+  id: BorgDuffel
+  name: borg's duffel bag
+  description: It's bigger on the inside.
+  components:
+  - type: Storage
+    quickInsert: true
+    areaInsert: true
+  - type: Dumpable

--- a/Resources/Prototypes/_Impstation/borg_types.yml
+++ b/Resources/Prototypes/_Impstation/borg_types.yml
@@ -12,7 +12,7 @@
     - BorgModuleCargo
 
   defaultModules:
-  - BorgModuleAppraisal
+  - BorgModuleAppraisal # imp modified
   - BorgModuleCourier # Imp
 
   radioChannels:


### PR DESCRIPTION
- Created a borg duffel bag for the purpose of inner storage.
- Added this borg duffel to the tools.yml
- Added the borg duffel to the default cargo borg Appraisal Module.

:cl:
- add: Added Cargo Borg inner storage via a special duffel bag in the Appraisal Module.
- tweak: Rearranged tools in the Appraisal Module for clear layout.
-->
