### PR TITLE
heretic ghoul fixes

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/GhoulSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/GhoulSystem.cs
@@ -3,7 +3,9 @@ using Content.Server.Atmos.Components;
 using Content.Server.Body.Components;
 using Content.Server.Humanoid;
 using Content.Server.Temperature.Components;
+using Content.Shared._Offbrand.Wounds;
 using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Heretic;
 using Content.Shared.Humanoid;
@@ -24,6 +26,7 @@ public sealed class GhoulSystem : Shared.Heretic.EntitySystems.SharedGhoulSystem
 
     public void GhoulifyEntity(Entity<GhoulComponent> ent)
     {
+        //base removals
         RemComp<RespiratorComponent>(ent);
         RemComp<BarotraumaComponent>(ent);
         RemComp<HungerComponent>(ent);
@@ -31,6 +34,35 @@ public sealed class GhoulSystem : Shared.Heretic.EntitySystems.SharedGhoulSystem
         RemComp<ReproductiveComponent>(ent);
         RemComp<ReproductivePartnerComponent>(ent);
         RemComp<TemperatureComponent>(ent);
+
+        _rejuvenate.PerformRejuvenate(ent);
+
+        //offmed adjustments. converts the entity into oldmed essentially. 
+        //we do this AFTER rejuvination because otherwise you get stuck in a weird halfway crit state. 
+        //something to do with brain damage i think
+        RemComp<HeartrateComponent>(ent);
+        RemComp<HeartDefibrillatableComponent>(ent);
+        RemComp<HeartStopOnHypovolemiaComponent>(ent);
+        RemComp<HeartStopOnHighStrainComponent>(ent);
+        RemComp<HeartStopOnBrainHealthComponent>(ent);
+        RemComp<PainComponent>(ent);
+        RemComp<HeartrateAlertsComponent>(ent);
+        RemComp<ShockThresholdsComponent>(ent);
+        RemComp<ShockAlertsComponent>(ent);
+        RemComp<BrainDamageComponent>(ent);
+        RemComp<BrainDamageOxygenationComponent>(ent);
+        RemComp<BrainDamageThresholdsComponent>(ent);
+        RemComp<BrainDamageOnDamageComponent>(ent);
+        RemComp<HeartDamageOnDamageComponent>(ent);
+        RemComp<MaximumDamageComponent>(ent);
+        RemComp<CprTargetComponent>(ent);
+        RemComp<Content.Server.Construction.Components.ConstructionComponent>(ent);
+        RemComp<CryostasisFactorComponent>(ent);
+        RemComp<UniqueWoundOnDamageComponent>(ent);
+        RemComp<IntrinsicPainComponent>(ent);
+        EnsureComp<MobThresholdsComponent>(ent);
+        EnsureComp<MobStateComponent>(ent);
+        EnsureComp<DamageableComponent>(ent);
 
         if (TryComp<HumanoidAppearanceComponent>(ent, out var humanoid))
         {
@@ -40,8 +72,6 @@ public sealed class GhoulSystem : Shared.Heretic.EntitySystems.SharedGhoulSystem
             _humanoid.SetSkinColor(ent, greycolor, true, false, humanoid);
             _humanoid.SetBaseLayerColor(ent, HumanoidVisualLayers.Eyes, greycolor, true, humanoid);
         }
-
-        _rejuvenate.PerformRejuvenate(ent);
 
         if (!TryComp<MobThresholdsComponent>(ent, out var th))
             return;

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -44,6 +44,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly TemperatureSystem _temperature = default!;
     [Dependency] private readonly MinionSystem _minion = default!;
+    [Dependency] private readonly GhoulSystem _ghoul = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
 
     private readonly ProtoId<NpcFactionPrototype> _hereticFaction = "Heretic";
@@ -79,9 +80,11 @@ public sealed partial class MansusGraspSystem : EntitySystem
                     && !TryComp<HellVictimComponent>(target, out _))
                 {
                     var minion = EnsureComp<MinionComponent>(target);
+                    var ghoul = EnsureComp<GhoulComponent>(target);
                     minion.BoundOwner = performer;
                     minion.FactionsToAdd.Add(_hereticFaction);
                     _minion.ConvertEntityToMinion((target, minion), true, true, true);
+                    _ghoul.GhoulifyEntity((target, ghoul));
                 }
                 break;
 


### PR DESCRIPTION
## About the PR
This PR fixes the conversion of players to ghouls in the Heretic flesh path. Conversion now also sets ghouls to the pre-offmed health model, to alleviate any unintended behavior that might be caused with them.

## Why / Balance
Flesh path sorely needs the ghouls back. Setting them to oldmed standards seemed to fix most bugs they were having in testing.

## Technical details
Added a large block of component removals and additions in ghoulsystem for reversion to oldmed, similar to how zombies are handled now. 
Tweaked some mansus grasp behaviors to make ghoul conversion work properly again after the ghoul refactor.
## Media
https://github.com/user-attachments/assets/4002048d-5f6f-4b7a-b1c3-421ac3d25e03


## Requirements
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- fix: Fixed Flesh Heretic ghouls not properly converting. 
- tweak: Ghouls now appear as ghost roles if the body is without a mind when converted.

