### PR TITLE
Cluster Updates

### DIFF
--- a/Resources/Maps/_Impstation/cluster.yml
+++ b/Resources/Maps/_Impstation/cluster.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 266.0.0
+  engineVersion: 267.2.0
   forkId: ""
   forkVersion: ""
-  time: 10/04/2025 21:55:03
-  entityCount: 13416
+  time: 10/08/2025 00:07:00
+  entityCount: 13433
 maps:
 - 1
 grids:
@@ -772,6 +772,14 @@ entities:
             1389: -18,-17
         - node:
             color: '#DE3A3A96'
+            id: BrickTileSteelInnerNw
+          decals:
+            2304: 33,28
+            2305: 33,28
+            2306: 33,28
+            2307: 33,28
+        - node:
+            color: '#DE3A3A96'
             id: BrickTileSteelInnerSe
           decals:
             2155: 30,27
@@ -994,10 +1002,6 @@ entities:
             2055: 27,24
             2056: 27,24
             2057: 27,24
-            2058: 27,25
-            2059: 27,25
-            2060: 27,25
-            2061: 27,25
             2062: 27,26
             2063: 27,26
             2064: 27,26
@@ -1006,6 +1010,10 @@ entities:
             2067: 27,27
             2068: 27,27
             2069: 27,27
+            2300: 27,25
+            2301: 27,25
+            2302: 27,25
+            2303: 27,25
         - node:
             color: '#DE3A3AFF'
             id: BrickTileSteelLineW
@@ -3140,6 +3148,7 @@ entities:
             id: StandClear
           decals:
             1058: -40,22
+            2290: 13,-8
         - node:
             color: '#334E6DC8'
             id: ThreeQuarterTileOverlayGreyscale
@@ -3419,6 +3428,7 @@ entities:
             79: -9,54
             80: -8,55
             964: 9,-28
+            2289: 13,-6
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSW
@@ -3468,6 +3478,9 @@ entities:
             1958: 24,-5
             1959: 24,-6
             1960: 24,-7
+            2286: 13,-9
+            2287: 13,-8
+            2288: 13,-7
         - node:
             zIndex: 1
             color: '#FFFFFFFF'
@@ -3706,7 +3719,8 @@ entities:
           0,0:
             0: 65535
           -1,0:
-            0: 28512
+            0: 2304
+            1: 26208
           0,1:
             0: 65528
           -1,1:
@@ -3788,7 +3802,7 @@ entities:
           -3,0:
             0: 65520
           -3,1:
-            0: 57328
+            0: 57296
           -3,2:
             0: 57341
           -3,3:
@@ -3879,10 +3893,10 @@ entities:
             0: 62207
           3,-3:
             0: 12671
-            1: 32768
+            2: 32768
           3,-2:
             0: 45875
-            1: 136
+            2: 136
           3,-5:
             0: 61160
           4,-3:
@@ -3923,7 +3937,7 @@ entities:
             0: 65535
           -1,8:
             0: 32783
-            1: 28928
+            2: 28928
           0,5:
             0: 63731
           0,6:
@@ -3954,7 +3968,7 @@ entities:
             0: 4080
           3,8:
             0: 221
-            1: 16384
+            2: 16384
           4,4:
             0: 36848
           4,5:
@@ -4080,7 +4094,7 @@ entities:
           3,-8:
             0: 9826
           4,-8:
-            1: 3918
+            2: 3918
           4,-7:
             0: 8191
           4,-6:
@@ -4102,7 +4116,7 @@ entities:
           -9,7:
             0: 3067
           -8,8:
-            1: 65327
+            2: 65327
           -7,6:
             0: 65294
           -7,7:
@@ -4110,80 +4124,80 @@ entities:
           -7,5:
             0: 61166
           -7,8:
-            1: 65375
+            2: 65375
           -6,5:
             0: 48059
           -6,6:
             0: 15115
           -6,7:
             0: 238
-            1: 8192
+            2: 8192
           -6,8:
-            1: 32079
+            2: 32079
           -5,8:
             0: 4
-            1: 28480
+            2: 28480
           0,8:
             0: 4352
