### PR TITLE
Make offbrand murder easier to contend with

### DIFF
--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -49,6 +49,7 @@ public sealed partial class StatusEffectsSystem
         SubscribeLocalEvent<StatusEffectContainerComponent, Content.Shared.Movement.Pulling.Events.PullStoppedMessage>(RelayStatusEffectEvent); // Offbrand
         SubscribeLocalEvent<StatusEffectContainerComponent, Content.Shared.Weapons.Ranged.Events.SelfBeforeGunShotEvent>(RelayStatusEffectEvent); // Offbrand
         SubscribeLocalEvent<StatusEffectContainerComponent, Content.Shared.Chemistry.Hypospray.Events.SelfBeforeHyposprayInjectsEvent>(RelayStatusEffectEvent); // Offbrand
+        SubscribeLocalEvent<StatusEffectContainerComponent, Content.Shared.Damage.DamageChangedEvent>(RelayStatusEffectEvent); // Offbrand
     }
 
     private void RefRelayStatusEffectEvent<T>(EntityUid uid, StatusEffectContainerComponent component, ref T args) where T : struct

--- a/Content.Shared/_Offbrand/StatusEffects/DisruptOnAttackStatusEffectComponent.cs
+++ b/Content.Shared/_Offbrand/StatusEffects/DisruptOnAttackStatusEffectComponent.cs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace Content.Shared._Offbrand.StatusEffects;
+
+[RegisterComponent]
+[Access(typeof(DisruptOnAttackStatusEffectSystem))]
+public sealed partial class DisruptOnAttackStatusEffectComponent : Component;

--- a/Content.Shared/_Offbrand/StatusEffects/DisruptOnAttackStatusEffectSystem.cs
+++ b/Content.Shared/_Offbrand/StatusEffects/DisruptOnAttackStatusEffectSystem.cs
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared.CombatMode;
+using Content.Shared.Damage;
+using Content.Shared.Mobs.Components;
+using Content.Shared.StatusEffectNew.Components;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared._Offbrand.StatusEffects;
+
+public sealed class DisruptOnAttackStatusEffectSystem : EntitySystem
+{
+    [Dependency] private readonly SharedUserInterfaceSystem _userInterface = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DisruptOnAttackEvent>(OnDisruptOnAttack);
+        SubscribeLocalEvent<DisruptOnAttackStatusEffectComponent, StatusEffectRelayedEvent<DamageChangedEvent>>(OnDamageChanged);
+    }
+
+    private void OnDisruptOnAttack(DisruptOnAttackEvent args)
+    {
+        var disarm = new DisarmedEvent(args.Damaged, args.Origin, 1f);
+        RaiseLocalEvent(args.Damaged, ref disarm);
+
+        _userInterface.CloseUserUis(args.Damaged);
+    }
+
+    private void OnDamageChanged(Entity<DisruptOnAttackStatusEffectComponent> ent, ref StatusEffectRelayedEvent<DamageChangedEvent> args)
+    {
+        if (!args.Args.DamageIncreased)
+            return;
+
+        if (args.Args.Origin is not {} origin)
+            return;
+
+        if (Comp<StatusEffectComponent>(ent).AppliedTo is not { } damaged)
+            return;
+
+        if (!HasComp<MobStateComponent>(origin))
+            return;
+
+        QueueLocalEvent(new DisruptOnAttackEvent(damaged, origin));
+    }
+}
+
+public sealed class DisruptOnAttackEvent(EntityUid damaged, EntityUid origin) : EntityEventArgs
+{
+    public readonly EntityUid Damaged = damaged;
+    public readonly EntityUid Origin = origin;
+}
+

--- a/Content.Shared/_Offbrand/Wounds/BrainDamageOnDamageComponent.cs
+++ b/Content.Shared/_Offbrand/Wounds/BrainDamageOnDamageComponent.cs
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Offbrand.Wounds;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(BrainDamageOnDamageSystem))]
+public sealed partial class BrainDamageOnDamageComponent : Component
+{
+    [DataField(required: true)]
+    public List<OrganDamageThresholdSpecifier> Thresholds;
+}

--- a/Content.Shared/_Offbrand/Wounds/BrainDamageOnDamageSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/BrainDamageOnDamageSystem.cs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._Offbrand.Wounds;
+
+public sealed class BrainDamageOnDamageSystem : EntitySystem
+{
+    [Dependency] private readonly BrainDamageSystem _brain = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BrainDamageOnDamageComponent, DamageChangedEvent>(OnDamageChanged, after: [typeof(WoundableSystem)]);
+    }
+
+    private void OnDamageChanged(Entity<BrainDamageOnDamageComponent> ent, ref DamageChangedEvent args)
+    {
+        if (args.DamageDelta is not { } delta || !args.DamageIncreased)
+            return;
+
+        var damageable = Comp<DamageableComponent>(ent);
+        var brain = Comp<BrainDamageComponent>(ent);
+
+        foreach (var threshold in ent.Comp.Thresholds)
+        {
+            var incomingAmount = ThresholdHelpers.Count(threshold.DamageTypes, delta);
+            var totalAmount = ThresholdHelpers.Count(threshold.DamageTypes, damageable.Damage);
+
+            var damageAmount = FixedPoint2.Max(incomingAmount - FixedPoint2.Max(threshold.MinimumTotalDamage - totalAmount, FixedPoint2.Zero), FixedPoint2.Zero);
+            var factored = FixedPoint2.New(damageAmount.Double() * threshold.ConversionFactor);
+
+            if (factored <= FixedPoint2.Zero)
+                return;
+
+            _brain.TryChangeBrainDamage((ent.Owner, brain), factored);
+        }
+    }
+}

