### PR TITLE
Nerf toy rocket launcher fire rate

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
@@ -129,7 +129,7 @@
   - type: Clothing
     sprite: _NF/Objects/Fun/emotional_support_rpg.rsi
   - type: Gun
-    fireRate: 1
+    fireRate: 1 #imp divide fire rate by 8
     soundGunshot:
       path: /Audio/Effects/thunk.ogg
     soundEmpty:


### PR DESCRIPTION
## About the PR
Reduce toy rocket launcher fire rate by factor of 8. One shot per second instead of 8/s.

## Why / Balance
8 shots per second of rockets that do 20 stam damage per hit = less than 1 second until 100 stam damage stamcrit. 

## Technical details
number divide by 8

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: toy rocket launcher fire slower