### PR TITLE
SM damage at extremely low mol values

### DIFF
--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -343,7 +343,7 @@ public sealed partial class SupermatterSystem
         var mix = _atmosphere.GetContainingMixture(uid, true, true);
 
         // We're in space or there is no gas to process
-        if (!xform.GridUid.HasValue || mix is not { } || MathHelper.CloseTo(mix.TotalMoles, 0f, 0.0005f)) //#IMP change from == 0f to <= 0.0005f
+        if (!xform.GridUid.HasValue || mix is not { } || MathHelper.CloseTo(mix.TotalMoles, 0f, 0.0005f)) //#IMP change from == 0f to MathHelper.CloseTo(mix.TotalMoles, 0f, 0.0005f)
         {
             sm.Damage += Math.Max(sm.Power / 1000 * sm.DamageIncreaseMultiplier, 0.1f);
             return;


### PR DESCRIPTION
SM will not get to exactly 0 gas by absorbing due to float, add epsilon to allow it to take damage.

## About the PR
Make Supermatter take damage when there is basically no gas because the SM ate it all. Previously this wouldn't happen because of float weirdness.

## Why / Balance
I think the SM should need SOME attention, even if its just keeping a small trickle of N2 in.

## Technical details
Changed an == 0 to a <= 0.0005f

## Requirements
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Supermatter will now realise that it has eaten all the gas in its room and get hangry.
