### PR TITLE
Fix crash when LightningResistance field of LightningTargetComponent is set to 0

### DIFF
--- a/Content.Server/Lightning/LightningSystem.cs
+++ b/Content.Server/Lightning/LightningSystem.cs
@@ -166,7 +166,7 @@ public sealed class LightningSystem : SharedLightningSystem
                 continue;
             }
 
-            if (outOfRange) { break; }
+            if (outOfRange || targetLightningResistance <= 0) { break; } //#IMP targetLightningResistance <= 0 check to fix crash
 
             var curTarget = targets[count];
             if (!_random.Prob(curTarget.Comp.HitProbability)) //Chance to ignore target


### PR DESCRIPTION
Fix crash when LightningResistance field of LightningTarget is set to 0

Note: May need to change this check when next upmerge goes through, seems to be changed on space-wizards/stable.

No CL, bugfix is not something the players will interact with.
