### PR TITLE
Fix textures pointing to PNGs directly instead of RSI files

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -218,7 +218,7 @@
   components:
   - type: Action
     icon: { sprite: Interface/Actions/actions_ai.rsi, state: station_records } #imp edit - use a real sprite for this since it's going on the AI as well.
-    iconOn: Interface/Actions/actions_ai.rsi/station_records.png
+    iconOn: { sprite: Interface/Actions/actions_ai.rsi, state: station_records }
     keywords: [ "AI", "console", "interface" ]
     priority: -10
   - type: InstantAction

--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -215,7 +215,7 @@
   components:
   - type: Action
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-basic-module }
-    iconOn: Interface/Actions/actions_borg.rsi/xenoborg-basic-module.png
+    iconOn: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-basic-module }
     keywords: [ "Mothership Core", "console", "interface" ]
     priority: -6
   - type: InstantAction
@@ -229,7 +229,7 @@
   components:
   - type: Action
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-eye-module }
-    iconOn: Interface/Actions/actions_borg.rsi/xenoborg-eye-module.png
+    iconOn: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-eye-module }
     keywords: [ "Mothership Core", "console", "interface" ]
     priority: -6
   - type: InstantAction

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -101,7 +101,7 @@
   - type: Action
     checkCanInteract: false
     icon: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
-    iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
+    iconOn: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
     keywords: [ "AI", "console", "interface" ]
     priority: -6
     useDelay: 60 # to discourage everyone from opening it at once and causing potential perf issues.


### PR DESCRIPTION
Required to resolve test fail in https://github.com/impstation/imp-station-14/pull/3514. Imp comments have not been included, since the inclusions in admin_ghost.yml and observer.yml are imp additions already commented on the entities added and the changes in mothershipcore.yml reflect the current state of these specific lines upstream.