### PR TITLE
give quad disabler 4 shots capacity instead of 0

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/quaddisabler.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/quaddisabler.yml
@@ -17,6 +17,9 @@
     quickEquip: false
     slots:
     - Back
+  - type: Battery #imp
+    maxCharge: 4000 #imp
+    startingCharge: 4000 #imp
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerQuad
     fireCost: 1000


### PR DESCRIPTION
practice disabler refactor a bit ago broke the quad disabler but noone noticed because they're rarely used gave them back ammo from 0 to 4 shots
no CL because we don't have admin facing changelogs in our CL bot ??