### PR TITLE
Security Guidebook Change

### DIFF
--- a/Resources/ServerInfo/_Impstation/Guidebook/Security/GuideToStationSecurity.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/Security/GuideToStationSecurity.xml
@@ -3,12 +3,12 @@
   <Box>[color=#999999][italic]by Davey D. Plaire, Secretary of Organic Safety Management[/italic][/color]
   </Box>
 Congratulations! You are one of the lucky few who has successfully passed through Security Academy and has entered their probationary Cadet Role! In addition to excellent benefits and executive support, you will enjoy a rich career that will take you to see the stars! We trust that you have familiarised yourself with Nanotrasen Space Law during your time at Security Academy. While much of that information is most used by your Warden and Head of Security, it is still important to be able to refer to the common crimes on the list to know what to respond to, to be familiar with what is or is not contraband, and to ALWAYS remember the rights of your prisoners!
-  
+
 But, you must be aware that there is more to being a Security Officer than your Space Law examinations have prepared you for! Allow us to take you through your new job, step by step!
 
 # Getting Started
 As a Security Officer, it’s important to familiarise yourself with your gear and equipment. Most cadets and officers are only permitted to take so much of their equipment off-station, so before you begin your patrols it’s important to ensure that you have the proper gear and know how to use it!
-  
+
 First and Foremost, remember that your Standard Issue Combat Boots come with a built-in holster that will always hold a Combat Knife! This knife will be a very useful tool during your time as an officer, but do not forget that your boots may holster Small Arms such as a pistol or disabler as well, if you so choose to do so.
 
 ## Non-Lethal Apprehension Weapons
@@ -18,15 +18,15 @@ First and Foremost, remember that your Standard Issue Combat Boots come with a b
     <GuideEntityEmbed Entity="Flash" Caption="Flash"/>
     <GuideEntityEmbed Entity="TearGasGrenade" Caption="Tear Gas Grenade"/>
   </Box>
-  
+
 Each officer comes equipped with their own Stun Baton (patent pending), and is permitted to carry one (1) Disabler on their person. They also are permitted to carry one Flash, Flash Bangs, and Tear Gas Grenades!
 
-Before using a Stun Baton, you must ensure that it is turned on! Our Stun Batons, while active, will theoretically cause no harm to the recipient, but if they are without charge or turned off, are no better than hitting your suspects with a metal rod! Please ensure your equipment is properly turned on. 
-  
+Before using a Stun Baton, you must ensure that it is turned on! Our Stun Batons, while active, will theoretically cause no harm to the recipient, but if they are without charge or turned off, are no better than hitting your suspects with a metal rod! Please ensure your equipment is properly turned on.
+
 Disablers are also useful in a pinch, and can allow you to disable perpetrators without causing any injuries! But please be aware, all Diona personnel will be burned by our non-lethal equipment!
-  
+
 With all electronic equipment, you will want to ensure they are at a full charge so you may be ready in the event of any situation! After using any of your non-lethal tools, ensure you give them a full charge at any Charging Station installed at your Security Department.
-  
+
 Your Flash will allow you to de-escalate almost any violent situation you find yourself encountering, allowing all present persons a chance to calm down and collect their bearings! Flash Bangs and Tear Gas Grenades will as well allow you to do so, but are more risky to use. Ensure you follow appropriate safety precautions, and check your angles when throwing any Non-Lethal Explosive Devices. Your standard equipment will not protect you from the effects of Tear Gas, so if you feel like your eyes are falling out of your sockets after deploying one do not worry!
 
 ## Other Tools and Equipment
@@ -48,9 +48,9 @@ Your Flash will allow you to de-escalate almost any violent situation you find y
     <GuideEntityEmbed Entity="MagazinePistol" Caption=".35 auto Pistol Magazine"/>
     <GuideEntityEmbed Entity="CombatKnife" Caption="Combat Knife"/>
   </Box>
-  
+
 	Each Officer and Cadet comes equipped with one (1) Mk 58 Service Pistol, a spare magazine, and a Combat Knife in their boots. Cadets are encouraged to remember that their Mk. 58 Service Pistol is only to be used in the events of emergencies. Your Combat Knife will serve excellently for dealing with any Pests or Creatures that may stow away on our Arrivals Shuttles and crawl through our vents. Your non-lethal equipment should be used first and foremost to apprehend any suspect, including violent ones! If all goes well, you should never have to use your pistol at all!
-  
+
 	In the event of an emergency, a Code Red Alert will be issued and all Security Officers will be permitted to use any lethal implements at their disposal to deal with the situation at hand. If you have any questions, do not hesitate to ask your superior officers!
 
 
@@ -58,34 +58,34 @@ Your Flash will allow you to de-escalate almost any violent situation you find y
 	As an officer, it’s important to know the various levels of alert a station may be under, and be prepared to act accordingly under their special circumstances.
 
 [color=#7cfc00]Green Alert[/color] - Congratulations! There are no known threats on your station and no present criminals! You may relax, patrol the halls, and socialise with any station personnel during this time without disrupting their productivity! Nanotrasen encourages all officers to get to know their crews and become familiar with their coworkers so they may best meet their needs!
-  
+
 	At this alert level, Central and Station Command have deemed that there are no Syndicate or Xenobiological Threats on the station, and therefore it is unnecessary to patrol Maintenance Tunnels, to avoid getting in the way of your highly skilled Engineers and their critical work! There is also no need to be constantly searching various hiding spots. Being on such a constant high-alert wears down on the energy and attention of our Valued Employees, and we encourage you to trust the judgement of your Command to have a relaxed patrol to ensure the safety and efficacy of your crew!
-  
+
 	To further trust the judgement of your Commanding Officers, we remind you that Security Personnel are NOT permitted to be openly carrying lethal implements, and to have your non-lethal tools secured in your belts and boots. You are also NOT permitted to search any Station Personnel without their consent.
 
 [color=#ffff00]Yellow Alert[/color] - Warning! The station has been significantly damaged and many of its departments have lost their atmosphere! At this point, the question of criminal activity is up in the air, but your highest priority is to ensure the safety of the crew. Equip a hardsuit and investigate the damaged portions with Engineering. Ensure any affected crew are pulled to safety, and keep anyone from accidentally wandering into the dangerous areas. You can also use your Portable Barrier Generators to help warn crew members of the dangers in these parts of the station!
 
 [color=#1e90ff]Blue Alert[/color] - Warning! An unknown threat has been detected on the station! A blue alert essentially means that Central Command, or your Station Command, have strong reason to believe that there is at least one malicious actor on your station. This can be learned by evidence of a crime, or Central Command has intercepted Syndicate Communications.
-  
+
 During a [color=#1e90ff]Blue Alert[/color], you need to be on your toes and ready for the unexpected! We strongly encourage officers to remain in pairs or groups and coordinate their patrols. As well, be sure to search hiding spots, such as lockers or potted plants, every so often. Doing a patrol through a maintenance tunnel now and then isn’t a bad idea either, but make sure you are with another officer as exploring those tunnels on your own can be a great risk! Also, be sure not to spend too much time there. The safety of the crew is your top priority, and being present in the main spaces is your best way to ensure it.
-  
+
 Remember that Lethals are NOT permitted for active use, and Station Procedure will otherwise run as a [color=#7cfc00]Green Alert[/color] for all Civilian Crewmembers. If a Lethal Implement is used and it is not an emergency case, expect a strong reprimand or potential loss of job.
-  
+
 You have permission to search Crew Members without consent, though searching everyone at any time is not the most productive way to protect your crew. If somebody does not permit you to search their belongings, remind them of the current alert level and proper procedure and that further refusal to cooperate is deemed as a Moderate Crime (2-00 Failure to Comply), granting you permission to apprehend them with handcuffs. In the event of such, if they have not put up violent arrest, simply proceed with the search, making sure that they are held with one hand while you search with the other so they cannot escape, and in the event no contraband is found simply let them go with a warning on their behaviour.
-  
+
 If contraband is found, bring them to the Security Department where the Warden and/or Head of Security may further investigate the issue.
 
 [color=#ee82ee]Violet Alert[/color] - Warning! A xenobiological contagion or threat has been discovered on the station! While uncommon, it is possible for the crew to be infected with a dangerous and contagious disease. In the event of such an occasion, your job is to ensure the status and safety of the crew. Make sure crew members are isolating and quarantined appropriately to reduce the risk of spread, and to ensure the elimination of any Permanently Compromised Crew Members. Be sure to be careful to not be infected yourself! All known xenocontagions contract through blood or fluid exchange, so hard suits or internals will not be necessary.
 In the event of an emergency, such as a massive outbreak, refer to the Chief Medical Officer, Head of Security and Warden for further instruction. This may include arming yourselves with protective weaponry to ensure the survival of yourself and any unaffected crew, or calling in a Burn Squad from Central Command.
 
 [color=#ff0000]Red Alert[/color] - Danger! A violent threat has been detected on the station, threatening the safety of the entire crew and/or the station itself! While we have little intel on what these threats could possibly be, as our company research has ensured the insignificant to impossible possibility of this alert level needing to be triggered, we still must ensure our security crews are  well prepared for the event of this occurrence!
-  
+
 Ensure all crew members are secured in their departments and nobody is present in public spaces! This is not a suggestion and MUST be enforced. Non-compliance is to be treated as a moderate crime, however you cannot waste time processing crimes in the event of a dire emergency!
-  
+
 Report immediately to your Security Department and proceed to suit yourself up with any equipment your Head of Security and/or Commanding Officer has deemed appropriate for the situation. Do so quickly and efficiently, any time wasted in the Department equipping yourself puts the station at unnecessary risk! Once equipped, respond to the threat in the manner your Commanding Officer has deemed most effective, and remember your combat training!
 
 # Searching a Crew Member
-In order to conduct a proper search, you must investigate all of their belongings, and put them down next to you once you have done so instead of returning them to the prisoner. Be absolutely sure you have:
+In order to conduct a proper search, the crew member must not be actively dying, and you must investigate all of their belongings, and put them down next to you once you have done so instead of returning them to the prisoner. Be absolutely sure you have:
 - Searched their backpack
 - Searched any belt
 - Searched their pockets
@@ -93,7 +93,7 @@ In order to conduct a proper search, you must investigate all of their belonging
 - Searched their boots, if any
 - Searched a large hat, if any
 - Checked their PDA for any malicious software
-  
+
     <Box>
     <GuideEntityEmbed Entity="ClothingBackpack" Caption=""/>
     <GuideEntityEmbed Entity="ClothingBeltUtility" Caption=""/>
@@ -102,22 +102,22 @@ In order to conduct a proper search, you must investigate all of their belonging
     <GuideEntityEmbed Entity="ClothingHeadHatMagician" Caption=""/>
     <GuideEntityEmbed Entity="PassengerPDA" Caption=""/>
   </Box>
-  
+
 Once a search is complete, return their items to them if done so in a public area. If done in the Security Department, ensure their belongings are organised and kept in one place so that any items that are not contraband and confiscated will not be lost and may be retrieved by the prisoner upon their release.
-  
+
 If a PDA is found to contain malicious software not approved by Nanotrasen, eject their Identification and confiscate the PDA. Your local Head of Personnel, or commanding officer, will then issue them a new PDA.
 
 
 # Arresting and Processing Perpetrators
 
 With sufficient evidence, you may find yourself arresting individuals who have violated Space Law. Congratulations! You have done your job! But, you need to be aware of the proper procedures when doing so.
-	
+
 Warning your Suspect - any suspect who will be put under arrest must be first informed they are under arrest. If you do not have time to stop and say something, use your whistle first to get their attention. If they comply, put them in cuffs and take them to the station for processing.
 
 Non-Compliance - A suspect who does not cooperate will be additionally guilty of Non-Compliance on top of any crime they are being accused of. If they will not allow you to place cuffs, or are actively fleeing the scene, use your non-lethal implements to apprehend the suspect so you may put them in cuffs and bring them back for processing.
 
 Arresting your Suspect - Before you bring your suspect to the Security Department, you must first assess their health. If the suspect became injured during or before their apprehension, it is your OBLIGATION to first bring them to the Medical Department so they may be treated. They will remain cuffed during the entire procedure and you will remain by their side the entire time. Once this is complete, bring them directly to the Security Department. Keeping a suspect held for an unnecessary amount of time will not be tolerated, and you must ensure you are doing everything you can to get your detainee to their destination as efficiently as possible.
-  
+
 Once more we encourage officers to work in pairs or teams, so one may bring a detainee to their destination while the other ensures any dangerous equipment or evidence left behind at the scene of a crime may be dealt with. Leaving contraband behind, out in the open, is simply irresponsible! But, if your team is severely understaffed, prioritise the prisoner and what needs to be done with them above any contraband left behind if you are unable to bring it all with you.
 
 Processing your Suspect - Once you have brought your suspect to the Department, conduct a search of their belongings if you have not yet done so. Remember that if you have a suspect convicted of strong evidence towards crimes that a public risk where you are confident there will be dangerous contraband is a great risk of those items being taken by a passer-by, so be sure to conduct your search at the Department instead.

--- a/Resources/ServerInfo/_Impstation/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -21,6 +21,8 @@
   ## Search and Seizure
   A [italic]personnel search[/italic] is a seizure of the objects in a person's backpack, hands, coat, belt, and pockets. If any [color=red]contraband items[/color] are found during a search, the officer may choose to either further the search into a detainment, or simply confiscate the restricted items. After the search is conducted, all legal items are to be returned to the person.
 
+  A search must not be done if the suspect being searched is actively dying, bring the suspect to receive medical care as soon as you can.
+
   A crewmate may decline any search conducted without a warrant while the alert level is [color=#7cfc00]Code Green[/color]. If the alert level is [color=#0000bb]Code Blue[/color] or above, personnel searches cannot be declined.
 
   A [italic]departmental search[/italic] is the sweep of an entire area or department for contraband. It is recommended that the officers be extremely thorough: checking all lockers, crates, and doors. These can only be done with permission or, ideally, a warrant signed by the department head or highest-ranking Command staff, which in most cases is the [color=#1b67a5]Captain[/color].


### PR DESCRIPTION
This change clarifies and adds extra stipulations.
- You should not under any circumstance search someone if they're actively dying.

**Why?**

Personally, I find it baffling when security officers choose to search detainees when they're actively dying
With offmed coming soon dying is RR, and security officers should attempt to keep people alive.

**Changelog**
:cl:
- tweak: Search and Seizure guidelines have been altered in the guidebook. Security Officers should reread relevant sections in the guidebook.