### PR TITLE
fixing some pervasive replicator bugs

### DIFF
--- a/Content.Server/_Impstation/Replicator/ReplicatorNestSystem.cs
+++ b/Content.Server/_Impstation/Replicator/ReplicatorNestSystem.cs
@@ -38,6 +38,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using System.Linq;
 using Content.Shared.Movement.Systems;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
 
 namespace Content.Server._Impstation.Replicator;
 
@@ -208,6 +209,10 @@ public sealed class ReplicatorNestSystem : SharedReplicatorNestSystem
 
     private void HandleDestruction(Entity<ReplicatorNestComponent> ent)
     {
+        // turn off the ambient sound on the points storage entity.
+        if (TryComp<AmbientSoundComponent>(ent.Comp.PointsStorage, out var ambientComp))
+            _ambientSound.SetAmbience(ent.Comp.PointsStorage, false, ambientComp);
+
         if (ent.Comp.Hole != null)
         {
             foreach (var uid in _containerSystem.EmptyContainer(ent.Comp.Hole))
@@ -235,22 +240,20 @@ public sealed class ReplicatorNestSystem : SharedReplicatorNestSystem
         // Figure out who the queen is & which replicators belonging to this nest are still alive.
         EntityUid? queen = null;
         HashSet<Entity<ReplicatorComponent>> livingReplicators = [];
-        foreach (var replicator in ent.Comp.SpawnedMinions)
+        var repQuery = EntityQueryEnumerator<ReplicatorComponent>();
+        while (repQuery.MoveNext(out var uid, out var comp))
         {
-            if (!TryComp<ReplicatorComponent>(replicator, out var replicatorComp))
+            if (!_mobState.IsAlive(uid))
                 continue;
 
-            if (!_mobState.IsAlive(replicator))
+            if (comp.MyNest != ent.Owner)
                 continue;
 
-            replicatorComp.MyNest = null;
+            comp.MyNest = null;
+            if (comp.Queen)
+                queen = uid;
 
-            if (replicatorComp.Queen)
-                queen = replicator;
-
-            livingReplicators.Add((replicator, replicatorComp));
-
-            _popup.PopupEntity(Loc.GetString("replicator-nest-destroyed"), replicator, replicator, Shared.Popups.PopupType.LargeCaution);
+            livingReplicators.Add((uid, comp));
         }
 
         // if there are living replicators, select one and give the action to create a new nest.
@@ -272,7 +275,11 @@ public sealed class ReplicatorNestSystem : SharedReplicatorNestSystem
             if (upgradedQueen is not { } upgradedQueenNotNull || !TryComp<MindContainerComponent>(upgradedQueen, out var mindContainer) || mindContainer.Mind is not { } mind)
                 return;
 
+            if (!TryComp<ReplicatorComponent>(upgradedQueenNotNull, out var upgradedQueenReplicatorComp))
+                return;
+
             queen = upgradedQueenNotNull;
+            livingReplicators.Add((upgradedQueenNotNull, upgradedQueenReplicatorComp));
 
             if (!mindContainer.HasMind)
                 upgradedComp.Actions.Add(_actions.AddAction(upgradedQueenNotNull, upgradedComp.SpawnNewNestAction));
@@ -284,10 +291,21 @@ public sealed class ReplicatorNestSystem : SharedReplicatorNestSystem
         }
 
         // finally, loop over our living replicators and set their pinpointers to target the queen, then downgrade them to level 1 and stun them.
-        foreach (var replicator in livingReplicators)
+        List<(EntityUid, ReplicatorComponent)> finalLivingReps = [];
+        var repQuery2 = EntityQueryEnumerator<ReplicatorComponent>();
+        while (repQuery2.MoveNext(out var uid, out var comp))
         {
-            // downgrade to level 1
-            var upgraded = ForceUpgrade(replicator, replicator.Comp.FirstStage);
+            finalLivingReps.Add((uid, comp));
+            if (HasComp<ReplicatorSignComponent>(uid))
+                queen = uid;
+        }
+        foreach (var (uid, comp) in finalLivingReps)
+        {
+            EntityUid? upgraded;
+            if (HasComp<ReplicatorSignComponent>(uid))
+                upgraded = uid;
+            else
+                upgraded = ForceUpgrade((uid, comp), comp.FirstStage);
             if (upgraded is not { } upgradedNotNull)
                 return;
 
@@ -296,13 +314,9 @@ public sealed class ReplicatorNestSystem : SharedReplicatorNestSystem
             if (!_inventory.TryGetSlotEntity(upgradedNotNull, "pocket1", out var pocket1) || !TryComp<PinpointerComponent>(pocket1, out var pinpointer))
                 continue;
 
-            // set the target to the queen
             _pinpointer.SetTarget(pocket1.Value, queen, pinpointer);
+            _popup.PopupEntity(Loc.GetString("replicator-nest-destroyed"), uid, uid, Shared.Popups.PopupType.LargeCaution);
         }
-
-        // turn off the ambient sound on the points storage entity.
-        if (TryComp<AmbientSoundComponent>(ent.Comp.PointsStorage, out var ambientComp))
-            _ambientSound.SetAmbience(ent.Comp.PointsStorage, false, ambientComp);
     }
 
     private void OnRoundEndTextAppend(RoundEndTextAppendEvent args)