-            1: 27712
+            2: 27712
           0,9:
-            1: 48826
+            2: 48826
           -1,9:
             0: 25800
-            1: 36912
+            2: 36912
           0,10:
-            1: 17525
+            2: 17525
           -1,10:
-            1: 144
+            2: 144
             0: 1122
           -1,11:
             0: 53247
           0,11:
-            1: 1252
+            2: 1252
           1,8:
-            1: 4368
+            2: 4368
           1,9:
-            1: 1
+            2: 1
           1,11:
-            1: 33392
+            2: 33392
           1,12:
-            1: 51340
+            2: 51340
           3,9:
-            1: 14
+            2: 14
           4,8:
             0: 35003
-            1: 8192
+            2: 8192
           4,9:
-            1: 3619
+            2: 3619
           -4,8:
-            1: 44896
+            2: 44896
           -4,9:
-            1: 19622
+            2: 19622
           -4,11:
-            1: 8812
+            2: 8812
           -4,12:
-            1: 8742
+            2: 8742
           -3,8:
-            1: 2304
+            2: 2304
             0: 17952
           -3,9:
-            1: 2315
+            2: 2315
             0: 25188
           -4,10:
-            1: 34952
+            2: 34952
           -3,10:
-            1: 4643
+            2: 4643
             0: 19596
           -3,11:
             0: 1220
           -3,12:
             0: 61164
           -2,8:
-            1: 58144
+            2: 58144
           -2,9:
-            1: 58361
+            2: 58361
           -2,10:
-            1: 2805
+            2: 2805
           -2,11:
             0: 2039
           -2,12:
@@ -4191,37 +4205,37 @@ entities:
           -1,12:
             0: 48049
           -9,8:
-            1: 17484
+            2: 17484
           -8,9:
-            1: 65327
+            2: 65327
           -9,9:
-            1: 50252
+            2: 50252
           -8,10:
-            1: 65327
+            2: 65327
           -8,11:
-            1: 11183
+            2: 11183
           -9,10:
-            1: 50244
+            2: 50244
           -9,11:
-            1: 3140
+            2: 3140
           -8,12:
-            1: 14
+            2: 14
           -7,9:
-            1: 65311
+            2: 65311
           -7,10:
-            1: 65439
+            2: 65439
           -7,11:
-            1: 43839
+            2: 43839
           -7,12:
-            1: 15
+            2: 15
           -6,9:
-            1: 21845
+            2: 21845
           -6,10:
-            1: 21831
+            2: 21831
           -6,11:
-            1: 1863
+            2: 1863
           -5,9:
-            1: 15
+            2: 15
           -8,-4:
             0: 65535
           -8,-5:
@@ -4247,10 +4261,10 @@ entities:
           -6,-2:
             0: 4080
           -6,-4:
-            1: 8736
+            2: 8736
             0: 34944
           -6,-3:
-            1: 8736
+            2: 8736
             0: 34944
           -6,-5:
             0: 35746
@@ -4289,15 +4303,15 @@ entities:
           -1,-9:
             0: 63344
           -8,-8:
-            1: 65525
+            2: 65525
           -8,-9:
-            1: 65525
+            2: 65525
           -9,-8:
-            1: 61412
+            2: 61412
           -8,-7:
-            1: 1909
+            2: 1909
           -9,-7:
-            1: 4068
+            2: 4068
             0: 4096
           -8,-6:
             0: 62071
@@ -4306,45 +4320,45 @@ entities:
           -9,-5:
             0: 65295
           -7,-8:
-            1: 10018
+            2: 10018
           -7,-7:
             0: 30464
-            1: 2
+            2: 2
           -7,-6:
             0: 62450
           -7,-9:
-            1: 58146
+            2: 58146
           -6,-8:
             0: 30464
-            1: 9
+            2: 9
           -6,-7:
             0: 30578
           -6,-6:
             0: 61042
           -6,-9:
-            1: 63624
+            2: 63624
           -5,-8:
-            1: 570
+            2: 570
           -5,-9:
-            1: 64186
+            2: 64186
           -12,-4:
