### PR TITLE
Randomize Bounty Hunter Appearance

### DIFF
--- a/Resources/Prototypes/_Impstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/events.yml
@@ -72,6 +72,8 @@
         - NamesBountyHunterTitle
         - NamesBountyHunter
         nameFormat: name-format-bounty-hunter
+      - type: RandomHumanoidAppearance
+        randomizeName: false
 
 #vrex
 - type: entity
@@ -172,7 +174,7 @@
     - id: TouristSmallShuttle
     - id: TouristMediumShuttle
     - id: TouristLargeShuttle
-    
+
 - type: entity
   id: TouristSmallShuttle #one tourist
   parent: BaseGameRule


### PR DESCRIPTION
## About the PR
Bounty Hunters now spawn with a randomized appearance (similarly to fugitives), instead of copying the appearance of whoever's playing them.

## Why / Balance
Bounty Hunters are often being confused for the character they look like. This is more of a problem for them than loneops / ninjas / etc. because they don't have designated uniforms and typically rp with the crew more. 

To see the full discussion check out:
https://discord.com/channels/1327800873660842097/1353180686810480790/1439123344703361077

## Technical details
Adds RandomHumanoidAppearance to the bounty hunter spawner

## Media
a couple random bh rolls: 
<img width="416" height="305" alt="Capture3" src="https://github.com/user-attachments/assets/648c4b8d-0450-4957-ab85-577167b6a674" />
<img width="517" height="286" alt="Capture2" src="https://github.com/user-attachments/assets/27051f9c-5cbb-4ce0-9dff-f60cdaf558e2" />
<img width="445" height="287" alt="Capture" src="https://github.com/user-attachments/assets/fbf6fdcd-4166-4e70-8986-db023d717023" />


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Bounty Hunters now spawn with a randomized appearance

