### PR TITLE
fix handheld sec radio output

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/radio.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/radio.yml
@@ -35,7 +35,7 @@
   - type: RadioMicrophone
     broadcastChannel: Security
     listenRange: 1
-    frequency: 1359
+    frequency: 1359 # imp. needed after handicomms update.
   - type: RadioSpeaker
     channels:
     - Security


### PR DESCRIPTION
## About the PR
handheld sec radios weren't outputting to the security frequency. 
i think they were just defaulting to greencomms which obviously doesn't work. this fixes that.

## Why / Balance
fixing broken thing

## Technical details
1 line yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: handheld sec radios now output messages correctly again.
