### PR TITLE
Offbrand pass 4: I love immediate feedback

### DIFF
--- a/Content.Server/_Offbrand/Wounds/BrainGaspThresholdsSystem.cs
+++ b/Content.Server/_Offbrand/Wounds/BrainGaspThresholdsSystem.cs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using System.Linq;
+using Content.Server.Chat.Systems;
+using Content.Shared._Offbrand.Wounds;
+
+namespace Content.Server._Offbrand.Wounds;
+
+public sealed class BrainGaspThresholdsSystem : EntitySystem
+{
+    [Dependency] private readonly ChatSystem _chat = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BrainGaspThresholdsComponent, AfterBrainDamageChanged>(OnAfterBrainDamageChanged);
+    }
+
+    private void OnAfterBrainDamageChanged(Entity<BrainGaspThresholdsComponent> ent, ref AfterBrainDamageChanged args)
+    {
+        var brain = Comp<BrainDamageComponent>(ent);
+
+        var message = ent.Comp.MessageThresholds.HighestMatch(brain.Damage);
+        if (message == ent.Comp.CurrentMessage)
+            return;
+
+        var previousMessage = ent.Comp.CurrentMessage;
+
+        ent.Comp.CurrentMessage = message;
+        Dirty(ent);
+
+        if (previousMessage is { } previous)
+        {
+            var previousKey = ent.Comp.MessageThresholds.FirstOrDefault(x => x.Value == previous).Key;
+            var currentKey = ent.Comp.MessageThresholds.FirstOrDefault(x => x.Value == message).Key;
+
+            if (previousKey >= currentKey)
+            {
+                return;
+            }
+        }
+
+        if (message is { } msg)
+            _chat.TryEmoteWithChat(ent.Owner, msg, ignoreActionBlocker: true);
+    }
+}

--- a/Content.Server/_Offbrand/Wounds/ShockGaspThresholdsSystem.cs
+++ b/Content.Server/_Offbrand/Wounds/ShockGaspThresholdsSystem.cs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using System.Linq;
+using Content.Server.Chat.Systems;
+using Content.Shared._Offbrand.Wounds;
+
+namespace Content.Server._Offbrand.Wounds;
+
+public sealed class ShockGaspThresholdsSystem : EntitySystem
+{
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly PainSystem _pain = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ShockGaspThresholdsComponent, AfterShockChangeEvent>(OnAfterShockChange);
+    }
+
+    private void OnAfterShockChange(Entity<ShockGaspThresholdsComponent> ent, ref AfterShockChangeEvent args)
+    {
+        var shock = _pain.GetShock(ent.Owner);
+
+        var message = ent.Comp.MessageThresholds.HighestMatch(shock);
+        if (message == ent.Comp.CurrentMessage)
+            return;
+
+        var previousMessage = ent.Comp.CurrentMessage;
+
+        ent.Comp.CurrentMessage = message;
+        Dirty(ent);
+
+        if (previousMessage is { } previous)
+        {
+            var previousKey = ent.Comp.MessageThresholds.FirstOrDefault(x => x.Value == previous).Key;
+            var currentKey = ent.Comp.MessageThresholds.FirstOrDefault(x => x.Value == message).Key;
+
+            if (previousKey >= currentKey)
+            {
+                return;
+            }
+        }
+
+        if (message is { } msg)
+            _chat.TryEmoteWithChat(ent.Owner, msg, ignoreActionBlocker: true);
+    }
+}

--- a/Content.Shared/_Offbrand/Wounds/BrainGaspThresholdsComponent.cs
+++ b/Content.Shared/_Offbrand/Wounds/BrainGaspThresholdsComponent.cs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Offbrand.Wounds;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class BrainGaspThresholdsComponent : Component
+{
+    [DataField(required: true)]
+    public SortedDictionary<FixedPoint2, ProtoId<EmotePrototype>> MessageThresholds = new();
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<EmotePrototype>? CurrentMessage;
+}

--- a/Content.Shared/_Offbrand/Wounds/ShockGaspThresholdsComponent.cs
+++ b/Content.Shared/_Offbrand/Wounds/ShockGaspThresholdsComponent.cs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Offbrand.Wounds;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ShockGaspThresholdsComponent : Component
+{
+    [DataField(required: true)]
+    public SortedDictionary<FixedPoint2, ProtoId<EmotePrototype>> MessageThresholds = new();
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<EmotePrototype>? CurrentMessage;
+}

--- a/Resources/Locale/en-US/_Offbrand/messages.ftl
+++ b/Resources/Locale/en-US/_Offbrand/messages.ftl
@@ -21,3 +21,8 @@ mmi-extractor-prompt =
 
 mmi-extractor-accept = Accept
 mmi-extractor-decline = Decline
+
+chat-emote-name-paingasp = Paingasp
+chat-emote-msg-paingasp = twitches uncontrollably, before drawing still...
+chat-emote-name-braingasp = Braingasp
+chat-emote-msg-braingasp = falls limp, a deathly pallor hovering over {OBJECT($entity)}...

--- a/Resources/Prototypes/_Offbrand/base_mob.yml
+++ b/Resources/Prototypes/_Offbrand/base_mob.yml
@@ -143,6 +143,9 @@
       60: SeverePain
       120: BlackoutPain
       200: UnconsciousPain
+  - type: ShockGaspThresholds
+    messageThresholds:
+      200: DefaultPaingasp
 
 - type: entity
   abstract: true
@@ -273,6 +276,9 @@
     - damageTypes: [Heat, Cold, Caustic, Shock]
       minimumTotalDamage: 200
       conversionFactor: 0.01
+  - type: BrainGaspThresholds
+    messageThresholds:
+      70: DefaultBraingasp
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_Offbrand/emotes.yml
+++ b/Resources/Prototypes/_Offbrand/emotes.yml
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+- type: emote
+  id: DefaultPaingasp
+  name: chat-emote-name-paingasp
+  icon: _Impstation/Interface/Emotes/deathgasp.png # Impstation
+  whitelist:
+    components:
+    - Pain
+  chatMessages: ["chat-emote-msg-paingasp"]
+  chatTriggers:
+  - paingasp
+
+- type: emote
+  id: DefaultBraingasp
+  name: chat-emote-name-braingasp
+  icon: _Impstation/Interface/Emotes/deathgasp.png # Impstation
+  whitelist:
+    components:
+    - BrainDamage
+  chatMessages: ["chat-emote-msg-braingasp"]
+  chatTriggers:
+  - paingasp


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
- there are now special deathgasps for braincrit & hard paincrit

## Why / Balance
- people want the satisfaction of a message telling them they did it

## Technical details
- two new components, two new systems, two new emotes

## Media
<img width="425" height="187" alt="grafik" src="https://github.com/user-attachments/assets/b841e15d-14cd-498c-8f20-fa4ae410e702" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Characters now have special deathgasps for braincrit & hard paincrit
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