-            1: 610
+            2: 610
           -12,-5:
-            1: 8802
+            2: 8802
           -11,-4:
             0: 49407
           -12,-2:
-            1: 34952
+            2: 34952
           -11,-2:
-            1: 16
+            2: 16
             0: 52428
           -12,-1:
-            1: 34952
+            2: 34952
           -11,-1:
-            1: 257
+            2: 257
             0: 52428
           -12,0:
-            1: 8
+            2: 8
             0: 32768
           -11,-5:
             0: 65535
@@ -4370,7 +4384,7 @@ entities:
             0: 30583
           5,7:
             0: 4919
-            1: 2048
+            2: 2048
           5,8:
             0: 65535
           6,5:
@@ -4379,7 +4393,7 @@ entities:
             0: 63739
           6,7:
             0: 11
-            1: 256
+            2: 256
           6,8:
             0: 65535
           7,5:
@@ -4388,7 +4402,7 @@ entities:
             0: 63479
           7,7:
             0: 32783
-            1: 3840
+            2: 3840
           7,8:
             0: 65459
           8,4:
@@ -4399,7 +4413,7 @@ entities:
             0: 29559
           8,7:
             0: 24679
-            1: 5888
+            2: 5888
           8,-1:
             0: 65419
           9,0:
@@ -4436,7 +4450,7 @@ entities:
             0: 30591
           11,-1:
             0: 13056
-            1: 34958
+            2: 34958
           11,4:
             0: 30583
           12,1:
@@ -4470,32 +4484,32 @@ entities:
           12,5:
             0: 768
           12,6:
-            1: 12800
+            2: 12800
           12,7:
-            1: 12834
+            2: 12834
           8,8:
             0: 65456
           8,9:
             0: 546
           7,9:
             0: 2184
-            1: 48
+            2: 48
           9,9:
-            1: 3992
+            2: 3992
           10,9:
-            1: 228
+            2: 228
           11,9:
-            1: 249
+            2: 249
           12,8:
-            1: 8994
+            2: 8994
           12,9:
-            1: 48
+            2: 48
           5,9:
-            1: 272
+            2: 272
             0: 2184
           6,9:
             0: 546
-            1: 128
+            2: 128
           4,-4:
             0: 61166
           4,-2:
@@ -4509,8 +4523,7 @@ entities:
           5,-5:
             0: 51698
           6,-4:
-            2: 1
-            0: 19932
+            0: 19933
           6,-3:
             0: 30719
           6,-2:
@@ -4548,145 +4561,145 @@ entities:
           10,-5:
             0: 65520
           11,-4:
-            1: 8738
+            2: 8738
             3: 8
             4: 2048
           11,-3:
-            1: 8738
+            2: 8738
             4: 2056
           11,-2:
-            1: 8738
+            2: 8738
             5: 8
             6: 2048
           11,-5:
-            1: 8750
+            2: 8750
             4: 2048
           12,-4:
             3: 3
             4: 768
-            1: 52428
+            2: 52428
           12,-3:
             4: 771
-            1: 52428
+            2: 52428
           12,-2:
             5: 3
             6: 768
-            1: 52428
+            2: 52428
           12,-1:
-            1: 511
+            2: 511
           5,-8:
-            1: 4015
+            2: 4015
           5,-7:
             0: 10103
           5,-6:
             0: 30591
           6,-8:
-            1: 4087
+            2: 4087
             0: 8192
           6,-7:
             0: 29303
           6,-6:
             0: 30471
           6,-9:
-            1: 30583
+            2: 30583
           7,-8:
-            1: 30576
+            2: 30576
           7,-7:
-            1: 7549
+            2: 7549
           7,-6:
-            1: 241
+            2: 241
             0: 28672
           7,-5:
             0: 4087
           8,-7:
-            1: 20303
+            2: 20303
           8,-6:
-            1: 33012
+            2: 33012
             0: 28672
           9,-7:
-            1: 7975
+            2: 7975
           9,-6:
-            1: 61713
+            2: 61713
             4: 204
           10,-7:
-            1: 20263
+            2: 20263
           10,-6:
             4: 17
