### PR TITLE
Prevent wizards from teleporting to artifacts, anomalies, and supermatter

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_xenoartifacts.yml
@@ -38,6 +38,12 @@
         - Opaque
         mask:
         - MachineMask
+  # imp edit start
+  - type: Tag
+    tags:
+    - GhostOnlyWarp
+    - Structure
+  # imp edit end
 
 - type: entity
   parent: BaseXAEXenoArtifactStructure #IMP 'XAE' in name

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
@@ -49,9 +49,17 @@
       Flammable: [Touch]
       Extinguish: [Touch]
       Acidic: [Touch]
-  - type: WarpPoint # imp addition
-  - type: NameIdentifier # imp addition
+  # imp edit start
+  - type: WarpPoint
+    blacklist:
+      tags:
+      - GhostOnlyWarp
+  - type: Tag
+    tags:
+    - GhostOnlyWarp
+  - type: NameIdentifier
     group: Artifact
+  # imp edit end
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -58,9 +58,17 @@
     damage:
       types:
         Radiation: 10
-  - type: WarpPoint # imp addition
-  - type: NameIdentifier # imp addition
+  # imp edit start
+  - type: WarpPoint
+    blacklist:
+      tags:
+      - GhostOnlyWarp
+  - type: Tag # imp edit
+    tags:
+    - GhostOnlyWarp
+  - type: NameIdentifier
     group: Anomaly
+  # imp edit end
 
 - type: entity
   id: AnomalyPyroclastic

--- a/Resources/Prototypes/_EE/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
@@ -59,10 +59,16 @@
   - type: WarpPoint
     follow: true
     location: supermatter
+    blacklist: # imp edit
+      tags:
+      - GhostOnlyWarp
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
   - type: SupermatterImmune
+  - type: Tag # imp edit
+    tags:
+    - GhostOnlyWarp
 
 - type: entity
   parent: BaseSupermatter

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -66,8 +66,15 @@
     guides:
     - Xenoarchaeology
   - type: WarpPoint
+    blacklist:
+      tags:
+      - GhostOnlyWarp
+  - type: Tag
+    tags:
+    - GhostOnlyWarp
   - type: NameIdentifier
     group: Artifact
+
 
 - type: entity
   parent: BaseXenoArtifactItem

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -65,6 +65,13 @@
         ents: [ ]
       revolver-ammo: !type:Container # needed for the EffectBigIron artifactEffect
   - type: WarpPoint
+    blacklist:
+      tags:
+      - GhostOnlyWarp
+  - type: Tag
+    tags:
+    - GhostOnlyWarp
+    - Structure
   - type: NameIdentifier
     group: Artifact
 


### PR DESCRIPTION
The wizard teleport scroll was added since we added these warp point locations and these were lacking support to make it so only ghosts could teleport to them. This fixes that, as wizards are only meant to be able to teleport to specific locations on the station.

<img width="758" height="587" alt="yXEPi96" src="https://github.com/user-attachments/assets/d24880ef-bccc-447c-aa53-44d32174adaa" />

<img width="453" height="667" alt="5MXKIje" src="https://github.com/user-attachments/assets/0d72e6d1-b720-439d-99e8-4ef2482345ff" />

**Changelog**
:cl:
- fix: Fixed wizards being able to teleport to artifacts, anomalies, and the supermatter.

