### PR TITLE
Moving won't cancel health analyzer do_after

### DIFF
--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -91,7 +91,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         var doAfterCancelled = !_doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, uid.Comp.ScanDelay, new HealthAnalyzerDoAfterEvent(), uid, target: args.Target, used: uid)
         {
             NeedHand = true,
-            BreakOnMove = true,
+            BreakOnMove = false, // Impstation
         });
 
         if (args.Target == args.User || doAfterCancelled || uid.Comp.Silent)


### PR DESCRIPTION
## About the PR
You can now move while scanning somebody with the health analyzer.

## Why / Balance
You should be able to run the health scanner over somebody while on the move, such as a patient on a roller bed.

## Technical details
N/A

## Media
N/A

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl: Banditoz
- tweak: You can now move while scanning somebody with the health analyzer.