-            1: 62660
+            2: 62660
           11,-7:
-            1: 4369
+            2: 4369
           11,-6:
-            1: 16145
+            2: 16145
           12,-6:
-            1: 20224
+            2: 20224
           12,-5:
-            1: 52431
+            2: 52431
             4: 768
           0,-10:
             0: 8192
           -4,-12:
-            1: 8752
+            2: 8752
             0: 192
           -4,-13:
             0: 65535
           -5,-12:
-            1: 60320
+            2: 60320
           -4,-11:
-            1: 44722
+            2: 44722
           -5,-11:
-            1: 60330
+            2: 60330
           -4,-10:
-            1: 43770
+            2: 43770
           -5,-10:
-            1: 60090
+            2: 60090
           -4,-9:
-            1: 1266
+            2: 1266
           -3,-12:
             0: 17
-            1: 2188
+            2: 2188
           -3,-9:
-            1: 784
+            2: 784
             0: 3276
           -3,-13:
             0: 4369
-            1: 35016
+            2: 35016
           -3,-10:
-            1: 226
+            2: 226
             0: 52224
           -2,-10:
-            1: 35057
+            2: 35057
             0: 30464
           13,-4:
-            1: 12834
+            2: 12834
           13,-3:
-            1: 12834
+            2: 12834
           13,-2:
-            1: 8994
+            2: 8994
           13,-1:
-            1: 562
+            2: 562
           13,-5:
-            1: 8754
+            2: 8754
           13,-6:
-            1: 256
+            2: 256
           -11,0:
             0: 64704
           -12,1:
             0: 128
           -11,1:
             0: 52476
-            1: 4096
+            2: 4096
           -12,2:
             0: 32768
           -11,2:
             0: 64716
-            1: 17
+            2: 17
           -12,3:
             0: 128
           -11,3:
             0: 52476
           -11,4:
             0: 52236
-            1: 16
+            2: 16
           -10,1:
             0: 56785
           -10,2:
@@ -4696,68 +4709,68 @@ entities:
           -10,4:
             0: 56781
           -12,4:
-            1: 34952
+            2: 34952
           -12,5:
-            1: 34952
+            2: 34952
           -11,5:
-            1: 1
+            2: 1
             0: 52428
           -12,6:
-            1: 136
+            2: 136
           -11,6:
-            1: 36513
+            2: 36513
           -10,5:
             0: 65521
           -11,7:
-            1: 136
+            2: 136
           -10,7:
-            1: 114
+            2: 114
           -10,6:
-            1: 26336
+            2: 26336
           -12,-6:
-            1: 8204
+            2: 8204
           -12,-7:
-            1: 17484
+            2: 17484
           -11,-7:
-            1: 159
+            2: 159
             0: 57344
           -11,-6:
             0: 61678
           -10,-7:
-            1: 2185
+            2: 2185
             0: 4096
           -10,-6:
             0: 57975
           -10,-8:
-            1: 34952
+            2: 34952
           -10,-9:
-            1: 34952
+            2: 34952
           -9,-9:
-            1: 65252
+            2: 65252
           -10,-11:
-            1: 32768
+            2: 32768
           -10,-10:
-            1: 34952
+            2: 34952
           -9,-11:
-            1: 45792
+            2: 45792
           -9,-10:
-            1: 61418
+            2: 61418
           -8,-11:
-            1: 63984
+            2: 63984
           -8,-10:
-            1: 65523
+            2: 65523
           -7,-11:
-            1: 12288
+            2: 12288
           -7,-10:
-            1: 8994
+            2: 8994
           -6,-12:
-            1: 3618
+            2: 3618
           -6,-13:
-            1: 25186
+            2: 25186
           -6,-11:
-            1: 34944
+            2: 34944
           -6,-10:
-            1: 34952
+            2: 34952
           -5,-13:
             0: 65532
           0,12:
@@ -4767,74 +4780,74 @@ entities:
           -1,13:
             0: 48059
           0,14:
-            1: 61952
+            2: 61952
           -1,14:
-            1: 43008
+            2: 43008
             0: 1
           0,15:
