### PR TITLE
Fix missing comment bookend in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 <!-- Summary of code changes for easier review. -->
 
 ## Media
-<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
+<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
 
 ## Requirements
 <!-- Confirm the following by placing an X in the brackets [X]: -->


### PR DESCRIPTION
The comment bookend (is this what you call it?) after the media section was missing, this should fix that.
