### PR TITLE
Poprtable cutter machine fixes

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -88,7 +88,6 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
-  - type: CollisionWake
   - type: Machine
     board: PortableCutterMachineCircuitboard
   - type: MaterialStorage

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -88,6 +88,7 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+  - type: CollisionWake
   - type: Machine
     board: PortableCutterMachineCircuitboard
   - type: MaterialStorage
@@ -111,6 +112,13 @@
       types:
         Blunt: 20 #matches the toolbox's 1.33 multiplier (rounded up), needed to be manually set to override BaseStructure's parameters
     staminaCost: 12.5
+  - type: DamageExaminable
+  - type: DamageOnHighSpeedImpact
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      collection: MetalThud
 
 - type: entity
   id: PortableCutterMachineFolded


### PR DESCRIPTION
Adds some components from BaseItem the cutter machine should probably have, notably DamageExaminable

**Changelog**
:cl:
- fix: Fixed not being able to examine the damage on the portable cutter machine.