--- a/Content.Shared/_Offbrand/Wounds/HeartDamageOnDamageComponent.cs
+++ b/Content.Shared/_Offbrand/Wounds/HeartDamageOnDamageComponent.cs
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Offbrand.Wounds;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(HeartDamageOnDamageSystem))]
+public sealed partial class HeartDamageOnDamageComponent : Component
+{
+    [DataField(required: true)]
+    public List<OrganDamageThresholdSpecifier> Thresholds;
+}
+
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class OrganDamageThresholdSpecifier
+{
+    /// <summary>
+    /// The damage type this unique wound happens to
+    /// </summary>
+    [DataField(required: true)]
+    public HashSet<ProtoId<DamageTypePrototype>> DamageTypes;
+
+    /// <summary>
+    /// The minimum overall damage of the DamageTypes required to apply organ damage
+    /// </summary>
+    [DataField(required: true)]
+    public FixedPoint2 MinimumTotalDamage;
+
+    /// <summary>
+    /// The factor for converting incoming damage into organ damage
+    /// </summary>
+    [DataField(required: true)]
+    public double ConversionFactor;
+}

--- a/Content.Shared/_Offbrand/Wounds/HeartDamageOnDamageSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/HeartDamageOnDamageSystem.cs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._Offbrand.Wounds;
+
+public sealed class HeartDamageOnDamageSystem : EntitySystem
+{
+    [Dependency] private readonly HeartSystem _heart = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HeartDamageOnDamageComponent, DamageChangedEvent>(OnDamageChanged, after: [typeof(WoundableSystem)]);
+    }
+
+    private void OnDamageChanged(Entity<HeartDamageOnDamageComponent> ent, ref DamageChangedEvent args)
+    {
+        if (args.DamageDelta is not { } delta || !args.DamageIncreased)
+            return;
+
+        var damageable = Comp<DamageableComponent>(ent);
+        var heart = Comp<HeartrateComponent>(ent);
+
+        foreach (var threshold in ent.Comp.Thresholds)
+        {
+            var incomingAmount = ThresholdHelpers.Count(threshold.DamageTypes, delta);
+            var totalAmount = ThresholdHelpers.Count(threshold.DamageTypes, damageable.Damage);
+
+            var damageAmount = FixedPoint2.Max(incomingAmount - FixedPoint2.Max(threshold.MinimumTotalDamage - totalAmount, FixedPoint2.Zero), FixedPoint2.Zero);
+            var factored = FixedPoint2.New(damageAmount.Double() * threshold.ConversionFactor);
+
+            if (factored <= FixedPoint2.Zero)
+                return;
+
+            _heart.ChangeHeartDamage((ent.Owner, heart), factored);
+        }
+    }
+}

--- a/Content.Shared/_Offbrand/Wounds/ThresholdHelpers.cs
+++ b/Content.Shared/_Offbrand/Wounds/ThresholdHelpers.cs
@@ -4,6 +4,10 @@
  */
 
 using System.Linq;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Offbrand.Wounds;
 
@@ -33,5 +37,18 @@ public static class ThresholdHelpers
         }
 
         return null;
+    }
+
+    public static FixedPoint2 Count(IEnumerable<ProtoId<DamageTypePrototype>> types, DamageSpecifier specifier)
+    {
+        var accumulator = FixedPoint2.Zero;
+
+        foreach (var type in types)
+        {
+            if (specifier.DamageDict.TryGetValue(type, out var amount))
+                accumulator += amount;
+        }
+
+        return accumulator;
     }
 }

--- a/Content.Shared/_Offbrand/Wounds/UniqueWoundOnDamageSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/UniqueWoundOnDamageSystem.cs
@@ -3,12 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-using System.Linq;
-using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage;
-using Content.Shared.FixedPoint;
 using Content.Shared.Random.Helpers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -26,19 +22,6 @@ public sealed partial class UniqueWoundOnDamageSystem : EntitySystem
         SubscribeLocalEvent<UniqueWoundOnDamageComponent, DamageChangedEvent>(OnDamageChanged, after: [typeof(WoundableSystem)]);
     }
 
