### PR TITLE
Various Gun Changes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -512,10 +512,15 @@
   - type: Clothing
     sprite: _Impstation/Objects/Weapons/Guns/Battery/laser_cannon.rsi #imp
   - type: Gun
+    burstFireRate: 9 #imp
+    shotsPerBurst: 3 #imp
+    burstCooldown: 0.70 #imp
     fireRate: 4.5 #imp
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/lasermil.ogg #imp
-    availableModes: FullAuto #imp
+    availableModes: #imp
+    - Burst
+    - FullAuto
     selectedMode: FullAuto #imp
   - type: HitscanBatteryAmmoProvider
     proto: RedRifleLaser #imp

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -178,7 +178,7 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
-    fireRate: 4
+    fireRate: 3.4 #imp
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/silenced.ogg
       params:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -203,6 +203,10 @@
   - type: Clothing
     sprite: _Impstation/Objects/Weapons/Guns/Rifles/lecter.rsi #imp
   - type: Gun
+    minAngle: 21 #imp
+    maxAngle: 38 #imp
+    angleIncrease: 2 #imp
+    angleDecay: 15 #imp
     fireRate: 4.5 #imp
     selectedMode: FullAuto
     availableModes:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -89,9 +89,11 @@
     - Back
     - suitStorage
   - type: AmmoCounter
+  - type: GunSpreadModifier #imp
+    spread: 1.3
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
-    fireRate: 2
+    fireRate: 3 #imp
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -215,6 +217,14 @@
 #imp edit begin; weapon melee
   - type: MeleeWeapon
     attackRate: 0.6
+  - type: Gun #imp - adds the 2-tap burst mode
+    selectedMode: SemiAuto
+    burstFireRate: 4
+    availableModes:
+    - Burst
+    - SemiAuto
+    shotsPerBurst: 2
+    burstCooldown: 1.25
   - type: StaminaDamageOnHit
     damage: 10 #slight stagger, but still like 10 hits to stun completely
   - type: MeleeRequiresWield

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -129,6 +129,7 @@
     sprite: _Impstation/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi #imp
   - type: GunRequiresWield
   - type: Gun
+    projectileSpeed: 35 #imp
     fireRate: 0.4
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/disablers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/disablers.yml
@@ -64,11 +64,11 @@
     steps: 5
     zeroVisible: true
   - type: Battery
-    maxCharge: 500
-    startingCharge: 500
+    maxCharge: 540
+    startingCharge: 540
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 100
+    fireCost: 90
 
 - type: entity
   name: auto disabler
@@ -99,7 +99,7 @@
     maxAngle: 15
     angleIncrease: 3
     angleDecay: 15
-    fireRate: 3
+    fireRate: 3.34
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -140,7 +140,7 @@
     steps: 5
     zeroVisible: true
   - type: Gun
-    fireRate: 0.9
+    fireRate: 1
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/stunprojector.ogg
   - type: HitscanBatteryAmmoProvider

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/blasterbolts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/blasterbolts.yml
@@ -82,8 +82,8 @@
     impactEffect: BulletImpactEffectSyndicate
     damage:
       types:
-        Heat: 10
-        Piercing: 10
+        Heat: 9.5
+        Piercing: 9.5
     soundHit:
       collection: WeakHit
     forceSound: true
@@ -102,8 +102,8 @@
   - type: Projectile
     damage:
       types:
-        Heat: 7.5
-        Piercing: 7.5
+        Heat: 8.5
+        Piercing: 8.5
 
 - type: entity
   name : toy blaster bolt

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/dmr.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/dmr.yml
@@ -21,6 +21,7 @@
     - suitStorage
   - type: GunRequiresWield
   - type: Gun
+    projectileSpeed: 35
     fireRate: 3
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/plasma.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/plasma.yml
@@ -32,7 +32,7 @@
   - type: Gun
     clumsyProof: false
     cameraRecoilScalar: 1
-    fireRate: 3.5
+    fireRate: 4
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
## About the PR
A number of balance changes and some additions to help just make a few guns feel a bit more interesting, help some along that need a bit of a boost, and bring a couple down that are a little too good for what they do.

## Why / Balance
A lot of these changes come from seeing all the numbers together on a spreadsheet and looking at time-to-crit/time-to-stun numbers. I'll go through the changes in terms of like, philosophy, from top to bottom:
- Laser Rifle - the burst mode is there to help differentiate the gun from other lasers. It doesn't make the gun necessarily much better but it does play into the fantasy of being a more professional weapon.
- Disablers - The rate-of-fire increases for the Auto Disabler and the Stun Projector help put their times-to-stun into line a bit better. The Stun Projector will still stun slower than a normal disabler, the difference is just a little less egregious now. The Pocket Disabler having more ammo helps the weapon not feel so punishing, and the higher ammo-density for its size gives more reason to use it.
- Daito and Lindwyrm - A small experiment that I ended up really liking-- the faster bullets help play into the "precision weapon" fantasy for these weapons, though I must admit I am concerned that this faster bullet speed might feel a bit too good compared to the normal bullets.
- Lecter - This gun had accuracy as good as the Daito before, and it that kinda rubbed me the wrong way. For its intended range it shouldn't perform much different, but if you're trying to use it like a Daito you'll probably start missing some shots.
- Cobra - This gun was killing as fast as a Viper, but with bullets that dealt 5 extra damage on top of the advantages of silenced shots. This change is to help this gun slot better into its role rather than be just a flat upgrade on the Viper.
- Adder - Looking at the numbers, the Adder was actually kind of really strong for its advantages and was clearly the better gun between itself and the Akurra.
- Akurra - On the flipside, the Akurra was definitely underperforming and needed a good boost in how it operates.
- Enforcer - Shotguns have always felt too similar, and an idea to help the Enforcer set itself apart a little was to add a sort of Half Life 2-inspired double-tap mode.
- Hydra - Similar thing going on, but it always rubbed me the wrong way that the full-auto shotgun didn't shoot very fast.

## Technical details

- Laser Rifle - Added 3-round burst mode (burst speed is 9/s, burst cooldown is 0.7s)
- Pocket Disabler - Ammo cost from 100 to 90, battery size from 500 to 540 (total shots from 5 to 6)
- Auto Disabler - Rate of Fire from 3 to 3.34 (time-to-stun from 1.67 to 1.50, same as the standard Disabler)
- Stun Projector - Rate of Fire from 0.9 to 1.0 (time-to-stun from 2.20s to 2.00s, still longer than the standard Disabler)
- Daito and Lindwyrm - Projectile speed from 25 (default bullet speed) to 35
- Lecter - Accuracy from 21/32 at 1/s to 21-38 at 2/s (maximum accuracy cone of 8 degrees)
- Cobra - Rate of Fire from 4 to 3.4 (time-to-crit from 1.00s to 1.18s)
- Adder - Damage from 10/10 to 9.5/9.5 -- Rate-of-Fire from 3.5 to 4.0 (time-to-crit from 1.14s to 1.25s)
- Akurra - Damage from 7.5/7.5 to 8.5/8.5 (time-to-crit from 1.13s to 0.94s)
- Enforcer - Added 2-round burst mode (burst speed is 4/s, burst cooldown is 1.25s)
- Hydra - Rate of Fire from 2 to 3 -- pellet spread increased by 30%

## Media

https://github.com/user-attachments/assets/56ac406f-f67c-44fe-8675-93e5df0082bb


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: A whole buncha gun changes-- click the PR for more details!
