### PR TITLE
Metabolizing theobromine now slightly increases pulse

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -406,6 +406,12 @@
   meltingPoint: 351
   boilingPoint: 554 # I'm not a chemist, but it boils at 295, lower than melting point, idk how it works so I gave it higher value
   metabolisms:
+    # Begin Offbrand
+    Drink:
+      effects: []
+      statusEffects:
+      - statusEffect: StatusEffectHeartStrainCaffeine
+    # End Offbrand
     Poison:
       metabolismRate: 0.045 #changed on impstation so that it can build up slightly
       effects:

--- a/Resources/Prototypes/_Offbrand/status_effects.yml
+++ b/Resources/Prototypes/_Offbrand/status_effects.yml
@@ -139,6 +139,14 @@
 
 - type: entity
   parent: MobStatusEffectBase
+  id: StatusEffectHeartStrainCaffeine
+  name: slightly increased heart rate
+  components:
+  - type: StrainStatusEffect
+    delta: 1
+
+- type: entity
+  parent: MobStatusEffectBase
   id: StatusEffectHeartStabilizationTHC
   name: minor heart stabilization
   components:


### PR DESCRIPTION
## About the PR
Things with theobromine in it (coffee, energy drinks, some mixed drinks, et. al) now slightly increase pulse. Should be accurate to real life, since theobromine, being a metabolite of caffeine, is a [cardiac stimulant.](https://pubchem.ncbi.nlm.nih.gov/compound/5429)

## Why / Balance
Keep medical on edge :^)

## Technical details
New status effect created and applied to theobromine reagent to raise strain by 1.

## Media
<img width="1229" height="424" alt="Content Client_mCTwVGVSOM" src="https://github.com/user-attachments/assets/c48295ff-f2d1-4078-9472-9f934688352b" />

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl: Banditoz
- add: Consuming caffeinated things now slightly raises your pulse.
