### PR TITLE
Update ai restoration and xenoborg computer sprites to use our computer frame sprite

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1719,14 +1719,17 @@
     layers:
     - map: ["computerLayerBody"]
       state: computer
+      sprite: _Impstation/Structures/Machines/computers.rsi # imp
     - map: ["computerLayerKeyboard"]
       state: generic_keyboard
+      sprite: _Impstation/Structures/Machines/computers.rsi # imp
     - map: ["computerLayerScreen"]
       state: xenorobot
     - map: ["computerLayerKeys"]
       state: rd_key
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
+      sprite: _Impstation/Structures/Machines/computers.rsi # imp
   - type: RoboticsConsole
     allowBorgControl: false
     radioChannel: Xenoborg


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
Made ai restoration computer use our computer frame sprite.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Look niceys.

## Technical details
<!-- Summary of code changes for easier review. -->
Make sprite layers point to desired rsi folder.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="147" height="156" alt="YidQlJx" src="https://github.com/user-attachments/assets/f6f9b951-0860-40f2-af62-bbf72d9ee291" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

