### PR TITLE
Heretic Unfucking Part 1 

### DIFF
--- a/Content.Client/Store/Ui/StoreMenu.xaml.cs
+++ b/Content.Client/Store/Ui/StoreMenu.xaml.cs
@@ -171,9 +171,9 @@ public sealed partial class StoreMenu : DefaultWindow
             //go on a long, arduous journey to get the stage of the knowledge
             var knowledgeID = listing.ProductHereticKnowledge;
             var knowledgeProto = _prototypeManager.Index<HereticKnowledgePrototype>(knowledgeID);
-            var knowledgeLevel = knowledgeProto.Stage;
+            var requiredPower = knowledgeProto.RequiredPower;
 
-            return Loc.GetString("store-ui-heretic-level-display", ("level", knowledgeLevel));
+            return Loc.GetString("store-ui-heretic-level-display", ("power", requiredPower));
         }
 
         return null;

--- a/Content.Client/_Goobstation/Heretic/UI/HereticRitualRuneRadialMenu.xaml.cs
+++ b/Content.Client/_Goobstation/Heretic/UI/HereticRitualRuneRadialMenu.xaml.cs
@@ -46,30 +46,39 @@ public sealed partial class HereticRitualRuneRadialMenu : RadialMenu
         if (!_entityManager.TryGetComponent<HereticComponent>(player, out var heretic))
             return;
 
-        foreach (var ritual in heretic.KnownRituals)
+        foreach (var knowledge in heretic.KnownKnowledge)
         {
-            if (!_prototypeManager.TryIndex(ritual, out var ritualPrototype))
+            if (!_prototypeManager.TryIndex(knowledge, out var knowledgePrototype))
                 continue;
 
-            var button = new HereticRitualMenuButton
-            {
-                SetSize = new Vector2(64, 64),
-                ToolTip = Loc.GetString(ritualPrototype.LocName),
-                ProtoId = ritualPrototype.ID
-            };
+            if (knowledgePrototype.RitualPrototypes == null)
+                continue;
 
-            var texture = new TextureRect
+            foreach (var ritual in knowledgePrototype.RitualPrototypes)
             {
-                VerticalAlignment = VAlignment.Center,
-                HorizontalAlignment = HAlignment.Center,
-                Texture = _spriteSystem.Frame0(ritualPrototype.Icon),
-                TextureScale = new Vector2(2f, 2f)
-            };
 
-            button.AddChild(texture);
-            main.AddChild(button);
+                if (!_prototypeManager.TryIndex(ritual, out var ritualPrototype))
+                    continue;
+
+                var button = new HereticRitualMenuButton
+                {
+                    SetSize = new Vector2(64, 64),
+                    ToolTip = Loc.GetString(ritualPrototype.LocName),
+                    ProtoId = ritualPrototype.ID
+                };
+
+                var texture = new TextureRect
+                {
+                    VerticalAlignment = VAlignment.Center,
+                    HorizontalAlignment = HAlignment.Center,
+                    Texture = _spriteSystem.Frame0(ritualPrototype.Icon),
+                    TextureScale = new Vector2(2f, 2f)
+                };
+
+                button.AddChild(texture);
+                main.AddChild(button);
+            }
         }
-
         AddHereticRitualMenuButtonOnClickAction(main);
     }
 

--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
@@ -87,7 +87,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
         // all heretics with the same path are also immune
         var pathQuery = EntityQueryEnumerator<HereticComponent>();
         while (pathQuery.MoveNext(out var uid, out var comp))
-            if (comp.CurrentPath == ent.Comp.CurrentPath)
+            if (comp.MainPath == ent.Comp.MainPath)
                 ignoredTargets.Add(uid);
 
         if (!_splitball.Spawn(ent, ignoredTargets))
