### PR TITLE
Re-add Service Worker to the Service department, hide Administrative Assistant on the ID card computer

### DIFF
--- a/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
@@ -9,6 +9,7 @@
   startingGear: AdminAssistantGear
   icon: "JobIconAdminAssitant"
   supervisors: job-supervisors-command
+  setPreference: false #imp
   canBeAntag: false
   access:
   - Command

--- a/Resources/Prototypes/_Impstation/Roles/departments.yml
+++ b/Resources/Prototypes/_Impstation/Roles/departments.yml
@@ -20,8 +20,8 @@
   - Reporter
   - Zookeeper
   # non-roundstart
-  - Visitor
   - ServiceWorker
+  - Visitor
 
 #Used for HD playtime requirments
 - type: department

--- a/Resources/Prototypes/_Impstation/Roles/departments.yml
+++ b/Resources/Prototypes/_Impstation/Roles/departments.yml
@@ -5,6 +5,7 @@
   color: "#9FED58" #imp edit, grey for the greytide
   weight: -10
   roles:
+  # roundstart
   - HospitalityDirector
   - Bartender
   - Botanist
@@ -17,9 +18,10 @@
   - Mime
   - Musician
   - Reporter
-  - Visitor
   - Zookeeper
-  #- ServiceWorker
+  # non-roundstart
+  - Visitor
+  - ServiceWorker
 
 #Used for HD playtime requirments
 - type: department


### PR DESCRIPTION
Sorry Laura Klaus, this doesn't actually re-enable service worker as a round start role.

Having a job be assignable by the HoP's ID card computer has some problems associated with it if that job isn't part of a department, namely, they will show up under the "Unknown" section of the crew monitoring console. I re-added Service Worker to the Service department so it will now show up under the Service tab. I opted to hide AA from the computer entirely, as readding it to command will have any AA playtime count as Command playtime, which I feel should be avoided.

:cl:
- fix: Crew members that have had their job set to Service Worker from the ID card computer will now show up under the Service tab on the crew monitoring console.
- remove: You can no longer change your job to Administrative Assistant from the ID card computer.
