### PR TITLE
Xenoarch: obscure foam contents

### DIFF
--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1311,7 +1311,7 @@
 - type: entity
   id: XenoArtifactFoamGood
   parent: BaseXenoArtifactEffect
-  description: Creates wave of foam #IMP desc changed
+  description: Biochemical disruption #IMP desc changed
   components:
   - type: XenoArtifactNode
     maxDurability: 7
@@ -1319,7 +1319,7 @@
       min: 0
       max: 5
   - type: XAEFoam
-    replaceDescription: true
+    replaceDescription: false #IMP -> false
     reagents:
     - Dermaline
     - Arithrazine
@@ -1332,12 +1332,12 @@
 - type: entity
   id: XenoArtifactFoamDangerous
   parent: BaseXenoArtifactEffect
-  description: Creates wave of foam #IMP desc changed
+  description: Biochemical disruption #IMP desc changed
   components:
   - type: XAEFoam
     minFoamAmount: 20
     maxFoamAmount: 30
-    replaceDescription: true
+    replaceDescription: false #Imp -> false
     reagents:
     - Tritium
     - Plasma

--- a/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
+++ b/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
@@ -233,10 +233,10 @@
 - type: entity
   id: XenoArtifactFoamVeryDangerous
   parent: BaseXenoArtifactEffect
-  description: Creates wave of foam
+  description: Biochemical disruption
   components:
   - type: XAEFoam
-    replaceDescription: true
+    replaceDescription: false
     reagents:
     - SpaceDrugs
     - BrosochloricBros
@@ -255,10 +255,10 @@
 - type: entity
   id: XenoArtifactFoamRomerol
   parent: BaseXenoArtifactEffect
-  description: Creates wave of foam
+  description: Biochemical disruption
   components:
   - type: XAEFoam
-    replaceDescription: true
+    replaceDescription: false
     reagents:
     - Romerol
     - Pilk


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
Changed name of foam effects except for most basic to "biochemical disruption"

## Why / Balance
Obscuring the contents of the foam. You're a scientist. Test the yummy foam.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have re d
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: artifact foam may have contents undetermined by the scanner