### PR TITLE
Fix vocal emotes done through chat not appearing in chat

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -189,7 +189,7 @@ public partial class ChatSystem
             validEmote = true; // DeltaV
         }
 
-        return !validEmote; //imp
+        return validEmote; //imp
 
         static string TrimPunctuation(string textInput)
         {


### PR DESCRIPTION
A bool was returning inverse when it shouldn't have been.

**Changelog**
:cl:
- fix: Vocal emotes now properly appear in chat when manually typed.

