### PR TITLE
Kill organs + brains bounty in prep for offmed

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -236,16 +236,16 @@
       tags:
       - Lime
 
-- type: cargoBounty
-  id: BountyLung
-  reward: 2000
-  description: bounty-description-lung
-  entries:
-  - name: bounty-item-lung
-    amount: 3
-    whitelist:
-      components:
-      - Lung
+# - type: cargoBounty
+#   id: BountyLung
+#   reward: 2000
+#   description: bounty-description-lung
+#   entries:
+#   - name: bounty-item-lung
+#     amount: 3
+#     whitelist:
+#       components:
+#       - Lung
 
 - type: cargoBounty
   id: BountyMonkeyCube


### PR DESCRIPTION
## About the PR
Organs and brains bounty is gone.

## Why / Balance
With offmed nearly here, it will no longer be possible to gib someone, and therefore take the brains or organs of a salvage corpse (or crew corpse, if folks were feeling spicy). This makes the organs and lungs bounties impossible, and brains nearly impossible. This PR removes them from the pool. Please see the offbrand medical thread on discord for further discussion and reasoning behind this change.

## Technical details
Does not depend on any offmed code, literally just commenting out the bounties in question.

## Requirements
- [ ] I have read and am following the Pull Request and Changelog Guidelines. 
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Offmed will obsolete the brain, organs and lungs cargo bounties, so we've removed them. (If you have any ideas for new bounties to replace them, there's a discord thread where you can suggest them!)