### PR TITLE
Removed drones flashing others when they toggle their pointlight.

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/silicon.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/silicon.yml
@@ -98,10 +98,10 @@
     thresholds:
       0: Alive
       25: Dead
-  - type: Flash
   - type: NoSlip
   - type: StatusEffects
     allowed:
+    - Flashed
     - Stun
     - KnockedDown
     - SlowedDown


### PR DESCRIPTION
This is a fix to drones that removes the flash component and allowed drones to experience the flashed status effect.

:cl:
- fix: Drones no longer know the joys of flashing others when they toggle their flashlight.
- fix: The tables have turned and now Drones are once again able to be flashed.