### PR TITLE
Psychologist's pill bottle and small loadout additions

### DIFF
--- a/Resources/Locale/en-US/_Impstation/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Impstation/preferences/loadout-groups.ftl
@@ -166,6 +166,9 @@ loadout-group-chemist-id = Chemist ID
 loadout-group-paramedic-neck = Paramedic neck
 loadout-group-paramedic-id = Paramedic ID
 
+loadout-group-psychologist-head = Psychologist head
+loadout-group-psychologist-mask = Psychologist mask
 loadout-group-psychologist-neck = Psychologist neck
 loadout-group-psychologist-shoes = Psychologist shoes
 loadout-group-psychologist-outerclothing = Psychologist outer clothing
+loadout-group-psychologist-backpack = Psychologist backpack

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -690,12 +690,14 @@
 - type: roleLoadout
   id: JobPsychologist
   groups:
+  - PsychologistHead # imp
+  - PsychologistMask # imp
   - PsychologistNeck # imp
   - PsychologistJumpsuit
   - PsychologistOuterClothing # DeltaV
   - PsychologistShoes # imp
   - Glasses
-  - MedicalBackpack # imp reorder
+  - PsychologistBackpack # imp MedicalBackpack > PsychologistBackpack
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -21,9 +21,11 @@
   equipment:
     id: PsychologistPDA
     ears: ClothingHeadsetMedical
+    belt: ClothingBeltPaperworkFilled # imp
   storage:
     back:
     - RubberStampPsychologist
+    - PillCanisterPsych # imp
 
 - type: chameleonOutfit
   id: PsychologistChameleonOutfit

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -22,7 +22,7 @@
   name: loadout-group-psychologist-outerclothing
   minLimit: 0
   loadouts:
-  - MedicalDoctorWintercoat
+  - WinterCoatBlack # imp edit
   - PsychologistSweater
 
 ## Chemist

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Deliveries/deliveries_items.yml
@@ -21,7 +21,7 @@
   id: SyringeTestosterone
   components:
   - type: Label
-    currentLabel: reagent-name-testosterone
+    currentLabel: testosterone 15u
   - type: SolutionContainerManager
     solutions:
       injector:
@@ -36,7 +36,7 @@
   id: SyringeEstradiol
   components:
   - type: Label
-    currentLabel: reagent-name-estradiol
+    currentLabel: estradiol 15u
   - type: SolutionContainerManager
     solutions:
       injector:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Medical/healing.yml
@@ -126,3 +126,258 @@
     contents:
     - id: PillHappiness
       amount: 5
+
+# psych pills and bottles
+
+- type: entity
+  name: psychologist's pill
+  suffix: Sugar 10u
+  parent: Pill
+  description: This pill looks particularly effective.
+  id: PillSugar
+  components:
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Sugar
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillSpaceMirage
+  components:
+  - type: Label
+    currentLabel: space mirage 20u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: SpaceDrugs
+          Quantity: 20
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillChloralHydrate
+  components:
+  - type: Label
+    currentLabel: chloral hydrate 10u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: ChloralHydrate
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillPax
+  components:
+  - type: Label
+    currentLabel: pax 10u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Pax
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillTestosterone
+  components:
+  - type: Label
+    currentLabel: testosterone 10u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Testosterone
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillEstradiol
+  components:
+  - type: Label
+    currentLabel: estradiol 10u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Estradiol
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillMindbreaker
+  components:
+  - type: Label
+    currentLabel: mindbreaker toxin 10u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: MindbreakerToxin
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillJuiceThatMakesYouWeh
+  components:
+  - type: Label
+    currentLabel: weh 10u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: JuiceThatMakesYouWeh
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillEphedrine
+  components:
+  - type: Label
+    currentLabel: ephedrine 10u
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Ephedrine
+          Quantity: 10
+
+- type: entity
+  name: pill
+  parent: Pill
+  categories: [ HideSpawnMenu ]
+  id: PillFrezon
+  components:
+  - type: Label
+    currentLabel: frezon 10u # this lasted about 6 minutes and was pretty managable
+  - type: Pill
+    pillType: 21
+  - type: Sprite
+    state: pill22
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Frezon
+          Quantity: 10
+
+- type: entityTable
+  id: RandomSafePyschPillTable #i thought about using the random stuff strange pills use but i really wanted these to be labelled
+  table: !type:GroupSelector
+    children:
+    - id: PillSugar
+      weight: 0.15
+    - id: PillSpaceMirage
+      weight: 0.2
+    - id: PillLacedPsicodine
+      weight: 0.05
+    - id: PillChloralHydrate
+      weight: 0.2
+    - id: PillPax
+      weight: 0.2
+    - id: PillTestosterone
+      weight: 0.1
+    - id: PillEstradiol
+      weight: 0.1
+
+- type: entityTable
+  id: RandomUnsafePyschPillTable
+  table: !type:GroupSelector
+    children:
+    - id: PillMindbreaker
+      weight: 0.25
+    - id: PillHappiness
+      weight: 0.2
+    - id: PillFrezon
+      weight: 0.15
+    - id: PillEphedrine
+      weight: 0.2
+    - id: PillJuiceThatMakesYouWeh
+      weight: 0.2
+
+- type: entity
+  name: psychologist's pill canister
+  parent: [PillCanister, BaseMedicalContraband]
+  description: An assortment of prescription medications well suited to the denizens of a space station.
+  id: PillCanisterPsych
+  suffix: Psychologist Random
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          rolls: !type:RangeNumberSelector
+            range: 7, 7
+          tableId: RandomSafePyschPillTable
+        - !type:NestedSelector
+          rolls: !type:RangeNumberSelector
+            range: 3, 3
+          tableId: RandomUnsafePyschPillTable

