### PR TITLE
Fix the shining spring's rsi error

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -10,7 +10,7 @@
       - state: icon
         map: ["enum.GunVisualLayers.Base"]
   - type: Clothing
-    sprite: Objects/Weapons/Guns/Launchers/cleaner_lake.rsi
+    sprite: _Impstation/Objects/Weapons/Guns/Launchers/cleaner_lake.rsi
     slots:
     - Back
     - suitStorage


### PR DESCRIPTION
no longer will the console be flooded every time a janitor wears one on their back


:cl:
- fix: The Shining Spring now properly appears on your back when you equip it in your back slot.