-    private FixedPoint2 Count(IEnumerable<ProtoId<DamageTypePrototype>> types, DamageSpecifier specifier)
-    {
-        var accumulator = FixedPoint2.Zero;
-
-        foreach (var type in types)
-        {
-            if (specifier.DamageDict.TryGetValue(type, out var amount))
-                accumulator += amount;
-        }
-
-        return accumulator;
-    }
-
     private void OnDamageChanged(Entity<UniqueWoundOnDamageComponent> ent, ref DamageChangedEvent args)
     {
         if (args.DamageDelta is not { } delta || !args.DamageIncreased)
@@ -52,8 +35,8 @@ public sealed partial class UniqueWoundOnDamageSystem : EntitySystem
 
         foreach (var wound in ent.Comp.Wounds)
         {
-            var incomingAmount = Count(wound.DamageTypes, delta);
-            var totalAmount = Count(wound.DamageTypes, damageable.Damage);
+            var incomingAmount = ThresholdHelpers.Count(wound.DamageTypes, delta);
+            var totalAmount = ThresholdHelpers.Count(wound.DamageTypes, damageable.Damage);
 
             if (incomingAmount < wound.MinimumDamage || totalAmount < wound.MinimumTotalDamage)
                 continue;

--- a/Resources/Prototypes/_Offbrand/base_mob.yml
+++ b/Resources/Prototypes/_Offbrand/base_mob.yml
@@ -199,6 +199,14 @@
     wound: WoundFracture
     woundProbability: 0.03
   - type: IVTarget
+  - type: HeartDamageOnDamage
+    thresholds:
+    - damageTypes: [Slash, Blunt, Piercing]
+      minimumTotalDamage: 200
+      conversionFactor: 0.3
+    - damageTypes: [Heat, Cold, Caustic, Shock]
+      minimumTotalDamage: 200
+      conversionFactor: 0.3
 
 - type: entity
   abstract: true
@@ -253,6 +261,14 @@
     - HealthIconCritical2
     - HealthIconCritical1
     deadIcon: HealthIconBrainDead
+  - type: BrainDamageOnDamage
+    thresholds:
+    - damageTypes: [Slash, Blunt, Piercing]
+      minimumTotalDamage: 200
+      conversionFactor: 0.1
+    - damageTypes: [Heat, Cold, Caustic, Shock]
+      minimumTotalDamage: 200
+      conversionFactor: 0.01
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_Offbrand/base_mob.yml
+++ b/Resources/Prototypes/_Offbrand/base_mob.yml
@@ -72,6 +72,16 @@
           Blunt: 100
       damageProbabilityCoefficient: 0.25
       damageProbabilityConstant: 0
+    - damageTypes: [Heat]
+      minimumDamage: 100
+      minimumTotalDamage: 0
+      woundPrototype: WoundHusking
+      woundDamages:
+        damageDict:
+          Heat: 100
+          Blunt: 100
+      damageProbabilityCoefficient: 1
+      damageProbabilityConstant: 0
     - damageTypes: [Slash, Blunt, Piercing]
       minimumDamage: 1
       minimumTotalDamage: 300
@@ -82,6 +92,17 @@
           Slash: 50
           Piercing: 50
       damageProbabilityCoefficient: 0.25
+      damageProbabilityConstant: 0
+    - damageTypes: [Slash, Blunt, Piercing]
+      minimumDamage: 100
+      minimumTotalDamage: 0
+      woundPrototype: WoundBoneDeath
+      woundDamages:
+        damageDict:
+          Blunt: 50
+          Slash: 50
+          Piercing: 50
+      damageProbabilityCoefficient: 1
       damageProbabilityConstant: 0
 
 - type: entity

--- a/Resources/Prototypes/_Offbrand/status_effects.yml
+++ b/Resources/Prototypes/_Offbrand/status_effects.yml
@@ -265,6 +265,7 @@
   - type: BlockMovementWhenPulledStatusEffect
   - type: GunBackfireStatusEffect
   - type: HyposprayBackfireStatusEffect
+  - type: DisruptOnAttackStatusEffect
 
 - type: entity
   parent: MobStatusEffectBase
@@ -316,6 +317,7 @@
     angleRangeModifier: 12
   - type: GunBackfireStatusEffect
   - type: HyposprayBackfireStatusEffect
+  - type: DisruptOnAttackStatusEffect
 
 - type: entity
   parent: MobStatusEffectBase


### PR DESCRIPTION
- maximum damage curve is now a continuous function (no more weird cliff at 200)
- above 200 damage, injuries start dealing direct brain and heart damage
- values are tuned such that a magdump will usually kill the heart and somewhat injure the brain
- a minibomb will bring the brain to "will be dead in seconds the victim better pray a paramedic is within seeing sight and isnt going to get killed trying to rescue them"
- values tuned against unarmoured victims
- getting attacked in paincrit or braincrit acts as a disarm and will disrupt PDA usage