### PR TITLE
Makes the doument printer able to fit on tables

### DIFF
--- a/Resources/Prototypes/_Corvax/Entities/Structures/Machines/printer.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Structures/Machines/printer.yml
@@ -13,6 +13,7 @@
   - type: Sprite
     sprite: _Corvax/Structures/Machines/printer.rsi
     snapCardinals: true
+    drawdepth: SmallObjects #imp
     layers:
     - state: icon
       map: ["enum.LatheVisualLayers.IsRunning"]
@@ -44,9 +45,9 @@
           bounds: "-0.25,-0.4,0.25,0.4"
         density: 25
         mask:
-        - MachineMask
+        - TabletopMachineMask #imp
         layer:
-        - MachineLayer
+        - TabletopMachineLayer #imp
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->

Makes it so the document printer can be placed on tables.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Makes sense and looks better then it just sitting on the floor.

## Technical details
<!-- Summary of code changes for easier review. -->

3 line code change, changed the document printers layer.
## Media
<img width="274" height="174" alt="Screenshot (1171)" src="https://github.com/user-attachments/assets/e79d2687-9138-4969-873d-7a28708f9acc" />

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl: 
- tweak: The document printer can now fit on tables!
-->
:cl: 
- tweak: The document printer can now fit on tables!