### PR TITLE
synfiltrator codeword

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/human.yml
@@ -7,7 +7,7 @@
   - type: AutoTraitor
     profile: TraitorInfiltrator
   - type: Loadout
-    prototypes: [SyndicateReinforcementSpy]
+    prototypes: [SyndicateInfiltratorGear]
     roleLoadout: [ RoleSurvivalSyndicate ]
   - type: EmitSoundOnSpawn # dumb fix for the clang sound not playing on spawn but only matters if youre spawning this prototype from the entity panel
     sound: /Audio/Effects/clang.ogg

--- a/Resources/Prototypes/_Impstation/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Antags/traitor.yml
@@ -1,0 +1,11 @@
+- type: startingGear
+  id: SyndicateInfiltratorGear
+  parent: SyndicateOperativeClothing
+  equipment:
+    id: AgentIDCard
+    mask: ClothingMaskGasVoiceChameleon
+    pocket1: WeaponPistolViper
+  storage:
+    back:
+    - TraitorCodePaper
+    - FlippoSyndicateLighter


### PR DESCRIPTION
ive had this idea for a while but surprisingly what made me want to actually pr giving infiltrators codewords finally was people complaining about not being able to see since infiltrators usually spawn in maints. now they have a light (for burning their codeword)

<img width="239" height="229" alt="image" src="https://github.com/user-attachments/assets/bfae7ca0-74e9-4862-8158-b6abb40c9fa3" />

**Changelog**
:cl:
- add: syndicate infiltrators now get a codeword, and a lighter. so you can see
