### PR TITLE
paradox clone trait fix

### DIFF
--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -5,7 +5,7 @@
 - type: traitCategory
   id: SpeechTraits
   name: trait-category-speech
-  maxTraitPoints: 3 # imp edit
+  maxTraitPoints: 2
 
 - type: traitCategory
   id: Quirks


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
adds some imp traits to the clone list so paradox clones get it when they spawn!
unfortunately does not add ALL, some replacementaccents i couldn't figure out- slime speech being one of them. but this is still better than before

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed most (but not all!) imp-exclusive accents and disabilities not being inherited by paradox clones.
