### PR TITLE
Head Revolutionary Deathrattle

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -281,9 +281,13 @@
       components:
       - type: Revolutionary
       - type: HeadRevolutionary
-      special:
-      - !type:AddImplantSpecial
-        implants: DeathRattleImplantCentcomm
+      - type: TriggerOnMobstateChange #imp
+        mobState:
+        - Critical
+        - Dead
+      - type: RattleOnTrigger #imp
+        targetUser: true
+        radioChannel: Revolution
       mindRoles:
       - MindRoleHeadRevolutionary
   - type: DynamicRuleCost

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/subdermal_implants.yml
@@ -31,12 +31,3 @@
     interfaces:
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
-
-- type: entity
-  parent: DeathRattleImplant
-  id: DeathRattleImplantHeadrev
-  name: revolutionary death rattle implant
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: RattleOnTrigger
-    radioChannel: Revolution


### PR DESCRIPTION
## About the PR
Head rev has an innate permanent death rattle (critical and death alert) sent to the Revolutionary radio channel.

## Why / Balance
Prevent full deconversion for solo rev randomly dying to vent slime 231.

## Technical details
YAML. Uses the rattle on trigger component instead of making it an actual implant, same as how thieves just have pacified.

## Media
<img width="388" height="141" alt="image" src="https://github.com/user-attachments/assets/dd08593e-63da-4284-af44-7ee68a3f1039" />

## Requirements
- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Head revolutionaries have a death rattle in their unionist noggin
