### PR TITLE
material composition examine

### DIFF
--- a/Content.Shared/_Impstation/MaterialExamine/MaterialExamineSystem.cs
+++ b/Content.Shared/_Impstation/MaterialExamine/MaterialExamineSystem.cs
@@ -1,0 +1,56 @@
+﻿using System.Text;
+using Content.Shared.Examine;
+using Content.Shared.Materials;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Impstation.MaterialExamine;
+
+public sealed class MaterialExamineSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PhysicalCompositionComponent, ExaminedEvent>(OnExamine);
+    }
+
+    private string ConstructMaterialList(PhysicalCompositionComponent component)
+    {
+        var text = new StringBuilder();
+
+        var index = 0;
+        foreach (var (id, amount) in component.MaterialComposition)
+        {
+            // this sucks and i hate it but i dont know any other way to do it <3
+            if (index > 0 && component.MaterialComposition.Count > 2)
+                text.Append(",");
+
+            text.Append(" ");
+
+            if (index == component.MaterialComposition.Count - 1 && component.MaterialComposition.Count > 1)
+                text.Append("and ");
+
+            if (!_prototypeManager.TryIndex<MaterialPrototype>(id, out var proto))
+                continue;
+
+            text.Append("[color=" + proto.Color.ToHex() + "]" + Loc.GetString(proto.Name) + "[/color]");
+            index++;
+        }
+
+        return text.ToString();
+    }
+
+    private void OnExamine(EntityUid uid, PhysicalCompositionComponent component, ExaminedEvent args)
+    {
+        if (component.MaterialComposition.Count == 0)
+            return;
+
+        // you dont need to be told the plastic is made out of plastic
+        if (HasComp<MaterialComponent>(uid))
+            return;
+
+        args.PushMarkup(Loc.GetString("material-examine", ("target", uid), ("materials", ConstructMaterialList(component))));
+    }
+}

--- a/Resources/Locale/en-US/_Impstation/materials/material-examine.ftl
+++ b/Resources/Locale/en-US/_Impstation/materials/material-examine.ftl
@@ -1,0 +1,1 @@
+﻿material-examine = {CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} made out of{$materials}.


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
When you examine something with a material composition it now tells you what that object is composed of.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I feel like it makes sense for the average guy to be able to tell if something is made out of steel or plastic or glass or whatever

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a new system `MaterialExamineSystem` that gets the ID of each material an entity is composed of and gets its name and color, then does some hacky shit to order them, and colors them.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="394" height="142" alt="image" src="https://github.com/user-attachments/assets/4d1393e6-aa23-4c03-9c27-b135520ff2b0" />
<img width="306" height="112" alt="image" src="https://github.com/user-attachments/assets/22ad58db-b549-488b-a20a-6157c16df726" />
<img width="405" height="115" alt="image" src="https://github.com/user-attachments/assets/941b1276-1dbf-490d-976f-cfd0a7c5b9f0" />

actual materials dont show it because it's obvious gold is gold
<img width="358" height="138" alt="image" src="https://github.com/user-attachments/assets/ec799ebb-d6a2-4f7a-99a8-8f340ada7f5f" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You're now able to see what materials some objects are made of.
