### PR TITLE
Adds Seclight to HoS locker, Swaps breathmask for Sec Gasmask for Warden Hardsuit

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -365,6 +365,7 @@
     - id: BaseSeclinkRadio #imp
     - id: PillCanisterHOS #imp
     - id: PersonalAILearnerSecurity #impspecial
+    - id: FlashlightSeclite # imp addition
     - id: PrinterDocFlatpack  # Corvax-Printer
 
 # Hardsuit table, used for suit storage as well

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -56,7 +56,7 @@
     children:
     - id: ClothingOuterHardsuitWarden
     - id: OxygenTankFilled
-    - id: ClothingMaskBreath
+    - id: ClothingMaskGasSecurity # imp edit, replacing basic gasmask
 
 - type: entity
   id: LockerSecurityFilled


### PR DESCRIPTION
Adds seclight to HoS locker, changes standard breath mask to sec gasmask in Warden's Hardsuit locker. First pr, if comment tags are wrong you can throngle me and I'll go and fix it

**Changelog**
:cl:
Security role lockers:
- add: Added a seclight to the HoS locker
- tweak: changed the standard gas mask in the Warden hardsuit table to the security gas mask, matching both the sec hardsuit locekr and HoS locker
- fix: Fixed fun!