--- a/Content.Server/_Impstation/Replicator/ReplicatorSystem.cs
+++ b/Content.Server/_Impstation/Replicator/ReplicatorSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Pinpointer;
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
@@ -37,6 +38,7 @@ public sealed class ReplicatorSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly PinpointerSystem _pinpointer = default!;
     [Dependency] private readonly SharedReplicatorNestSystem _replicatorNest = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -103,7 +105,13 @@ public sealed class ReplicatorSystem : EntitySystem
         // then set that nest's spawned minions to our saved list of related replicators.
         // while we're in here, we might as well update all their pinpointers.
         HashSet<EntityUid> newMinions = [];
-        foreach (var (uid, comp) in ent.Comp.RelatedReplicators)
+        HashSet<(EntityUid, ReplicatorComponent)> livingReplicators = [];
+        var query = EntityQueryEnumerator<ReplicatorComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            livingReplicators.Add((uid, comp));
+        }
+        foreach (var (uid, comp) in livingReplicators)
         {
             newMinions.Add(uid);
 
@@ -175,16 +183,19 @@ public sealed class ReplicatorSystem : EntitySystem
 
     private void OnMobStateChanged(Entity<ReplicatorComponent> ent, ref MobStateChangedEvent args)
     {
-        if (args.NewMobState != MobState.Critical | args.NewMobState != MobState.Dead)
+        if (_mobState.IsAlive(ent))
             return;
 
         _appearance.SetData(ent, ReplicatorVisuals.Combat, false);
 
         if (HasComp<ReplicatorSignComponent>(ent))
         {
-            foreach (var (uid, comp) in ent.Comp.RelatedReplicators)
+            RemComp<ReplicatorSignComponent>(ent);
+            // notify all living replicators that they are likely orphaned.
+            var query = EntityQueryEnumerator<ReplicatorComponent>();
+            while (query.MoveNext(out var uid, out var replicatorComp))
             {
-                _popup.PopupEntity(Loc.GetString(comp.QueenDiedMessage), uid, uid, PopupType.LargeCaution);
+                _popup.PopupEntity(Loc.GetString(replicatorComp.QueenDiedMessage), uid, uid, PopupType.LargeCaution);
             }
         }
     }

--- a/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
+++ b/Content.Shared/_Impstation/Replicator/SharedReplicatorNestSystem.cs
@@ -245,25 +245,22 @@ public abstract class SharedReplicatorNestSystem : EntitySystem
         if (_net.IsClient || !_timing.IsFirstTimePredicted)
             return;
 
-        foreach (var replicator in ent.Comp.SpawnedMinions)
+        // this upgrades *all living replicators.* all nests are one hive
+        var query = EntityQueryEnumerator<ReplicatorComponent, MindContainerComponent>();
+        while (query.MoveNext(out var uid, out var replicatorComp, out var mindContainerComp))
         {
-            if (!TryComp<ReplicatorComponent>(replicator, out var comp) || comp.UpgradeActions.Count == 0)
+            if (replicatorComp.UpgradeActions.Count == 0 || replicatorComp.HasBeenGivenUpgradeActions == true || mindContainerComp.Mind == null)
                 continue;
 
-            if (comp.HasBeenGivenUpgradeActions == true)
-                continue;
-
-            if (!TryComp<MindContainerComponent>(replicator, out var mindContainer) || mindContainer.Mind == null)
-                continue;
-
-            foreach (var action in comp.UpgradeActions)
+            foreach (var action in replicatorComp.UpgradeActions)
             {
-                if (!mindContainer.HasMind)
-                    comp.Actions.Add(_actions.AddAction(replicator, action));
-                else if (mindContainer.Mind != null)
-                    comp.Actions.Add(_actionContainer.AddAction((EntityUid)mindContainer.Mind, action));
+                if (!mindContainerComp.HasMind)
+                    replicatorComp.Actions.Add(_actions.AddAction(uid, action));
+                else
+                    replicatorComp.Actions.Add(_actionContainer.AddAction((EntityUid)mindContainerComp.Mind, action));
             }
-            comp.HasBeenGivenUpgradeActions = true;
+
+            replicatorComp.HasBeenGivenUpgradeActions = true;
         }
     }
 

--- a/Resources/Locale/en-US/_Impstation/replicators/replicators.ftl
+++ b/Resources/Locale/en-US/_Impstation/replicators/replicators.ftl
@@ -33,7 +33,7 @@ replicator-nest-destroyed = Your nest has been destroyed.
                             A Replicator has been selected to replace it.
                             Your pinpointer has been updated to follow them.
 replicator-queen-died-msg = The Queen has been deactivated.
-                            You are orphaned from the nest.
+                            It is probable that you are orphaned from your nest.
 
 # action confirmations
 replicator-nest-confirm = Are you sure? Use the action again to confirm.


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

trying to keep track of every related replicator was kind of stupid when their UIDs were changing constantly. i just replaced most of the code that attempted to keep track of them with EQEs generating lists of every living replicator. The event can only naturally run once, so this won't be a problem outside of admemes. 

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed replicator nest sound effects lingering after the nest is destroyed.
- fix: Fixed replicators from old nests not getting leveled up from their new nest - instead, all replicators on the map are affected by all nests. There is one Hive. 
- fix: Fixed replicators not getting a popup notification when they are orphaned (when their Queen dies.) The Queen will also now lose its Crown upon its death.

