### PR TITLE
Whitelisted the ribbon for all borgs, tweaked placement, and removed whitelist for service borg neckslot

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/borg.yml
+++ b/Resources/Prototypes/InventoryTemplates/borg.yml
@@ -14,13 +14,11 @@
     slotFlags: NECK
     uiWindowPos: 0,2
     strippingWindowPos: 0,1
-    displayName: Medal
-    offset: 0.03, -0.15
-    whitelist:
-      tags:
-        - Medal
+    displayName: neck
+    offset: 0.05, -0.22
   # 🌟Starlight🌟 end
 
+# Engineering borg
 - type: inventoryTemplate
   id: borgShort
   slots:
@@ -30,20 +28,47 @@
     uiWindowPos: 1,0
     strippingWindowPos: 0,0
     displayName: Head
-    offset: 0.015625, -0.1875
+    offset: 0.015625, -0.09375
   # 🌟Starlight🌟 start
   - name: neck
     slotTexture: neck
     slotFlags: NECK
     uiWindowPos: 0,2
     strippingWindowPos: 0,1
-    displayName: Medal
-    offset: 0.075, -0.22
+    displayName: neck
+    offset: 0.05, -0.22
     whitelist:
       tags:
         - Medal
+        - TeddyRibbon
   # 🌟Starlight🌟 end
 
+# Janitor borg
+- type: inventoryTemplate
+  id: borgJanitor
+  slots:
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiWindowPos: 1,0
+    strippingWindowPos: 0,0
+    displayName: Head
+    offset: 0.015625, -0.15
+  # 🌟Starlight🌟 start
+  - name: neck
+    slotTexture: neck
+    slotFlags: NECK
+    uiWindowPos: 0,2
+    strippingWindowPos: 0,1
+    displayName: neck
+    offset: 0.0, -0.22
+    whitelist:
+      tags:
+      - Medal
+      - TeddyRibbon
+  # 🌟Starlight🌟 end
+
+# salvage borg
 - type: inventoryTemplate
   id: borgTall
   slots:
@@ -53,20 +78,22 @@
     uiWindowPos: 1,0
     strippingWindowPos: 0,0
     displayName: Head
-    offset: 0.015625, 0
+    offset: 0.015625, -0.05
   # 🌟Starlight🌟 start
   - name: neck
     slotTexture: neck
     slotFlags: NECK
     uiWindowPos: 0,2
     strippingWindowPos: 0,1
-    displayName: Medal
-    offset: 0.01, -0.125
+    displayName: neck
+    offset: 0.02, -0.125
     whitelist:
       tags:
         - Medal
+        - TeddyRibbon
   # 🌟Starlight🌟 end
 
+#medical borg
 # taller than tall
 - type: inventoryTemplate
   id: borgDutch
@@ -84,9 +111,31 @@
     slotFlags: NECK
     uiWindowPos: 0,2
     strippingWindowPos: 0,1
-    displayName: Medal
-    offset: 0.02, -0.125
+    displayName: neck
+    offset: 0.0, -0.125
     whitelist:
       tags:
         - Medal
+        - TeddyRibbon
+  # 🌟Starlight🌟 end
+
+# service borg
+- type: inventoryTemplate
+  id: borgHumanoid
+  slots:
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiWindowPos: 1,0
+    strippingWindowPos: 0,0
+    displayName: Head
+    offset: 0.0, 0.0
+  # 🌟Starlight🌟 start
+  - name: neck
+    slotTexture: neck
+    slotFlags: NECK
+    uiWindowPos: 0,2
+    strippingWindowPos: 0,1
+    displayName: neck
+    offset: 0.0, 0.0
   # 🌟Starlight🌟 end

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -131,7 +131,7 @@
   - Service
 
   # Visual
-  inventoryTemplateId: borgShort
+  inventoryTemplateId: borgJanitor
   spriteBodyState: janitor
   spriteBodyMovementState: janitor_moving
   spriteHasMindState: janitor_e
@@ -223,7 +223,7 @@
   - Service
 
   # Visual
-  inventoryTemplateId: borgTall
+  inventoryTemplateId: borgHumanoid
   spriteBodyState: service
   spriteHasMindState: service_e
   spriteNoMindState: service_e_r


### PR DESCRIPTION
I want to slowly expand fashion options for borgs while also maintaining a clean and aesthetic appearance. I do not intend to add all clothes to borgs, except the service borg, because of the very unique sprites for them. So going forward, I want to manually test and verify equippables on borg chassis before PRs add them.

In the future, we might get an upstream merge that adds a displacement map for borg fashion, but I dont know how to port or code one, so this will be a solution for Imp in the meantime.

:cl:
- add: Some cyborgs want ribbons to go with their hat.
- remove: Removed the whitelist for service borg neck slot. Unleash your fashion, for it is the true endgame.
- tweak: All borgs have had their neck and hat positions manually tweaked to look more clean and aesthetic. Not all items will look the best however since borgs have unique proportions.