### PR TITLE
Fix kill or maroon objective always being green.

### DIFF
--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -49,6 +49,27 @@ public sealed class KillPersonConditionSystem : EntitySystem
             requireMaroon = false;
         }
 
+        //#IMP KILL OR MAROON
+        if (!requireDead && !requireMaroon)
+        {
+            if (targetDead)
+                return 1f;
+            if (_config.GetCVar(CCVars.EmergencyShuttleEnabled))
+            {
+                // Always failed if the target needs to be marooned and the shuttle hasn't even arrived yet
+                if (!_emergencyShuttle.EmergencyShuttleArrived)
+                    return 0f;
+
+                // If the shuttle hasn't left, give 50% progress if the target isn't on the shuttle as a "almost there!"
+                if (!_emergencyShuttle.ShuttlesLeft)
+                    return targetMarooned ? 0.5f : 0f;
+
+                // If the shuttle has already left, and the target isn't on it, 100%
+                if (_emergencyShuttle.ShuttlesLeft)
+                    return targetMarooned ? 1f : 0f;
+            }
+        }//#IMP END IMP SECTION FOR KILL OR MAROON
+
         if (requireDead && !targetDead)
             return 0f;
 


### PR DESCRIPTION
Fix kill or maroon objective always being green.

:cl:
- Fix: Kill or maroon objective has stopped being a "yes man" and always saying you succeeded
