### PR TITLE
Remove non-functional yaml from washing machines.

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Structures/Storage/wash.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Storage/wash.yml
@@ -20,7 +20,7 @@
       sprite: _Impstation/Structures/Storage/Crates/labels.rsi
       map: [ "enum.PaperLabelVisuals.Layer" ]
       offset: 0.025, -0.25
-      rotation: 180 #look this is about as it's gonna get without new sprites
+      rotation: 180 #look this is about good as it's gonna get without new sprites
   - type: Transform
     anchored: true
   - type: Physics


### PR DESCRIPTION
Right now, washing machines are functionally fancy looking crates, but there's a lot going on in their prototype that straight up doesn't work or doesn't serve a function. This PR
- removes the sprite offset inherited from CrateBaseWeldable
- make it so paper labels applied to it actually appear instead of showing an error
- unparents it from BaseMachinePowered and removes any power draw it had
- removes the point light from it (why on earth would a washing machine being turned on give off so much light?)
- makes the unshaded light sprite Actually Appear (though with the power component being removed, there's no way to toggle between the on and off sprites, so it's just permanently off for now)
- moves the reagent container from it since there was no way to actually interact with the water inside of it
- removes the ambient noise, which was also non-functional regardless of whether the machine was turned on or off
