### PR TITLE
Allow heretics to sacrifice crit-condition bodies

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
@@ -96,7 +96,7 @@ public partial class RitualSacrificeBehavior : RitualCustomBehavior
             || args.EntityManager.HasComponent<GhoulComponent>(look)) //shouldn't happen because they gib on death but. sanity check
                 continue;
 
-            if (mobstate.CurrentState == Shared.Mobs.MobState.Dead)
+            if ((mobstate.CurrentState == Shared.Mobs.MobState.Dead) || (mobstate.CurrentState == Shared.Mobs.MobState.Critical))
                 Uids.Add(look);
         }
 

--- a/Resources/Locale/en-US/_Goobstation/Heretic/heretic/rituals.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/heretic/rituals.ftl
@@ -12,7 +12,7 @@ heretic-ritual-basic-codex = Codex Cicatrix
 
 
 heretic-ritual-fail-sacrifice = There is no corpse to sacrifice.
-heretic-ritual-fail-sacrifice-ineligible = They're not dead yet.
+heretic-ritual-fail-sacrifice-ineligible = The sacrifice must be dead or dying.
 heretic-ritual-fail-reagentpuddle = This ritual needs a puddle of one of these: {$reagentname}.
 heretic-ritual-fail-temperature-hot = It is too hot here.
 heretic-ritual-fail-temperature-cold = It is not cold enough here.


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
what it says on da tin. if you're gasping, you can be sacrificed

## Why / Balance
it takes a ton of effort to fully kill someone now that offmed's here, so this is to balance that out.

## Technical details
this changes two lines. tested and working in-game

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: heretics can now sacrifice critical-condition (gasping) bodies.
