### PR TITLE
Let multiple people use the engineering computers at the same time.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -43,7 +43,7 @@
           False: { visible: true }
   - type: AtmosAlertsComputer
   - type: ActivatableUI
-    singleUser: true
+    singleUser: false #imp edit, changed from true
     key: enum.AtmosAlertsComputerUiKey.Key
   - type: UserInterface
     interfaces:
@@ -83,7 +83,7 @@
     navMapTileColor: "#1a1a1a"
     navMapWallColor: "#404040"
   - type: ActivatableUI
-    singleUser: true
+    singleUser: false #imp edit, changed from true
     key: enum.AtmosMonitoringConsoleUiKey.Key
   - type: UserInterface
     interfaces:
@@ -348,7 +348,7 @@
         !type:CableDeviceNode
         nodeGroupID: HVPower
   - type: ActivatableUI
-    singleUser: true
+    singleUser: false #imp edit, changed from true
     key: enum.PowerMonitoringConsoleUiKey.Key
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/intercom.yml
@@ -63,7 +63,7 @@
   - type: ActivatableUIRequiresPower
   - type: ActivatableUI
     key: enum.IntercomUiKey.Key
-    singleUser: true
+    singleUser: false #imp edit, changed from true
   - type: UserInterface
     interfaces:
       enum.IntercomUiKey.Key:

--- a/Resources/Prototypes/Entities/Structures/deskintercom.yml
+++ b/Resources/Prototypes/Entities/Structures/deskintercom.yml
@@ -66,7 +66,7 @@
   - type: ActivatableUIRequiresPower
   - type: ActivatableUI
     key: enum.IntercomUiKey.Key
-    singleUser: true
+    singleUser: false #imp edit, changed from true
   - type: UserInterface
     interfaces:
       enum.IntercomUiKey.Key:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Allows multiple people to use the engineering computers and also intercoms at the same time by setting the variable singleUser to false.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It sucks and i hate it and as far as i can tell serves no purpose. These are the only computers in the game that work like this.
## Technical details
<!-- Summary of code changes for easier review. -->
Changed 5 instances of singleUser of true to false for the atmos alert computer, atmos monitor computer, power monitor computer, and both types of intercom.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
![24px-Bulborb_icon_png_75](https://github.com/user-attachments/assets/bb10bd3f-4a05-44f4-bfbe-75fab4edbd53)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Multiple people can now use the engineering computers and also intercoms at the same time.