### PR TITLE
add UnableToWieldComponent

### DIFF
--- a/Content.Shared/_Impstation/UnableToWield/UnableToWieldComponent.cs
+++ b/Content.Shared/_Impstation/UnableToWield/UnableToWieldComponent.cs
@@ -1,0 +1,29 @@
+using Content.Shared.Mobs;
+using Content.Shared.Popups;
+using Content.Shared.Wieldable;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._Impstation.UnableToWield;
+
+public sealed class UnableToWieldSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<UnableToWieldComponent, WieldAttemptEvent>(OnWieldAttempt);
+    }
+
+    private void OnWieldAttempt(Entity<UnableToWieldComponent> ent, ref WieldAttemptEvent args)
+    {
+        args.Cancel();
+
+        if (_net.IsClient && _timing.IsFirstTimePredicted && ent.Comp.PopupText != null)
+            _popup.PopupEntity(Loc.GetString(ent.Comp.PopupText), ent, ent);
+    }
+}

--- a/Content.Shared/_Impstation/UnableToWield/UnableToWieldSystem.cs
+++ b/Content.Shared/_Impstation/UnableToWield/UnableToWieldSystem.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Impstation.UnableToWield;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class UnableToWieldComponent : Component
+{
+    [DataField]
+    public LocId? PopupText = "unable-to-wield-cant-do";
+}

--- a/Resources/Locale/en-US/unable-to-wield/unable-to-wield.ftl
+++ b/Resources/Locale/en-US/unable-to-wield/unable-to-wield.ftl
@@ -1,0 +1,1 @@
+unable-to-wield-cant-do = You can't wield this, it's too big!


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Requested by Kip for Wolfie's raptors.
Honestly, in an ideal world, wielding would be its own component, instead of just being tied to hands, but that's a different issue.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds UnableToWieldComponent (as-yet unused,) which prevents its owner from wielding items, and throws a popup on attempt. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
