### PR TITLE
Prevent mimes from using AAC tablet

### DIFF
--- a/Content.Server/_DV/AACTablet/AACTabletSystem.cs
+++ b/Content.Server/_DV/AACTablet/AACTabletSystem.cs
@@ -1,11 +1,11 @@
 using Content.Server.Chat.Systems;
-using Content.Server.Popups; // imp
 using Content.Server.Speech.Components;
 using Content.Shared._DV.AACTablet;
-using Content.Shared.Abilities.Mime; // imp
 using Content.Shared.IdentityManagement;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Server.Popups; // imp
+using Content.Shared.Abilities.Mime; // imp
 
 namespace Content.Server._DV.AACTablet;
 

--- a/Resources/Locale/en-US/_Impstation/abilities/mime.ftl
+++ b/Resources/Locale/en-US/_Impstation/abilities/mime.ftl
@@ -1,1 +1,1 @@
-mime-cant-use-AAC-tablet = Your vow of silence prevents you from using the tablet.]
+mime-cant-use-AAC-tablet = Your vow of silence prevents you from using the tablet.


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
The AAC tablet will now fail to send messages when used by a mime with an active vow of silence. Breaking the vow will allow them to send messages as normal. 

## Technical details
<!-- Summary of code changes for easier review. -->
The `OnSendPhrase` method in `AACTabletSystem` will now return if the user has the `MimePowersComponent` and an active vow. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/401f68ee-727a-42ab-b8ff-e1b0ef1237c5



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Mimes can no longer use AAC tablets without first breaking their vow. 
