### PR TITLE
Fix manifest hidden departments appearing on crew monitoring console

### DIFF
--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -344,7 +344,8 @@ public abstract class SharedSuitSensorSystem : EntitySystem
             userJobIcon = card.Comp.JobIcon;
 
             foreach (var department in card.Comp.JobDepartments)
-                userJobDepartments.Add(Loc.GetString(_proto.Index(department).Name));
+                if (!_proto.Index(department).ManifestHidden) // imp edit, ignore departments that are manifest hidden
+                    userJobDepartments.Add(Loc.GetString(_proto.Index(department).Name));
         }
 
         // get health mob state


### PR DESCRIPTION
This was originally implemented in https://github.com/impstation/imp-station-14/pull/2066 and it looks like this got eaten in the previous upstream merge when suit sensors were made predicted.

<img width="542" height="141" alt="ev5tlsP" src="https://github.com/user-attachments/assets/8cc689b3-3e88-44f3-8623-1ff988052d60" />


**Changelog**
:cl:
- fix: Station Specific and Dining Services departments are now properly hidden from the crew monitoring console once again.
