### PR TITLE
fix lowpop heretics not rolling

### DIFF
--- a/Resources/Prototypes/_Impstation/game_presets.yml
+++ b/Resources/Prototypes/_Impstation/game_presets.yml
@@ -229,7 +229,7 @@
   cooldown: 1
   showInVote: false
   rules:
-    - Heretic
+    - HereticLowpop
     - HereticBooksEventScheduler
     - SubGamemodesRule
     - BasicStationEventScheduler
@@ -246,7 +246,7 @@
   description: secret-description
   showInVote: false
   rules:
-    - Heretic
+    - HereticLowpop
     - HereticBooksEventScheduler
     - SubGamemodesRule
     - BasicStationEventScheduler


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
lowpop heretics will actually roll now

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
make the video game work

## Technical details
<!-- Summary of code changes for easier review. -->

i forgot to set it to roll the special variant gamerule i made for the lowpop version, so lowpop heretics could only roll when population was higher than 20, but lower than 19 (so never).

two line change to use the correct gamerule.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: heretics will ACTUALLY roll in lowpop now. oops.
