### PR TITLE
mre wrappers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -964,6 +964,9 @@
     tags:
     - ClothMade
     - Trash
+  - type: FlavorProfile # imp
+    flavors:
+      - paper
   - type: Sprite
     state: mre-wrapper
   - type: Item


### PR DESCRIPTION
did you guys know that sometimes edible things decide their taste by their material composition instead of their reagents for some reason unless you manually override it and also mre wrappers are trash um basically im sorry moths your wrappers taste pulpy again sorry

**Changelog**
:cl:
- fix: Fixed MRE wrappers tasting trashy