### PR TITLE
Disable flash overlay for those with reduced motion on

### DIFF
--- a/Content.Client/Flash/FlashOverlay.cs
+++ b/Content.Client/Flash/FlashOverlay.cs
@@ -86,10 +86,11 @@ namespace Content.Client.Flash
             {
                 // TODO: This is a very simple placeholder.
                 // Replace it with a proper shader once we come up with something good.
-                // Turns out making an effect that is supposed to be a bright, sudden, and disorienting flash 
+                // Turns out making an effect that is supposed to be a bright, sudden, and disorienting flash
                 // not do any of that while also being equivalent in terms of game balance is hard.
-                var alpha = 1 - MathF.Pow(PercentComplete, 8f); // similar falloff curve to the flash shader
-                worldHandle.DrawRect(args.WorldBounds, new Color(0f, 0f, 0f, alpha));
+                //imp edit, comment these out to disable flashes for people with reduced motion due to complaints.
+                //var alpha = 1 - MathF.Pow(PercentComplete, 8f); // similar falloff curve to the flash shader
+                //worldHandle.DrawRect(args.WorldBounds, new Color(0f, 0f, 0f, alpha));
             }
             else
             {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Made it so the flashing effect is entirely disabled for those with reduced motion toggled
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Especially with the tourists now this issue has become a significant barrier. so disabling until someone actually figures out something.
## Technical details
<!-- Summary of code changes for easier review. -->
commented out 2 lines
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Temporarily disabled flashes for people with reduced motion on.

