### PR TITLE
antique disabler box in-hand sprite

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/hopdisablerbox.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/hopdisablerbox.yml
@@ -5,6 +5,7 @@
   description: Pristine packaging containing your priceless antique disabler.
   components:
   - type: Item
+    sprite: _Wizden/Objects/Storage/boxes.rsi
     size: Normal
   - type: Sprite
     sprite: _Impstation/Objects/Weapons/Guns/Disablers/hopdisabler.rsi


### PR DESCRIPTION
## About the PR
same problem as the certificate. Same fix. I've learned a valuable lesson.

## Why / Balance
so I can learn a valuable lesson and fix this weird thing.

## Technical details
One line change.

## Media
![ss+(2025-11-28+at+11 12 59)](https://github.com/user-attachments/assets/16c6d163-c5bd-4756-ab8f-9dc42b4f7e88)


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: the antique disabler's package doesn't look like a gun in your hands anymore.