### PR TITLE
Leviathan fix

### DIFF
--- a/Content.Shared/_Impstation/Weapons/Ranged/DamageOnShootSystem.cs
+++ b/Content.Shared/_Impstation/Weapons/Ranged/DamageOnShootSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Popups;
 using Robust.Shared.Random;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Content.Shared.Stunnable;
 using Content.Shared.Weapons.Ranged.Systems;
@@ -14,6 +15,7 @@ namespace Content.Shared.Damage.Systems;
 
 public sealed class DamageOnShootSystem : EntitySystem
 {
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
@@ -61,7 +63,7 @@ public sealed class DamageOnShootSystem : EntitySystem
 
         totalDamage = _damageableSystem.TryChangeDamage(args.User, totalDamage, entity.Comp.IgnoreResistances);
 
-        if (totalDamage != null)
+        if (totalDamage != null && totalDamage.AnyPositive())
         {
             _adminLogger.Add(LogType.Damaged, $"{ToPrettyString(args.User):user} shot {ToPrettyString(entity):gun} and took {totalDamage.GetTotal():damage} recoil damage");
             _audioSystem.PlayPredicted(entity.Comp.DamageSound, entity, args.User);
@@ -69,9 +71,12 @@ public sealed class DamageOnShootSystem : EntitySystem
             if (entity.Comp.PopupText != null)
                 _popupSystem.PopupClient(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
 
-            // Attempt to paralyze the user after they have taken damage
-            if (_random.Prob(entity.Comp.StunChance))
-                _stun.TryParalyze(args.User, TimeSpan.FromSeconds(entity.Comp.StunSeconds), true);
+            if (_net.IsClient)
+                return;
+            {
+                if (_random.Prob(entity.Comp.StunChance))
+                    _stun.TryParalyze(args.User, TimeSpan.FromSeconds(entity.Comp.StunSeconds), true);
+            }
         }
     }
 }

--- a/Content.Shared/_Impstation/Weapons/Ranged/DamageOnShootSystem.cs
+++ b/Content.Shared/_Impstation/Weapons/Ranged/DamageOnShootSystem.cs
@@ -61,7 +61,7 @@ public sealed class DamageOnShootSystem : EntitySystem
 
         totalDamage = _damageableSystem.TryChangeDamage(args.User, totalDamage, entity.Comp.IgnoreResistances);
 
-        if (totalDamage != null && totalDamage.AnyPositive())
+        if (totalDamage != null)
         {
             _adminLogger.Add(LogType.Damaged, $"{ToPrettyString(args.User):user} shot {ToPrettyString(entity):gun} and took {totalDamage.GetTotal():damage} recoil damage");
             _audioSystem.PlayPredicted(entity.Comp.DamageSound, entity, args.User);


### PR DESCRIPTION
It's a weird problem that has its fingers somewhere in the netcode. The Leviathan has been making hardsuits fall over and be stunned despite that shouldn't be happening. I can't get the problem to replicate in a localhost, but hopefully adding some extra special care in the prediction and netcode can help? At the very least this fix doesn't hurt the functionality, but I won't know if it didn't fix it until the problem happens again in the server proper.

**Changelog**
:cl:
- fix: The Leviathan won't be knocking over blood-reds, hopefully. Fingers crossed.