### PR TITLE
Early merge "Remove the dynamic game mode from player votes (#39902)"

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -109,7 +109,7 @@
   - multiantag
   - director
   name: dynamic-title
-  showInVote: true
+  showInVote: false # admin-only for now until we fix some bugs
   description: dynamic-description
   rules:
   - DynamicRule


### PR DESCRIPTION
Early merges https://github.com/space-wizards/space-station-14/pull/39902, disabling dynamic from player votes. Evidently still needs a bit more cooking and we also still need to add our own antags to the dynamic pool, so this just prevents players from changing it to a gamemode that's not fully implemented yet.
