### PR TITLE
Tools and paper for cargo cyborg

### DIFF
--- a/Resources/Locale/en-US/_Impstation/borg/borg.ftl
+++ b/Resources/Locale/en-US/_Impstation/borg/borg.ftl
@@ -1,4 +1,6 @@
-﻿borg-type-cargo-name = Cargo
+﻿borg-slot-mail-empty = Mail and paper
+
+borg-type-cargo-name = Cargo
 borg-type-cargo-desc = Assist cargo operations by processing supply requests, delivering mail, and transporting goods across the station. Equipped with appraisal and courier tools.
 borg-type-cargo-transponder = cargo cyborg
 

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
@@ -110,5 +110,14 @@
     hands:
     - item: MailBag
     - item: BorgHoloBellProjector
+    - hand:
+        emptyLabel: borg-slot-mail-empty
+        emptyRepresentative: Paper
+        whitelist:
+          components:
+          - Delivery
+          tags:
+          - Document
+          - Paper
   - type: BorgModuleIcon
     icon: { sprite: _Impstation/Interface/Actions/actions_borg.rsi, state: courier-module }

--- a/Resources/Prototypes/_Impstation/borg_types.yml
+++ b/Resources/Prototypes/_Impstation/borg_types.yml
@@ -12,6 +12,7 @@
     - BorgModuleCargo
 
   defaultModules:
+  - BorgModuleTool
   - BorgModuleAppraisal
   - BorgModuleCourier # Imp
 


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
This PR makes the following two additions to the cargo cyborg to make it a little more usable:
1. Makes it start with a tools module. Roundstart tools module has been standard issue for upstream cyborgs for months now, so this just brings the cargo chassis up to speed.
2. Adds a whitelisted hand to the courier module which accepts any item with the `Delivery` component, or the `Document` or `Paper` tags.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently the cargo chassis provides very little utility in terms of performing cargo technician (and even courier) duties, rendering it little more than a metal Cargorilla. The new hand allows cargo cyborgs to process acquisition slips and bounty manifests, as well as providing them a little more finesse when it comes to taking mail out of their bag. 

## Technical details
<!-- Summary of code changes for easier review. -->
All YAML. Whitelist specifics are listed in the about section above. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->


https://github.com/user-attachments/assets/42e6adf8-1e9c-442c-9155-1a9f9b2e48ce





## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The courier module now has a hand for picking up paper and mail. 
- tweak: Cargo cyborgs now start with a tools module like all other cyborgs.
