### PR TITLE
THUSD PR JORL THESIUS -  replace [U]nr with unrevivable

### DIFF
--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -190,8 +190,5 @@ chatsan-replacement-66 = something
 chatsan-word-67 = allg
 chatsan-replacement-67 = all good
 # imp
-chatsan-word-68 = dnr
-chatsan-replacement-68 = do not revive
-
-chatsan-word-69 = unr
-chatsan-replacement-69 = unrevivable
+chatsan-word-68 = unr
+chatsan-replacement-68 = unrevivable

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -189,6 +189,9 @@ chatsan-replacement-66 = something
 
 chatsan-word-67 = allg
 chatsan-replacement-67 = all good
+# imp
+chatsan-word-68 = dnr order
+chatsan-replacement-68 = dnr order
 
-chatsan-word-68 = dnr
-chatsan-replacement-68 = unrevivable
+chatsan-word-69 = dnr
+chatsan-replacement-69 = unrevivable

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -190,8 +190,8 @@ chatsan-replacement-66 = something
 chatsan-word-67 = allg
 chatsan-replacement-67 = all good
 # imp
-chatsan-word-68 = dnr order
-chatsan-replacement-68 = dnr order
+chatsan-word-68 = dnr
+chatsan-replacement-68 = do not revive
 
-chatsan-word-69 = dnr
+chatsan-word-69 = unr
 chatsan-replacement-69 = unrevivable

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -189,3 +189,6 @@ chatsan-replacement-66 = something
 
 chatsan-word-67 = allg
 chatsan-replacement-67 = all good
+
+chatsan-word-68 = dnr
+chatsan-replacement-68 = unrevivable

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -528,6 +528,7 @@
     chatsan-word-65: chatsan-replacement-65
     chatsan-word-66: chatsan-replacement-66
     chatsan-word-67: chatsan-replacement-67
+    chatsan-word-68: chatsan-replacement-68 #imp edit
 
 - type: accent
   id: liar

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -529,6 +529,7 @@
     chatsan-word-66: chatsan-replacement-66
     chatsan-word-67: chatsan-replacement-67
     chatsan-word-68: chatsan-replacement-68 #imp edit
+    chatsan-word-69: chatsan-replacement-69 #imp edit
 
 - type: accent
   id: liar

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -529,7 +529,6 @@
     chatsan-word-66: chatsan-replacement-66
     chatsan-word-67: chatsan-replacement-67
     chatsan-word-68: chatsan-replacement-68 #imp edit
-    chatsan-word-69: chatsan-replacement-69 #imp edit
 
 - type: accent
   id: liar


### PR DESCRIPTION
People use "dnr" as shorthand for unrevivable
because the latter is annoying to type
_But,_ that is not what "dnr" means and I was able to verify I'm not the only one mildly annoyed by this.
So this PR adds "unr" to the chat sanitization system (same thing that replaces "wtf" to "what the fuck" and whatnot) as a shortcut for unrevivable
<img width="336" height="256" alt="dnr" src="https://github.com/user-attachments/assets/f0952388-57f1-4327-8c27-a981d451f680" />

[deleted paragraph bc its not accurate anymore]
:cl:
- add: you can now use "UNR" as a shortcut for "Unrevivable"! 
