### PR TITLE
HoS Shoulder Holster now parents off ClothingBeltSecurity

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Belt/belts.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseCommandContraband]
+  parent: [BaseSecurityCommandContraband, ClothingBeltSecurity]
   id: ClothingBeltHolsterHOS
   name: head of security's shoulder holster
   description: A low-profile shoulder holster for your gear. Remind them who you are.
@@ -8,36 +8,6 @@
     sprite: _Impstation/Clothing/Belt/hosholster.rsi
   - type: Clothing
     sprite: _Impstation/Clothing/Belt/hosholster.rsi
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
-  - type: Storage
-    whitelist:
-      tags:
-        - CigPack
-        - Taser
-        - SecBeltEquip
-        - Radio
-        - Sidearm
-        - MagazinePistol
-        - MagazineMagnum
-        - CombatKnife
-        - Truncheon
-        - HandGrenade
-        - SecTicket
-        - Pribar
-        - SpaceBladeSec
-        - HandheldCriminalRecords
-      components:
-        - Stunbaton
-        - FlashOnTrigger
-        - SmokeOnTrigger
-        - Flash
-        - Handcuff
-        - BallisticAmmoProvider
-        - CartridgeAmmo
-        - DoorRemote
-        - Whistle
-        - BalloonPopper
 
 - type: entity
   parent: ClothingBeltUtility


### PR DESCRIPTION
## About the PR
The HoS's shoulder holster is now parenting off of the security belt as well as BaseSecurityCommandContraband.
In practice, this means the HoS shoulder holster can now store SecLink utility items which it could not do before, and is now Security AND Command Contraband, rather than just Command Contraband.

## Why / Balance
Much better for this to be parenting off the security belt instead of having its own bespoke whitelist, especially if things like new SecLink utility items or so-on get added. ty mq for encouraging me to do a better fix here :]

## Technical details
ClothingBeltHolsterHOS now parents off of BaseSecurityCommandContraband and ClothingBeltSecurity. A consequence to this is it is now also inheriting the Security Belt's itemmapper component, the overlay for which was not made with the shoulder holster in mind, but I think it looks good, so, nice bonus here.

The changed files comparison does a better job explaining this than I do.

## Media
<img width="370" height="360" alt="paintdotnet_SzYAxv0dHC" src="https://github.com/user-attachments/assets/af8d817c-de75-4396-9cdf-57fd89ac853b" />
<img width="265" height="129" alt="Content Client_BX1IxL2cpQ" src="https://github.com/user-attachments/assets/ff16d47a-46fd-466c-96fc-da3faae2c5ce" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: the head of security's shoulder holster can now store SecLink utility items.

