### PR TITLE
Clean last message of * symbol

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -840,12 +840,12 @@ public sealed partial class ChatSystem : SharedChatSystem
     {
         if (desiredType == InGameICChatType.Emote)
         {
-            var newMessage = "*" + message + "*";
+            var newMessage = "*" + message.Replace("*", "") + "*";
             _lastMessageBeforeDeathSystem.AddMessage(source, player, newMessage);
         }
         else
         {
-            var newMessage = TransformSpeech(source, message);
+            var newMessage = TransformSpeech(source, message.Replace("*", ""));
             _lastMessageBeforeDeathSystem.AddMessage(source, player, newMessage);
         }
     }


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
asterisk is how you define italics in discord text, so I am now cleaning any saved messages of this character.

**Changelog**
:cl:
- fix: Fixed last messages with * messing with discord formatting
