### PR TITLE
spawnOnTrigger parity with upstream

### DIFF
--- a/Content.Shared/Trigger/Components/Effects/SpawnOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/SpawnOnTriggerComponent.cs
@@ -29,17 +29,4 @@ public sealed partial class SpawnOnTriggerComponent : BaseXOnTriggerComponent
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool Predicted;
-
-    /// <summary>
-    ///     #IMP Allows multiple entities to be spawned.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public int Amount = 1;
-
-    /// <summary>
-    ///     #IMP Amount reduces by one for every entity spawned.
-    ///     If SingleUse is set to false, this will be reset after all entities spawned.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool SingleUse = true;
 }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Spawn.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Spawn.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.GameTicking;
+﻿﻿using Content.Shared.GameTicking;
 using Content.Shared.Trigger.Components.Effects;
 using Content.Shared.Trigger.Components.Triggers;
 using Robust.Shared.Prototypes;
@@ -38,15 +38,7 @@ public sealed partial class TriggerSystem
             return;
 
         var xform = Transform(target.Value);
-        var savedAmount = ent.Comp.Amount; //imp
-        while (savedAmount > 0) //imp
-        {
-            SpawnTriggerHelper((target.Value, xform), ent.Comp.Proto, ent.Comp.UseMapCoords, ent.Comp.Predicted);
-            savedAmount--;
-        }
-        // #IMP: SingleUse
-        if (!ent.Comp.SingleUse)
-            ent.Comp.Amount = savedAmount;
+        SpawnTriggerHelper((target.Value, xform), ent.Comp.Proto, ent.Comp.UseMapCoords, ent.Comp.Predicted);
     }
 
     private void HandleSpawnTableOnTrigger(Entity<SpawnEntityTableOnTriggerComponent> ent, ref TriggerEvent args)

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/ouroborosbolt.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/ouroborosbolt.yml
@@ -45,5 +45,10 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SpawnOnTrigger
-    proto: FoesSeofSpawner
-    amount: 2
+    proto: FoesSeofSpawner #override the MobBeeroboros
+  - type: SpawnEntityTableOnTrigger
+    table: !type:AllSelector
+      children:
+      - id: FoesSeofSpawner #this plus the spawn on trigger = amount 2
+    keysIn:
+    - trigger

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -11,9 +11,12 @@
     spreadAmount: 30
     keysIn:
     - timer
-  - type: SpawnOnTrigger
-    proto: MobAngryBee
-    amount: 6
+  - type: SpawnEntityTableOnTrigger
+    table: !type:GroupSelector
+      rolls: 6
+      children:
+      - id: MobAngryBee
+    useMapCoords: true
     keysIn:
     - timer
 
@@ -34,9 +37,13 @@
         Quantity: 15
     keysIn:
     - timer
-  - type: SpawnOnTrigger
-    proto: BrosSorbSpawner
-    amount: 60
+  - type: SpawnEntityTableOnTrigger
+    table: !type:GroupSelector
+      rolls: 60
+      children:
+      - id: MobBros
+      - id: MobSorb
+    useMapCoords: true
     keysIn:
     - timer
   - type: EmitSoundOnTrigger


### PR DESCRIPTION
## About the PR
Removed my changes to SpawnOnTriggerComponent and TriggerSystem.Spawn. This makes these files the same as upstream. Replace anywhere that uses the removed code with the SpawnEntityTableOnTrigger (Beenade, Brosnade, ouroboros & oroBROS)

## Why / Balance
Not needed, we can use SpawnEntityTableOnTrigger in place of my code. May also fix bugs caused by SpawnOnTrigger being nonparity.

## Technical details
Parity with upstream.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am     ow   the        quest           log     li es. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL, nothing player facing.
