### PR TITLE
First pass of Offbrand adjustments

### DIFF
--- a/Content.Shared/_Offbrand/EntityEffects/HeartDamage.cs
+++ b/Content.Shared/_Offbrand/EntityEffects/HeartDamage.cs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared._Offbrand.Wounds;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Offbrand.EntityEffects;
+
+public sealed partial class HeartDamage : EntityEffectCondition
+{
+    [DataField]
+    public FixedPoint2 Max = FixedPoint2.MaxValue;
+
+    [DataField]
+    public FixedPoint2 Min = FixedPoint2.Zero;
+
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        if (args.EntityManager.TryGetComponent<HeartrateComponent>(args.TargetEntity, out var heartrate))
+        {
+            return heartrate.Damage >= Min && heartrate.Damage <= Max;
+        }
+
+        return false;
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        return Loc.GetString("reagent-effect-condition-guidebook-heart-damage",
+            ("max", Max == FixedPoint2.MaxValue ? (float) int.MaxValue : Max.Float()),
+            ("min", Min.Float()));
+    }
+}

--- a/Content.Shared/_Offbrand/EntityEffects/ModifyHeartDamage.cs
+++ b/Content.Shared/_Offbrand/EntityEffects/ModifyHeartDamage.cs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared._Offbrand.Wounds;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Offbrand.EntityEffects;
+
+public sealed partial class ModifyHeartDamage : EntityEffect
+{
+    [DataField(required: true)]
+    public FixedPoint2 Amount;
+
+    protected override string ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        if (Amount < FixedPoint2.Zero)
+            return Loc.GetString("reagent-effect-guidebook-modify-heart-damage-heals", ("chance", Probability), ("amount", -Amount));
+        else
+            return Loc.GetString("reagent-effect-guidebook-modify-heart-damage-deals", ("chance", Probability), ("amount", -Amount));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var scale = FixedPoint2.New(1);
+
+        if (args is EntityEffectReagentArgs reagentArgs)
+            scale = reagentArgs.Scale;
+
+        args.EntityManager.System<HeartSystem>()
+            .ChangeHeartDamage(args.TargetEntity, Amount * scale);
+    }
+}

--- a/Content.Shared/_Offbrand/Wounds/WoundableHealthAnalyzer.cs
+++ b/Content.Shared/_Offbrand/Wounds/WoundableHealthAnalyzer.cs
@@ -112,8 +112,8 @@ public sealed class WoundableHealthAnalyzerSystem : EntitySystem
         if (!TryComp<BrainDamageComponent>(uid, out var brainDamage))
             return null;
 
-        var brainHealth = 1d - (brainDamage.Damage / brainDamage.MaxDamage).Double();
-        var heartHealth = 1d - (heartrate.Damage / heartrate.MaxDamage).Double();
+        var brainHealth = 1d - ((double)brainDamage.Damage / (double)brainDamage.MaxDamage);
+        var heartHealth = 1d - ((double)heartrate.Damage / (double)heartrate.MaxDamage);
         var strain = _heart.HeartStrain((uid, heartrate)).Double() / 4d;
         var (upper, lower) = _heart.BloodPressure((uid, heartrate));
         var oxygenation = _heart.BloodOxygenation((uid, heartrate)).Double();

--- a/Resources/Locale/en-US/_Offbrand/effects.ftl
+++ b/Resources/Locale/en-US/_Offbrand/effects.ftl
@@ -15,6 +15,21 @@ reagent-effect-guidebook-modify-brain-damage-deals = { $chance ->
         [1] Deals { $amount } brain damage
    *[other] deal { $amount } brain damage
 }
