### PR TITLE
Silo range nerf

### DIFF
--- a/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
+++ b/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
@@ -23,7 +23,7 @@ public sealed partial class OreSiloComponent : Component
     /// Default value should be big enough to span a single large department.
     /// </remarks>
     [DataField, AutoNetworkedField]
-    public float Range = 10f;
+    public float Range = 10f; // imp 20>10
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
## About the PR
Halve the range of the material silo
## Why / Balance
This was a long requested change from @heirdragonair and others about the fact that the range of the material silo. There was a lot of confusion about where the actual value was stored so I found it and changed it to be half it's default value. This should have no mapping impact

## Technical details
1 line change of a hardcoded value in OreSiloComponent.cs

## Media
<img width="857" height="380" alt="image" src="https://github.com/user-attachments/assets/1cfb2287-6012-4b83-9bca-55a18c18cb27" />
Lathe on the left is linked. Lathe in the middle is linked. Lathe on the right is NOT linked but would be without this change. this change largely impacts Amber and Whale to stop science from stealing Cargo's mats without any interaction.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Halved the range of the material silo
-->
