### PR TITLE
Return roundstart service worker

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -1,4 +1,3 @@
-# imp: removed service worker. playtime tracker & visitor service worker roles will remain.
 - type: job
   id: ServiceWorker
   name: job-name-serviceworker
@@ -11,15 +10,14 @@
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service
-  setPreference: false #imp
-  overrideConsoleVisibility: true #imp
   access:
   - Service
   - Maintenance
-  - Bar
-  - Kitchen
+  #- Bar #imp edit
+  #- Kitchen #imp edit
   extendedAccess:
   - Hydroponics
+  - Kitchen #imp edit
 
 - type: startingGear
   id: ServiceWorkerGear

--- a/Resources/Prototypes/_Impstation/Maps/Eclipse.yml
+++ b/Resources/Prototypes/_Impstation/Maps/Eclipse.yml
@@ -19,7 +19,7 @@
         - type: StationCargoShuttle
           path: /Maps/_Harmony/Shuttles/cargo_eclipse.yml
         - type: StationJobs
-          availableJobs: #78 jobs available (update after paramed/brigmed re-added please)
+          availableJobs: #80 jobs available (update after paramed/brigmed re-added please)
             #command: 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -39,6 +39,7 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 1, 1 ]
             Lawyer: [ 2, 2 ]
             #engineering: 12

--- a/Resources/Prototypes/_Impstation/Maps/amber.yml
+++ b/Resources/Prototypes/_Impstation/Maps/amber.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_amber.yml
         - type: StationJobs
-          availableJobs: # total of 52 jobs roundstart, max of 60 inc. latejoins and trainees.
+          availableJobs: # total of 51 jobs roundstart, max of 59 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -37,6 +37,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
+            ServiceWorker: [ 1, 1 ]
             # engineering - 5-7
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/anthill.yml
+++ b/Resources/Prototypes/_Impstation/Maps/anthill.yml
@@ -39,7 +39,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            #ServiceWorker: [ 2, 2 ]
+            ServiceWorker: [ 2, 2 ]
             # engineering - 7-8
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/_Impstation/Maps/bagel.yml
+++ b/Resources/Prototypes/_Impstation/Maps/bagel.yml
@@ -36,6 +36,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             # engineering - 7-11
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/barratry.yml
+++ b/Resources/Prototypes/_Impstation/Maps/barratry.yml
@@ -19,7 +19,7 @@
         - type: StationCargoShuttle
           path: /Maps/_Harmony/Shuttles/cargo_barratry.yml
         - type: StationJobs
-          availableJobs: # Total of 64 jobs roundstart, max of 75 inc. latejoins and trainees.
+          availableJobs: # Total of 65 jobs roundstart, max of 76 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -39,6 +39,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             # engineering - 8-12
             AtmosphericTechnician: [ 3, 3 ]
@@ -46,16 +47,16 @@
             TechnicalAssistant: [ 4, 4 ]
             # medical - 7-11
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 5, 5 ] 
+            MedicalDoctor: [ 5, 5 ]
             MedicalIntern: [ 2, 4 ]
-           #Paramedic: [ 0, 0 ] 
+           #Paramedic: [ 0, 0 ]
             # science - 8-9
             Borg: [ 2, 2 ]
             ResearchAssistant: [ 1, 1]
             Scientist: [ 5, 5 ]
             StationAi: [ 1, 1 ]
             # security - 9-13
-           #Brigmedic: [ 0, 0 ] 
+           #Brigmedic: [ 0, 0 ]
             Detective: [ 1, 1 ]
             Lawyer: [ 2, 2 ]
             SecurityCadet: [ 4, 4 ]

--- a/Resources/Prototypes/_Impstation/Maps/boat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/boat.yml
@@ -19,7 +19,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_fland.yml
         - type: StationJobs
-          availableJobs: # Total of 65 jobs roundstart, max of 75 inc. latejoins and trainees.
+          availableJobs: # Total of 64 jobs roundstart, max of 74 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -34,12 +34,13 @@
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chaplain: [ 1, 1 ]
-            Chef: [ 3, 3 ]
+            Chef: [ 2, 2 ]
             Clown: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Librarian: [ 1, 1 ]
             Mime: [ 2, 2 ]
             Musician: [ 2, 2 ]
