### PR TITLE
crematorium and meatspike require fullstrip

### DIFF
--- a/Resources/Locale/en-US/_Impstation/kitchen/kitchen-spike.ftl
+++ b/Resources/Locale/en-US/_Impstation/kitchen/kitchen-spike.ftl
@@ -1,0 +1,1 @@
+comp-kitchen-spike-deny-requires-strip = {CAPITALIZE(THE($victim))} can't be butchered. {CAPITALIZE(SUBJECT($victim))} must be fully stripped!

--- a/Resources/Locale/en-US/_Impstation/morgue/crematorium.ftl
+++ b/Resources/Locale/en-US/_Impstation/morgue/crematorium.ftl
@@ -1,0 +1,1 @@
+crematorium-entity-storage-component-requires-strip = {CAPITALIZE(THE($ent))}'s failsafe activates. The body inside must be fully stripped!

--- a/Resources/Locale/en-US/morgue/components/crematorium-entity-storage-component.ftl
+++ b/Resources/Locale/en-US/morgue/components/crematorium-entity-storage-component.ftl
@@ -4,8 +4,6 @@ crematorium-entity-storage-component-on-examine-details-empty = The content ligh
 crematorium-entity-storage-component-is-cooking-safety-message = Safety first, not while it's active!
 crematorium-entity-storage-component-suicide-message = You cremate yourself!
 crematorium-entity-storage-component-suicide-message-others = {$victim} is cremating {$victim}!
-#imp
-crematorium-entity-storage-component-interact-using-no-power = It has no power!
 
 # CremateVerb
 cremate-verb-get-data-text = Cremate


### PR DESCRIPTION
i've always hated that meat spikes just magically delete everything on a mob, and there's been contention in the past around the crematorium being easy round removal that also removes every piece of physical evidence alongside it. so this pr is saying No. you will Leave Evidence. ok?

has some redundant checks to make sure you can't slip an item back onto the body after starting a meat spike doafter, and there are checks for unremoveable items for decapoids/admemes. i cleaned up some crematorium stuff from #2502 as well, including deleting an unused ftl

<img width="453" height="203" alt="image" src="https://github.com/user-attachments/assets/674d761f-4f48-4df1-9763-d0af4621bd3d" />

<img width="403" height="193" alt="image" src="https://github.com/user-attachments/assets/432079b2-6e46-43df-b2bc-d9c9dfae2314" />

**Changelog**
:cl:
- tweak: The chapel's crematorium and kitchen's meat spike require mobs to be fully stripped before use.
