### PR TITLE
Remove Thief DAGD

### DIFF
--- a/Resources/Prototypes/_Impstation/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/objectiveGroups.yml
@@ -49,7 +49,7 @@
     AnnoyDisruptGimmickObjective: 1
     SpaceAssholeGimmickObjective: 1
     PrankGimmickObjective: 1
-    ThiefDieObjective: 1
+    #ThiefDieObjective: 1 commenting this out because how does it WORK when they also have an escape alive also its probably more common than Traitor DAGD like this
 
 # wizard
 


### PR DESCRIPTION
## About the PR
Commented out Thief Die a glorious death gimmick objective

## Why / Balance
It was die a glorious death. It could well be more common than traitor DAGD. You always have the escape objective even with Thief DAGD, which leads to confusion about how you try to both die and survive. It is a gimmick objective with an autocomplete, so it is always tracked at 100%. Therefore removing this from game until admin consensus on how to rule this + player decisions on if this should be changed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="641" height="81" alt="{1231EEC0-254A-43DF-ABBF-7D5FDF35B2BF}" src="https://github.com/user-attachments/assets/391f0b3d-bea5-4c5e-b631-04cbb5235515" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Thieves will no longer feel the urge to die a glorious death.