### PR TITLE
Remove the last line from the ahelp disclaimer

### DIFF
--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -10,7 +10,8 @@ bwoink-system-introductory-message =
     Please describe the issue that you have encountered in detail. Assume that the game administrator who is resolving the problem does not have first-hand knowledge of what has occurred.
     Please do not ask for special events or punishments for other players.
     Any bugs and other related issues should be reported through Discord or Github.
-    Misuse of this message system may result in disciplinary action.
+    
+#imp edit, delete last line, previously was "Misuse of this message system may result in disciplinary action."
 
 bwoink-system-typing-indicator = {$players} {$count ->
 [one] is


### PR DESCRIPTION
previously, the ahelp box had a disclaimer that said that misuse could lead to disciplinary action. this is true, but also it already tells you what not to do and it seems kind of obvious anyway. i'm removing it specifically because at least one player has said that the line had discouraged them from ahelping, which runs counter to our "ahelp anything and everything" philosophy.

also that last line bumped the top line off the screen, which annoys me cause that first line is the most important one.

<img width="502" height="295" alt="image" src="https://github.com/user-attachments/assets/008bc554-c36e-4f4b-9c68-28debd7a4f6e" />

