### PR TITLE
all disablers can be used by pacifists for real now

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/disablers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Battery/disablers.yml
@@ -152,6 +152,7 @@
     startingCharge: 1050
   - type: MeleeWeapon
     wideAnimationRotation: -80
+  - type: PacifismAllowedGun
 
 - type: entity
   name: antique disabler
@@ -250,3 +251,4 @@
     damage:
       types:
         Blunt: 8
+  - type: PacifismAllowedGun


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
disablers that aren't parented to the practice disabler didn't inherit the upstream change to allow pacifists use disablers. mouse fix it

## Why / Balance
if you make most functional disabler allow pacifist use, you should allow them all for consistency sake

## Technical details
copy and paste yaml line for magnum disabler and disabler carbine, 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="244" height="21" alt="image" src="https://github.com/user-attachments/assets/8811200b-8857-448b-8aa2-fcacaccc02af" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have                          the Pull Request                          . <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: magnum disabler and disabler carbine have been pacifism approved to match various developments in the disabler field.
