### PR TITLE
let wardens use the security communications computer

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Computers/computers.yml
@@ -54,7 +54,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: AccessReader
-    access: [[ "HeadOfSecurity" ]]
+    access: [[ "Armory" ]]
   - type: CommunicationsConsole
     title: comms-console-announcement-title-security
     color: "#de3a3a"


### PR DESCRIPTION
changes the access on the security communications computer to armory instead of headofsecurity, because wardens are the second in command of security and such. also alex asked me to do this

:cl:
- tweak: Wardens can now use the security communications computer.