-            1: 44660
+            2: 44660
           -1,15:
-            1: 3999
+            2: 3999
           1,14:
-            1: 14732
+            2: 14732
           0,16:
-            1: 35016
+            2: 35016
           1,13:
-            1: 35976
+            2: 35976
           -4,13:
-            1: 25126
+            2: 25126
           -4,14:
-            1: 11810
+            2: 11810
           -4,15:
-            1: 8
+            2: 8
           -3,15:
-            1: 15
+            2: 15
           -3,13:
             0: 61166
           -3,14:
-            1: 4096
+            2: 4096
             0: 12
           -2,13:
             0: 63663
           -2,14:
             0: 15
-            1: 36864
+            2: 36864
           -2,15:
-            1: 34831
+            2: 34831
           -2,16:
-            1: 34952
+            2: 34952
           -6,-14:
-            1: 34952
+            2: 34952
           -5,-14:
-            1: 271
+            2: 271
             0: 52224
           -5,-16:
-            1: 11852
+            2: 11852
           -5,-15:
-            1: 44714
+            2: 44714
           -4,-16:
-            1: 32543
+            2: 32543
           -4,-15:
-            1: 12287
+            2: 12287
           -4,-14:
-            1: 15
+            2: 15
             0: 65280
           -3,-16:
-            1: 8977
+            2: 8977
           -3,-15:
-            1: 8754
+            2: 8754
           -3,-14:
-            1: 35971
+            2: 35971
             0: 4352
           -1,16:
-            1: 1
+            2: 1
             3: 128
           -2,17:
-            1: 8
+            2: 8
           -1,17:
-            1: 245
+            2: 245
           0,17:
-            1: 124
+            2: 124
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -4852,10 +4865,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          immutable: True
+          temperature: 235
           moles:
-          - 0
-          - 0
+          - 27.225372
+          - 102.419266
           - 0
           - 0
           - 0
@@ -4867,10 +4880,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.14975
+          immutable: True
           moles:
-          - 20.078888
-          - 75.53487
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -4950,6 +4963,28 @@ entities:
     - type: GridPathfinding
     - type: NavMap
     - type: ImplicitRoof
+  - uid: 12733
+    mapInit: true
+    paused: true
+    components:
+    - type: MetaData
+      name: solution - steel
+    - type: Transform
+      parent: 10697
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: steel
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 9
+        - data: []
+          ReagentId: Carbon
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: steel
+      container: 10697
   - uid: 13346
     mapInit: true
     paused: true
@@ -4969,6 +5004,28 @@ entities:
     - type: ContainedSolution
       containerName: food
       container: 13345
+  - uid: 13428
+    mapInit: true
+    paused: true
+    components:
+    - type: MetaData
+      name: solution - lvcable
+    - type: Transform
+      parent: 13427
+    - type: Solution
+      solution:
+        maxVol: 5
+        name: lvcable
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 3
+        - data: []
+          ReagentId: Copper
+          Quantity: 2
+    - type: ContainedSolution
+      containerName: lvcable
+      container: 13427
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 3
@@ -5050,20 +5107,14 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 5527
+      - 7503
+      - 7400
+      - 12632
+      - 95
       - 5526
+      - 5527
       - 5530
       - 5529
-      - 7400
-      - 7503
-      - 7401
-      - 7502
-      - 7398
-      - 7501
-      - 7399
-      - 7500
-      - 95
-      - 12632
     - type: Fixtures
       fixtures: {}
   - uid: 8
@@ -5075,17 +5126,11 @@ entities:
     - type: DeviceList
       devices:
       - 5522
-      - 5525
-      - 5527
-      - 5526
-      - 5523
       - 7499
       - 7395
-      - 7508
-      - 7396
-      - 7397
-      - 7509
       - 12627
+      - 5527
+      - 5526
       - 13230
     - type: Fixtures
       fixtures: {}
@@ -5186,8 +5231,6 @@ entities:
       - 5492
       - 5489
       - 5490
-      - 7370
-      - 7530
       - 7506
       - 7369
       - 12975
@@ -6172,6 +6215,55 @@ entities:
       - 13143
     - type: Fixtures
       fixtures: {}
