### PR TITLE
ExaminedEvent is now inventory relayed + Obvious examine refactor

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using JetBrains.Annotations;
@@ -293,8 +294,10 @@ namespace Content.Shared.Examine
     ///     If you're pushing multiple messages that should be grouped together (or ordered in some way),
     ///     call <see cref="PushGroup"/> before pushing and <see cref="PopGroup"/> when finished.
     /// </summary>
-    public sealed class ExaminedEvent : EntityEventArgs
+    public sealed class ExaminedEvent : EntityEventArgs, IInventoryRelayEvent // IMP EDIT: Inventory relayed
     {
+        public SlotFlags TargetSlots => SlotFlags.WITHOUT_POCKET; // IMP EDIT: Inventory relayed
+
         /// <summary>
         ///     The message that will be displayed as the examine text.
         ///     You should use <see cref="PushMarkup"/> and similar instead to modify this,

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Interaction;
-using Content.Shared.Inventory;
+using Content.Shared.Inventory; // imp
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using JetBrains.Annotations;

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -33,7 +33,7 @@ using Content.Shared._Impstation.SalvoHud; // imp edit
 using Content.Shared.Mobs; // EE edit
 using Content.Shared.Wieldable;
 using Content.Shared.Zombies;
-using Content.Shared.Examine;
+using Content.Shared.Examine; // imp
 
 namespace Content.Shared.Inventory;
 

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -33,6 +33,7 @@ using Content.Shared._Impstation.SalvoHud; // imp edit
 using Content.Shared.Mobs; // EE edit
 using Content.Shared.Wieldable;
 using Content.Shared.Zombies;
+using Content.Shared.Examine;
 
 namespace Content.Shared.Inventory;
 
@@ -79,6 +80,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, WieldAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, UnwieldAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, MobStateChangedEvent>(RefRelayInventoryEvent); // imp
+        SubscribeLocalEvent<InventoryComponent, ExaminedEvent>(RefRelayInventoryEvent); // imp
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextComponent.cs
+++ b/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared._Impstation.Clothing;
 /// <summary>
 /// Adds examine text to the entity that wears item, for making things obvious.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent]
 [Access(typeof(WearerGetsExamineTextSystem))]
 public sealed partial class WearerGetsExamineTextComponent : Component
 {
@@ -37,24 +37,11 @@ public sealed partial class WearerGetsExamineTextComponent : Component
     public LocId ExamineOnWearer = "obvious-desc-default";
 
     /// <summary>
-    /// Reference to the entity wearing this clothing.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public EntityUid? Wearer;
-    /// <summary>
     /// The string that is attached to this item's ExamineOnWearer.
     /// Typically doesn't need to be redefined.
     /// </summary>
     [DataField]
     public LocId PrefixExamineOnWearer = "obvious-prefix-wearing";
-
-    /// <summary>
-    /// If true, an entity with this item in any slot (i.e. in pockets) will gain the examine text,
-    /// instead of when just equipped as clothing.
-    /// Should be used sparingly only when truly appropriate; this is effectively a half-measure for lack of a special pin slot.
-    /// </summary>
-    [DataField]
-    public bool PocketEvident;
 
     /// <summary>
     /// If true, the entity's description will inform examiners what others will see on the wearer (before they equip it).

--- a/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextSystem.cs
+++ b/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextSystem.cs
@@ -1,12 +1,8 @@
-using Content.Shared.Clothing.Components;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
-using Content.Shared.Inventory.Events;
-using Content.Shared.Contraband;
-using Content.Shared._Impstation.Examine;
-using System.Text;
-using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Inventory;
+using Content.Shared.Contraband;
+using System.Text;
 
 namespace Content.Shared._Impstation.Clothing;
 

--- a/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextSystem.cs
+++ b/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextSystem.cs
@@ -5,8 +5,8 @@ using Content.Shared.Inventory.Events;
 using Content.Shared.Contraband;
 using Content.Shared._Impstation.Examine;
 using System.Text;
-using Robust.Shared.Toolshed.Commands.Values;
-using System.Diagnostics.CodeAnalysis;
+using Content.Shared.IdentityManagement.Components;
+using Content.Shared.Inventory;
 
 namespace Content.Shared._Impstation.Clothing;
 
@@ -19,44 +19,15 @@ public sealed class WearerGetsExamineTextSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<WearerGetsExamineTextComponent, GotEquippedEvent>(OnEquipped);
-        SubscribeLocalEvent<WearerGetsExamineTextComponent, GotUnequippedEvent>(OnUnequipped);
         SubscribeLocalEvent<WearerGetsExamineTextComponent, ExaminedEvent>(OnExamine);
-    }
-
-    private void OnEquipped(Entity<WearerGetsExamineTextComponent> entity, ref GotEquippedEvent args)
-    {
-        if (!TryComp(entity, out ClothingComponent? clothing))
-            return;
-        var isCorrectSlot = (clothing.Slots & args.SlotFlags) != Inventory.SlotFlags.NONE;
-        if (!entity.Comp.PocketEvident) //if it can't be evident in our pockets
-        {
-            // Make sure the clothing item was equipped to the right slot, and not just held in a hand.
-            if (!isCorrectSlot)
-                return;
-        }
-
-        entity.Comp.Wearer = args.Equipee;
-        Dirty(entity);
-
-        //GIVE THEM INSPECT TEXT
-        var obviousExamine = EnsureComp<ExtraExamineTextComponent>(args.Equipee);
-        if (!TryConstructExamineText(entity, !isCorrectSlot, args.Equipee, out var examineText))
-            return;
-
-        obviousExamine.Lines.TryAdd(entity.Owner, examineText); //using try so that we don't cause an error if we move something from slot to slot
-        Dirty(args.Equipee, obviousExamine);
+        SubscribeLocalEvent<WearerGetsExamineTextComponent, InventoryRelayedEvent<ExaminedEvent>>(OnExamineWorn);
     }
 
 
-    private bool TryConstructExamineText(Entity<WearerGetsExamineTextComponent> entity, bool prefixFallback, EntityUid affecting,
-        [NotNullWhen(true)] out string? examineText)
+    private string ConstructExamineText(Entity<WearerGetsExamineTextComponent> entity, bool prefixFallback, EntityUid affecting)
     {
         if (!Exists(affecting))
-        {
-            examineText = string.Empty;
-            return false;
-        }
+            return "";
 
         //parameters (these are the same between both constructions)
         var user = Identity.Entity(affecting, EntityManager);
@@ -77,50 +48,35 @@ public sealed class WearerGetsExamineTextSystem : EntitySystem
                 ("thing", thing),
                 ("type", type),
                 ("short-type", shortType));
-        examineText = prefix + " " + suffix;
-        return true;
-    }
-
-    private void OnUnequipped(Entity<WearerGetsExamineTextComponent> entity, ref GotUnequippedEvent args)
-    {
-        if (entity.Comp.Wearer is not { } wearer)
-            return;
-
-        if (TryComp<ExtraExamineTextComponent>(wearer, out var obviousExamine))
-        {
-            obviousExamine.Lines.Remove(entity.Owner);
-            Dirty(wearer, obviousExamine);
-        }
-
-        entity.Comp.Wearer = null;
-        Dirty(entity);
+        return prefix + " " + suffix;
     }
 
     private void OnExamine(Entity<WearerGetsExamineTextComponent> entity, ref ExaminedEvent args)
     {
-        var currentlyWorn = entity.Comp.Wearer != null;
-        var outString = new StringBuilder(Loc.GetString(currentlyWorn ? "obvious-on-item-currently" : "obvious-on-item",
-            ("used", Loc.GetString(entity.Comp.PocketEvident ? "obvious-reveal-pockets" : "obvious-reveal-default")),
+        var outString = new StringBuilder(Loc.GetString("obvious-on-item",
+            ("used", Loc.GetString("obvious-reveal-default")),
             ("thing", entity.Comp.Category),
             ("me", Identity.Entity(entity, EntityManager))));
 
         if (entity.Comp.WarnExamine)
         {
-            if (!currentlyWorn && TryComp(entity, out ContrabandComponent? contra)) // if the item's contra and we're not wearing it yet
+            if (TryComp<ContrabandComponent>(entity, out var contra)) // if the item's contra and we're not wearing it yet
             {
                 var contraLocId = "obvious-on-item-contra-" + contra.Severity; // apply additional text if the item is contraband to note that displaying it might be really bad
                 if (Loc.HasString(contraLocId)) // saves us the trouble of making a switch block for this
                     outString.Append(" " + Loc.GetString(contraLocId));
             }
-            var affecting = currentlyWorn ? entity.Comp.Wearer.GetValueOrDefault() : args.Examiner;
-            if (!TryConstructExamineText(entity, false, affecting, out var testOut))
-                return;
+            var testOut = ConstructExamineText(entity, false, args.Examiner);
 
             outString.Append("\n" + Loc.GetString("obvious-on-item-for-others",
-                ("will", currentlyWorn ? "can" : "will"), // i love hardcoding strings it's my favorite thing ever
                 ("output", testOut)));
         }
 
         args.PushMarkup(outString.ToString());
+    }
+
+    private void OnExamineWorn(Entity<WearerGetsExamineTextComponent> entity, ref InventoryRelayedEvent<ExaminedEvent> args)
+    {
+        args.Args.PushMarkup(ConstructExamineText(entity, false, args.Args.Examined));
     }
 }

--- a/Resources/Locale/en-US/_Impstation/obvious.ftl
+++ b/Resources/Locale/en-US/_Impstation/obvious.ftl
@@ -1,6 +1,6 @@
 obvious-on-item = When {$used}, { SUBJECT($me) } will be [color=white]obvious[/color] to casual examination.
 obvious-on-item-currently = { CAPITALIZE(SUBJECT($me)) } { CONJUGATE-BE($me) } [color=white]obvious[/color] to casual examination.
-obvious-on-item-for-others = [italic][color=#777777]Others {$will} see:[/color] "{$output}"[/italic]
+obvious-on-item-for-others = [italic][color=#777777]Others will see:[/color] "{$output}"[/italic]
 
 obvious-reveal-default = worn
 obvious-reveal-pockets = worn or pocketed

--- a/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
@@ -24,7 +24,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 
 

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -19,7 +19,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-pin
     examineText: obvious-desc-default
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckPinBase


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

This PR is a refactor of the [obvious examine](#2462) system for items like pride pins. This fixed an error that would cause a full state refresh under specific conditions. In the process of reworking this, I have made `ExaminedEvent` an inventory-relayed event, so worn items can hook into `InventoryRelayedEvent<ExaminedEvent>` and modify the wearing entity's examine text.

In the process of refactoring, I decided not to keep the functionality where pins could be kept in the pocket and still apply extra examine text. It didn't make intuitive sense for `ExaminedEvent` to be relayed to items within pockets, which should not be externally visible from a gameplay perspective. As far as I'm aware, there's no quick and easy way to check whether or not an item is within a pocket, which would be too much burden for what is essentially a workaround for only having one neck slot.

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Pride pins are no longer visible from the pocket slot. The examine functionality was reworked in a way that made this unreasonable to keep without burdening other parts of the codebase. :broken_heart: 
