### PR TITLE
Emergency patch: Disable industrial reagent grinder (server crash bug)

### DIFF
--- a/Resources/Maps/Lavaland/mug_factory.yml
+++ b/Resources/Maps/Lavaland/mug_factory.yml
@@ -1152,13 +1152,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 13.5,-3.5
       parent: 1
-- proto: ReagentGrinderIndustrial
-  entities:
-  - uid: 123
-    components:
-    - type: Transform
-      pos: 5.5,-2.5
-      parent: 1
+#- proto: ReagentGrinderIndustrial #IMP commented out due to server crash
+#  entities:
+#  - uid: 123
+#    components:
+#    - type: Transform
+#      pos: 5.5,-2.5
+#      parent: 1
 - proto: ReinforcedWindow
   entities:
   - uid: 102

--- a/Resources/Maps/_Impstation/banana.yml
+++ b/Resources/Maps/_Impstation/banana.yml
@@ -19493,13 +19493,13 @@ entities:
     - type: Transform
       pos: -14.478317,8.2416725
       parent: 2
-- proto: ReagentGrinderIndustrial
-  entities:
-  - uid: 309
-    components:
-    - type: Transform
-      pos: -23.5,7.5
-      parent: 2
+#- proto: ReagentGrinderIndustrial #IMP commented out due to server crash
+#  entities:
+#  - uid: 309
+#    components:
+#    - type: Transform
+#      pos: -23.5,7.5
+#      parent: 2
 - proto: Recycler
   entities:
   - uid: 40

--- a/Resources/Maps/_Impstation/banana.yml
+++ b/Resources/Maps/_Impstation/banana.yml
@@ -20285,19 +20285,19 @@ entities:
           - Reverse
         - - Off
           - Off
-  - uid: 3436
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,6.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        309:
-        - - On
-          - Forward
-        - - Off
-          - Off
+#  - uid: 3436 #IMP remove industrial reagent grinder due to server crash
+#    components:
+#    - type: Transform
+#      rot: 3.141592653589793 rad
+#      pos: -23.5,6.5
+#      parent: 2
+#    - type: DeviceLinkSource
+#      linkedPorts:
+#        309:
+#        - - On
+#          - Forward
+#        - - Off
+#          - Off
 - proto: SignApid
   entities:
   - uid: 2435

--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -228,7 +228,7 @@
     - id: HellfireFreezerMachineCircuitBoard
     - id: HellfireHeaterMachineCircuitBoard
     - id: ReagentGrinderMachineCircuitboard
-    - id: ReagentGrinderIndustrialMachineCircuitboard
+    #- id: ReagentGrinderIndustrialMachineCircuitboard #IMP commented out due to server crash
     - id: BoozeDispenserMachineCircuitboard
     - id: MiniGravityGeneratorCircuitboard
     - id: AmmoTechFabCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -64,6 +64,6 @@
   - HydroponicsTrayMachineCircuitboard # roundstart gear being unlocked roundstart when
   - SeedExtractorMachineCircuitboard # ^
   - MassMediaCircuitboard
-  - ReagentGrinderIndustrialMachineCircuitboard
+  #- ReagentGrinderIndustrialMachineCircuitboard #IMP comment out industrial reagent grinder until bug is fixed
   - JukeboxCircuitBoard
   - DawInstrumentMachineCircuitboard

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -12,7 +12,7 @@
   recipeUnlocks:
   - SeedExtractorMachineCircuitboard
   - HydroponicsTrayMachineCircuitboard
-  - ReagentGrinderIndustrialMachineCircuitboard
+  #- ReagentGrinderIndustrialMachineCircuitboard #IMP commented out due to server crash
   - PlantAnalyzer # Frontier
 
 - type: technology


### PR DESCRIPTION
Remove industrial reagent grinder from lathe, maps, and other sources until underlying server crash bug is fixed.
Crash can be caused by "throwing three stacks of plastic at it" while its running


:cl:
- remove: Industrial Reagent Grinder has been taken out back due to server crash bug. Will be restored when crash bug is fixed.

