### PR TITLE
Fix grappling and fishing rope sprites pointing directly to PNGs

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Fishing/fishing_rods.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Fishing/fishing_rods.yml
@@ -4,7 +4,7 @@
   id: FishingRodBase
   components:
     - type: FishingRod #The component that handles all the joint stuff
-      ropeSprite: _Impstation/Objects/Fishing/fishingrod.rsi/rope.png
+      ropeSprite: { sprite: _Impstation/Objects/Fishing/fishingrod.rsi, state: rope }
     - type: Gun #The component that handles the firing
       soundGunshot: /Audio/Weapons/Guns/Gunshots/harpoon.ogg
       fireRate: 0.5
@@ -62,7 +62,7 @@
       size: Ginormous
     - type: FishingRod #The component that handles all the joint stuff
       cycleSound: /Audio/Effects/Fluids/glug.ogg
-      ropeSprite: _Impstation/Objects/Fishing/fishingrod_Ling.rsi/rope.png
+      ropeSprite: { sprite: _Impstation/Objects/Fishing/fishingrod_Ling.rsi, state: rope }
       reelRate: 5
     - type: Gun #The component that handles the firing
       soundGunshot: /Audio/Effects/demon_attack1.ogg #scorpion-get_over_here.ogg

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -119,7 +119,7 @@
         path: /Audio/Weapons/pop.ogg
         params:
           pitch: .75
-      ropeSprite: _Impstation/Objects/Weapons/Guns/Launchers/grappling_gun_improvised.rsi/rope.png
+      ropeSprite: { sprite: _Impstation/Objects/Weapons/Guns/Launchers/grappling_gun_improvised.rsi, state: rope }
     - type: Gun
       soundGunshot: /Audio/Effects/thunk.ogg
       fireRate: 0.5


### PR DESCRIPTION
Noticed and upstream PR that points to this engine PR https://github.com/space-wizards/RobustToolbox/pull/6155 that will make the game throw an error if a sprite specifier is pointing directly to a PNG. This gets ahead of this issue with the sprites that I know this will cause an issue with. Not really sure how to check for other violators of this until we receive this engine PR.
