### PR TITLE
emergency fix for prize ticket ash bomb

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
@@ -47,11 +47,6 @@
         !type:DamageTrigger
         damage: 15
       behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Ash:
-            min: 1
-            max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: StaticPrice


### PR DESCRIPTION
prize tickets stacks created ash for each individual ticket in stack
Given the huge sizes that these come in, it means that a stack can create thousands of ash in a single tick
Fixed
<img width="576" height="294" alt="image" src="https://github.com/user-attachments/assets/93fd23d1-ae56-4bf2-abdc-a07a15b5563d" />
<img width="318" height="195" alt="image" src="https://github.com/user-attachments/assets/a7ccced0-55bd-4734-8b7b-f3dcfa600cbc" />


:cl:
- tweak: prize tickets being burned no longer leave any ash

