### PR TITLE
Xenoarch fixes & tweaks sep 2025

### DIFF
--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
@@ -50,8 +50,8 @@ public sealed class XAEPortalSystem : BaseXAESystem<XAEPortalComponent>
         if(!TrySpawnNextTo(ent.Comp.PortalProto, target, out var secondPortal))
             return;
 
-        // Manual position swapping, because the portal that opens doesn't trigger a collision, and doesn't teleport targets the first time.
-        _transform.SwapPositions(target, args.Artifact.Owner);
+        //#IMP NO LONGER NEEDED(but i'm leaving it in commented in case how portals work changes and we need it again)  // Manual position swapping, because the portal that opens doesn't trigger a collision, and doesn't teleport targets the first time.
+        //#IMP NO LONGER NEEDED  _transform.SwapPositions(target, args.Artifact.Owner);
 
         _link.TryLink(firstPortal.Value, secondPortal.Value, true);
     }

--- a/Content.Server/_Impstation/Xenoarchaeology/Equipment/Systems/OldArtifactAnalyzerSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/Equipment/Systems/OldArtifactAnalyzerSystem.cs
@@ -221,7 +221,7 @@ public sealed class ArtifactAnalyzerSystem : EntitySystem
                         if (Transform(current).Coordinates.TryDistance(EntityManager, Transform((EntityUid)component.AnalyzerEntity).Coordinates, out var distance))
                         {
                             if (distance < 2) //Hardcoded distance because i am not dealing with collison checks
-                               canScan = true;
+                                canScan = true;
                         }
                     }
                 }

--- a/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/PortalArtifactSystem.cs
+++ b/Content.Server/_Impstation/Xenoarchaeology/XenoArtifacts/Effects/Systems/PortalArtifactSystem.cs
@@ -45,8 +45,8 @@ public sealed class PortalArtifactSystem : EntitySystem
 
         var secondPortal = Spawn(artifact.Comp.PortalProto, _transform.GetMapCoordinates(target));
 
-        //Manual position swapping, because the portal that opens doesn't trigger a collision, and doesn't teleport targets the first time.
-        _transform.SwapPositions(target, artifact.Owner);
+        //No longer needed-> //Manual position swapping, because the portal that opens doesn't trigger a collision, and doesn't teleport targets the first time.
+        //_transform.SwapPositions(target, artifact.Owner);
 
         _link.TryLink(firstPortal, secondPortal, true);
     }

--- a/Resources/Prototypes/_Impstation/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/_Impstation/XenoArch/Effects/normal_effects.yml
@@ -1145,7 +1145,7 @@
 - type: artifactEffect
   id: EffectGridKnockdown
   targetDepth: 4
-  effectHint: artifact-effect-hint-environment
+  effectHint: artifact-effect-hint-stationwide-disruption
   effectProb: 0.6
   components:
   - type: SpawnArtifact

--- a/Resources/Prototypes/_Impstation/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/_Impstation/XenoArch/artifact_triggers.yml
@@ -124,7 +124,7 @@
   triggerHint: artifact-trigger-hint-expression
   components:
   - type: ArtifactExpressionTrigger
-    range: 4
+    range: 7
 
 - type: artifactTrigger
   id: TriggerMedical
@@ -249,7 +249,7 @@
   triggerHint: artifact-trigger-hint-expression
   components:
   - type: ArtifactExpressionTrigger
-    range: 3
+    range: 6
 
 # Separate drinks into twenty chunks. one chunk has a total probability of 1/20, so all drinks together have same prob as normal trigger
 # Some Chunks have multiple drinks (such as the tricky drink chunk)


### PR DESCRIPTION
Fixed error on hint for gridwide knockdown: "Environmental disruption" -> "stationwide disruption"
Fixed artifact portals not teleporting the target and artifact
Increased range of expression trigger
Fix the "Blink" effect making pad think its still got an artifact on it

:cl:
- tweak: Xenoarch - tweak expression trigger range
- fix: Xenoarch - fix a missing hint
- fix: Xenoarch - fix artifacts not going through their own portals
- fix: Xenoarch - fix teleporting artifacts not saying goodbye to the artifact analyzer

