### PR TITLE
add TooShortForUIComponent

### DIFF
--- a/Content.Shared/_Impstation/TooShortForUI/TooShortForUIComponent.cs
+++ b/Content.Shared/_Impstation/TooShortForUI/TooShortForUIComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Impstation.TooShortForUI;
+
+/// <summary>
+/// Blocks the use of machine UI on blacklisted or non-whitelisted machines if the entity is not:
+/// 1) buckled into something, like a chair or a bed
+/// 2) weightless
+/// or 3) vaulted on a table.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TooShortForUIComponent : Component
+{
+    /// <summary>
+    /// These entities will *not* be allowed.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityWhitelist Blacklist;
+
+    [DataField]
+    public LocId? PopupText = "too-short-for-ui-cant-use";
+}

--- a/Content.Shared/_Impstation/TooShortForUI/TooShortForUIComponent.cs
+++ b/Content.Shared/_Impstation/TooShortForUI/TooShortForUIComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class TooShortForUIComponent : Component
 {
     /// <summary>
     /// These entities will *not* be allowed.
-    /// If the blacklist is null,
+    /// If the blacklist is null, blocks all entities.
     /// </summary>
     [DataField]
     public EntityWhitelist? Blacklist = null;

--- a/Content.Shared/_Impstation/TooShortForUI/TooShortForUIComponent.cs
+++ b/Content.Shared/_Impstation/TooShortForUI/TooShortForUIComponent.cs
@@ -14,9 +14,10 @@ public sealed partial class TooShortForUIComponent : Component
 {
     /// <summary>
     /// These entities will *not* be allowed.
+    /// If the blacklist is null,
     /// </summary>
-    [DataField(required: true)]
-    public EntityWhitelist Blacklist;
+    [DataField]
+    public EntityWhitelist? Blacklist = null;
 
     [DataField]
     public LocId? PopupText = "too-short-for-ui-cant-use";

--- a/Content.Shared/_Impstation/TooShortForUI/TooShortForUISystem.cs
+++ b/Content.Shared/_Impstation/TooShortForUI/TooShortForUISystem.cs
@@ -1,0 +1,54 @@
+using Content.Shared.Buckle.Components;
+using Content.Shared.Climbing.Components;
+using Content.Shared.Gravity;
+using Content.Shared.Popups;
+using Content.Shared.UserInterface;
+using Content.Shared.Whitelist;
+using Robust.Shared.Network;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._Impstation.TooShortForUI;
+
+public sealed class TooShortForUI : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedGravitySystem _gravity = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TooShortForUIComponent, UserOpenActivatableUIAttemptEvent>(OnUIOpenAttempt);
+    }
+
+    public void OnUIOpenAttempt(Entity<TooShortForUIComponent> ent, ref UserOpenActivatableUIAttemptEvent args)
+    {
+        // first, check if we're buckled to something, and if we are, return
+        if (TryComp<BuckleComponent>(ent, out var buckle) && buckle.Buckled)
+            return;
+
+        // next, check if we're in the air. if we are, return
+        if (TryComp<PhysicsComponent>(ent, out var physics) && physics.BodyStatus != BodyStatus.OnGround)
+            return;
+
+        // next, check if we're weightless. you get the idea
+        if (TryComp<GravityAffectedComponent>(ent, out var gravityAffected) && _gravity.IsWeightless((ent.Owner, gravityAffected)))
+            return;
+
+        // finally, check if we're on a table.
+        if (TryComp<ClimbingComponent>(ent, out var climbing) && climbing.IsClimbing)
+            return;
+
+        // if the target entity is on the blacklist or no blacklist is defined, cancel the event
+        if (_whitelist.IsBlacklistPassOrNull(ent.Comp.Blacklist, args.Target))
+            args.Cancel();
+
+        // if the event has been cancelled and there is popup text, popup
+        if (args.Cancelled && ent.Comp.PopupText != null && _net.IsClient && _timing.IsFirstTimePredicted)
+            _popup.PopupEntity(Loc.GetString(ent.Comp.PopupText), ent, ent);
+    }
+}

--- a/Resources/Locale/en-US/too-short-for-ui/too-short-for-ui.ftl
+++ b/Resources/Locale/en-US/too-short-for-ui/too-short-for-ui.ftl
@@ -1,0 +1,1 @@
+too-short-for-ui-cant-use = You're too short to reach the controls! Try getting up higher.


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Requested by Kip for Wolfie's raptors.
Might be neat to add this to like, goblins and monkeys too, but I'll leave that to another PR.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a new (as yet unused) component that prevents the owner from using any blacklisted entities' UI unless they are strapped into a chair, vaulted onto a table, weightless, or otherwise in the air. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
