### PR TITLE
paperwork belt holds pens

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
@@ -48,6 +48,7 @@
       - Document
       - Flashlight
       - Radio
+      - Write # imp
       components:
       - FitsInDispenser
       - Stamp


### PR DESCRIPTION
## About the PR
paperwork belt holds writing utensils

## Why / Balance
folders already hold them and you can put folder in belt.

## Technical details
whitelisted 'write' tag yuuup

## Media
<img width="267" height="75" alt="image" src="https://github.com/user-attachments/assets/19f7e3c0-9c0e-4682-96cb-240bd52f4cf5" />

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://www.youtube.com/watch?v=0iVlSNpq8i8).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: The paperwork belt holds pens, too.