### PR TITLE
Update service techfab to work with materials silos and use recipe unlock announcements

### DIFF
--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -102,13 +102,13 @@
   - type: Contraband
     allowedDepartments: [ Medical ]
 
-- type: entity
-  id: BaseServiceContraband #imp edit
-  parent: BaseRestrictedContraband
-  abstract: true
-  components:
-  - type: Contraband
-    allowedDepartments: [ Service ] #imp edit
+#- type: entity #imp edit, use BaseServiceContraband or job-specific contrabands instead
+#  id: BaseCivilianContraband
+#  parent: BaseRestrictedContraband
+#  abstract: true
+#  components:
+#  - type: Contraband
+#    allowedDepartments: [ Civilian ]
 
 - type: entity
   id: BaseCargoContraband

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -11,7 +11,7 @@
 
 - type: entity
   id: ServiceTechFabCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseServiceContraband ]
   name: service techfab machine board
   description: A machine printed circuit board for a Service techfab.
   components:
@@ -60,7 +60,7 @@
       Glass: 1
 
 - type: entity
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseCommandContraband ]
   id: PortableCutterMachineCircuitboard
   name: portable cutter machine board
   description: A machine printed circuit board for a portable cutter machine.

--- a/Resources/Prototypes/_Impstation/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/base_contraband.yml
@@ -1,4 +1,12 @@
 - type: entity
+  id: BaseServiceContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Service ]
+
+- type: entity
   id: BaseRestrictedLawyerContraband
   parent: BaseRestrictedContraband
   abstract: true

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ServiceTechFab
-  parent: BaseLatheLube
+  parent: [ BaseLatheLube, BaseServiceContraband ]
   name: service techfab
   description: Produces supplies useful for the service crew.
   components:
@@ -51,6 +51,9 @@
         - Sheet
         - RawMaterial
         - Ingot
+  - type: OreSiloClient
+  - type: LatheAnnouncing
+    channels: [ Service ]
 
 - type: entity
   id: PortableCutterMachine


### PR DESCRIPTION
Title, service techfab hasn't been update since these were added. Additionally, marks it and its circuitboard as service contraband, marks the HD portable cutter machine board as command contraband, and moves the service contraband entity to our namespace.

**Changelog**

:cl:
- add: The service techfab can now be linked to material silos and will announce on service comms when new recipes are available from unlocked research technologies.

