### PR TITLE
Ouroboros works again

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/ouroborosbolt.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/ouroborosbolt.yml
@@ -28,11 +28,7 @@
   - type: SpawnOnTrigger
     keysIn:
     - trigger
-    keyOut: delete
     proto: MobBeeroboros
-  - type: DeleteOnTrigger
-    keysIn:
-    - delete
   - type: Projectile
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:


### PR DESCRIPTION
## About the PR
Updated the Ouroboros shots to work with the new trigger systems from upstream.

## Why / Balance
The trigger refactor had broken the old prototype so it needed to be redone to work in the new system.

## Technical details
It's all YAML. I had to put appropriate keysIn and keyOut inputs on the trigger events so that they sequenced appropriately. If there are multiple trigger conditions occurring on a prototype the intention is to make liberal use of these so the prototype knows what order everything works in. The words used for the keysIn and keyOut entries don't need to be anything specific, they just need to be consistent within the same prototype as these triggers refer to each other.

## Media

https://github.com/user-attachments/assets/705234be-25bd-441a-94e7-b6c52a94b8b6


## Requirements
- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: The Ouroboros works again so you should be fining shooting bees and BROS at your besties