+reagent-effect-guidebook-modify-heart-damage-heals = { $chance ->
+        [1] Heals { $amount } heart damage
+   *[other] heal { $amount } heart damage
+}
+reagent-effect-guidebook-modify-heart-damage-deals = { $chance ->
+        [1] Deals { $amount } heart damage
+   *[other] deal { $amount } heart damage
+}
+reagent-effect-condition-guidebook-heart-damage = { $max ->
+    [2147483648] it has at least {NATURALFIXED($min, 2)} heart damage
+    *[other] { $min ->
+                [0] it has at most {NATURALFIXED($max, 2)} heart damage
+                *[other] it has between {NATURALFIXED($min, 2)} and {NATURALFIXED($max, 2)} heart damage
+             }
+}
 reagent-effect-guidebook-modify-brain-oxygen-heals = { $chance ->
         [1] Replenishes { $amount } brain oxygenation
    *[other] replenish { $amount } brain oxygenation

--- a/Resources/Locale/en-US/_Offbrand/health-analyzer.ftl
+++ b/Resources/Locale/en-US/_Offbrand/health-analyzer.ftl
@@ -26,6 +26,7 @@ health-analyzer-window-entity-blood-oxygenation-value = {$value}% { -health-anal
 health-analyzer-window-entity-blood-pressure-value = {$diastolic}/{$systolic} { -health-analyzer-rating(rating: $rating) }
 health-analyzer-window-entity-blood-circulation-value = {$value}% { -health-analyzer-rating(rating: $rating) }
 
+wound-bone-death = [color=red]Patient has systemic bone failure.[/color]
 wound-internal-fracture = [color=red]Patient has internal fractures.[/color]
 wound-incision = [color=red]Patient has open incision.[/color]
 wound-clamped = [color=red]Patient has clamped arteries.[/color]

--- a/Resources/Locale/en-US/_Offbrand/reagents.ftl
+++ b/Resources/Locale/en-US/_Offbrand/reagents.ftl
@@ -16,3 +16,9 @@ reagent-desc-sanguine = A deeply crimson and oily gel that can replenish blood o
 
 reagent-name-saline-glucose = saline-glucose solution
 reagent-desc-saline-glucose = A solution of saline and glucose that can be administered intravenously to encourage healing, effective only at low doses.
+
+reagent-name-cloneoxadone = cloneoxadone
+reagent-desc-cloneoxadone = A derivative of cryoxadone used in cloning processes. More potent, but requires lower temperatures to work.
+
+reagent-name-peridaxon = peridaxon
+reagent-desc-peridaxon = A beady medicine that encourages internal organs to recover from minor traumas.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -205,6 +205,11 @@
         - !type:Temperature
           max: 213.0
       effects:
+      - !type:ModifyHeartDamage
+        amount: -0.15
+        conditions:
+        - !type:Temperature
+          max: 213.0
       - !type:EvenHealthChange
         conditions:
         - !type:Temperature
@@ -1428,10 +1433,12 @@
   metabolisms:
     Medicine:
       # Begin Offbrand
-      metabolismRate: 0.2
+      metabolismRate: 0.05
       statusEffects:
       - statusEffect: StatusEffectBrainHealingMannitol
       effects:
+      - !type:ModifyBrainDamage
+        amount: -0.05
       - !type:Drunk
         boozePower: 1
       - !type:Jitter

--- a/Resources/Prototypes/_Offbrand/base_mob.yml
+++ b/Resources/Prototypes/_Offbrand/base_mob.yml
@@ -151,9 +151,9 @@
     maxDamage: 50
     damage: 0
     strainDamageThresholds:
-      1: [0.04, 1]
-      2: [0.1, 1]
-      3: [0.3, 1]
+      1: [0.04, 0.05]
+      2: [0.1, 0.05]
+      3: [0.3, 0.05]
       4: [0.4, 1]
     circulationStrainModifierCoefficient: 0.075
     circulationStrainModifierConstant: 1.025
@@ -178,7 +178,7 @@
     threshold: 4
   - type: HeartStopOnBrainHealth
     chance: 0.8
-    threshold: 60
+    threshold: 70
   - type: HeartrateAlerts
     strainAlert: HeartRate
     stoppedAlert: HeartStopped

--- a/Resources/Prototypes/_Offbrand/internal_wounds.yml
+++ b/Resources/Prototypes/_Offbrand/internal_wounds.yml
@@ -107,7 +107,7 @@
     maximumDamage: 150
   - type: AnalyzableWound
     descriptions:
-      0: wound-internal-fracture
+      0: wound-bone-death
   - type: PainfulWound
     painCoefficients:
       Blunt: 0.8

--- a/Resources/Prototypes/_Offbrand/reactions.yml
+++ b/Resources/Prototypes/_Offbrand/reactions.yml
@@ -60,3 +60,28 @@
       amount: 1
   products:
     SalineGlucose: 1
+
+- type: reaction
+  id: Cloneoxadone
+  reactants:
+    Cryoxadone:
+      amount: 1
+    Sodium:
+      amount: 1
+    Inaprovaline:
+      amount: 1
+  products:
+    Cloneoxadone: 3
+
+- type: reaction
+  id: Peridaxon
+  reactants:
+    Bicaridine:
+      amount: 1
+    Cryoxadone:
+      amount: 1
+    Plasma:
+      amount: 1
+      catalyst: true
+  products:
+    Peridaxon: 2

--- a/Resources/Prototypes/_Offbrand/reagents.yml
+++ b/Resources/Prototypes/_Offbrand/reagents.yml
@@ -136,6 +136,76 @@
           max: 1
 
 - type: reagent
+  id: Peridaxon
+  name: reagent-name-peridaxon
+  group: Medicine
+  desc: reagent-desc-peridaxon
+  physicalDesc: reagent-physical-desc-shiny
+  flavor: bitter
+  flavorMinimum: 0.02
+  color: "#561ec3"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.05
+      effects:
+      - !type:ModifyHeartDamage
+        amount: -0.2
+        conditions:
+        - !type:HeartDamage
+          max: 25
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 5.5
+        damage:
+          types:
+            Poison: 0.05
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 5.5
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          min: 5.5
+        probability: 0.1
+
+- type: reagent
+  id: Cloneoxadone
+  name: reagent-name-cloneoxadone
+  group: Medicine
+  desc: reagent-desc-cloneoxadone
+  physicalDesc: reagent-physical-desc-fizzy
+  flavor: medicine
+  color: "#4053b0"
+  metabolisms:
+    Medicine:
+      statusEffects:
+      - statusEffect: StatusEffectMajorOxygenationCloneoxadone
+        conditions:
+        - !type:Temperature
+          max: 170.0
+      - statusEffect: StatusEffectHeartStabilizationCloneoxadone
+        conditions:
+        - !type:Temperature
+          max: 170.0
+      effects:
+      - !type:ModifyHeartDamage
+        amount: -0.3
+        conditions:
+        - !type:Temperature
+          max: 170.0
+      - !type:EvenHealthChange
+        conditions:
+        - !type:Temperature
+          max: 170.0
+        damage:
+          Airloss: -6
+          Brute: -4
+          Burn: -4
+          Toxin: -4
+
+- type: reagent
   id: SalineGlucose
   name: reagent-name-saline-glucose
   group: Medicine

--- a/Resources/Prototypes/_Offbrand/status_effects.yml
+++ b/Resources/Prototypes/_Offbrand/status_effects.yml
@@ -150,6 +150,10 @@
   id: StatusEffectHeartStabilizationCryoxadone
 
 - type: entity
+  parent: StatusEffectHeartStabilizationInaprovaline
+  id: StatusEffectHeartStabilizationCloneoxadone
+
+- type: entity
   parent: MobStatusEffectBase
   id: StatusEffectBrainStabilizationInaprovaline
   name: brain stabilization
@@ -199,6 +203,10 @@
   components:
   - type: BloodOxygenationModifierStatusEffect
     minimumOxygenation: 0.8
+
+- type: entity
+  parent: StatusEffectMajorOxygenationDexalinPlus
+  id: StatusEffectMajorOxygenationCloneoxadone
 
 - type: entity
   parent: MobStatusEffectBase


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
- feedback that i noticed from actually seeing offbrand used in a round

## Why / Balance
- atm heart damage is severely overtuned, dragging the rest of the system down with it
- also some other bugfixes

## Technical details
- reagent effects for heart stuff
<!-- Summary of code changes for easier review. -->

## Media
<img width="661" height="386" alt="grafik" src="https://github.com/user-attachments/assets/fea9207d-a6b7-4a11-a1b7-fd1344d7d23a" />
<img width="659" height="435" alt="grafik" src="https://github.com/user-attachments/assets/b5d375bb-4a89-45a3-afd6-494892592668" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Peridaxon now exists, a chemical that can heal mild cases of heart damage without requiring surgical intervention!
- add: Cloneoxadone now exists, a stronger variant of Cryoxadone that requires a colder body temperature to work, and thus, more pronounced stasis.
- tweak: Cryoxadone now heals a minor amount of heart damage
- tweak: The heart will now take half the damage from high heartrate
- fix: Health analyzers no longer incorrectly round brain and heart damage
- fix: The heart stops from brain damage at the advertised 30% activity instead of at higher levels
- fix: Bone death no longer reports as internal fractures on the health analyzer
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
