### PR TITLE
Kodepiiae can now eat meat lollipops

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/candy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/candy.yml
@@ -351,7 +351,6 @@
     tags:
     - Meat
     - FoodSnack
-    - KodeEdible
   - type: Food
     trash:
     - FoodKebabSkewer


### PR DESCRIPTION
the joke of meat lollipops is that they're raw, but when i first made them i didn't know about uncooked animal proteins. this fixes that and finally lets kode eat them. yay!


:cl:
- tweak: Nanotrasen culinary guidelines have loosened and kodepiiae can now safely eat meat lollipops.

