### PR TITLE
Fix Heretic ghouling, further future proof sacrificing

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -79,6 +79,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
                     && !TryComp<HellVictimComponent>(target, out _))
                 {
                     var minion = EnsureComp<MinionComponent>(target);
+                    EnsureComp<GhoulComponent>(target);
                     minion.BoundOwner = performer;
                     minion.FactionsToAdd.Add(_hereticFaction);
                     _minion.ConvertEntityToMinion((target, minion), true, true, true);

--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
@@ -10,6 +10,7 @@ using Content.Shared.Heretic;
 using Content.Shared.Heretic.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Mind;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
@@ -96,7 +97,7 @@ public partial class RitualSacrificeBehavior : RitualCustomBehavior
             || args.EntityManager.HasComponent<GhoulComponent>(look)) //shouldn't happen because they gib on death but. sanity check
                 continue;
 
-            if ((mobstate.CurrentState == Shared.Mobs.MobState.Dead) || (mobstate.CurrentState == Shared.Mobs.MobState.Critical))
+            if (mobstate.CurrentState != MobState.Alive)
                 Uids.Add(look);
         }
 


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
Oops. I broke ghouling. fixes https://github.com/impstation/imp-station-14/issues/3518

## Why / Balance
fix.

## Technical details
Basically I forgot to add the ghoul component when ghouling when I separated the ghoul component into two.. Oops!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Heretics can now make ghouls again.. Huzzah! 
