### PR TITLE
Prize ticket fixes - single ash and repli nest

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -29,6 +29,9 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
         [DataField]
         public bool SpawnInContainer;
 
+        [DataField]
+        public bool MultiplyByNumberInStack = true;
+
         public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
         {
             var tSys = system.EntityManager.System<TransformSystem>();
@@ -39,7 +42,8 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
             var executions = 1;
             if (system.EntityManager.TryGetComponent<StackComponent>(owner, out var stack))
             {
-                executions = stack.Count;
+                if (MultiplyByNumberInStack)
+                    executions = stack.Count;
             }
 
             foreach (var (entityId, minMax) in Spawn)

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-nest.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-nest.yml
@@ -23,6 +23,7 @@
       - Cartridge
       - CartridgeMagnum
       - Ectoplasm # causes problems for the revenant if they're consumed
+      - PrizeTicket
     preservationBlacklist: # delete stuff that passes this, even if it also passes the preservationWhitelist
       components:
       - SiliconLawBound

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
@@ -52,6 +52,7 @@
           Ash:
             min: 1
             max: 1
+        multiplyByNumberInStack: false
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: StaticPrice

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
@@ -47,11 +47,6 @@
         !type:DamageTrigger
         damage: 15
       behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Ash:
-            min: 1
-            max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: StaticPrice

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fun/prizeticket.yml
@@ -47,6 +47,11 @@
         !type:DamageTrigger
         damage: 15
       behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: StaticPrice


### PR DESCRIPTION
Return ability to ash to prize tickets, but only into one no matter the number of items in the stack
Does this by adding a new field to the SpawnEntitiesBehavior in DestructibleComponent which turns off the 'spawn one set of things per item in stack' which is explicitly in (for 30 glass shard attack purposes, i assume).
Also adds PrizeTicket tag to the ReplicatorNest blacklist so that replicators mass-printing tickets is not the optimal play for points (1000 tickets = 1000 point)


:cl:
- tweak: prize tickets can now ash again - into ONE ash
- tweak: prize tickets are not allowed in replicator nests