### PR TITLE
Guarantee the portable cutter machine's machine board drops if the machine is broken

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Machines/lathe.yml
@@ -88,6 +88,19 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+  - type: Destructible #edited to bypass the 200 damage threshold in MachineFrame, which would destroy the contents of the machine frame
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 150 #made a little more durable than normal machines
+      behaviors: #this behavior mimics the 100 damage threshold in MachineFrame, making it turn into an emptied machine frame, spawning its contents the ground
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:ChangeConstructionNodeBehavior
+        node: missingWires
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: Machine
     board: PortableCutterMachineCircuitboard
   - type: MaterialStorage


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
Modified the destruction behavior of the portable cutter machine so that it reverts to the emptied machine frame construction node when it takes 150 damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The standard behavior for lathes when they take 100 damage is to revert to a filled machine frame, which has a behavior to delete all of its contents if it takes 200 damage, in the event it takes an excessive damage all at once. Since you can only ever have one cutter machine board in a round, this makes it possible to permanently lose it without any backup if it takes enough damage from something like an exploding C4, which can feel bad for the HD and any thieves that have it as a target. This bypasses the possibility of the cutter machine reverting into a filled machine frame and then immediately taking enough damage to fully delete itself.

## Technical details
<!-- Summary of code changes for easier review. -->
Edited portable cutter machine's Destructable triggers to mimic the 100 damage threshold in the MachineFrame prototype, which turns it into an empty machine frame and spits out its construction components. This triggers at 150 damage, since I thought it would be appropriate to make it a bit more durable than normal machines.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/64f426d3-22d0-4241-858c-bfbad57a4834

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: The HD's portable cutter machine is now a bit more durable and is guaranteed to drop its machine board when destroyed.