+  - uid: 13429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,24.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 7502
+      - 7401
+      - 5529
+    - type: Fixtures
+      fixtures: {}
+  - uid: 13430
+    components:
+    - type: Transform
+      pos: -1.5,22.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 7508
+      - 7396
+      - 5523
+      - 13432
+      - 13433
+    - type: Fixtures
+      fixtures: {}
+  - uid: 13431
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,26.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 7500
+      - 7399
+      - 5530
+      - 7398
+      - 7501
+    - type: Fixtures
+      fixtures: {}
+- proto: AirAlarmElectronics
+  entities:
+  - uid: 13426
+    components:
+    - type: Transform
+      pos: 37.073864,-18.318573
+      parent: 2
 - proto: AirCanister
   entities:
   - uid: 54
@@ -6482,7 +6574,7 @@ entities:
       pos: -4.5,45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -62156.836
+      secondsUntilStateChange: -67004.36
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -6802,6 +6894,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -16.5,30.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
         149:
@@ -6878,6 +6972,9 @@ entities:
         151:
         - - DoorStatus
           - DoorBolt
+        156:
+        - - DoorStatus
+          - DoorBolt
   - uid: 151
     components:
     - type: Transform
@@ -6888,6 +6985,9 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         149:
+        - - DoorStatus
+          - DoorBolt
+        156:
         - - DoorStatus
           - DoorBolt
   - uid: 154
@@ -7373,6 +7473,11 @@ entities:
       parent: 2
 - proto: AirlockMaintAtmoLocked
   entities:
+  - uid: 605
+    components:
+    - type: Transform
+      pos: 34.5,-17.5
+      parent: 2
   - uid: 12261
     components:
     - type: Transform
@@ -7555,12 +7660,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,-9.5
-      parent: 2
-  - uid: 4199
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,-17.5
       parent: 2
   - uid: 7682
     components:
@@ -7992,8 +8091,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
       - 5307
+      - 8
   - uid: 12630
     components:
     - type: Transform
@@ -9201,6 +9300,38 @@ entities:
     - type: Transform
       pos: 48.5,-17.5
       parent: 2
+- proto: AtmosFixFreezerMarker
+  entities:
+  - uid: 13418
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 13419
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 13420
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 13421
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 13422
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 13423
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
 - proto: AtmosFixNitrogenMarker
   entities:
   - uid: 10495
@@ -10373,14 +10504,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 21.5,-9.5
       parent: 2
-- proto: ButtonFrameGrey
+- proto: ButtonFrameExit
   entities:
-  - uid: 605
+  - uid: 4199
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,8.5
       parent: 2
+- proto: ButtonFrameGrey
+  entities:
   - uid: 5216
     components:
     - type: Transform
@@ -17236,6 +17369,30 @@ entities:
       parent: 2
     - type: Stack
       count: 5
+  - uid: 13427
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: -12.7455635,-1.4815841
+      parent: 2
+    - type: Stack
+      count: 2
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - lvcable
+    - type: EmitSoundOnCollide
+      nextSound: -1811.2648554
+    - type: ContainerContainer
+      containers:
+        solution@lvcable: !type:ContainerSlot
+          ent: 13428
+    - type: Forensics
+      residues: []
+      dnas: []
+      fibers: []
+      fingerprints: []
 - proto: CableHV
   entities:
   - uid: 53
@@ -30412,6 +30569,11 @@ entities:
     - type: Transform
       pos: 14.5,-14.5
       parent: 2
+  - uid: 13425
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 2
 - proto: ClosetSteelBase
   entities:
   - uid: 4287
@@ -32639,11 +32801,6 @@ entities:
     components:
     - type: Transform
       pos: 3.247385,4.510758
-      parent: 2
-  - uid: 4579
-    components:
-    - type: Transform
-      pos: 3.278635,-0.52339196
       parent: 2
   - uid: 8024
     components:
@@ -37219,10 +37376,10 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
+      - 5529
+      - 5530
       - 5527
       - 5526
-      - 5530
-      - 5529
       - 95
       - 12632
     - type: Fixtures
