### PR TITLE
allow one-handed characters to draw heretic runes

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -196,10 +196,15 @@ public sealed partial class MansusGraspSystem : EntitySystem
     {
         var tags = ent.Comp.Tags;
 
+        if(!TryComp<HandsComponent>(args.User, out var userHands))
+        {
+            return;
+        }
+
         if (!args.CanReach
         || !args.ClickLocation.IsValid(EntityManager)
         || !TryComp<HereticComponent>(args.User, out var heretic) // not a heretic - how???
-        || !MansusGraspActive(args.User) // no grasp - not special
+        || !MansusGraspActive(args.User) && !(userHands.Count <= 1) // no grasp or no extra hand to make a grasp
         || HasComp<ActiveDoAfterComponent>(args.User) // prevent rune shittery
         || (!tags.Contains("Write") && !tags.Contains("DecapoidClaw")) // not a writing implement or decapoid claw
         || args.Target != null && HasComp<ItemComponent>(args.Target)) //don't allow clicking items (otherwise the circle gets stuck to them)


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
<!-- What did you change? -->
what it says on da tin. if a heretic only has one hand, they don't need an active mansus grasp to make a rune.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
allulalos can play the video game now
## Technical details
<!-- Summary of code changes for easier review. -->
four line change. get number of hands when a heretic clicks, and bypass the mansus grasp check if it's got 1 or less hands
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="494" height="323" alt="image" src="https://github.com/user-attachments/assets/565c113d-1f52-424e-b5c0-92a289c05df5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: allulalo heretics are no longer forced to have a mansus grasp in their nonexistent second hand when drawing a transmutation rune.

