### PR TITLE
Runtime and Shiva no longer detect Initial Infected

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -91,7 +91,7 @@ namespace Content.Server.Zombies
         private void OnPendingMapInit(EntityUid uid, IncurableZombieComponent component, MapInitEvent args)
         {
             _actions.AddAction(uid, ref component.Action, component.ZombifySelfActionPrototype);
-            _faction.AddFaction(uid, Faction);
+            //_faction.AddFaction(uid, Faction); #IMP We have our own II not attacked by zombies, and this makes II attacked by station pets.
 
             if (HasComp<ZombieComponent>(uid) || HasComp<ZombieImmuneComponent>(uid))
                 return;


### PR DESCRIPTION
3 months ago upstream made their own 'fix' for zombies attacking II... by giving II the zombie faction. Shiva and Runtime attack things with the Zombie faction. I made my own fix for it way before upstream, but I didn't upstream it so its sort of on me. Anyway, fixed now.

:cl:
- fix: Shiva and Runtime can no longer sense zombie infections in initial infected (attacked IIs on sight)