### PR TITLE
fastest bug fix hospitality director can use their communications computer now

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Computers/computers.yml
@@ -87,7 +87,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: AccessReader
-    access: [[ "HeadOfPersonnel" ]]
+    access: [[ "HospitalityDirector" ]]
   - type: CommunicationsConsole
     title: comms-console-announcement-title-service
     color: "#88be14"


### PR DESCRIPTION
i forget to change the headofpersonnel access to hospitalitydirector on the service communications computer fuckkkkkk

:cl:
- fix: Hospitality Directors are now allowed to use their own communications console.
