### PR TITLE
Crew Weapon Balance Changes

### DIFF
--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_armory.yml
@@ -44,7 +44,7 @@
     sprite: _Impstation/Objects/Weapons/Guns/Rifles/ak.rsi
     state: icon
   product: CrateArmoryAKMS
-  cost: 11000
+  cost: 16000
   category: cargoproduct-category-name-armory
   group: market
 

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/blasterbolts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/blasterbolts.yml
@@ -51,16 +51,16 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    maxIntensity: 2
+    maxIntensity: 1.5
     intensitySlope: 3
-    totalIntensity: 24
+    totalIntensity: 12
     canCreateVacuum: false
   - type: Ammo
   - type: Projectile
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 15
+        Heat: 13
     soundHit:
       collection: WeakHit
     forceSound: true
@@ -144,8 +144,8 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 22
-        Structural: 50
+        Blunt: 25
+        Structural: 75
 
 - type: entity
   name : flare shot


### PR DESCRIPTION
## About the PR
Some number changes to help adjust some matters especially against nuclear operatives.

## Why / Balance
**M-1 Energy Shotgun**
- Kinetic Blaster Bolt damage from 22/50 blunt/structural up to 25/75
This shot was turning out underwhelming in practice. These numbers feel better in practice-- making it pretty effective at breaking windows (2 shots + 1 for the grill against a reinforced window), and needing half the battery to bust down a normal airlock (6 shots). It requires 7 shots total to bust totally through a normal wall, and is incapable of busting down a reinforced wall, vault door/fire lock in a single battery. Against Tier-3 Replicators, it will down one in 4 shots, the same as a Kammerer landing all of its pellets. This feels like a really good sweet spot.

**Blaster Cannon**
- Explosive and damage values changed to shrink the explosion size down to a 3x3 square and reduce the total damage of a direct impact down to 35.5 (from 45).
The prior iteration of the blaster cannon was for sure not good enough, and the last balance pass overcorrected just a tich. The blast size is still big enough to be useful (larger than the plus-size of the first iteration but not a full 5x5 diamond). These values put the cannon into a nicer place I feel.

**AKMS Cargo Purchase**
- Price increased from 11,000 spesos to 16,000 spesos
The rifle was put into the cargo purchase because there was a desire to see the weapon in-game more often, but the gun is, really strong. Upping the price to 16,000 keeps it within the realm of a comfortable possibility to purchase if security wants a special toy to play with as a splurge purchase, but makes its price objectively impractical to try and arm the crew with when a Lecter or Daito crate cost 8,000 spesos, which will matter the most for war ops.

## Technical details
All YAML.

## Media

https://github.com/user-attachments/assets/718a23e7-6e59-4351-bcf7-8682c8faecc9

https://github.com/user-attachments/assets/0fee2846-91d4-41df-a969-c7283fb77ee3


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The M1's kinetic bolt now packs a bit more of a punch. The Blaster Cannon, instead, packs less of a punch.
- tweak: the AKMS crate is now more expensive.