@@ -107,7 +107,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
 
         foreach (var look in lookup)
         {
-            if ((TryComp<HereticComponent>(look, out var th) && th.CurrentPath == ent.Comp.CurrentPath)
+            if ((TryComp<HereticComponent>(look, out var th) && th.MainPath == ent.Comp.MainPath)
             || HasComp<GhoulComponent>(look))
                 continue;
 

--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Flesh.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Flesh.cs
@@ -28,7 +28,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
             return;
 
         if (HasComp<GhoulComponent>(args.Target)
-        || TryComp<HereticComponent>(args.Target, out var th) && th.CurrentPath == ent.Comp.CurrentPath)
+        || TryComp<HereticComponent>(args.Target, out var th) && th.MainPath == ent.Comp.MainPath)
         {
             var dargs = new DoAfterArgs(EntityManager, ent, 10f, new EventHereticFleshSurgeryDoAfter(), ent, args.Target)
             {

--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.cs
@@ -72,7 +72,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
         foreach (var look in lookup)
         {
             // ignore heretics with the same path*, affect everyone else
-            if ((TryComp<HereticComponent>(look, out var th) && th.CurrentPath == ent.Comp.CurrentPath)
+            if ((TryComp<HereticComponent>(look, out var th) && th.MainPath == ent.Comp.MainPath)
             || HasComp<GhoulComponent>(look))
                 continue;
 

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticBladeSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticBladeSystem.cs
@@ -109,7 +109,7 @@ public sealed partial class HereticBladeSystem : EntitySystem
         var queuedel = true;
 
         // void path exxclusive
-        if (heretic.MainPath == "Void" && heretic.PathStage >= 7)
+        if (heretic.MainPath == "Void" && heretic.Power >= 7)
         {
             var look = _lookupSystem.GetEntitiesInRange<HereticCombatMarkComponent>(Transform(ent).Coordinates, 20f);
             if (look.Count > 0)
@@ -137,7 +137,7 @@ public sealed partial class HereticBladeSystem : EntitySystem
         if (!TryComp<HereticComponent>(args.Examiner, out var heretic))
             return;
 
-        var isUpgradedVoid = heretic.MainPath == "Void" && heretic.PathStage >= 7;
+        var isUpgradedVoid = heretic.MainPath == "Void" && heretic.Power >= 7;
 
         var sb = new StringBuilder();
         sb.AppendLine(Loc.GetString("heretic-blade-examine"));
@@ -166,7 +166,7 @@ public sealed partial class HereticBladeSystem : EntitySystem
                 RemComp(hit, mark);
             }
 
-            if (hereticComp.PathStage >= 7)
+            if (hereticComp.Power >= 7)
                 ApplySpecialEffect(args.User, hit);
         }
     }

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticBladeSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticBladeSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class HereticBladeSystem : EntitySystem
         if (!TryComp<HereticComponent>(performer, out var hereticComp))
             return;
 
-        switch (hereticComp.CurrentPath)
+        switch (hereticComp.MainPath)
         {
             case "Ash":
                 _flammable.AdjustFireStacks(target, 2.5f, ignite: true);
@@ -109,7 +109,7 @@ public sealed partial class HereticBladeSystem : EntitySystem
         var queuedel = true;
 
         // void path exxclusive
-        if (heretic.CurrentPath == "Void" && heretic.PathStage >= 7)
+        if (heretic.MainPath == "Void" && heretic.PathStage >= 7)
         {
             var look = _lookupSystem.GetEntitiesInRange<HereticCombatMarkComponent>(Transform(ent).Coordinates, 20f);
             if (look.Count > 0)
@@ -137,7 +137,7 @@ public sealed partial class HereticBladeSystem : EntitySystem
         if (!TryComp<HereticComponent>(args.Examiner, out var heretic))
             return;
 
-        var isUpgradedVoid = heretic.CurrentPath == "Void" && heretic.PathStage >= 7;
+        var isUpgradedVoid = heretic.MainPath == "Void" && heretic.PathStage >= 7;
 
         var sb = new StringBuilder();
         sb.AppendLine(Loc.GetString("heretic-blade-examine"));

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticKnowledgeSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticKnowledgeSystem.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Shared.Actions;
 using Content.Shared.Heretic.Prototypes;
 using Content.Shared.Heretic;
@@ -15,7 +17,9 @@ public sealed partial class HereticKnowledgeSystem : EntitySystem
     [Dependency] private readonly HereticRitualSystem _ritual = default!;
 
     public HereticKnowledgePrototype GetKnowledge(ProtoId<HereticKnowledgePrototype> id)
-        => _proto.Index(id);
+    {
+        return _proto.Index(id);
+    }
 
     public void AddKnowledge(EntityUid uid, HereticComponent comp, ProtoId<HereticKnowledgePrototype> id, bool silent = true)
     {
@@ -25,25 +29,42 @@ public sealed partial class HereticKnowledgeSystem : EntitySystem
             RaiseLocalEvent(uid, (object) data.Event, true);
 
         if (data.ActionPrototypes != null && data.ActionPrototypes.Count > 0)
+        {
             foreach (var act in data.ActionPrototypes)
+            {
                 _action.AddAction(uid, act);
+            }
+        }
 
         if (data.RitualPrototypes != null && data.RitualPrototypes.Count > 0)
+        {
             foreach (var ritual in data.RitualPrototypes)
+            {
                 comp.KnownRituals.Add(_ritual.GetRitual(ritual));
+            }
+        }
 
         Dirty(uid, comp);
 
-        // set path if out heretic doesn't have it, or if it's different from whatever he has atm
-        if (string.IsNullOrWhiteSpace(comp.CurrentPath))
+        // Manage Path Data
+        if (GetKnowledgePath(data, out var path))
         {
-            if (!data.SideKnowledge && comp.CurrentPath != data.Path)
-                comp.CurrentPath = data.Path;
+            // set main path to knowledge's path if there is none
+            if (comp.MainPath == null)
+            {
+                comp.MainPath = path;
+            }
+            // If the knowledge is from main path, increase path stage to value
+            if (data.Stage > comp.PathStage && path== comp.MainPath)
+            {
+                comp.PathStage = data.Stage;
+            }
+            // add path to sidepaths if knowledge is of the main path
+            if (comp.MainPath != path)
+            {
+                comp.SidePaths.Add(path);
+            }
         }
-
-        // make sure we only progress when buying current path knowledge
-        if (data.Stage > comp.PathStage && data.Path == comp.CurrentPath)
-            comp.PathStage = data.Stage;
 
         if (!silent)
             _popup.PopupEntity(Loc.GetString("heretic-knowledge-gain"), uid, uid);
@@ -56,21 +77,46 @@ public sealed partial class HereticKnowledgeSystem : EntitySystem
         {
             foreach (var act in data.ActionPrototypes)
             {
-                var actionName = (EntityPrototype) _proto.Index(typeof(EntityPrototype), act);
+                var actionName = _proto.Index<EntityPrototype>(act);
                 // jesus christ.
                 foreach (var action in _action.GetActions(uid))
+                {
                     if (Name(action.Owner) == actionName.Name)
                         _action.RemoveAction(action.Owner);
+                }
             }
         }
 
         if (data.RitualPrototypes != null && data.RitualPrototypes.Count > 0)
+        {
             foreach (var ritual in data.RitualPrototypes)
+            {
                 comp.KnownRituals.Remove(_ritual.GetRitual(ritual));
+            }
+        }
 
         Dirty(uid, comp);
 
         if (!silent)
             _popup.PopupEntity(Loc.GetString("heretic-knowledge-loss"), uid, uid);
+    }
+
+    public bool GetKnowledgePath(ProtoId<HereticKnowledgePrototype> knowledge, [NotNullWhen(true)] out HereticPathPrototype? path)
+    {
+        var paths = _proto.EnumeratePrototypes<HereticPathPrototype>().ToList();
+        foreach (var protoPath in paths)
+        {
+            foreach (var protoKnowledge in protoPath.Knowledge)
+            {
+                if (knowledge != protoKnowledge)
+                {
+                    continue;
+                }
+                path = protoPath;
+                return true;
+            }
+        }
+        path = null;
+        return false;
     }
 }

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticKnowledgeSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticKnowledgeSystem.cs
@@ -49,23 +49,23 @@ public sealed partial class HereticKnowledgeSystem : EntitySystem
         // Manage Path Data
         if (GetKnowledgePath(data, out var path))
         {
-            // set main path to knowledge's path if there is none
+            // set main path to knowledge's path if there is none and increase power
             if (comp.MainPath == null)
             {
                 comp.MainPath = path;
+                comp.Power += 1;
             }
-            // If the knowledge is from main path, increase path stage to value
-            if (data.Stage > comp.PathStage && path== comp.MainPath)
+            // If the knowledge is from main path, increase power by one
+            else if (path== comp.MainPath)
             {
-                comp.PathStage = data.Stage;
+                comp.Power += 1;
             }
-            // add path to sidepaths if knowledge is of the main path
-            if (comp.MainPath != path)
+            // add path to sidepaths if knowledge isn't of the main path
+            else
             {
                 comp.SidePaths.Add(path);
             }
         }
-
         if (!silent)
             _popup.PopupEntity(Loc.GetString("heretic-knowledge-gain"), uid, uid);
     }

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticRitualSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticRitualSystem.cs
@@ -162,7 +162,7 @@ public sealed partial class HereticRitualSystem : EntitySystem
         if (!TryComp<HereticComponent>(args.User, out var heretic))
             return;
 
-        if (heretic.KnownRituals.Count == 0)
+        if (_knowledge.AllKnownRituals(heretic).Count == 0)
         {
             _popup.PopupEntity(Loc.GetString("heretic-ritual-norituals"), args.User, args.User);
             return;

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
@@ -89,23 +89,20 @@ public sealed partial class HereticSystem : EntitySystem
         ent.Comp.Ascended = true;
 
         // how???
-        if (ent.Comp.CurrentPath == null)
+        if (ent.Comp.MainPath == null)
             return;
 
-        var pathLoc = ent.Comp.CurrentPath!.ToLower();
+        var pathLoc = ent.Comp.MainPath!.Value.Id.ToLower();
         var ascendSound = new SoundPathSpecifier($"/Audio/_Goobstation/Heretic/Ambience/Antag/Heretic/ascend_{pathLoc}.ogg");
         _chat.DispatchGlobalAnnouncement(Loc.GetString($"heretic-ascension-{pathLoc}"), Name(ent), true, ascendSound, Color.Pink);
 
         // do other logic, e.g. make heretic immune to whatever
-        switch (ent.Comp.CurrentPath!)
+        switch (ent.Comp.MainPath)
         {
             case "Ash":
                 RemComp<TemperatureComponent>(ent);
                 RemComp<RespiratorComponent>(ent);
                 RemComp<BarotraumaComponent>(ent);
-                break;
-
-            default:
                 break;
         }
     }
@@ -125,7 +122,7 @@ public sealed partial class HereticSystem : EntitySystem
         if (!ent.Comp.Ascended)
             return;
 
-        switch (ent.Comp.CurrentPath)
+        switch (ent.Comp.MainPath)
         {
             case "Ash":
                 // nullify heat damage because zased

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticSystem.cs
@@ -10,10 +10,8 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Heretic;
 using Content.Shared.Heretic.Prototypes;
 using Content.Shared.Mind;
-using Content.Shared.Roles;
 using Content.Shared.Store.Components;
 using Robust.Shared.Audio;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Heretic.EntitySystems;
 
@@ -25,9 +23,8 @@ public sealed partial class HereticSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly StoreSystem _store = default!;
 
-    private float _timer = 0f;
+    private float _timer;
     private float _passivePointCooldown = 20f * 60f;
-    private static readonly ProtoId<JobPrototype> SecOffJobProtoID = "SecurityOfficer";
 
     public override void Initialize()
     {

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -135,10 +135,10 @@ public sealed partial class MansusGraspSystem : EntitySystem
         // upgraded grasp
         if (hereticComp.MainPath != null)
         {
-            if (hereticComp.PathStage >= 2)
+            if (hereticComp.Power >= 2)
                 ApplyGraspEffect(args.User, target, hereticComp.MainPath!);
 
-            if (hereticComp.PathStage >= 4 && HasComp<StatusEffectsComponent>(target))
+            if (hereticComp.Power >= 4 && HasComp<StatusEffectsComponent>(target))
             {
                 var markComp = EnsureComp<HereticCombatMarkComponent>(target);
                 markComp.Path = hereticComp.MainPath;

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -118,7 +118,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
 
         var target = (EntityUid)args.Target;
 
-        if ((TryComp<HereticComponent>(args.Target, out var th) && th.CurrentPath == ent.Comp.Path))
+        if (TryComp<HereticComponent>(args.Target, out var heretic) && heretic.MainPath == ent.Comp.Path)
             return;
 
         args.Handled = true;
@@ -133,15 +133,15 @@ public sealed partial class MansusGraspSystem : EntitySystem
         }
 
         // upgraded grasp
-        if (hereticComp.CurrentPath != null)
+        if (hereticComp.MainPath != null)
         {
             if (hereticComp.PathStage >= 2)
-                ApplyGraspEffect(args.User, target, hereticComp.CurrentPath!);
+                ApplyGraspEffect(args.User, target, hereticComp.MainPath!);
 
             if (hereticComp.PathStage >= 4 && HasComp<StatusEffectsComponent>(target))
             {
                 var markComp = EnsureComp<HereticCombatMarkComponent>(target);
-                markComp.Path = hereticComp.CurrentPath;
+                markComp.Path = hereticComp.MainPath;
             }
         }
 

--- a/Content.Server/_Goobstation/Magic/ImmovableVoidRodSystem.cs
+++ b/Content.Server/_Goobstation/Magic/ImmovableVoidRodSystem.cs
@@ -48,7 +48,7 @@ public sealed partial class ImmovableVoidRodSystem : EntitySystem
 
     private void OnCollide(Entity<ImmovableVoidRodComponent> ent, ref StartCollideEvent args)
     {
-        if ((TryComp<HereticComponent>(args.OtherEntity, out var th) && th.CurrentPath == "Void")
+        if ((TryComp<HereticComponent>(args.OtherEntity, out var th) && th.MainPath == "Void")
         || HasComp<GhoulComponent>(args.OtherEntity))
             return;
 

--- a/Content.Server/_Goobstation/Store/Conditions/HereticPathCondition.cs
+++ b/Content.Server/_Goobstation/Store/Conditions/HereticPathCondition.cs
@@ -13,7 +13,7 @@ public sealed partial class HereticPathCondition : ListingCondition
     [DataField] public HashSet<ProtoId<HereticPathPrototype>>? Whitelist = [];
     [DataField] public HashSet<ProtoId<HereticPathPrototype>>? Blacklist = [];
 
-    [DataField] public int Stage = 0;
+    [DataField] public int RequiredPower;
 
     public override bool Condition(ListingConditionArgs args)
     {
@@ -28,41 +28,6 @@ public sealed partial class HereticPathCondition : ListingCondition
 
         //Stage is the level of the knowledge we're looking at
         //always check for level
-        if (Stage > hereticComp.PathStage)
-            return false;
-
-        if (Whitelist != null && hereticComp.MainPath != null)
-        {
-            foreach (var white in Whitelist)
-            {
-                if (hereticComp.MainPath == white)
-                    return true;
-            }
-            return false;
-        }
-
-        if (Blacklist != null && hereticComp.MainPath != null)
-        {
-            foreach (var black in Blacklist)
-            {
-                if (hereticComp.MainPath == black)
-                    return false;
-            }
-            return true;
-        }
-
-        // If the heretic has a main path
-        if (hereticComp.MainPath == null || args.Listing.ProductHereticKnowledge == null)
-            return true;
-
-        var knowledgeProtoId = new ProtoId<HereticKnowledgePrototype>((ProtoId<HereticKnowledgePrototype>)args.Listing.ProductHereticKnowledge);
-        knowledgeSys.GetKnowledgePath(knowledgeSys.GetKnowledge(knowledgeProtoId), out var knowledgePath);
-
-        // and the knowledge isn't from the main path
-        if (knowledgePath != null && hereticComp.MainPath == knowledgePath)
-            return true;
-
-        // then add a penalty
-        return Stage <= hereticComp.PathStage - AlternatePathPenalty;
+        return hereticComp.Power >= RequiredPower;
     }
 }

--- a/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
+++ b/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
@@ -23,28 +23,36 @@ public sealed partial class HereticComponent : Component
     [DataField, AutoNetworkedField] public List<ProtoId<HereticRitualPrototype>> KnownRituals = new();
     [DataField] public ProtoId<HereticRitualPrototype>? ChosenRitual;
 
-    // hardcoded paths because i hate it
-    // "Ash", "Lock", "Flesh", "Void", "Blade", "Rust"
     /// <summary>
-    ///     Indicates a path the heretic is on.
+    ///     The main path the heretic is on.
     /// </summary>
-    [DataField, AutoNetworkedField] public string? CurrentPath = null;
+    [DataField]
+    public ProtoId<HereticPathPrototype>? MainPath;
+
+    /// <summary>
+    ///     All side paths the heretic is on.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<HereticPathPrototype>> SidePaths = [];
 
     /// <summary>
     ///     Indicates a stage of a path the heretic is on. 0 is no path, 10 is ascension
     /// </summary>
-    [DataField, AutoNetworkedField] public int PathStage = 0;
+    [DataField, AutoNetworkedField] public int PathStage;
 
-    [DataField, AutoNetworkedField] public bool Ascended = false;
+    [DataField, AutoNetworkedField] public bool Ascended;
 
     /// <summary>
     ///     Used to prevent double casting mansus grasp.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)] public bool MansusGraspActive = false;
 
-    /// <summary>
-    ///     Indicates if a heretic is able to cast advanced spells.
-    ///     Requires wearing focus, codex cicatrix, hood or anything else that allows him to do so.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)] public bool CanCastSpells = false;
+    public List<ProtoId<HereticPathPrototype>> AllPaths()
+    {
+        var paths = new List<ProtoId<HereticPathPrototype>>();
+        paths.AddRange(SidePaths);
+        if (MainPath != null)
+            paths.Add(MainPath.Value);
+        return paths;
+    }
 }

--- a/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
+++ b/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
@@ -30,15 +30,15 @@ public sealed partial class HereticComponent : Component
     public ProtoId<HereticPathPrototype>? MainPath;
 
     /// <summary>
+    ///     Indicates the power level of a heretic.
+    /// </summary>
+    [DataField, AutoNetworkedField] public int Power;
+
+    /// <summary>
     ///     All side paths the heretic is on.
     /// </summary>
     [DataField]
     public List<ProtoId<HereticPathPrototype>> SidePaths = [];
-
-    /// <summary>
-    ///     Indicates a stage of a path the heretic is on. 0 is no path, 10 is ascension
-    /// </summary>
-    [DataField, AutoNetworkedField] public int PathStage;
 
     [DataField, AutoNetworkedField] public bool Ascended;
 

--- a/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
+++ b/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
@@ -20,8 +20,12 @@ public sealed partial class HereticComponent : Component
 
     #endregion
 
-    [DataField, AutoNetworkedField] public List<ProtoId<HereticRitualPrototype>> KnownRituals = new();
     [DataField] public ProtoId<HereticRitualPrototype>? ChosenRitual;
+
+    /// <summary>
+    ///     All knowledge the heretic knows.
+    /// </summary>
+    [DataField, AutoNetworkedField] public List<ProtoId<HereticKnowledgePrototype>> KnownKnowledge = [];
 
     /// <summary>
     ///     The main path the heretic is on.

--- a/Content.Shared/_Goobstation/Heretic/Prototypes/HereticKnowledgePrototype.cs
+++ b/Content.Shared/_Goobstation/Heretic/Prototypes/HereticKnowledgePrototype.cs
@@ -14,11 +14,6 @@ public sealed partial class HereticKnowledgePrototype : IPrototype
     [DataField] public int Stage = 1;
 
     /// <summary>
-    ///     Indicates that this should not be on a main branch.
-    /// </summary>
-    [DataField] public bool SideKnowledge = false;
-
-    /// <summary>
     ///     What event should be raised
     /// </summary>
     [DataField] public object? Event;

--- a/Content.Shared/_Goobstation/Heretic/Prototypes/HereticKnowledgePrototype.cs
+++ b/Content.Shared/_Goobstation/Heretic/Prototypes/HereticKnowledgePrototype.cs
@@ -11,7 +11,7 @@ public sealed partial class HereticKnowledgePrototype : IPrototype
 
     [DataField] public string? Path;
 
-    [DataField] public int Stage = 1;
+    [DataField] public int RequiredPower = 1;
 
     /// <summary>
     ///     What event should be raised

--- a/Content.Shared/_Goobstation/Heretic/Prototypes/HereticPathPrototype.cs
+++ b/Content.Shared/_Goobstation/Heretic/Prototypes/HereticPathPrototype.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Store;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Heretic.Prototypes;
+
+[Prototype]
+[Serializable, NetSerializable]
+public sealed partial class HereticPathPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    public List<ProtoId<HereticKnowledgePrototype>> Knowledge = [];
+}

--- a/Resources/Locale/en-US/_Goobstation/Heretic/store/store.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/store/store.ftl
@@ -1,1 +1,1 @@
-store-ui-heretic-level-display = [Stage: {$level}]
+store-ui-heretic-level-display = [Required power: {$power}]

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_ash.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_ash.yml
@@ -12,7 +12,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 0
     # add every path here because you shouldn't be able to buy more starter knowledge
     blacklist:
     - Ash
@@ -36,11 +35,9 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 1
     whitelist:
     - Ash
 
-# side
 - type: listing
   id: HereticAshPath3
   name: knowledge-path-ash-s3-name
@@ -55,7 +52,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 2
 
 - type: listing
   id: HereticAshPath4
@@ -71,7 +67,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 3
     whitelist:
     - Ash
 
@@ -89,11 +84,9 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 4
     whitelist:
     - Ash
 
-# side
 - type: listing
   id: HereticAshPath6
   name: knowledge-path-ash-s6-name
@@ -108,7 +101,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 5
 
 - type: listing
   id: HereticAshPath7
@@ -124,11 +116,9 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 6
     whitelist:
     - Ash
 
-# side
 - type: listing
   id: HereticAshPath8
   name: knowledge-path-ash-s8-name
@@ -143,7 +133,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 7
 
 - type: listing
   id: HereticAshPath9
@@ -159,6 +148,5 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 8
     whitelist:
     - Ash

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_blade.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_blade.yml
@@ -12,7 +12,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 0
     # add every path here because you shouldn't be able to buy more starter knowledge
     blacklist:
     - Ash

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_flesh.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_flesh.yml
@@ -12,7 +12,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 0
     # add every path here because you shouldn't be able to buy more starter knowledge
     blacklist:
     - Ash
@@ -36,7 +35,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 1
     whitelist:
     - Flesh
 
@@ -55,7 +53,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 2
 
 - type: listing
   id: HereticFleshPath4
@@ -71,7 +68,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 3
     whitelist:
     - Flesh
 
@@ -89,7 +85,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 4
     whitelist:
     - Flesh
 
@@ -108,7 +103,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 5
 
 - type: listing
   id: HereticFleshPath7
@@ -124,7 +118,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 6
     whitelist:
     - Flesh
 
@@ -143,7 +136,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 7
 
 - type: listing
   id: HereticFleshPath9
@@ -159,6 +151,5 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 8
     whitelist:
     - Flesh

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_lock.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_lock.yml
@@ -12,7 +12,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 0
     # add every path here because you shouldn't be able to buy more starter knowledge
     blacklist:
     - Ash

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_rust.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_rust.yml
@@ -12,7 +12,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 0
     # add every path here because you shouldn't be able to buy more starter knowledge
     blacklist:
     - Ash

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_side.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_side.yml
@@ -13,7 +13,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 1
 
 - type: listing
   id: HereticSidePath3Armor
@@ -29,7 +28,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 2
 
 - type: listing
   id: HereticSidePath3Flask
@@ -45,7 +43,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 2
 
 - type: listing
   id: HereticSidePath3Mirror
@@ -61,7 +58,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 2
 
 - type: listing
   id: HereticSidePathKnowledge
@@ -76,4 +72,3 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 5

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_void.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_void.yml
@@ -12,7 +12,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 0
     # add every path here because you shouldn't be able to buy more starter knowledge
     blacklist:
     - Ash
@@ -36,7 +35,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 1
     whitelist:
     - Void
 
@@ -54,7 +52,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 2
 
 - type: listing
   id: HereticVoidPath4
@@ -70,7 +67,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 3
     whitelist:
     - Void
 
@@ -88,7 +84,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 4
     whitelist:
     - Void
 
@@ -106,7 +101,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 5
 
 - type: listing
   id: HereticVoidPath7
@@ -122,7 +116,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 6
     whitelist:
     - Void
 
@@ -140,7 +133,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 7
 
 - type: listing
   id: HereticVoidPath9
@@ -156,6 +148,5 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:HereticPathCondition
-    stage: 8
     whitelist:
     - Void

--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
@@ -23,204 +23,204 @@
 ### ash path
 - type: hereticKnowledge
   id: NightwatcherSecret
-  stage: 1
+  requiredPower: 0
   ritualPrototypes:
   - BladeAsh
 
 - type: hereticKnowledge
   id: GraspOfAsh
-  stage: 2
+  requiredPower: 1
 
 - type: hereticKnowledge
   id: BlazingDash
   sideKnowledge: true
-  stage: 3
+  requiredPower: 2
   actionPrototypes:
   - ActionHereticBlazingDash
 
 - type: hereticKnowledge
   id: AshenShift
   sideKnowledge: true
-  stage: 3
+  requiredPower: 2
   actionPrototypes:
   - ActionHereticJaunt
 
 - type: hereticKnowledge
   id: MarkOfAsh
-  stage: 4
+  requiredPower: 3
 
 - type: hereticKnowledge
   id: VolcanicBlast
-  stage: 5
+  requiredPower: 4
   actionPrototypes:
   - ActionHereticVolcanoBlast
 
 - type: hereticKnowledge
   id: MaskOfMadness
   sideKnowledge: true
-  stage: 6
+  requiredPower: 5
   ritualPrototypes:
   - MaskOfMadness
 
 - type: hereticKnowledge
   id: FieryBlade
-  stage: 7
+  requiredPower: 6
 
 - type: hereticKnowledge
   id: NightwatcherRebirth
   sideKnowledge: true
-  stage: 8
+  requiredPower: 7
   actionPrototypes:
   - ActionHereticNightwatcherRebirth
 
 - type: hereticKnowledge
   id: AscensionAsh
-  stage: 9
+  requiredPower: 8
   ritualPrototypes:
   - AscensionAsh
 
 - type: hereticKnowledge
   id: AshlordRite
-  stage: 10
+  requiredPower: 00
   actionPrototypes:
+  - ActionHereticAscension0
   - ActionHereticAscension1
-  - ActionHereticAscension2
 
 ### flesh path
 - type: hereticKnowledge
   id: PrincipleOfHunger
-  stage: 1
+  requiredPower: 0
   ritualPrototypes:
   - BladeFlesh
 
 - type: hereticKnowledge
   id: GraspOfFlesh
-  stage: 2
+  requiredPower: 1
 
 - type: hereticKnowledge
   id: ImperfectRitual
   sideKnowledge: true
-  stage: 3
+  requiredPower: 2
   ritualPrototypes:
   - ImperfectRitual
 
 - type: hereticKnowledge
   id: MarkOfFlesh
-  stage: 4
+  requiredPower: 3
 
 - type: hereticKnowledge
   id: KnittingOfFlesh
-  stage: 5
+  requiredPower: 4
   actionPrototypes:
   - ActionHereticFleshSurgery
 
 - type: hereticKnowledge
   id: RawRitual
   sideKnowledge: true
-  stage: 6
+  requiredPower: 5
   ritualPrototypes:
   - RawRitual
 
 - type: hereticKnowledge
   id: BleedingSteel
-  stage: 7
+  requiredPower: 6
 
 - type: hereticKnowledge
   id: LonelyRitual
   sideKnowledge: true
-  stage: 8
+  requiredPower: 7
   ritualPrototypes:
   - LonelyRitual
 
 - type: hereticKnowledge
   id: AscensionFlesh
-  stage: 9
+  requiredPower: 8
   ritualPrototypes:
   - AscensionFlesh
 
 - type: hereticKnowledge
   id: PriestFinalHymn
-  stage: 10
+  requiredPower: 00
   actionPrototypes:
   - ActionPolymorphHereticHorror
 
 ### void path
 - type: hereticKnowledge
   id: GlimmerOfWinter
-  stage: 1
+  requiredPower: 0
   ritualPrototypes:
   - BladeVoid
 
 - type: hereticKnowledge
   id: GraspOfVoid
-  stage: 2
+  requiredPower: 1
 
 - type: hereticKnowledge
   id: AristocratWay
   sideKnowledge: true
-  stage: 3
+  requiredPower: 2
   event: !type:HereticAristocratWayEvent
 
 - type: hereticKnowledge
   id: MarkOfVoid
-  stage: 4
+  requiredPower: 3
 
 - type: hereticKnowledge
   id: VoidBlast
-  stage: 5
+  requiredPower: 4
   actionPrototypes:
   - ActionHereticVoidBlast
 
 - type: hereticKnowledge
   id: VoidPhase
   sideKnowledge: true
-  stage: 6
+  requiredPower: 5
   actionPrototypes:
   - ActionHereticVoidPhase
 
 - type: hereticKnowledge
   id: SeekingBlade
-  stage: 7
+  requiredPower: 6
 
 - type: hereticKnowledge
   id: VoidPull
   sideKnowledge: true
-  stage: 8
+  requiredPower: 7
   actionPrototypes:
   - ActionHereticVoidPull
 
 - type: hereticKnowledge
   id: AscensionVoid
-  stage: 9
+  requiredPower: 8
   ritualPrototypes:
   - AscensionVoid
 
 - type: hereticKnowledge
   id: WaltzAtTheEndOfTime
-  stage: 10
+  requiredPower: 00
   event: !type:HereticAscensionVoidEvent
 
 ### side paths
 - type: hereticKnowledge
   id: RitualOfKnowledge
   sideKnowledge: true
-  stage: 5
+  requiredPower: 4
   ritualPrototypes:
   - RitualOfKnowledge
 
-## stage 3
+## requiredPower 2
 - type: hereticKnowledge
   id: ArmorerRitual
   sideKnowledge: true
-  stage: 3
+  requiredPower: 2
   ritualPrototypes:
   - ArmorerRitual
 
 - type: hereticKnowledge
   id: PriestRitual
   sideKnowledge: true
-  stage: 3
+  requiredPower: 2
   ritualPrototypes:
   - PriestRitual
 
-## stage 7
+## requiredPower 6

--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
@@ -8,7 +8,7 @@
 - type: hereticKnowledge
   id: HeartbeatOfMansus
   ritualPrototypes:
-  - Sacrifice  
+  - Sacrifice
 
 - type: hereticKnowledge
   id: AmberFocus
@@ -23,19 +23,16 @@
 ### ash path
 - type: hereticKnowledge
   id: NightwatcherSecret
-  path: Ash
   stage: 1
   ritualPrototypes:
-  - BladeAsh  
+  - BladeAsh
 
 - type: hereticKnowledge
   id: GraspOfAsh
-  path: Ash
   stage: 2
 
 - type: hereticKnowledge
   id: BlazingDash
-  path: Ash
   sideKnowledge: true
   stage: 3
   actionPrototypes:
@@ -43,7 +40,6 @@
 
 - type: hereticKnowledge
   id: AshenShift
-  path: Ash
   sideKnowledge: true
   stage: 3
   actionPrototypes:
@@ -51,19 +47,16 @@
 
 - type: hereticKnowledge
   id: MarkOfAsh
-  path: Ash
   stage: 4
 
 - type: hereticKnowledge
   id: VolcanicBlast
-  path: Ash
   stage: 5
   actionPrototypes:
   - ActionHereticVolcanoBlast
 
 - type: hereticKnowledge
   id: MaskOfMadness
-  path: Ash
   sideKnowledge: true
   stage: 6
   ritualPrototypes:
@@ -71,12 +64,10 @@
 
 - type: hereticKnowledge
   id: FieryBlade
-  path: Ash
   stage: 7
 
 - type: hereticKnowledge
   id: NightwatcherRebirth
-  path: Ash
   sideKnowledge: true
   stage: 8
   actionPrototypes:
@@ -84,14 +75,12 @@
 
 - type: hereticKnowledge
   id: AscensionAsh
-  path: Ash
   stage: 9
   ritualPrototypes:
   - AscensionAsh
 
 - type: hereticKnowledge
   id: AshlordRite
-  path: Ash
   stage: 10
   actionPrototypes:
   - ActionHereticAscension1
@@ -100,19 +89,16 @@
 ### flesh path
 - type: hereticKnowledge
   id: PrincipleOfHunger
-  path: Flesh
   stage: 1
   ritualPrototypes:
   - BladeFlesh
 
 - type: hereticKnowledge
   id: GraspOfFlesh
-  path: Flesh
   stage: 2
 
 - type: hereticKnowledge
   id: ImperfectRitual
-  path: Flesh
   sideKnowledge: true
   stage: 3
   ritualPrototypes:
@@ -120,19 +106,16 @@
 
 - type: hereticKnowledge
   id: MarkOfFlesh
-  path: Flesh
   stage: 4
 
 - type: hereticKnowledge
   id: KnittingOfFlesh
-  path: Flesh
   stage: 5
   actionPrototypes:
   - ActionHereticFleshSurgery
 
 - type: hereticKnowledge
   id: RawRitual
-  path: Flesh
   sideKnowledge: true
   stage: 6
   ritualPrototypes:
@@ -140,12 +123,10 @@
 
 - type: hereticKnowledge
   id: BleedingSteel
-  path: Flesh
   stage: 7
 
 - type: hereticKnowledge
   id: LonelyRitual
-  path: Flesh
   sideKnowledge: true
   stage: 8
   ritualPrototypes:
@@ -153,14 +134,12 @@
 
 - type: hereticKnowledge
   id: AscensionFlesh
-  path: Flesh
   stage: 9
   ritualPrototypes:
   - AscensionFlesh
 
 - type: hereticKnowledge
   id: PriestFinalHymn
-  path: Flesh
   stage: 10
   actionPrototypes:
   - ActionPolymorphHereticHorror
@@ -168,38 +147,32 @@
 ### void path
 - type: hereticKnowledge
   id: GlimmerOfWinter
-  path: Void
   stage: 1
   ritualPrototypes:
   - BladeVoid
 
 - type: hereticKnowledge
   id: GraspOfVoid
-  path: Void
   stage: 2
 
 - type: hereticKnowledge
   id: AristocratWay
-  path: Void
   sideKnowledge: true
   stage: 3
   event: !type:HereticAristocratWayEvent
 
 - type: hereticKnowledge
   id: MarkOfVoid
-  path: Void
   stage: 4
 
 - type: hereticKnowledge
   id: VoidBlast
-  path: Void
   stage: 5
   actionPrototypes:
   - ActionHereticVoidBlast
 
 - type: hereticKnowledge
   id: VoidPhase
-  path: Void
   sideKnowledge: true
   stage: 6
   actionPrototypes:
@@ -207,12 +180,10 @@
 
 - type: hereticKnowledge
   id: SeekingBlade
-  path: Void
   stage: 7
 
 - type: hereticKnowledge
   id: VoidPull
-  path: Void
   sideKnowledge: true
   stage: 8
   actionPrototypes:
@@ -221,14 +192,12 @@
 - type: hereticKnowledge
   id: AscensionVoid
   stage: 9
-  path: Void
   ritualPrototypes:
   - AscensionVoid
 
 - type: hereticKnowledge
   id: WaltzAtTheEndOfTime
   stage: 10
-  path: Void
   event: !type:HereticAscensionVoidEvent
 
 ### side paths
@@ -245,7 +214,7 @@
   sideKnowledge: true
   stage: 3
   ritualPrototypes:
-  - ArmorerRitual  
+  - ArmorerRitual
 
 - type: hereticKnowledge
   id: PriestRitual

--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
@@ -33,14 +33,12 @@
 
 - type: hereticKnowledge
   id: BlazingDash
-  sideKnowledge: true
   requiredPower: 2
   actionPrototypes:
   - ActionHereticBlazingDash
 
 - type: hereticKnowledge
   id: AshenShift
-  sideKnowledge: true
   requiredPower: 2
   actionPrototypes:
   - ActionHereticJaunt
@@ -57,7 +55,6 @@
 
 - type: hereticKnowledge
   id: MaskOfMadness
-  sideKnowledge: true
   requiredPower: 5
   ritualPrototypes:
   - MaskOfMadness
@@ -68,7 +65,6 @@
 
 - type: hereticKnowledge
   id: NightwatcherRebirth
-  sideKnowledge: true
   requiredPower: 7
   actionPrototypes:
   - ActionHereticNightwatcherRebirth
@@ -83,7 +79,6 @@
   id: AshlordRite
   requiredPower: 00
   actionPrototypes:
-  - ActionHereticAscension0
   - ActionHereticAscension1
 
 ### flesh path
@@ -99,7 +94,6 @@
 
 - type: hereticKnowledge
   id: ImperfectRitual
-  sideKnowledge: true
   requiredPower: 2
   ritualPrototypes:
   - ImperfectRitual
@@ -116,7 +110,6 @@
 
 - type: hereticKnowledge
   id: RawRitual
-  sideKnowledge: true
   requiredPower: 5
   ritualPrototypes:
   - RawRitual
@@ -127,7 +120,6 @@
 
 - type: hereticKnowledge
   id: LonelyRitual
-  sideKnowledge: true
   requiredPower: 7
   ritualPrototypes:
   - LonelyRitual
@@ -157,7 +149,6 @@
 
 - type: hereticKnowledge
   id: AristocratWay
-  sideKnowledge: true
   requiredPower: 2
   event: !type:HereticAristocratWayEvent
 
@@ -173,7 +164,6 @@
 
 - type: hereticKnowledge
   id: VoidPhase
-  sideKnowledge: true
   requiredPower: 5
   actionPrototypes:
   - ActionHereticVoidPhase
@@ -184,7 +174,6 @@
 
 - type: hereticKnowledge
   id: VoidPull
-  sideKnowledge: true
   requiredPower: 7
   actionPrototypes:
   - ActionHereticVoidPull
@@ -203,7 +192,6 @@
 ### side paths
 - type: hereticKnowledge
   id: RitualOfKnowledge
-  sideKnowledge: true
   requiredPower: 4
   ritualPrototypes:
   - RitualOfKnowledge
@@ -211,14 +199,12 @@
 ## requiredPower 2
 - type: hereticKnowledge
   id: ArmorerRitual
-  sideKnowledge: true
   requiredPower: 2
   ritualPrototypes:
   - ArmorerRitual
 
 - type: hereticKnowledge
   id: PriestRitual
-  sideKnowledge: true
   requiredPower: 2
   ritualPrototypes:
   - PriestRitual

--- a/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_knowledge.yml
+++ b/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_knowledge.yml
@@ -1,12 +1,12 @@
 ##side paths
 - type: hereticKnowledge
   id: SeekersHeartRitual
-  stage: 1
+  requiredPower: 1
   ritualPrototypes:
   - SeekersHeartRitual
 
 - type: hereticKnowledge
   id: HereticMirrorRitual
-  stage: 3
+  requiredPower: 3
   ritualPrototypes:
   - HereticMirrorRitual

--- a/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_knowledge.yml
+++ b/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_knowledge.yml
@@ -1,14 +1,12 @@
 ##side paths
 - type: hereticKnowledge
   id: SeekersHeartRitual
-  sideKnowledge: true
   stage: 1
   ritualPrototypes:
   - SeekersHeartRitual
-  
+
 - type: hereticKnowledge
   id: HereticMirrorRitual
-  sideKnowledge: true
   stage: 3
   ritualPrototypes:
   - HereticMirrorRitual

--- a/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_paths.yml
+++ b/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_paths.yml
@@ -1,0 +1,42 @@
+- type: hereticPath
+  id: Ash
+  knowledge:
+  - NightwatcherSecret
+  - GraspOfAsh
+  - BlazingDash
+  - AshenShift
+  - MarkOfAsh
+  - VolcanicBlast
+  - MaskOfMadness
+  - FieryBlade
+  - NightwatcherRebirth
+  - AscensionAsh
+  - AshlordRite
+
+- type: hereticPath
+  id: Flesh
+  knowledge:
+  - PrincipleOfHunger
+  - GraspOfFlesh
+  - ImperfectRitual
+  - MarkOfFlesh
+  - KnittingOfFlesh
+  - RawRitual
+  - BleedingSteel
+  - LonelyRitual
+  - AscensionFlesh
+  - PriestFinalHymn
+
+- type: hereticPath
+  id: Void
+  knowledge:
+  - GlimmerOfWinter
+  - GraspOfVoid
+  - AristocratWay
+  - MarkOfVoid
+  - VoidBlast
+  - VoidPhase
+  - SeekingBlade
+  - VoidPull
+  - AscensionVoid
+  - WaltzAtTheEndOfTime

--- a/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_paths.yml
+++ b/Resources/Prototypes/_Impstation/Heretic/Heretic/heretic_paths.yml
@@ -40,3 +40,15 @@
   - VoidPull
   - AscensionVoid
   - WaltzAtTheEndOfTime
+
+# dummy paths
+
+- type: hereticPath
+  id: Blade
+
+- type: hereticPath
+  id: Rust
+
+- type: hereticPath
+  id: Lock
+


### PR DESCRIPTION
First part of making the heretic backend not absolutely dogshit to work with! This part covers the main heretic component, heretic path and knowledge prototypes, and the custom condition for the shop. 

This should be a drag and drop, pretty much 0 player facing changes afaik besides minor wording ones.

I also think in a future PR we should move all heretic code to the main impstation namespace and remove all unused paths, so we can start fresh (we're never merging goob heretic code again most likely) 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Slightly adjusted wording relating to the heretic shop.