### PR TITLE
cargo invoice lists crate contents

### DIFF
--- a/Resources/Locale/en-US/_Impstation/cargo/invoice.ftl
+++ b/Resources/Locale/en-US/_Impstation/cargo/invoice.ftl
@@ -1,0 +1,10 @@
+﻿cargo-invoice-text = [head=2]Order #{$orderNumber}[/head]
+    {"[bold]Item:[/bold]"} {$itemName} (x{$orderQuantity})
+    {"[bold]Requested by:[/bold]"} {$requester}
+
+    {"[head=3]Item Contents[/head]"}
+    {$contents}
+    {"[head=3]Order Information[/head]"}
+    {"[bold]Payer[/bold]:"} {$account} [font="Monospace"]\[{$accountcode}\][/font]
+    {"[bold]Approved by:[/bold]"} {$approver}
+    {"[bold]Reason:[/bold]"} {$reason}


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
When cargo orders a crate (or any other EntityContainer) the invoice will now show a list of everything inside it. 

This does not include the system in ss13 where approving the manifest and selling it would give you money if you were correct, or the chance that the crate is missing stuff so you'd have to deny it and sell it. Maybe in the future if that's wanted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cuteness and flavor

## Technical details
<!-- Summary of code changes for easier review. -->
New block of imp edit code in `CargoSystem.Orders`. Checks if the item's an entity container, and if it is goes through each item and adds it and its amount to a dictionary. Then it builds a string to put into the paper.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="535" height="637" alt="image" src="https://github.com/user-attachments/assets/040f22bf-e835-4fd7-b574-509e6aaf0031" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cargo invoices now list the items included in crates.
