### PR TITLE
Repositioned Drone's Head Slot Offset

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/drone_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/drone_inventory_template.yml
@@ -7,7 +7,7 @@
     uiWindowPos: 1,0
     strippingWindowPos: 0,0
     displayName: Head
-    offset: 0, -0.45
+    offset: 0, -0.25
   - name: pocket1
     slotTexture: pocket
     fullTextureName: template_small


### PR DESCRIPTION
The misaligned positioning of the head slot for drones was driving me crazy so I reposition it. It should look a lot better now.

:cl:
- tweak: Reposition the head slot for drones so their hats are more properly offset.