### PR TITLE
Kill Reach and Banana with hammers (reduce the max pop of "minpop" stations to 4, reduce the min pop of "lowpop" stations to 5)

### DIFF
--- a/Resources/Prototypes/_Impstation/Maps/banana.yml
+++ b/Resources/Prototypes/_Impstation/Maps/banana.yml
@@ -3,7 +3,7 @@
   mapName: 'Banana'
   mapPath: /Maps/_Impstation/banana.yml
   minPlayers: 0
-  maxPlayers: 7
+  maxPlayers: 4
   stations:
     Banana:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/bedlam.yml
+++ b/Resources/Prototypes/_Impstation/Maps/bedlam.yml
@@ -2,7 +2,7 @@
   id: Bedlam
   mapName: 'Bedlam'
   mapPath: /Maps/_Impstation/bedlam.yml
-  minPlayers: 8
+  minPlayers: 5
   maxPlayers: 25
   stations:
     Bedlam:

--- a/Resources/Prototypes/_Impstation/Maps/elkridge.yml
+++ b/Resources/Prototypes/_Impstation/Maps/elkridge.yml
@@ -2,7 +2,7 @@
   id: ElkridgeImp
   mapName: 'Elkridge Depot'
   mapPath: /Maps/_Impstation/elkridge.yml
-  minPlayers: 8
+  minPlayers: 5
   maxPlayers: 34
   stations:
     Elkridge:

--- a/Resources/Prototypes/_Impstation/Maps/lilboat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/lilboat.yml
@@ -2,7 +2,7 @@
   id: Lilboat
   mapName: 'NTAS Dolphin'
   mapPath: /Maps/_Impstation/lilboat.yml
-  minPlayers: 8
+  minPlayers: 5
   maxPlayers: 34
   stations:
     Lilboat:

--- a/Resources/Prototypes/_Impstation/Maps/packed.yml
+++ b/Resources/Prototypes/_Impstation/Maps/packed.yml
@@ -2,7 +2,7 @@
   id: PackedImp
   mapName: 'Packed'
   mapPath: /Maps/_Impstation/packed.yml
-  minPlayers: 8
+  minPlayers: 5
   maxPlayers: 34
   stations:
     Packed:

--- a/Resources/Prototypes/_Impstation/Maps/reach.yml
+++ b/Resources/Prototypes/_Impstation/Maps/reach.yml
@@ -3,7 +3,7 @@
   mapName: 'Reach'
   mapPath: /Maps/_Impstation/reach.yml
   minPlayers: 0
-  maxPlayers: 7
+  maxPlayers: 4
   stations:
     Reach:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/refsdal.yml
+++ b/Resources/Prototypes/_Impstation/Maps/refsdal.yml
@@ -2,7 +2,7 @@
   id: Refsdal
   mapName: 'Refsdal'
   mapPath: /Maps/_Impstation/refsdal.yml
-  minPlayers: 8
+  minPlayers: 5
   maxPlayers: 20
   stations:
     Refsdal:

--- a/Resources/Prototypes/_Impstation/Maps/saltern.yml
+++ b/Resources/Prototypes/_Impstation/Maps/saltern.yml
@@ -2,7 +2,7 @@
   id: SalternImp
   mapName: 'Saltern'
   mapPath: /Maps/_Impstation/saltern.yml
-  minPlayers: 8
+  minPlayers: 5
   maxPlayers: 34
   fallback: true
   stations:

--- a/Resources/Prototypes/_Impstation/Maps/skimmer.yml
+++ b/Resources/Prototypes/_Impstation/Maps/skimmer.yml
@@ -3,7 +3,7 @@
   mapName: 'Skimmer'
   mapPath: /Maps/_Impstation/skimmer.yml
   minPlayers: 0
-  maxPlayers: 7
+  maxPlayers: 4
   randomRotation: false
   stations:
     Skimmer:


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
Reduces the max pop of Reach and Banana to 4.
Reduces the min pop of Bedlam, Elkridge, Dolphin, Packed, and Saltern to 5.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Further tweak to https://github.com/impstation/imp-station-14/pull/3501. Reach and Banana rolling can lead to a feedback loop of people not joining the server because they don't want to play on minpop stations, leading to the next highest bracket of station not rolling, due to the population being too low. This also goes along with my philosophy that it's better for a map to be too large for the current population than for it to be too small.

This leads to a new set of population range brackets:

**Min pop:** 0 - 4
**Low pop:** 5 - 34
**Mid pop:** 34 - 69
**High pop:** 70 - 100

A new graph after the changes (opening excel makes me want to pull my teeth out):

<img width="3414" height="2592" alt="mapranges" src="https://github.com/user-attachments/assets/fc69c9a4-511c-41b1-b4cd-6c30de892e9e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: The max population for rolling "min-pop" maps (Banana and Reach) has been lowered to 4 players, "low-pop" maps now roll at 5 players.

