### PR TITLE
Codex Erasure Bugfix

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -39,8 +39,6 @@
     - type: HereticMagicItem
     - type: Contraband
       severity: TierXContraband
-    - type: Paper #imp heretic book now writeable
-      contentSize: 12000
     - type: UserInterface
       interfaces:
         enum.PaperUiKey.Key:
@@ -49,6 +47,8 @@
     key: enum.PaperUiKey.Key
     requiresComplex: false
     verbOnly: true #imp end
+  - type: Paper #imp heretic book now writeable
+    contentSize: 12000
   - type: ItemTogglePointLight
   - type: ToggleableVisuals
     spriteLayer: enum.ToggleableVisuals.Layer


### PR DESCRIPTION
## About the PR
Bugfix for Codex writeability, made it not erase its contents on closure

## Why / Balance
bugfix good

## Technical details
moved one component from the wrong spot to the right spot

## Media
<img width="736" height="736" alt="image" src="https://github.com/user-attachments/assets/43f8da9b-8377-45c4-8d08-cf70ab31e286" />

## Requirements

- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I do not recognise the bodies in the water.

**Changelog**
:cl:
- fix: The codex cicatrix no longer erases its own contents upon being closed, diary enjoyers rejoice.
