### PR TITLE
The minigun works again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -8,7 +8,7 @@
   - type: Sprite
   - type: Item
     size: Ginormous
-  - type: MultiHandedItem
+  # - type: MultiHandedItem #imp-- messes with gun-requires-wield and wielding is cooler than an item always needing two hands to hold.
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8


### PR DESCRIPTION
I remember miniguns being updated by upstream to require 2 hands but my brain assumed they would go the wielded-weapon route and not, like, this? Weird decision imo.

**Changelog**
:cl:
- fix: You can use the minigun again