### PR TITLE
Fix random characters sometimes having ghost hair

### DIFF
--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -128,13 +128,13 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
     {
         var random = IoCManager.Resolve<IRobustRandom>();
         var markingManager = IoCManager.Resolve<MarkingManager>();
-        var hairStyles = markingManager.MarkingsByCategoryAndSpecies(MarkingCategories.Hair, species).Keys.ToList();
-        var facialHairStyles = markingManager.MarkingsByCategoryAndSpecies(MarkingCategories.FacialHair, species).Keys.ToList();
-
 
         // IMP EDIT BEGIN - RANDOMIZED CHARACTER MARKINGS BY BECK (& mq)
 
-        /* var newHairStyle = hairStyles.Count > 0
+        /* var hairStyles = markingManager.MarkingsByCategoryAndSpecies(MarkingCategories.Hair, species).Keys.ToList();
+        var facialHairStyles = markingManager.MarkingsByCategoryAndSpecies(MarkingCategories.FacialHair, species).Keys.ToList();
+
+        var newHairStyle = hairStyles.Count > 0
             ? random.Pick(hairStyles)
             : HairStyles.DefaultHairStyle.Id;
 
@@ -219,6 +219,11 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
         var newHairStyle = HairStyles.DefaultFacialHairStyle.Id;
         var newFacialHairStyle = HairStyles.DefaultFacialHairStyle.Id;
 
+        // we're also declaring a new marking set for our species, so we can grab weight later.
+        var markingSet = new Dictionary<MarkingCategories, MarkingPoints>();
+        if (protoMan.TryIndex(species, out SpeciesPrototype? speciesProto))
+            markingSet = new MarkingSet(speciesProto.MarkingPoints, markingManager, protoMan).Points;
+
         // now we loop through every extant marking category,
         foreach (var category in Enum.GetValues<MarkingCategories>())
         {
@@ -231,10 +236,6 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                 markingWeights.Add(marking.Key, marking.Value.RandomWeight);
 
             // grab the markingset from our category..
-            var markingSet = new Dictionary<MarkingCategories, MarkingPoints>();
-            if (protoMan.TryIndex(species, out SpeciesPrototype? speciesProto))
-                markingSet = new MarkingSet(speciesProto.MarkingPoints, markingManager, protoMan).Points;
-
             if (!markingSet.TryGetValue(category, out var categorySet))
                 continue;
 
@@ -248,7 +249,7 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
             }
 
             // if it's facial hair, there are entries in the category, and the character is not female, roll & assign a random one. else bald
-            if (category == MarkingCategories.FacialHair)
+            else if (category == MarkingCategories.FacialHair)
             {
                 newFacialHairStyle = markings.Count == 0 || sex == Sex.Female || !random.Prob(categorySet.Weight)
                     ? HairStyles.DefaultFacialHairStyle.Id


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
Fixes bug where randomly generated markings would grab hair twice, and try to append it as a marking.
Also moved some iteration around for performance optimization

this bug occurred because it was an `if` and not an `else if`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Banished ghost hair.
