### PR TITLE
Fix natural artifact salvage magnet trigger throwing error

### DIFF
--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMagnetTriggerSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMagnetTriggerSystem.cs
@@ -69,7 +69,8 @@ public sealed class ArtifactMagnetTriggerSystem : EntitySystem
             if (distance > artifact.Range)
                 continue;
 
-            _toActivate.Add(uid);
+            if (HasComp<ArtifactComponent>(uid))
+                _toActivate.Add(uid);
         }
 
         foreach (var a in _toActivate)


### PR DESCRIPTION
Natural artifact magnet trigger (when triggered by salvage magnet) did not check to make sure that the entity that had ArtifactMagnetTriggerComponent actually had artifact component. This could result in an error if the artifact component was removed (e.g by an admin) without touching the magnet trigger component. Fixed. No CL because not player-facing.
