### PR TITLE
lenses will always at least spawn on the ground no matter what

### DIFF
--- a/Content.Server/_Impstation/StartWithLenses/StartWithLensesSystem.cs
+++ b/Content.Server/_Impstation/StartWithLenses/StartWithLensesSystem.cs
@@ -1,13 +1,14 @@
 ﻿using System.Linq;
 using Content.Server._Impstation.TraitRandomizer;
+using Content.Server.Bed.Cryostorage;
+using Content.Server.Traits;
 using Content.Shared.Clothing;
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.GameTicking;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Lens;
-using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server._Impstation.StartWithLenses;
 
@@ -15,56 +16,71 @@ public sealed class StartWithLensesSystem : EntitySystem
 {
     [Dependency] private readonly InventorySystem _inventorySystem = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
-    [Dependency] private readonly SharedContainerSystem _containers = default!;
     [Dependency] private readonly SharedHandsSystem _sharedHandsSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<StartWithLensesComponent, MapInitEvent>(OnMapInit, after: [typeof(LoadoutSystem), typeof(TraitRandomizerSystem)]);
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete, after: [typeof(TraitSystem), typeof(LoadoutSystem), typeof(TraitRandomizerSystem), typeof(CryostorageSystem)]);
     }
 
-    private void OnMapInit(Entity<StartWithLensesComponent> ent, ref MapInitEvent args)
+    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args)
     {
-        if (!_inventorySystem.TryGetSlot(ent, "eyes", out var slot))
-            return;
-
-        var eyeSet = _inventorySystem.GetHandOrInventoryEntities(ent.Owner, SlotFlags.EYES);
-
-        if (!eyeSet.Any())
+        if (!TryComp<StartWithLensesComponent>(args.Mob, out var comp))
         {
-            _inventorySystem.SpawnItemInSlot(ent, "eyes", ent.Comp.LensPrototype);
             return;
         }
 
-        var eyes = eyeSet.First();
+        // spawn it on the floor first Just In Case
+        var spawnedLens = Spawn(comp.LensPrototype, Transform(args.Mob).Coordinates);
 
-        if (TryComp<LensSlotComponent>(eyes, out var lensSlot))
+        // check if the entity has an eyes slot
+        if (_inventorySystem.TryGetSlot(args.Mob, "eyes", out var slotDefinition))
         {
-            var item = Spawn(ent.Comp.LensPrototype, Transform(ent).Coordinates);
+            // get the item in the eyes slot
+            var eyeSet = (_inventorySystem.GetHandOrInventoryEntities(args.Mob, SlotFlags.EYES));
 
-            if (_itemSlotsSystem.TryGetSlot(eyes, lensSlot.LensSlotId, out ItemSlot? itemSlot))
+            // check if there's anything in the eye slot
+            if (!eyeSet.Any())
             {
-                if (itemSlot.Item != null)
+                // if not, spawn them in the eyes slot
+                if (_inventorySystem.SpawnItemInSlot(args.Mob, "eyes", comp.LensPrototype))
                 {
-                    Del(itemSlot.Item);
+                    // delete the one on the floor
+                    Del(spawnedLens);
+                    return;
                 }
-                _itemSlotsSystem.TryInsert(eyes, itemSlot, item, user: null);
             }
 
-        }
-        else
-        {
-            if (TryComp<HandsComponent>(ent, out var handsComponent))
+            // there's something there, get it
+            if (_inventorySystem.TryGetSlotEntity(args.Mob, "eyes", out var slotEntity))
             {
-                var coords = Transform(ent).Coordinates;
-                var inhandEntity = EntityManager.SpawnEntity(ent.Comp.LensPrototype, coords);
-                _sharedHandsSystem.TryPickup(ent,
-                    inhandEntity,
-                    checkActionBlocker: false,
-                    handsComp: handsComponent);
+                // check if it has a lens slot component
+                if (TryComp<LensSlotComponent>(slotEntity, out var lensSlotComponent))
+                {
+                    if (_itemSlotsSystem.TryGetSlot(slotEntity.Value, lensSlotComponent.LensSlotId, out ItemSlot? lensSlot))
+                    {
+                        // if there's something already in the lens slot, delete it
+                        if (lensSlot.Item != null)
+                        {
+                            Del(lensSlot.Item);
+                        }
+                        if (_itemSlotsSystem.TryInsert(slotEntity.Value, lensSlot, spawnedLens, user: null))
+                        {
+                            return;
+                        }
+                    }
+                }
             }
+        }
+
+        // eye slot didn't work, it's hand time
+        // check if the entity has hands
+        if (TryComp<HandsComponent>(args.Mob, out var handsComponent))
+        {
+            // try to put it in their hands
+            _sharedHandsSystem.TryPickup(args.Mob, spawnedLens, checkActionBlocker: false, handsComp: handsComponent);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
Found out there was a bug where lenses wouldn't spawn if you latejoin in cryo, turns out there's even more problems than that though. This makes it so that they will Always spawn even if everything else fails. There's still issues I have no idea how to fix, like if you spawn roundstart with a trait item in your hand but no glasses on the lenses stay on the floor and aren't put in your eyes, even though it works fine if you do the exact same thing if you don't have a trait item?? But if you start with glasses with a lens slot they start slotted in like normal even with a trait item???? Also cryo's still a little fucked, they won't start in your eyes but they'll at least be in your hand (if you don't have a trait item, in which case they're on the floor).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it a bug fix :)

## Technical details
<!-- Summary of code changes for easier review. -->
Basically completely recoded `StartWithLensesSystem` so it's somewhat better, making sure the first thing it does is spawn the lenses on the floor.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
I don't think media's necessary for this

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Strong prescription lenses will definitely always spawn now. If they're not in your eyes, in your glasses, or in your hands, they're on the floor!