@@ -37236,11 +37393,9 @@ entities:
     - type: DeviceList
       devices:
       - 5522
-      - 5525
+      - 12627
       - 5527
       - 5526
-      - 5523
-      - 12627
       - 13230
     - type: Fixtures
       fixtures: {}
@@ -38805,6 +38960,24 @@ entities:
       deviceLists:
       - 8
       - 5307
+  - uid: 13432
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,21.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13430
+  - uid: 13433
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,20.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13430
 - proto: FirelockEdge
   entities:
   - uid: 5392
@@ -39645,12 +39818,19 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,20.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+      - 5307
   - uid: 5523
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,18.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13430
   - uid: 5524
     components:
     - type: Transform
@@ -39668,24 +39848,46 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,26.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+      - 5307
+      - 7
+      - 5306
   - uid: 5527
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,26.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+      - 5307
+      - 7
+      - 5306
   - uid: 5529
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,26.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+      - 5306
+      - 13429
   - uid: 5530
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,28.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+      - 5306
+      - 13431
   - uid: 5531
     components:
     - type: Transform
@@ -54348,6 +54550,12 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 5514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
   - uid: 5694
     components:
     - type: Transform
@@ -54453,14 +54661,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 7370
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -54604,6 +54804,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,23.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 7396
@@ -54611,6 +54814,9 @@ entities:
     - type: Transform
       pos: -0.5,21.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13430
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 7397
@@ -54626,6 +54832,9 @@ entities:
     - type: Transform
       pos: 3.5,30.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13431
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 7399
@@ -54634,6 +54843,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,29.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13431
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 7400
@@ -54641,6 +54853,9 @@ entities:
     - type: Transform
       pos: -1.5,29.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 7401
@@ -54649,6 +54864,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,24.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13429
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 7402
@@ -55331,6 +55549,12 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4602
+  - uid: 7370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 2
   - uid: 7464
     components:
     - type: Transform
@@ -55519,6 +55743,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 4.5,22.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 7500
@@ -55527,6 +55754,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,28.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13431
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 7501
@@ -55534,6 +55764,9 @@ entities:
     - type: Transform
       pos: 4.5,30.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13431
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 7502
@@ -55542,6 +55775,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,24.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13429
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 7503
@@ -55550,6 +55786,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,29.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 7504
@@ -55589,6 +55828,9 @@ entities:
     - type: Transform
       pos: 0.5,21.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 13430
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 7509
@@ -55766,14 +56008,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,-9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 7530
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -63052,6 +63286,22 @@ entities:
     - type: Grammar
       attributes:
         indefinite: some
+- proto: MaterialSiloMachineCircuitboard
+  entities:
+  - uid: 4579
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: -12.6049385,-1.6065841
+      parent: 2
+    - type: EmitSoundOnCollide
+      nextSound: -1811.2648554
+    - type: Forensics
+      residues: []
+      dnas: []
+      fibers: []
+      fingerprints: []
 - proto: MaterialWoodPlank
   entities:
   - uid: 8668
@@ -63221,6 +63471,11 @@ entities:
     - type: Transform
       pos: 28.411085,-7.574147
       parent: 2
+  - uid: 13424
+    components:
+    - type: Transform
+      pos: -26.660732,11.706658
+      parent: 2
 - proto: MedkitToxinFilled
   entities:
   - uid: 8698
@@ -63255,6 +63510,22 @@ entities:
     - type: Transform
       pos: -3.960114,-31.306107
       parent: 2
+  - uid: 12734
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: -12.4330635,-1.4972091
+      parent: 2
+    - type: Stack
+      count: 4
+    - type: EmitSoundOnCollide
+      nextSound: -1811.2648554
+    - type: Forensics
+      residues: []
+      dnas: []
+      fibers: []
+      fingerprints: []
 - proto: MicrophoneInstrument
   entities:
   - uid: 4363
@@ -71706,6 +71977,39 @@ entities:
     - type: Transform
       pos: -31.575851,30.529917
       parent: 2
