### PR TITLE
Marathon and Bagel map fixes

### DIFF
--- a/Resources/Maps/_Impstation/bagel.yml
+++ b/Resources/Maps/_Impstation/bagel.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/14/2025 05:03:17
-  entityCount: 25985
+  time: 09/22/2025 04:25:02
+  entityCount: 25996
 maps:
 - 1
 grids:
@@ -43787,6 +43787,41 @@ entities:
     components:
     - type: Transform
       pos: -8.5,51.5
+      parent: 2
+  - uid: 23832
+    components:
+    - type: Transform
+      pos: -14.5,3.5
+      parent: 2
+  - uid: 23880
+    components:
+    - type: Transform
+      pos: -15.5,3.5
+      parent: 2
+  - uid: 23940
+    components:
+    - type: Transform
+      pos: -15.5,4.5
+      parent: 2
+  - uid: 23941
+    components:
+    - type: Transform
+      pos: -15.5,5.5
+      parent: 2
+  - uid: 24090
+    components:
+    - type: Transform
+      pos: -15.5,6.5
+      parent: 2
+  - uid: 24091
+    components:
+    - type: Transform
+      pos: -15.5,7.5
+      parent: 2
+  - uid: 24171
+    components:
+    - type: Transform
+      pos: -15.5,8.5
       parent: 2
   - uid: 25353
     components:
@@ -115669,6 +115704,16 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: IntercomCommandSecurity
+  entities:
+  - uid: 24257
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -31.5,0.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: IntercomCommandService
   entities:
   - uid: 4676
@@ -115914,6 +115959,30 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-27.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 21744
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-2.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 24206
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-20.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 24249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -121048,19 +121117,19 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 21744
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,-2.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 21745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-21.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 24256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -137267,6 +137336,8 @@ entities:
       parent: 2
   - uid: 19963
     components:
+    - type: MetaData
+      name: AI SMES
     - type: Transform
       pos: -110.5,31.5
       parent: 2
@@ -141080,6 +141151,8 @@ entities:
       parent: 2
   - uid: 20618
     components:
+    - type: MetaData
+      name: AI Substation
     - type: Transform
       pos: -112.5,31.5
       parent: 2
@@ -147318,7 +147391,7 @@ entities:
     - type: Transform
       pos: 50.5,-25.5
       parent: 2
-- proto: VaultDoorCommandLocked
+- proto: VaultDoorLocked
   entities:
   - uid: 16722
     components:

--- a/Resources/Maps/_Impstation/marathon.yml
+++ b/Resources/Maps/_Impstation/marathon.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/14/2025 04:43:00
-  entityCount: 23586
+  time: 09/22/2025 04:09:28
+  entityCount: 23592
 maps:
 - 1
 grids:
@@ -14013,6 +14013,16 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,41.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 19080
+    components:
+    - type: MetaData
+      name: Security Front APC
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,41.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -33599,6 +33609,11 @@ entities:
     - type: Transform
       pos: -6.5,-25.5
       parent: 2
+  - uid: 23587
+    components:
+    - type: Transform
+      pos: -30.5,41.5
+      parent: 2
 - proto: CableApcStack
   entities:
   - uid: 4451
@@ -45611,6 +45626,31 @@ entities:
     components:
     - type: Transform
       pos: -18.5,8.5
+      parent: 2
+  - uid: 23588
+    components:
+    - type: Transform
+      pos: -32.5,43.5
+      parent: 2
+  - uid: 23589
+    components:
+    - type: Transform
+      pos: -31.5,43.5
+      parent: 2
+  - uid: 23590
+    components:
+    - type: Transform
+      pos: -31.5,42.5
+      parent: 2
+  - uid: 23591
+    components:
+    - type: Transform
+      pos: -31.5,41.5
+      parent: 2
+  - uid: 23592
+    components:
+    - type: Transform
+      pos: -30.5,41.5
       parent: 2
 - proto: CableMVStack
   entities:
@@ -129185,17 +129225,6 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Brig Corridor
-  - uid: 19080
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -41.5,65.5
-      parent: 2
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraSecurity
-      nameSet: True
-      id: Armory Space View
   - uid: 19081
     components:
     - type: Transform
@@ -133258,7 +133287,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 11.5,61.5
       parent: 2
-- proto: VaultDoorCommandLocked
+- proto: VaultDoorLocked
   entities:
   - uid: 10272
     components:


### PR DESCRIPTION
On Marathon, added an APC to security, fixing the front area starting with no power.

On Bagel, fixed grav gen SMES not being connected to the station's hv grid, added a couple of intercoms to the sec front desks.
