### PR TITLE
Remove numbers from health analyzer

### DIFF
--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -61,4 +61,11 @@ public sealed partial class HealthAnalyzerComponent : Component
     /// </summary>
     [DataField]
     public bool Silent;
+
+    // IMP ADD
+    /// <summary>
+    /// Whether to show the exact numerical damage, or just have a vague descriptor
+    /// </summary>
+    [DataField]
+    public bool ShowExactValues = false;
 }

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -189,9 +189,11 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
         TryComp<TemperatureComponent>(entity.Comp.BodyContainer.ContainedEntity, out var temp);
         TryComp<BloodstreamComponent>(entity.Comp.BodyContainer.ContainedEntity, out var bloodstream);
 
+        var showExactValues = false; // imp add
         if (TryComp<HealthAnalyzerComponent>(entity, out var healthAnalyzer))
         {
             healthAnalyzer.ScannedEntity = entity.Comp.BodyContainer.ContainedEntity;
+            showExactValues = healthAnalyzer.ShowExactValues; // imp add
         }
 
         // TODO: This should be a state my dude
@@ -206,7 +208,8 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
                 : 0,
             null,
             null,
-            null
+            null,
+            showExactValues // imp add showexactvalues
         ));
     }
 

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -211,13 +211,20 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         if (TryComp<UnrevivableComponent>(target, out var unrevivableComp) && unrevivableComp.Analyzable)
             unrevivable = true;
 
+        // imp add
+        var showExactValues = false;
+        if (TryComp<HealthAnalyzerComponent>(healthAnalyzer, out var healthAnalyzerComp))
+            showExactValues = healthAnalyzerComp.ShowExactValues;
+        // imp add end
+
         _uiSystem.ServerSendUiMessage(healthAnalyzer, HealthAnalyzerUiKey.Key, new HealthAnalyzerScannedUserMessage(
             GetNetEntity(target),
             bodyTemperature,
             bloodAmount,
             scanMode,
             bleeding,
-            unrevivable
+            unrevivable,
+            showExactValues // imp add
         ));
     }
 }

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -14,8 +14,9 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
     public bool? ScanMode;
     public bool? Bleeding;
     public bool? Unrevivable;
+    public bool ShowExactValues; // imp add
 
-    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable)
+    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, bool showExactValues)
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -23,6 +24,7 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
         ScanMode = scanMode;
         Bleeding = bleeding;
         Unrevivable = unrevivable;
+        ShowExactValues = showExactValues; // imp
     }
 }
 

--- a/Resources/Locale/en-US/_Impstation/health-analyzer/health-analyzer.ftl
+++ b/Resources/Locale/en-US/_Impstation/health-analyzer/health-analyzer.ftl
@@ -1,0 +1,18 @@
+# Levels of overall damage:
+
+heath-analyzer-window-entity-damage-cataclysmic-text = Cataclysmic
+heath-analyzer-window-entity-damage-extreme-text = Extreme
+heath-analyzer-window-entity-damage-severe-text = Severe
+heath-analyzer-window-entity-damage-extensive-text = Extensive
+heath-analyzer-window-entity-damage-substantial-text = Substantial
+heath-analyzer-window-entity-damage-moderate-text = Moderate
+heath-analyzer-window-entity-damage-negligible-text = Negligible
+heath-analyzer-window-entity-damage-none-text = None
+
+# Levels of group damage:
+
+health-analyzer-window-damage-all-text = All damage
+health-analyzer-window-damage-most-text = Most of damage
+health-analyzer-window-damage-some-text = Some of damage
+health-analyzer-window-damage-little-text = Little of damage
+health-analyzer-window-damage-error-text = ERROR!

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -991,6 +991,7 @@
     maxScanRange: null
     scanDelay: 0
     silent: true
+    showExactValues: true # imp
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
     notificationsEnabled: false

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: HandheldHealthAnalyzerAdmeme
+  parent: HandheldHealthAnalyzer
+  suffix: Show Exact Values
+  components:
+  - type: HealthAnalyzer
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
+    showExactValues: true


### PR DESCRIPTION
ive been loving playing medical without using health analyzers recently, and apparently (according to our big medheads) im not the only one. one of the big issues with the current medical meta is that by having easy access to a lot of damage numbers, it encourages a bit of powergaming vis a vis exact values.

obfuscation of information is a great tool in ss14 and can create new challenges in gameplay. if i dont know exactly how to treat every patient, i'm more encouraged to try new things. there's more risk. i'm killing the meta, squirtle.

this implementation doesnt work atm so im setting it as a draft (lol) i dont know what the fuck is up with the c#, but otherwise in theory it should all function.

what this implementation does is it grab's a mob's death threshold, then weighs the amount of damage done against that percentage and gives you vague text based on that percentage. so, hamlet taking 10 damage might have the same output as a human who's taken 50. this is the same system used for the medhud health bar overlay!

for damage types, it tells you what percentage of total damage the individual damage type takes up. for example, someone might read as having "some brute damage, all of which is blunt" or "a little heat damage, most of which is cold and a little of which is caustic".

exact numbers and text can totally be tweaked, but i want to keep it low. if someone gets 14,000 cold damage, they should seem to be the same as someone with 500 cold damage. beware my sunk cost fallacy puzzle.

admin pdas still show the exact values, and theres a spawnable health analyzer that also shows the exact values.

media coming soon when it all actually works lol

:cl:
- remove: Health analyzers no longer give the exact number of damage sustained.