+- proto: SheetSteel1
+  entities:
+  - uid: 10697
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: -11.3705635,-0.6065841
+      parent: 2
+    - type: Stack
+      count: 5
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - steel
+    - type: PluralName
+      nameSomeOf: steel
+      nameOneOf: steel
+      overrideName: steel
+    - type: EmitSoundOnCollide
+      nextSound: -1811.2648554
+    - type: ContainerContainer
+      containers:
+        solution@steel: !type:ContainerSlot
+          ent: 12733
+    - type: Grammar
+      attributes:
+        indefinite: some sheets of
+    - type: Forensics
+      residues: []
+      dnas: []
+      fibers: []
+      fingerprints: []
 - proto: SheetUranium
   entities:
   - uid: 4443
@@ -73583,6 +73887,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,6.5
+      parent: 2
+- proto: SmartFridgeKitchenHydroponics
+  entities:
+  - uid: 7530
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
       parent: 2
 - proto: SMESAdvanced
   entities:
@@ -76640,12 +76951,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,4.5
       parent: 2
-  - uid: 10697
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-0.5
-      parent: 2
   - uid: 10699
     components:
     - type: Transform
@@ -78100,7 +78405,7 @@ entities:
   - uid: 10928
     components:
     - type: Transform
-      pos: -12.421816,-1.1351945
+      pos: -12.3861885,-0.9190841
       parent: 2
   - uid: 10930
     components:
@@ -78176,7 +78481,7 @@ entities:
   - uid: 10943
     components:
     - type: Transform
-      pos: -12.515566,-1.4320695
+      pos: -12.5736885,-1.1222091
       parent: 2
   - uid: 10945
     components:
@@ -88795,17 +89100,6 @@ entities:
       parent: 2
 - proto: WindoorServiceLocked
   entities:
-  - uid: 12733
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-0.5
-      parent: 2
-  - uid: 12734
-    components:
-    - type: Transform
-      pos: 3.5,-0.5
-      parent: 2
   - uid: 12735
     components:
     - type: Transform

--- a/Resources/Maps/_Impstation/cluster.yml
+++ b/Resources/Maps/_Impstation/cluster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.2.0
   forkId: ""
   forkVersion: ""
-  time: 10/08/2025 00:07:00
-  entityCount: 13433
+  time: 10/08/2025 00:18:08
+  entityCount: 13432
 maps:
 - 1
 grids:
@@ -6574,7 +6574,7 @@ entities:
       pos: -4.5,45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -67004.36
+      secondsUntilStateChange: -67154.625
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -32771,11 +32771,6 @@ entities:
     components:
     - type: Transform
       pos: -8.258537,-4.530675
-      parent: 2
-  - uid: 4573
-    components:
-    - type: Transform
-      pos: -12.205997,12.431334
       parent: 2
   - uid: 4574
     components:
@@ -73895,6 +73890,13 @@ entities:
     - type: Transform
       pos: 3.5,-0.5
       parent: 2
+- proto: SmartFridgeMedical
+  entities:
+  - uid: 4573
+    components:
+    - type: Transform
+      pos: -12.5,12.5
+      parent: 2
 - proto: SMESAdvanced
   entities:
   - uid: 4513
@@ -76663,12 +76665,6 @@ entities:
     components:
     - type: Transform
       pos: -22.5,13.5
-      parent: 2
-  - uid: 10638
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,12.5
       parent: 2
   - uid: 10639
     components:


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
Minor updates to Cluster, mostly covering a few things that were missed in testing.

## Map Changelog
Added:
- Smartfridges in botany and chemistry
- Extra radiation treatment kit in medical
- Supplies to build a material silo in science
- Additional radiation suit closet and clearer decals in front of the window into the supermatter
- Spare air alarm board in atmos

Fixed:
- Chef's freezer should be cold now
- Cleaned up air alarm links on the bridge/HoP's office/Captain's bedroom
- Maints door into atmos is atmos access
- A handful of missing decals
- Exit button for medical uses the right frame

## Media
<img width="3232" height="4288" alt="Cluster-0" src="https://github.com/user-attachments/assets/63d72a11-cbaa-4b40-b788-b12a257576b1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
