### PR TITLE
kodepiia focused food recipe tweaks

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
@@ -78,6 +78,12 @@
       - !type:AdjustReagent
         reagent: UncookedAnimalProteins
         amount: 0.5
+      - !type:AdjustReagent # imp
+        conditions:
+          - !type:OrganType
+            type: Kodepiia
+        reagent: UncookedAnimalProteins
+        amount: 1
 
 - type: reagent
   id: EggCooked
@@ -92,6 +98,10 @@
     Food:
       effects:
       - !type:AdjustReagent
+        conditions: # imp - this is for you selene
+        - !type:OrganType
+          type: Kodepiia
+          shouldHave: false
         reagent: Protein
         amount: 1
 

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -2538,6 +2538,7 @@
     FoodTacoShell: 1
     FoodMeatDragonCutlet: 2
     FoodChiliPepper: 1
+  recipeType: Oven # imp
 
 - type: microwaveMealRecipe
   id: RecipeCroissant
@@ -2673,7 +2674,7 @@
     MobMothroach: 1
     OrganAnimalHeart: 1
     MoproachShoes: 1
-  recipeType: Microwave # Frontier
+  recipeType: Assembler # imp
 
 - type: microwaveMealRecipe
   id: RecipeCottonCake

--- a/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Cooking/meal_recipes.yml
@@ -114,12 +114,13 @@
   name: heart carpaccio recipe
   result: MealHeartCarpaccio
   group: Savory
-  time: 5 # warming it as a formality
+  time: 5
   solids:
-    OrganAnimalHeart: 1 # use the whole mouse. whatever
-    OrganAnimalLiver: 1
-    OrganAnimalLungs: 1
-    OrganAnimalKidneys: 1
+    OrganHumanHeart: 1 # use the whole body. whatever
+    OrganHumanLiver: 1
+    OrganHumanLungs: 1
+    OrganHumanStomach: 1
+    OrganHumanKidneys: 1
   recipeType: Assembler
 
 - type: microwaveMealRecipe


### PR DESCRIPTION
couple small things id been meaning to do forever

- heart carpaccio now uses human organs because, i cannot fucking believe this, these are now significantly more available than mouse organs. it also uses a stomach which was originally intended
- moproach recipe uses assembler. youre torturing it
- draco uses oven, this just got missed during the frontier food port process
- cooked eggs now metabolize into nothing at all for kodepiia & uncooked eggs metabolize into uncooked protein at a 1:1 ratio. im not 100% on the cooked egg thing but i felt like showing a small mercy today.

**Changelog**
:cl:
- tweak: The recipes for heart carpaccio, moproach, and draco have been altered.
- fix: Cooked eggs no longer poison Kodepiiae.
