### PR TITLE
Recruiter bugfix + Weight increase

### DIFF
--- a/Content.Server/_DV/Recruiter/RecruiterPenSystem.cs
+++ b/Content.Server/_DV/Recruiter/RecruiterPenSystem.cs
@@ -70,6 +70,6 @@ public sealed class RecruiterPenSystem : SharedRecruiterPenSystem
     public void Reward(Entity<RecruiterPenComponent> ent, EntityUid user)
     {
         var pay = Spawn(ent.Comp.Currency);
-        _hands.PickupOrDrop(user, pay);
+        _hands.PickupOrDrop(user, pay, dropNear: true);
     }
 }

--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -11,7 +11,7 @@
   components:
   - type: StationEvent
     startAnnouncement: false
-    weight: 4
+    weight: 8
     minimumPlayers: 20
     maxOccurrences: 1
     duration: null
@@ -55,7 +55,7 @@
   components:
   - type: StationEvent
     startAnnouncement: false # Impstation no announcement
-    weight: 4
+    weight: 8
     minimumPlayers: 20
     maxOccurrences: 1
     duration: null


### PR DESCRIPTION
## About the PR
Fixed an issue where Recruiter Treatcoins didnt spawn if your hands were full
Increased the Weight of the two DV shuttle roles to be about equal to the party UFO instead of half that

## Why / Balance
Bugfix good
the DV roles spawn so rarely that most people dont even know we have them

## Technical details
tiny C# thing, rest yml

## Media
no

## Requirements
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I will gib legal curricula next time i see him during a round

**Changelog**
:cl:
- tweak: Recruiters and Synthesis Specialists are less rare now
- fix: Treatcoins actually spawn properly despite full hands