+            ServiceWorker: [ 2, 2 ] # this just feels right
             Reporter: [ 1, 1 ]
             # engineering - 6-9
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/box.yml
+++ b/Resources/Prototypes/_Impstation/Maps/box.yml
@@ -44,6 +44,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             # engineering - 8-12
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/cog.yml
+++ b/Resources/Prototypes/_Impstation/Maps/cog.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_wode.yml
         - type: StationJobs
-          availableJobs: # Total of 67 jobs roundstart, max of 79 inc. latejoins and trainees.
+          availableJobs: # Total of 68 jobs roundstart, max of 81 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -37,6 +37,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
             # engineering - 7-10

--- a/Resources/Prototypes/_Impstation/Maps/core.yml
+++ b/Resources/Prototypes/_Impstation/Maps/core.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_core.yml
         - type: StationJobs
-          availableJobs: # Total of 59 jobs roundstart, max of 70 inc. latejoins and trainees.
+          availableJobs: # Total of 60 jobs roundstart, max of 71 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -39,6 +39,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 2, 2 ]
             # engineering - 6-8
             StationEngineer: [ 4, 4 ]

--- a/Resources/Prototypes/_Impstation/Maps/gate.yml
+++ b/Resources/Prototypes/_Impstation/Maps/gate.yml
@@ -15,7 +15,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
         - type: StationJobs
-          availableJobs: # Total of 67 jobs roundstart, max of 82 inc. latejoins and trainees.
+          availableJobs: # Total of 68 jobs roundstart, max of 84 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -35,6 +35,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
             # engineering - 7-11

--- a/Resources/Prototypes/_Impstation/Maps/hash.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hash.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/_Impstation/Shuttles/Hash_cargo.yml
         - type: StationJobs
-          availableJobs: # Total of 50 jobs roundstart, max of 57 inc. latejoins and trainees.
+          availableJobs: # Total of 51 jobs roundstart, max of 58 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -39,6 +39,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             # engineering - 5-6
             AtmosphericTechnician: [ 2, 2 ]

--- a/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/_Impstation/Shuttles/emergency_courser_hummingbird.yml
         - type: StationJobs
-          availableJobs: # Total of 65 nice jobs roundstart, max of 76 inc. latejoins and trainees.
+          availableJobs: # Total of 66 nice jobs roundstart, max of 78 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -37,6 +37,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 2, 2 ]
             Musician: [ 2, 2 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 2, 2 ]
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/luna.yml
+++ b/Resources/Prototypes/_Impstation/Maps/luna.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/_Impstation/Shuttles/cargojeep_luna.yml
         - type: StationJobs
-          availableJobs: # Total of 57 jobs roundstart, max of 65 inc. latejoins and trainees.
+          availableJobs: # Total of 58 jobs roundstart, max of 67 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -40,6 +40,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 2, 2 ]
             # engineering - 5-6
             AtmosphericTechnician: [ 2, 2 ]

--- a/Resources/Prototypes/_Impstation/Maps/oasis.yml
+++ b/Resources/Prototypes/_Impstation/Maps/oasis.yml
@@ -15,7 +15,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_accordia.yml
         - type: StationJobs
-          availableJobs: # Total of 76 jobs roundstart, max of 90 inc. latejoins and trainees.
+          availableJobs: # Total of 78 jobs roundstart, max of 92 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -35,6 +35,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 2, 2 ]
             Musician: [ 2, 2 ]
+            ServiceWorker: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
             # engineering - 8-12

--- a/Resources/Prototypes/_Impstation/Maps/plasma.yml
+++ b/Resources/Prototypes/_Impstation/Maps/plasma.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_plasma.yml
         - type: StationJobs
-          availableJobs: #Total of 68 nice jobs roundstart, max of 84 inc. latejoins and trainees.
+          availableJobs: #Total of 69 nice jobs roundstart, max of 86 inc. latejoins and trainees.
             #command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -38,6 +38,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 2, 2 ]
             # engineering - 8-12
             AtmosphericTechnician: [ 4, 4 ]

--- a/Resources/Prototypes/_Impstation/Maps/refsdal.yml
+++ b/Resources/Prototypes/_Impstation/Maps/refsdal.yml
@@ -40,7 +40,7 @@
             Librarian: [1, 1]
             Reporter: [1, 1]
             Boxer: [2, 2]
