### PR TITLE
fix server stall from EnsureComp (old) statuseffect system

### DIFF
--- a/Content.Shared/StatusEffect/StatusEffectsComponent.cs
+++ b/Content.Shared/StatusEffect/StatusEffectsComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.StatusEffect
         ///     A list of status effect IDs to be allowed
         /// </summary>
         [DataField("allowed", required: true), Access(typeof(StatusEffectsSystem), Other = AccessPermissions.ReadExecute)]
-        public List<string> AllowedEffects = default!;
+        public List<string> AllowedEffects = new(); //IMP stop ensurecomp from angering PVS with null collection
     }
 
     [RegisterComponent]


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
Reverted revert of Flotsam's undocumented bugfix that was introduced in the revenant rework 3000 PRs ago. 

## Why / Balance
Fixes server stall.

## Technical details
The revenant code is the only place that StatusEffectComponent is EnsureComp'd, and doing that with `AllowedEffects = default!;` causes AllowedEffects to initialize as null, leading to the PVS serialization stalling the server forever. The bugfix was to make it `AllowedEffects = new();` which was fixed for ages until MQ accidently reverted it in the imp comment cleanup.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read                       P                 h          i   l    
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: killing revenants will (once again) not also kill the server