### PR TITLE
Randomize destination of bluespace lockers spawned by the event scheduler

### DIFF
--- a/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
@@ -44,6 +44,18 @@ public sealed class BluespaceLockerRule : StationEventSystem<BluespaceLockerRule
             _bluespaceLocker.GetTarget(potentialLink, comp, true);
             _bluespaceLocker.BluespaceEffect(potentialLink, comp, comp, true);
 
+            // begin imp edit
+            // makes bluespace lockers randomize their destinations with each use.
+            comp.BehaviorProperties.ClearLinksDebluespaces = true;
+            comp.BehaviorProperties.TransportEntities = true;
+            comp.BehaviorProperties.ClearLinksEvery = 2;
+            comp.AutoLinkProperties.DestroyAfterUses = 2;
+            comp.AutoLinkProperties.DestroyType = BluespaceLockerDestroyType.DeleteComponent;
+            comp.UsesSinceLinkClear = -1;
+            comp.AutoLinkProperties.InvalidateOneWayLinks = true;
+            comp.AutoLinkProperties.TransportEntities = false;
+            // end imp edit
+
             Sawmill.Info($"Converted {ToPrettyString(potentialLink)} to bluespace locker");
 
             return;


### PR DESCRIPTION
Title.
Demonstration of what this does:

https://github.com/user-attachments/assets/b33d3f24-0e4f-4d1f-bd9e-a7629778c300

This can only target containers on the same grid as the source locker, so you can't get to Centcomm or the VGroid with this.

:cl:
- tweak: Bluespace lockers' destinations are now randomized.