### PR TITLE
Thrown Item Spin Behavior Port

### DIFF
--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -28,6 +28,11 @@ public sealed class ThrowingSystem : EntitySystem
 
     private const float TileFrictionMod = 1.5f;
 
+    // ES START
+    public const float ESThrowSpinStep = 4f;
+
+    // ES END
+
     private float _frictionModifier;
     private float _airDamping;
 
@@ -184,7 +189,15 @@ public sealed class ThrowingSystem : EntitySystem
         {
             if (physics.InvI > 0f && (!TryComp(uid, out throwingAngle) || throwingAngle.AngularVelocity))
             {
-                _physics.ApplyAngularImpulse(uid, ThrowAngularImpulse / physics.InvI, body: physics);
+                // ES START
+                // We step the amount of 'full spins' according to distance
+                // less than 4m we dont want to spin at all, then 1 more full spin each 4 more
+                // this is so we can normalize the rotation to 0 at the end of the throw without it looking weird
+                // (we want to avoid arbitrarily rotated items where possible for readability reasons)
+                var spins = MathF.Floor(direction.Length() / ESThrowSpinStep);
+                if (spins > 0)
+                    _physics.ApplyAngularImpulse(uid, spins * MathF.Tau / (flyTime * physics.InvI), body: physics);
+                // ES END
             }
             else
             {

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -25,6 +25,9 @@ namespace Content.Shared.Throwing
         [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
+        // ES START
+        [Dependency] private readonly SharedTransformSystem _transform = default!;
+        // ES END
 
         private const string ThrowingFixture = "throw-fixture";
 
@@ -125,6 +128,11 @@ namespace Content.Shared.Throwing
             // Assume it's uninteresting if it has no thrower. For now anyway.
             if (thrownItem.Thrower is not null)
                 _adminLogger.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(uid):entity} thrown by {ToPrettyString(thrownItem.Thrower.Value):thrower} landed.");
+
+            // ES START
+            _transform.SetLocalRotation(uid, Angle.Zero);
+            _physics.SetAngularVelocity(uid, 0f, body: physics);
+            // ES END
 
             _broadphase.RegenerateContacts((uid, physics));
             var landEvent = new LandEvent(thrownItem.Thrower, playSound);


### PR DESCRIPTION
This PR tweaks the behavior of items when thrown, so that they almost always land naturally, facing 0 degrees.
This behavior is ported from https://github.com/EphemeralSpace/ephemeral-space/pull/116, with minor changes to retain the usual amount of friction items have when thrown. 
Credit to https://github.com/mirrorcult for the initial PR.
It isn't 100% perfect, as seen in the video items SOMETIMES land horizontally, but it works well enough.

## Why / Balance
Readability. I personally think it looks better.

## Technical details
Minor tweaks to ThrowingSystem and ThrownItemSystem.

## Media
Old Behavior:
https://github.com/user-attachments/assets/d44533f1-0fe0-4b04-9362-a5fe0f3daf4b

New Behavior:
https://github.com/user-attachments/assets/5ea434dd-8bcc-4d69-94c4-d0f604da7164

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Thrown items now land gracefully.