--- a/Resources/Prototypes/_Impstation/Loadouts/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Jobs/Wildcards/psychologist.yml
@@ -1,0 +1,16 @@
+# head
+- type: loadout
+  id: PsychologistCapGrey
+  equipment:
+    head: ClothingHeadHatGreyFlatcap
+
+- type: loadout
+  id: PsychologistCapBrown
+  equipment:
+    head: ClothingHeadHatBrownFlatcap
+
+# Shoes
+- type: loadout
+  id: BlackWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterColorBlack

--- a/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/loadout_groups.yml
@@ -1238,6 +1238,21 @@
   - SeniorParamedicPDA
 
 - type: loadoutGroup
+  id: PsychologistHead
+  name: loadout-group-psychologist-head
+  minLimit: 0
+  loadouts:
+  - PsychologistCapGrey
+  - PsychologistCapBrown
+
+- type: loadoutGroup
+  id: PsychologistMask
+  name: loadout-group-psychologist-mask
+  minLimit: 0
+  loadouts:
+  - DoctorClown
+
+- type: loadoutGroup
   id: PsychologistNeck
   name: loadout-group-psychologist-neck
   minLimit: 0
@@ -1253,4 +1268,14 @@
   - LacedShoes
   - LeatherShoes
   - BlackHeels
+  - BlackWinterBoots
   - ClownShoesExpert
+
+- type: loadoutGroup
+  id: PsychologistBackpack
+  name: loadout-group-psychologist-backpack
+  loadouts:
+  - MedicalDoctorBackpack
+  - MedicalDoctorSatchel
+  - MedicalDoctorDuffel
+  - LeatherSatchel


### PR DESCRIPTION
I perused some other forks like dv, cd, and den to see if anyone is doing anything cool with psych. Unfortunately unique drip was lacking. 
I saw that some give psychologists the options between canisters of space mirage, pax, and chloral hydrate. This is cool, but I don't like the idea of a meta choice emerging. So I made it randomized and added more reagents. I hope these will act as cute RP prompts and encourage psychologists to match their beautiful tablets to needful members of the crew, and maybe even get refills from chem. I tested all of the pills and none are particularly crazy in my opinion. The rarer ephedrine roll doesn't last for very long, and the chloral pills had me fall asleep briefly about twice. Could see some use in specific scenarios, but won't come up too often. I'd be open to reducing it to 5 pills instead of 10 if it's too many.
I might one day come back and swap these to the colorful canisters and give people a choice, but I couldn't find the sprites on discord.
<img width="872" height="401" alt="image" src="https://github.com/user-attachments/assets/eebe5637-0345-44cc-8026-135d1902d925" />
<img width="731" height="501" alt="image" src="https://github.com/user-attachments/assets/48b889f3-7efd-4e37-84ac-ac35b845a408" />
<img width="336" height="89" alt="image" src="https://github.com/user-attachments/assets/f02f4bd4-9479-40be-8932-63cf326ee43a" />

Loadout receives flatcaps, a clown mask (they already had the shoes), winter gear, a leather satchel, and a paperwork belt.

**Changelog**
:cl:
- add: Added the psychologist's pill canister and a couple of other loadout options to psychologist.
