### PR TITLE
hide behind plants with this one weird trick

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -59,6 +59,12 @@
   components:
   - type: Sprite
     state: applebush #whoever named this texture in the rsi sucks
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: applebush
+      right:
+      - state: applebush
 
 - type: entity
   id: PottedPlant1
@@ -66,6 +72,12 @@
   components:
   - type: Sprite
     state: plant-01
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-01
+      right:
+      - state: plant-01
 
 - type: entity
   id: PottedPlant2
@@ -73,6 +85,12 @@
   components:
   - type: Sprite
     state: plant-02
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-02
+      right:
+      - state: plant-02
 
 - type: entity
   id: PottedPlant3
@@ -80,6 +98,12 @@
   components:
   - type: Sprite
     state: plant-03
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-03
+      right:
+      - state: plant-03
 
 - type: entity
   id: PottedPlant4
@@ -87,6 +111,12 @@
   components:
   - type: Sprite
     state: plant-04
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-04
+      right:
+      - state: plant-04
 
 - type: entity
   id: PottedPlant5
@@ -94,6 +124,12 @@
   components:
   - type: Sprite
     state: plant-05
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-05
+      right:
+      - state: plant-05
 
 - type: entity
   id: PottedPlant6
@@ -101,6 +137,12 @@
   components:
   - type: Sprite
     state: plant-06
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-06
+      right:
+      - state: plant-06
 
 - type: entity
   id: PottedPlant7
@@ -108,6 +150,12 @@
   components:
   - type: Sprite
     state: plant-07
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-07
+      right:
+      - state: plant-07
 
 - type: entity
   id: PottedPlant8
@@ -115,6 +163,12 @@
   components:
   - type: Sprite
     state: plant-08
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-08
+      right:
+      - state: plant-08
 
 - type: entity
   id: PottedPlantBioluminscent #PottedPlant9 but i didn't want map conflicts
@@ -127,6 +181,12 @@
   - type: PointLight
     radius: 2
     color: "#2cb2e8"
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-09
+      right:
+      - state: plant-09
 
 - type: entity
   id: PottedPlant10
@@ -135,6 +195,12 @@
   components:
   - type: Sprite
     state: plant-10
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-10
+      right:
+      - state: plant-10
 
 - type: entity
   id: PottedPlant11
@@ -142,6 +208,12 @@
   components:
   - type: Sprite
     state: plant-11
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-11
+      right:
+      - state: plant-11
 
 - type: entity
   id: PottedPlant12
@@ -149,6 +221,12 @@
   components:
   - type: Sprite
     state: plant-12
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-12
+      right:
+      - state: plant-12
 
 - type: entity
   id: PottedPlant13
@@ -156,6 +234,12 @@
   components:
   - type: Sprite
     state: plant-13
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-13
+      right:
+      - state: plant-13
 
 - type: entity
   id: PottedPlant14
@@ -163,6 +247,12 @@
   components:
   - type: Sprite
     state: plant-14
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-14
+      right:
+      - state: plant-14
 
 - type: entity
   id: PottedPlant15
@@ -170,6 +260,12 @@
   components:
   - type: Sprite
     state: plant-15
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-15
+      right:
+      - state: plant-15
 
 - type: entity
   id: PottedPlant16
@@ -177,6 +273,12 @@
   components:
   - type: Sprite
     state: plant-16
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-16
+      right:
+      - state: plant-16
 
 - type: entity
   id: PottedPlant17
@@ -184,6 +286,12 @@
   components:
   - type: Sprite
     state: plant-17
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-17
+      right:
+      - state: plant-17
 
 - type: entity
   id: PottedPlant18
@@ -191,6 +299,12 @@
   components:
   - type: Sprite
     state: plant-18
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-18
+      right:
+      - state: plant-18
 
 - type: entity
   id: PottedPlant19
@@ -198,6 +312,12 @@
   components:
   - type: Sprite
     state: plant-19
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-19
+      right:
+      - state: plant-19
 
 - type: entity
   id: PottedPlant20
@@ -205,6 +325,12 @@
   components:
   - type: Sprite
     state: plant-20
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-20
+      right:
+      - state: plant-20
 
 - type: entity
   id: PottedPlant21
@@ -212,6 +338,12 @@
   components:
   - type: Sprite
     state: plant-21
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-21
+      right:
+      - state: plant-21
 
 - type: entity
   id: PottedPlant22
@@ -219,6 +351,12 @@
   components:
   - type: Sprite
     state: plant-22
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-22
+      right:
+      - state: plant-22
 
 - type: entity
   id: PottedPlant23
@@ -226,6 +364,12 @@
   components:
   - type: Sprite
     state: plant-23
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-23
+      right:
+      - state: plant-23
 
 - type: entity
   id: PottedPlant24
@@ -233,6 +377,12 @@
   components:
   - type: Sprite
     state: plant-24
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-24
+      right:
+      - state: plant-24
 
 - type: entity
   id: PottedPlantRD #PottedPlant25
@@ -244,6 +394,12 @@
     state: plant-25
   - type: StealTarget
     stealGroup: PlantRD
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-25
+      right:
+      - state: plant-25
 
 - type: entity
   id: PottedPlant26
@@ -252,6 +408,12 @@
   components:
   - type: Sprite
     state: plant-26
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-26
+      right:
+      - state: plant-26
 
 #these are all the plastic plants. They inherit from the first one because they don't have
 #enough differences to warrant getting a unique abstract prototype. It's just the name and description.
@@ -263,6 +425,12 @@
   components:
   - type: Sprite
     state: plant-27
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-27
+      right:
+      - state: plant-27
 
 - type: entity
   id: PottedPlant28
@@ -270,6 +438,12 @@
   components:
   - type: Sprite
     state: plant-28
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-28
+      right:
+      - state: plant-28
 
 - type: entity
   id: PottedPlant29
@@ -277,6 +451,12 @@
   components:
   - type: Sprite
     state: plant-29
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-29
+      right:
+      - state: plant-29
 
 - type: entity
   id: PottedPlant30
@@ -284,3 +464,9 @@
   components:
   - type: Sprite
     state: plant-30
+  - type: Item # imp
+    inhandVisuals:
+      left:
+      - state: plant-30
+      right:
+      - state: plant-30


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
changed all the inhands for potted plants to be the same as their normal sprite so you can pick up a potted plant to hide behind it

## Why / Balance
funny


## Media

https://github.com/user-attachments/assets/4f8e078c-6c09-4f00-9eaa-b3495ac50eb6


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: qwat, hivehum
- tweak: Pick up a potted plant to hide behind it.
