### PR TITLE
Antique Disabler Certificate Inhands Fix

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/hopdisablerbox.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/hopdisablerbox.yml
@@ -23,9 +23,10 @@
   parent: BaseItem
   id: AntiqueDisablerCertification
   name: certificate of authenticity
-  description: This ornate document hereby certifies your disabler as an authentic Antique Disabler. Don't mind all the fine print.
+  description: This ornate framed document hereby certifies your disabler as an authentic Antique Disabler. Don't mind all the fine print.
   components:
   - type: Item
+    sprite: Objects/Misc/clipboard.rsi #the brown seems off but it looks like it's framed with the white on the one side
     size: Tiny
   - type: Sprite
     sprite: _Impstation/Objects/Weapons/Guns/Disablers/hopdisabler.rsi


### PR DESCRIPTION
## About the PR
The certificate's inhands won't be the gun itself anymore. I used the clipboard inhands because it reasonably looks like a framed certificate. Changed the certificate's description a little so that's at least apparent.

## Why / Balance
Oops.

## Technical details
It's a single file path.

## Media
<img width="109" height="114" alt="ss+(2025-11-26+at+10 30 17)" src="https://github.com/user-attachments/assets/a26adfc3-5c32-4e1d-a2a2-3ea2bea74ad7" />
<img width="115" height="134" alt="ss+(2025-11-26+at+10 30 30)" src="https://github.com/user-attachments/assets/7eded391-bef3-43bd-a626-75d0e290d7d6" />

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Massively nerfed the HoP's origami skills so they can no longer make their certificate look like a disabler.