### PR TITLE
gastropoid + vulpkanin guidebook fix

### DIFF
--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -8,13 +8,13 @@
   - Decapoid # imp
   - Diona
   - Dwarf
+  - Gastropoid # imp
   - Gray # imp
   - Human
   - Kodepiia # imp
   - Moth
   - Reptilian
   - SlimePerson # imp
-  - Snail # imp
   - Thaven # imp
   - Ungu # imp
   - Vox
@@ -60,7 +60,7 @@
   name: species-name-vox
   text: "/ServerInfo/_Impstation/Guidebook/Mobs/Vox.xml" # imp
 
-- type: guideEntry
-  id: Vulpkanin
-  name: species-name-vulpkanin
-  text: "/ServerInfo/Guidebook/Mobs/Vulpkanin.xml"
+#- type: guideEntry # imp, disabled roundstart
+#  id: Vulpkanin
+#  name: species-name-vulpkanin
+#  text: "/ServerInfo/Guidebook/Mobs/Vulpkanin.xml"

--- a/Resources/Prototypes/_Impstation/Guidebook/species.yml
+++ b/Resources/Prototypes/_Impstation/Guidebook/species.yml
@@ -4,7 +4,7 @@
   text: "/ServerInfo/_Impstation/Guidebook/Mobs/Gray.xml"
 
 - type: guideEntry
-  id: Snail
+  id: Gastropoid
   name: Gastropoid
   text: "/ServerInfo/_Impstation/Guidebook/Mobs/Snail.xml"
 


### PR DESCRIPTION
Gastropoid are alphabetical again in the species list and vulpkanin no longer have a species tab as they are not roundstart

## Media
<img width="716" height="635" alt="image" src="https://github.com/user-attachments/assets/2f11c626-b73e-4de5-b635-ac32ae151d7d" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://www.youtube.com/watch?v=kxtfgmBUKew).
- [X] I have added media to this PR or it does not require an ingame showcase.

no cl