### PR TITLE
delete effect on pulp

### DIFF
--- a/Resources/Prototypes/_Impstation/Reagents/fun.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/fun.yml
@@ -337,9 +337,3 @@
       - !type:AdjustReagent #imp
         reagent: Cellulose
         amount: 0.5
-      - !type:ModifyBleedAmount
-        amount: 1
-        conditions:
-        - !type:OrganType
-          type: Moth
-          shouldHave: false


### PR DESCRIPTION
Pulp doesn't make you bleed anymore since wood and cardboard are not edible once again

**Changelog**
:cl:
- remove: Pulp no longer makes non-moths bleed