### PR TITLE
Ready manifest ToggleReady fix again 

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -183,6 +183,13 @@ namespace Content.Server.GameTicking
                 return;
             }
 
+            // imp edit start, no need to update if the player is already (un)readied
+            var status = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
+            if (_playerGameStatuses[player.UserId] == status)
+            {
+                return;
+            }
+            // imp edit end
             _playerGameStatuses[player.UserId] = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
             RaiseNetworkEvent(GetStatusMsg(player), player.Channel);
             RaiseLocalEvent(new PlayerToggleReadyEvent(player)); //imp edit, for preround ready manifest


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
Pretty much just a repeat of #63, which fixes the ready manifest counting redundant ToggleReady commands. Looks like it got deleted during a recent upstream merge, presumably because the `status` variable was removed for being unused upstream.

## Technical details
<!-- Summary of code changes for easier review. -->
The `ToggleReady` method in `GameTicker.lobby.cs` now returns when attempting to change a player's ready status to what it already is.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
Example of bug: 

https://github.com/user-attachments/assets/81ccee5a-4174-4906-8980-4c1457ade1c2

Fixed behavior: 

https://github.com/user-attachments/assets/3014a88a-f7c4-436d-bc20-8aa592b6e1cd




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the ready manifest displaying jobs as having negative players readied, and other inaccuracies.
