### PR TITLE
pdas get zapped

### DIFF
--- a/Content.Shared/Light/EntitySystems/UnpoweredFlashlightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/UnpoweredFlashlightSystem.cs
@@ -9,6 +9,8 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Shared.Item.ItemToggle; //imp
+using Content.Shared.Item.ItemToggle.Components; //imp
 
 namespace Content.Shared.Light.EntitySystems;
 
@@ -24,6 +26,7 @@ public sealed class UnpoweredFlashlightSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly EmagSystem _emag = default!;
+    [Dependency] private readonly ItemToggleSystem _itemToggle = default!; //imp
 
     public override void Initialize()
     {
@@ -100,6 +103,11 @@ public sealed class UnpoweredFlashlightSystem : EntitySystem
     {
         if (!Resolve(ent, ref ent.Comp, false))
             return;
+
+        if (TryComp<ItemToggleComponent>(ent, out var toggleComp)) // imp
+        {
+            _itemToggle.Toggle(toggleComp!.Owner);
+        }
 
         SetLight(ent, !ent.Comp.LightOn, user, quiet);
     }

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -128,6 +128,11 @@
     damage:
       types:
         Blunt: 4
+  - type: ComponentToggler #imp :)
+    components:
+    - type: LightningTarget
+      priority: 1
+  - type: ItemToggle # imp
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
this PR makes it so that pdas get struck by lightning and followed by tesla balls when the flashlight is on.
also some minor system changes to unpowered flashlight to facilitate this.

https://github.com/user-attachments/assets/2e08215f-ffc4-491b-8002-aada3c2ef654


**Changelog**
:cl:
- tweak: Nanotrasen would like to once again dispel the foolish rumor of job issued PDAs being conductive to electricity.
