### PR TITLE
derelict syndieborg typing indicator fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -436,6 +436,10 @@
       Unsexed: UnisexSiliconSyndicate
   - type: PointLight
     color: "#dd200b"
+  # imp edit start
+  - type: TypingIndicator
+    proto: syndibot
+  # imp edit end
 
 - type: entity
   parent: BaseBorgChassisNotIonStormable


### PR DESCRIPTION
## About the PR
this PR fixes the derelict syndicate borg to use the "syndiebot" typing indicator, as the regular versions do. 
i have no idea why they didnt just parent off the regular syndieborgs but here we are i guess.

## Why / Balance
needs more red

## Technical details
2 lines yaml

## Media
<img width="110" height="130" alt="image" src="https://github.com/user-attachments/assets/e9e5177c-8fe9-4bd0-ac5c-453eb8862adb" />

## Requirements
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: fixed derelict syndieborgs having a blue typing indicator

