### PR TITLE
fix goblin belt not being able to insuls

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Belt/belts.yml
@@ -80,7 +80,7 @@
       - TrayScanner
       - GasAnalyzer
       - HandLabeler
-      - Insulated
+      - Insulated # <-- we copy this whole tower for one component ok?
 
 # chaplain
 - type: entity


### PR DESCRIPTION
## About the PR
im sorry goblins. i have failed you. 
random uncommented change comes for us all in the end.

you can now put insuls in the goblin toolbelt once more.

resolves https://github.com/impstation/imp-station-14/issues/3757

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

