### PR TITLE
delta alert wording change

### DIFF
--- a/Resources/Locale/en-US/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/en-US/alert-levels/alert-levels.ftl
@@ -28,8 +28,8 @@ alert-level-gamma-announcement = Central Command has ordered the Gamma security 
 alert-level-gamma-instructions = All civilians are to immediately seek their nearest head for transportation to a secure location.
 
 alert-level-delta = Delta
-alert-level-delta-announcement = The station is currently under threat of imminent destruction. If unintentional, crewmembers are advised to prevent this at any cost, failure to comply will be met with termination of all contracts.
-alert-level-delta-instructions = If unintentional, crewmembers are advised to prevent this at any cost, failure to comply will be met with termination of all contracts.
+alert-level-delta-announcement = The station is currently under threat of imminent destruction. If unintentional, crewmembers are advised to prevent this at any cost. Failure to comply will be met with termination of all contracts.
+alert-level-delta-instructions = If unintentional, crewmembers are advised to prevent this at any cost. Failure to comply will be met with termination of all contracts.
 
 alert-level-epsilon = Epsilon
 alert-level-epsilon-announcement = Central Command has ordered the Epsilon security level on the station. Consider all contracts terminated.

--- a/Resources/Locale/en-US/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/en-US/alert-levels/alert-levels.ftl
@@ -28,8 +28,8 @@ alert-level-gamma-announcement = Central Command has ordered the Gamma security 
 alert-level-gamma-instructions = All civilians are to immediately seek their nearest head for transportation to a secure location.
 
 alert-level-delta = Delta
-alert-level-delta-announcement = The station is currently under threat of imminent destruction. Crewmembers are advised to listen to heads of staff for more information.
-alert-level-delta-instructions = Crewmembers are advised to listen to heads of staff for more information.
+alert-level-delta-announcement = The station is currently under threat of imminent destruction. If unintentional, crewmembers are advised to prevent this at any cost, failure to comply will be met with termination of all contracts.
+alert-level-delta-instructions = If unintentional, crewmembers are advised to prevent this at any cost, failure to comply will be met with termination of all contracts.
 
 alert-level-epsilon = Epsilon
 alert-level-epsilon-announcement = Central Command has ordered the Epsilon security level on the station. Consider all contracts terminated.

--- a/Resources/ServerInfo/_Impstation/Guidebook/AlertProcedure.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/AlertProcedure.xml
@@ -69,7 +69,7 @@ There are some restrictions on when certain alert levels can be used. They are e
 - [color=#a4885c]Rules of Engagement[/color]: Engage with necessary force; lethal force is permitted in self-defense, or to effect an arrest.
 
 ## Code Delta
-[color=#8b0000]Emergency alert status. The station is currently under threat of imminent destruction. Should reversal of impending destruction prove impossible, evacuate.[/color]
+[color=#8b0000]Emergency alert status. The station is currently under threat of imminent destruction. If unintentional, crewmembers are advised to prevent this at any cost, failure to comply will be met with termination of all contracts.[/color]
 - [color=#a4885c]Chain of Command[/color]: Captain ◃ Head of Security ◃ Head of Personnel ◃ Security Personnel ◃ Department Heads
 - [color=#a4885c]Armory Policy[/color]: Open carrying weaponry permitted for all security personnel. Standard ballistic armor mandatory, EVA suits heavily advised.
 - [color=#a4885c]Discipline[/color]: Martial law is in effect. Searches and departmental raids may be performed at the discretion of security personnel and without a warrant. Arrests of officers permitted at discretion of security personnel. Threats that have been incapacitated by lethal force may be kept in Preservative Stasis until Code Delta has been rescinded. Security is fully authorized to take whatever actions deemed necessary to neutralize or repel station threats.

--- a/Resources/ServerInfo/_Impstation/Guidebook/AlertProcedure.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/AlertProcedure.xml
@@ -69,7 +69,7 @@ There are some restrictions on when certain alert levels can be used. They are e
 - [color=#a4885c]Rules of Engagement[/color]: Engage with necessary force; lethal force is permitted in self-defense, or to effect an arrest.
 
 ## Code Delta
-[color=#8b0000]Emergency alert status. The station is currently under threat of imminent destruction. If unintentional, crewmembers are advised to prevent this at any cost, failure to comply will be met with termination of all contracts.[/color]
+[color=#8b0000]Emergency alert status. The station is currently under threat of imminent destruction. If unintentional, crewmembers are advised to prevent this at any cost. Failure to comply will be met with termination of all contracts.[/color]
 - [color=#a4885c]Chain of Command[/color]: Captain ◃ Head of Security ◃ Head of Personnel ◃ Security Personnel ◃ Department Heads
 - [color=#a4885c]Armory Policy[/color]: Open carrying weaponry permitted for all security personnel. Standard ballistic armor mandatory, EVA suits heavily advised.
 - [color=#a4885c]Discipline[/color]: Martial law is in effect. Searches and departmental raids may be performed at the discretion of security personnel and without a warrant. Arrests of officers permitted at discretion of security personnel. Threats that have been incapacitated by lethal force may be kept in Preservative Stasis until Code Delta has been rescinded. Security is fully authorized to take whatever actions deemed necessary to neutralize or repel station threats.


### PR DESCRIPTION
Original text doesn't align with our policy of no running during nukies. This has been made clearer now and gives an IC reason to stay and fight.

**Changelog**
:cl:
- tweak: contracts will now be terminated if you run during delta alert