### PR TITLE
Make PetsNT faction not hostile to wizards (Re-PR)

### DIFF
--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -50,7 +50,7 @@
   - Zombie
   - Xeno
   - AllHostile
-  - Wizard
+  # - Wizard #imp, commented out
   - Dino # imp
   - Dragon
   - Replicator # imp


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
Single line change. 
the NPC faction PetsNT is now no longer hostile to wizards so Shiva doesn't attack them on sight. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
because Shiva instantly being hostile to some people evokes imagery of police dogs being trained to attack certain types of people on sight which is gross and bad and goes against our de-cop-ifying of security. 
also it just isn't very fun for any party involved in practice

## Technical details
<!-- Summary of code changes for easier review. -->
single line change
removed wizard as one of the hostile factions for the PetsNT faction

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: AbstractedOlm
- tweak: Shiva doesn't profile wizards anymore 
