### PR TITLE
NanoChat notifications for borg PDAs

### DIFF
--- a/Content.Server/_DV/NanoChat/NanoChatSystem.cs
+++ b/Content.Server/_DV/NanoChat/NanoChatSystem.cs
@@ -8,10 +8,10 @@ using Content.Shared._DV.NanoChat;
 using Content.Shared.Database;
 using Content.Shared.NameIdentifier;
 using Content.Shared.PDA;
-using Content.Shared.Silicons.Borgs.Components; // imp edit
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Content.Shared.Silicons.Borgs.Components; // imp
 
 namespace Content.Server._DV.NanoChat;
 
@@ -151,7 +151,7 @@ public sealed class NanoChatSystem : SharedNanoChatSystem
         _name.GenerateUniqueName(ent, _nameIdentifierGroup, out var number);
         ent.Comp.Number = (uint)number;
 
-        // imp edit - notifications for borgs
+        // imp - notifications for borgs
         if (HasComp<BorgChassisComponent>(ent))
             ent.Comp.PdaUid = ent.Owner;
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Fixes an oversight that resulted in borgs not receiving ringtone or chat notifications for unread NanoChat messages.

Note that this only fixes borgs, I tried applying the same solution to AIs but it didn't do anything.

## Technical details
<!-- Summary of code changes for easier review. -->

In order for `NanoChatCartridgeSystem` to send out notifications, the `NanoChatCardComponent` needs to have a `PdaUid` assigned. Previously this variable was only assigned when a card was inserted into a container (such as an ID into a PDA), but since borgs are both NanoChat cards and PDAs this event never occured.

This PR adds a check to `OnCardInit` in `NanoChatSystem` and assigns the card's `PdaUid` to itself if the card has the `BorgChassisComponent`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="1920" height="1011" alt="2025-11-26_19 36 48" src="https://github.com/user-attachments/assets/da0d3e79-b99d-4b33-b9e9-f25a1fdca65b" />


`PdaUid` assigned to same UID as the borg itself:
<img width="1276" height="419" alt="image" src="https://github.com/user-attachments/assets/c3f985b8-8aa7-46fd-b099-2b9c0a45ff54" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Cyborgs now receive notifications for new unread NanoChat messages.

