### PR TITLE
Fix Last Message Webhook, Add proper emote support

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -244,7 +244,7 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         if (player != null) // Imp Edit: Last Message Before Death System
         {
-            HandleLastMessageBeforeDeath(source, player, message);
+            HandleLastMessageBeforeDeath(source, player, message, desiredType);
         }
 
         // This message may have a radio prefix, and should then be whispered to the resolved radio channel
@@ -835,10 +835,18 @@ public sealed partial class ChatSystem : SharedChatSystem
     /// <summary>
     ///     Imp Edit: First modify message to respect entity accent, then send it to LastMessage system to record last message info for player
     /// </summary>
-    public void HandleLastMessageBeforeDeath(EntityUid source, ICommonSession player, string message)
+    public void HandleLastMessageBeforeDeath(EntityUid source, ICommonSession player, string message, InGameICChatType desiredType)
     {
-        var newMessage = TransformSpeech(source, message);
-        _lastMessageBeforeDeathSystem.AddMessage(source, player, newMessage);
+        if (desiredType == InGameICChatType.Emote)
+        {
+            var newMessage = "*" + message + "*";
+            _lastMessageBeforeDeathSystem.AddMessage(source, player, newMessage);
+        }
+        else
+        {
+            var newMessage = TransformSpeech(source, message);
+            _lastMessageBeforeDeathSystem.AddMessage(source, player, newMessage);
+        }
     }
 
     // ReSharper disable once InconsistentNaming


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Turns out messages saved postround (regardless if the person died after!) were being saved. This adds a fix to make sure postround messages are NOT saved. This also adds better handling of emotes (as you can see below)

(this is separate rounds)

<img width="1380" height="199" alt="Discord_5mbpIjfKmG" src="https://github.com/user-attachments/assets/bc06b70e-c0f8-422e-a0ac-b00794056ee5" />


I will eventually be doing more changes down the line.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: AirFryerBuyOneGetOneFree
- tweak: Last Message Before Death Webhook fixes
