### PR TITLE
Add tooltips to the cargo bounty status thingimajig

### DIFF
--- a/Content.Client/Cargo/UI/BountyEntry.xaml.cs
+++ b/Content.Client/Cargo/UI/BountyEntry.xaml.cs
@@ -55,6 +55,7 @@ public sealed partial class BountyEntry : BoxContainer
         BountyStatusSelector.AddItem(Loc.GetString("bounty-console-status", ("status", 1)), 1);
         BountyStatusSelector.AddItem(Loc.GetString("bounty-console-status", ("status", 2)), 2);
         BountyStatusSelector.Select((int) bounty.Status);
+        BountyStatusSelector.ToolTip = Loc.GetString("bounty-console-status-tooltip", ("status", (int) bounty.Status));
 
         var claimedByText = string.IsNullOrEmpty(bounty.ClaimedBy) ? Loc.GetString("bounty-console-claimed-by-none") : bounty.ClaimedBy;
         ClaimedBylabel.SetMarkup(Loc.GetString("bounty-console-claimed-by", ("claimant", claimedByText)));

--- a/Resources/Locale/en-US/cargo/cargo-bounty-console.ftl
+++ b/Resources/Locale/en-US/cargo/cargo-bounty-console.ftl
@@ -23,8 +23,14 @@ bounty-console-status-label = Status: {$status ->
     }
 bounty-console-status = {$status ->
         [2] On Shuttle
-            [1] Waiting
+        [1] Waiting
         *[other] Undelivered
+    }
+
+bounty-console-status-tooltip = {$status ->
+    [2] This bounty is on the shuttle, ready to be delivered to the trade station
+    [1] This bounty is waiting to be fulfilled
+    *[other] This bounty has not yet been sent out for fulfilment
     }
 #imp edit end
 


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

I didn't play for like a month and forgor what the three different options actually meant so I added a tooltip to reinforce it.
wording could probably do with some refinement but w/e

no cl; tiny change

<img width="1036" height="398" alt="image" src="https://github.com/user-attachments/assets/e0d8753a-b199-4d82-b219-82b522a03320" />

<img width="987" height="395" alt="image" src="https://github.com/user-attachments/assets/3297ee4f-ae3b-4287-8a33-146a42697e12" />

<img width="1209" height="386" alt="image" src="https://github.com/user-attachments/assets/762d5bf6-d60d-409b-a473-c879d6691af9" />

