### PR TITLE
Add hypertension/hypotension traits

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -622,6 +622,18 @@ namespace Content.Client.Lobby.UI
                         selector.Checkbox.Label.FontColorOverride = Color.Red;
                     }
 
+                    // Begin Impstation - UI code to support traits where only one among them is allowed.
+                    // For shared logic that this UI is driven by, go to HumanoidCharacterProfile.cs's WithTraitPreference
+                    if (selector.Trait.OnlyOneAllowedAmongstTraitsWith is not null &&
+                        selectors.Any(tt =>
+                            tt?.Trait.ID != selector.Trait.ID &&
+                            tt?.Trait.OnlyOneAllowedAmongstTraitsWith ==
+                            selector.Trait.OnlyOneAllowedAmongstTraitsWith && tt.Preference))
+                    {
+                        selector.Checkbox.Label.FontColorOverride = Color.Red;
+                    }
+                    // End Impstation
+
                     TraitsList.AddChild(selector);
                 }
             }

--- a/Content.Client/Lobby/UI/Roles/TraitPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/Roles/TraitPreferenceSelector.xaml.cs
@@ -9,7 +9,9 @@ namespace Content.Client.Lobby.UI.Roles;
 [GenerateTypedNameReferences]
 public sealed partial class TraitPreferenceSelector : Control
 {
-    public int Cost;
+    // Impstation - having the selector hold the entire trait as opposed to cost simplifies UI logic a bit
+    public readonly TraitPrototype Trait;
+    public int Cost => Trait.Cost;
 
     public bool Preference
     {
@@ -26,7 +28,7 @@ public sealed partial class TraitPreferenceSelector : Control
         var text = trait.Cost != 0 ? $"[{trait.Cost}] " : "";
         text += Loc.GetString(trait.Name);
 
-        Cost = trait.Cost;
+        Trait = trait;
         Checkbox.Text = text;
         Checkbox.OnToggled += OnCheckBoxToggled;
 

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -434,6 +434,7 @@ namespace Content.Shared.Preferences
             }
 
             var count = 0;
+            Dictionary<string, string> distinctiveTraits = new(); // Impstation
             foreach (var trait in list)
             {
                 // If trait not found or another category don't count its points.
@@ -442,6 +443,22 @@ namespace Content.Shared.Preferences
                 {
                     continue;
                 }
+
+                // Begin Impstation
+                if (otherProto.OnlyOneAllowedAmongstTraitsWith is null)
+                {
+                    continue;
+                }
+
+                if (distinctiveTraits.TryGetValue(otherProto.OnlyOneAllowedAmongstTraitsWith, out var onlyUniqueTrait) &&
+                    onlyUniqueTrait != otherProto.ID)
+                {
+                    // trait is distinct amongst others that have its value, and such a trait was selected already, don't add it
+                    return new(this);
+                }
+
+                distinctiveTraits.Add(otherProto.OnlyOneAllowedAmongstTraitsWith, otherProto.ID);
+                // End Impstation
 
                 count += otherProto.Cost;
             }

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -74,4 +74,11 @@ public sealed partial class TraitPrototype : IPrototype
     /// </summary>
     [DataField]
     public HashSet<ProtoId<SpeciesPrototype>> ExcludedSpecies = new();
+
+    /// <summary>
+    /// Impstation - Given multiple traits with this value, only one is allowed to be selected.
+    /// This is different from cost, as cost is by category.
+    /// </summary>
+    [DataField]
+    public string? OnlyOneAllowedAmongstTraitsWith;
 }

--- a/Content.Shared/_Impstation/Traits/Assorted/BloodPressureVariationComponent.cs
+++ b/Content.Shared/_Impstation/Traits/Assorted/BloodPressureVariationComponent.cs
@@ -1,0 +1,22 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Impstation.Traits.Assorted;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BloodPressureVariationComponent : Component
+{
+    /// <summary>
+    /// Multiplier to apply to systolic blood pressure.
+    /// This is applied after blood pressure deviation.
+    /// </summary>
+    [DataField(required: true)]
+    public FixedPoint2 SystolicMultiplier = 1;
+
+    /// <summary>
+    /// Multiplier to apply to diastolic blood pressure.
+    /// This is applied after blood pressure deviation.
+    /// </summary>
+    [DataField(required: true)]
+    public FixedPoint2 DiastolicMultiplier = 1;
+}

--- a/Resources/Locale/en-US/_Impstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Impstation/traits/traits.ftl
@@ -102,3 +102,9 @@ trait-unadapted-to-space-desc = Your body hasn't adapted to space, making you ta
 
 trait-vowelrotation-name = Vowel Rotation
 trait-vowelrotation-desc = Yua'ri frum en udd curnir uf speci whiri iviry vuwil os shoftid uvir by uni. AEIOU -> EIOUA
+
+trait-hypertension-name = Hypertension
+trait-hypertension-desc = You have slightly higher blood pressure.
+
+trait-hypotension-name = Hypotension
+trait-hypotension-desc = You have slightly lower blood pressure.

--- a/Resources/Prototypes/_Impstation/Traits/quirks.yml
+++ b/Resources/Prototypes/_Impstation/Traits/quirks.yml
@@ -5,3 +5,25 @@
   category: Quirks
   components:
   - type: HeavyweightDrunk
+
+- type: trait
+  id: Hypertension
+  name: trait-hypertension-name
+  description: trait-hypertension-desc
+  category: Quirks
+  onlyOneAllowedAmongstTraitsWith: BloodPressureTrait
+  components:
+  - type: BloodPressureVariation
+    systolicMultiplier: 1.05
+    diastolicMultiplier: 1.03
+
+- type: trait
+  id: Hypotension
+  name: trait-hypotension-name
+  description: trait-hypotension-desc
+  category: Quirks
+  onlyOneAllowedAmongstTraitsWith: BloodPressureTrait
+  components:
+  - type: BloodPressureVariation
+    systolicMultiplier: 0.97
+    diastolicMultiplier: 0.95


### PR DESCRIPTION
## About the PR
Hypertension/hypotension traits were added. They're mutually exclusive to eachother, and slightly change how much blood pressure a patient has in the analyzer.

## Why / Balance
To add slight variation to blood pressure outside of blood volume.

## Technical details
* Long-lived `BloodPressureVariationComponent` added by the trait system.
* Trait system extended to support mutually exclusive traits
  * Only one trait can be selected amongst a category of them.
  * Separate from categories/points system.

## Media
### Mutually exclusive traits
https://github.com/user-attachments/assets/345238f5-b8ec-4b57-afaf-a3226ec400a6

### Scanner output
<img width="296" height="373" alt="Content Client_ZmNV3hryof" src="https://github.com/user-attachments/assets/a827ad6f-923e-4721-9576-80f4981a3b60" />

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl: Banditoz
- add: Added hypertension and hypotension traits, which slightly changes your blood pressure on a health analyzer.

