### PR TITLE
keep analyzer active in pocket

### DIFF
--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -61,4 +61,10 @@ public sealed partial class HealthAnalyzerComponent : Component
     /// </summary>
     [DataField]
     public bool Silent;
+
+    /// <summary>
+    ///     IMP ADD: whether this entity should stop scanning on insert into container
+    /// </summary>
+    [DataField]
+    public bool RemainActiveInContainer;
 }

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -39,7 +39,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
     {
         SubscribeLocalEvent<HealthAnalyzerComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<HealthAnalyzerComponent, HealthAnalyzerDoAfterEvent>(OnDoAfter);
-        //SubscribeLocalEvent<HealthAnalyzerComponent, EntGotInsertedIntoContainerMessage>(OnInsertedIntoContainer); //imp remove lol
+        SubscribeLocalEvent<HealthAnalyzerComponent, EntGotInsertedIntoContainerMessage>(OnInsertedIntoContainer); //imp remove lol
         SubscribeLocalEvent<HealthAnalyzerComponent, ItemToggledEvent>(OnToggled);
         SubscribeLocalEvent<HealthAnalyzerComponent, DroppedEvent>(OnDropped);
     }
@@ -119,7 +119,8 @@ public sealed class HealthAnalyzerSystem : EntitySystem
     /// </summary>
     private void OnInsertedIntoContainer(Entity<HealthAnalyzerComponent> uid, ref EntGotInsertedIntoContainerMessage args)
     {
-        if (uid.Comp.ScannedEntity is { } patient)
+        if (!uid.Comp.RemainActiveInContainer && // imp add
+            uid.Comp.ScannedEntity is { } patient)
             _toggle.TryDeactivate(uid.Owner);
     }
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -28,6 +28,7 @@
   - type: HealthAnalyzer
     scanningEndSound:
       path: "/Audio/Items/Medical/healthscanner.ogg"
+    remainActiveInContainer: true # imp add
   - type: Tag
     tags:
       - DiscreteHealthAnalyzer


### PR DESCRIPTION
## About the PR
new bool for handheld analyzers. they remain active in pockets. pda doesnt

## Why / Balance
ORIGINAL: to be honest im torn on this one. i kind of want to make this feature unique to the handheld analyzers as opposed to the pda, because rn the pda is just a straight upgrade (doesnt run out of power). introducing some qol to the handheld analyzer without giving it to the pda would encourage doctors to be more intentional with their choice of what to use. also its always funny when doctors slip and drop their pda lol

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Health analyzers now remain active when in your pocket. PDAs with the MedTek function don't.
