### PR TITLE
Sound Tweaks for Flamethrower and Foam Rifle

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -327,6 +327,10 @@
       - BulletFoam
     capacity: 10
     proto: BulletFoam
+    soundInsert: #imp
+      path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
+    soundRack: #imp
+      path: /Audio/Weapons/Guns/Cock/smg_cock.ogg
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 2

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/flamers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/flamers.yml
@@ -75,7 +75,6 @@
       path: /Audio/Weapons/Guns/Hits/energy_meat1.ogg
       params:
         variation: 0.250
-        volume: -12
   - type: StaminaDamageOnHit
     damage: 15 #slight stagger, but still like 7 hits to stun completely
   - type: MeleeRequiresWield


### PR DESCRIPTION
## About the PR
Tiny little thing to make the flamethrower melee sounds a bit louder, since I think the original file had its sound tweaked, making it quieter. Works well for the lit welder, but not as well here. Also changed the foam force astro ace sounds to not be the shotgun sounds, but just generic gun sounds.

## Why / Balance
Volume and feel of big special weapon melee. Fix for foam gun after the parent, baseshotgun was tweaked.

## Technical details
Removed volume parameter for melee sound; changed two parented sounds via ballisticammoprovider.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Foam Force Astro Aces are no longer made with genuine shotgun parts but now with cheap plastic due to budget cuts.
- fix: Flamethrower melee sounds more burn-y.