### PR TITLE
syndicate shuttle pilot shouldn't sleep

### DIFF
--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -58,5 +58,6 @@ public sealed partial class SSDIndicatorComponent : Component
     /// #IMP used to disable the SSD sleeping, for NPCs such as syndicate footsoldiers, etc
     /// </summary>
     [AutoNetworkedField]
+    [DataField]
     public bool DoNotSleep = false;
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -53,4 +53,10 @@ public sealed partial class SSDIndicatorComponent : Component
     /// </summary>
     [AutoNetworkedField]
     public bool HasHadPlayer;
+
+    /// <summary>
+    /// #IMP used to disable the SSD sleeping, for NPCs such as syndicate footsoldiers, etc
+    /// </summary>
+    [AutoNetworkedField]
+    public bool DoNotSleep = false;
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -84,6 +84,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         {
             // Forces the entity to sleep when the time has come
             if (!ssd.IsSSD
+                || ssd.DoNotSleep //#IMP npcs shouldn't fall asleep
                 || ssd.NextUpdate > curTime
                 || ssd.FallAsleepTime > curTime
                 || TerminatingOrDeleted(uid))

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -68,6 +68,9 @@
   name: syndicate shuttle pilot
   parent: MobSyndicateFootsoldier
   id: MobSyndicateFootsoldierPilot
+  components: #IMP SSD no sleeping
+    - type: SSDIndicator
+      doNotSleep: true
 
 - type: entity
   parent: BaseMobHuman

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/salvage.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/salvage.yml
@@ -4,6 +4,8 @@
   id: MobRadioGuard
   description: "Product of Cybersun Cloning technology, this Syndicate puppet-guard is tasked with protecting the outpost. They will throw their life away to defend their objective."
   components:
+    - type: SSDIndicator #IMP do not sleep on the job, guard
+      doNotSleep: true
     - type: NpcFactionMember
       factions:
         - Syndicate

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/mindlessclones/basemindlessclone.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/mindlessclones/basemindlessclone.yml
@@ -171,6 +171,7 @@
         Blunt: 5
   - type: SleepEmitSound
   - type: SSDIndicator
+    doNotSleep: true
   - type: StandingState
   - type: Dna
   - type: MindContainer


### PR DESCRIPTION
Disable SSD sleep for syndicate shuttle pilot (from the salv static), listening post guards, and mindless clones, this can also be applied to other NPCs that we don't want sleeping.

:cl:
- fix: Syndicate Shuttle Pilots and listening post guards have been woken up (also mindless clones won't fall asleep)