### PR TITLE
Make singlecritter a fallback event

### DIFF
--- a/Resources/Prototypes/_Impstation/GameRules/pests.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/pests.yml
@@ -84,8 +84,8 @@
   - type: StationEvent
     earliestStart: 20
     minimumPlayers: 4
-    reoccurrenceDelay: 10
-    weight: 3
+    reoccurrenceDelay: 0
+    weight: 4
     duration: 60
   - type: VentCrittersRule
     announce: false


### PR DESCRIPTION
Recurrence delays are global, so if enough events happen (e.g if admins addgamerule RSES 30 times) then they will keep rolling rarer and rarer events because all the less rare events will be out of the pool. This will keep singlecritter in the pool so there is always an alternative.


## About the PR
Reduced recurrence delay to 0 and increased weight for singlecritter event.

## Why / Balance
Always have a 'safe' event that can happen, so the more dangerous rare events have something to weigh against.

## Technical details
2 values changed in YML

## Requirements
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
No CL, not player facing.
