### PR TITLE
Blaster Cells are Power Cells

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/blastermag.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/blastermag.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: Blaster Cell
-  description: A rechargeable power cell built for blaster pistols.
+  description: A rechargeable power cell compatible with blaster pistols. Can be used as a weak power source in a pinch, too!
   id: PowerCellBlaster
   suffix: Full
   parent: [ BaseItem, BaseSecurityContraband ]
@@ -39,11 +39,11 @@
   - type: Item
     size: Small
   - type: Battery
-    maxCharge: 600
-    startingCharge: 600
+    maxCharge: 288
+    startingCharge: 288
   - type: ProjectileBatteryAmmoProvider
     proto: BulletBlasterPistol
-    fireCost: 75
+    fireCost: 36
   - type: Tag
     tags:
       - BlasterCell
@@ -62,5 +62,5 @@
         map: ["enum.GunVisualLayers.MagUnshaded"]
         shader: unshaded
   - type: Battery
-    maxCharge: 600
+    maxCharge: 288
     startingCharge: 0


### PR DESCRIPTION
but not vice-versa! Adjusting the max charge around them being able to be used as power cells as well, and changing the description so that there's something that points this out.

**Changelog**
:cl:
- tweak: Blaster Cells working as power cells is intended now. Max charge very much reduced, but it still shoots 8 shots per cell.