-            #ServiceWorker: [2, 2]
+            ServiceWorker: [1, 2]
             # engineering
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/submarine.yml
+++ b/Resources/Prototypes/_Impstation/Maps/submarine.yml
@@ -17,7 +17,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/_Impstation/Shuttles/NTES_Propeller.yml
         - type: StationJobs
-          availableJobs: # Total of 66 jobs roundstart, max of 80 inc. latejoins and trainees.
+          availableJobs: # Total of 68 jobs roundstart, max of 82 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -37,6 +37,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
             Boxer: [1, 1]

--- a/Resources/Prototypes/_Impstation/Maps/train.yml
+++ b/Resources/Prototypes/_Impstation/Maps/train.yml
@@ -18,7 +18,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_omega.yml # TODO - add railway station
         - type: StationJobs
-          availableJobs: # Total of 60 jobs roundstart, max of 71 inc. latejoins and trainees.
+          availableJobs: # Total of 61 jobs roundstart, max of 72 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -38,6 +38,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/union.yml
+++ b/Resources/Prototypes/_Impstation/Maps/union.yml
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
         - type: StationJobs
-          availableJobs: # Total of 64 jobs roundstart, max of 76 inc. latejoins and trainees.
+          availableJobs: # Total of 65 jobs roundstart, max of 78 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -37,6 +37,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 2 ]
             Reporter: [ 2, 2 ]
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Maps/xeno.yml
+++ b/Resources/Prototypes/_Impstation/Maps/xeno.yml
@@ -27,7 +27,7 @@
             station-event-game-rule-meteor-swarm-medium-announcement: station-event-game-rule-meteor-swarm-artifact-announcement
             station-event-game-rule-meteor-swarm-large-announcement: station-event-game-rule-meteor-swarm-artifact-announcement
         - type: StationJobs
-          availableJobs: # Total of 60 jobs roundstart, max of 72 inc. latejoins and trainees.
+          availableJobs: # Total of 61 jobs roundstart, max of 73 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -47,6 +47,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+            ServiceWorker: [ 1, 1 ]
             Reporter: [ 2, 2 ]
             # engineering - 7-10
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/_Impstation/Roles/departments.yml
+++ b/Resources/Prototypes/_Impstation/Roles/departments.yml
@@ -32,7 +32,7 @@
   roles:
   - Bartender
   - Chef
-  #- ServiceWorker
+  - ServiceWorker
   primary: false
   editorHidden: true
   manifestHidden: true


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Yesterday I played bartender and had a plan for a themed menu in the bar. It required exotic ingredients, so I was juggling a bunch of ingredient acquisition and drink-making at the same time, and in the midst of it I idly thought to myself "I sure could use someone in service whose job was to perform little errands for me... I wish we had that." And then I remembered.

This PR restores roundstart service worker, albeit with nothing but service access, a reduced roundstart population in most maps (1 roundstart, 1 latejoin only, 2 total) and a reduced total population in midpop maps. They're absent from small ones.
I tried to prioritize higher service worker populations on maps that I know to be physically large, like Cog, because errand-people are more valuable in layouts like those.

Why:

- Removing accesses easily prevents the job-stealing problems Service Worker was infamous for. Other forks/servers have done this and don't seem to have the issues that we did.
  - In retrospect, we probably should have tried this before removing the job entirely.
- "Maintskissing"/slacking off isn't as prevalent an issue in the community anymore, and with an influx of new players, now is the best time to shape our culture in the way that we like. Besides, we never got rid of passenger.  
  - What is slacking off? Is it failing to take initiative on projects, or is it ignoring explicit orders to do something?
    - If it's the former, I'm not sure I agree that it's an issue worth removing an entire role over.
    - If it's the latter, as Command, I've had my orders willfully ignored by nearly every subordinate role in the game. Including borgs. And security. This is not an issue unique to service worker.
- A reduced amount of roundstart workers will make queuing players more likely to roll other service jobs first.
- HD needs generalized workers that can do shit for them without interrupting whatever project that worker was busy with. Like, you can't really send a bartender, botanist chef to go fetch ingredients for you so you can prepare a five-course dinner. You ESPECIALLY can't send a janitor. They're all busy doing their jobs. No other department has this issue-- CMO can send stray doctors on little tasks, HoS secoffs, CEs engineers, etc. 
- With AA also gone, who is there left for Command to send running for coffee? We need peons!!!!!!!!!!

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Restored Service Worker. Welcome back Laura Klaus
