### PR TITLE
teg flow rate on examine

### DIFF
--- a/Resources/Locale/en-US/power/teg.ftl
+++ b/Resources/Locale/en-US/power/teg.ftl
@@ -1,3 +1,6 @@
 ﻿teg-generator-examine-power = It's currently supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-power-max-output = It's capable of supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-connection = To function, a [color=white]circulator[/color] must be attached on both sides.
+
+# imp add flow rate
+teg-circulator-examine-flow-rate = The flow rate meter indicates [color=lightblue]{$flowRate} L/s[/color].


### PR DESCRIPTION

<img width="716" height="433" alt="image" src="https://github.com/user-attachments/assets/b87314f2-dacb-472c-89a2-3c5bc6e5a799" />

https://github.com/user-attachments/assets/8ab2b711-186d-4014-9ea1-9161748ee556

pretty straightforward. sorry about line 182 my ide just Did That
theres currently no good way to see flow rate of a teg circulator, which makes figuring out WHY a teg isnt working pretty unintuitive. the current in game solution would be to use passive gates on either side, but thats stupid so i fix it :>

:cl:
- add: TEG circulators have been fitted with flow rate meters.
