### PR TITLE
Temporarily disable the animate spell from the wizard store until it is fixed

### DIFF
--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -266,18 +266,19 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- type: listing
-  id: SpellbookStaffAnimation
-  name: spellbook-staff-animation-name
-  description: spellbook-staff-animation-description
-  productEntity: AnimationStaff
-  cost:
-    WizCoin: 3
-  categories:
-  - SpellbookEquipment
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+# imp (Removed until it is fixed and no longer makes everyone miserable)
+#- type: listing
+#  id: SpellbookStaffAnimation
+#  name: spellbook-staff-animation-name
+#  description: spellbook-staff-animation-description
+#  productEntity: AnimationStaff
+#  cost:
+#    WizCoin: 3
+#  categories:
+#  - SpellbookEquipment
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
 # Event
 - type: listing


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
Wizards can no longer buy the animate spell

## Why / Balance
Currently the spell is absolutely miserable, objects can be animated and have an unbelievably long time until it wears off. This compiled with objects having what seems to be more than 100 HP, dealing large amounts of damage and having very little cooldown leads to a spell that primarily makes people miserable.

Apparently this is all coming from bug's with how animating works but until then the spell should be disabled since it almost always results in a large amount of end of round salt when it's actually getting used how it's seemingly designed to be

While we should focus on fixing it, it's still good to disable it rather than leave something in the game that makes people miserable to deal with and makes people feel bad for even using

## Technical details
Commented out the animate spell section in the spellbook_catalogue.yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- remove: Wizards can no longer buy the Animate spell until it is fixed!