### PR TITLE
Half toy RPG stamina damage

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
@@ -169,4 +169,4 @@
     sound:
       path: /Audio/Weapons/rubberhammer.ogg
   - type: StaminaDamageOnCollide
-    damage: 7 #IMP this used to be 20
+    damage: 10 #IMP this used to be 20


### PR DESCRIPTION
## About the PR
Halved stamina damage of toy RPG from 20 to 10.

## Why / Balance
Time to stun is was still high, 5 seconds to stun is short given that is not a huge amount of time to flee.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: reduced toy RPG stun power by 50%. The nerfing will continue until morale improves.