### PR TITLE
we took cerberus out back (for nerfs)

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2166,9 +2166,9 @@
   productEntity: BibleNecronomicon
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 4  #imp #original - 2
   cost:
-    Telecrystal: 4
+    Telecrystal: 6  #imp #original - 4
   categories:
   - UplinkJob
   conditions:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3385,6 +3385,8 @@
     heatDamage:
       types:
         Heat : 1 #per second, scales with temperature & other constants
+  - type: StaminaDamageOnHit #imp #mailman hate prevention
+    damage: 0
 
 - type: entity
   name: corgi puppy

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -79,15 +79,15 @@
   - type: Bible
     damage:
       types:
-        Caustic: 20 ## ~15 dps
+        Caustic: 10 #imp #original - 20, comment: ## ~15 dps
     damageOnFail:
       groups:
-        Brute: 15
-        Airloss: 25
+        Brute: -15 #imp #original - 15 brute
+        Burn: -20 #imp #original - 25 airloss
     damageOnUntrainedUse:
       types:
         Caustic: 50
-    failChance: 0
+    #failChance: 0 #imp #chance to heal lol
     locPrefix: "necro"
     healSound: "/Audio/Effects/lightburn.ogg"
   - type: Summonable


### PR DESCRIPTION
## About the PR
after various events, a lot has been realized about the necronomicon. this PR just does a few tweaks to 1. make cerberus a fair purchase, and 2. ensure that the necronomicon isn't used in the future for a wombo combo

there was also some inheritance giving it 20 stamina damage. 
he can't have that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ouppy dog hell forever. see about section.
## Technical details
<!-- Summary of code changes for easier review. -->

- the narsii corgi, which cerberus is a child of, has had its stamina damage set to 0
- the necronomicon, purchase you use to summon cerberus, has been changed from 4 to 6
- the necronomicon damage changes, now letting it deal 10 caustic on success
- you can also fail to use the necronomicon now, healing the target

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
you're not getting that
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: cerberus no longer has stunning abilities
- tweak: cutbacks on the supernatural division of the syndicate have resulted in weaker necronomicons at a steeper price.