### PR TITLE
Fix ninja not being able to drain power

### DIFF
--- a/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
+++ b/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
@@ -103,11 +103,7 @@ public sealed class BatteryDrainerSystem : SharedBatteryDrainerSystem
         var available = targetBattery.CurrentCharge;
         var required = battery.MaxCharge - battery.CurrentCharge;
         // higher tier storages can charge more
-        // IMP EDIT START- why the fuck does draintime affecting the amount drained go undocumented!!!
-        var maxDrained = comp.FullDrain ?
-            pnb.MaxSupply * comp.DrainTime :
-            required;
-        // IMP EDIT END
+        var maxDrained = pnb.MaxSupply * comp.DrainTime;
         var input = Math.Min(Math.Min(available, required / comp.DrainEfficiency), maxDrained);
         if (!_battery.TryUseCharge(target, input, targetBattery))
             return false;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
There has been a bug ever since the eeep was added that made it so the ninja power drain was like .01 watts which makes it basically impossible to recharge. This PR fixes that issue and causes no issues to the eeep.

I believe the changed code was left in on accident or it simply wasn't realized what it did exactly.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ninja kinda needs to be able to drain power to use its stuff.
## Technical details
<!-- Summary of code changes for easier review. -->
The code removed made it so eeeps drain power normally and ninjas drain almost nothing. The original code before the eeep change makes both the eeep and ninja drain power properly. I just reverted it back to the original.

(I did not add the #imp thing as this is literally reverting it to the upstream code , im not sure if that was correct and you can kill me if I did that wrong)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
The first video is in before the change I made.

https://github.com/user-attachments/assets/f1130364-4b24-4c7a-be18-75db251a7bb5

The second video is after the change I made.

https://github.com/user-attachments/assets/80b6ed52-5c14-45bb-b021-682a5df3b19d

The third video is the eeep after my change. (Although it is the same for both versions)

https://github.com/user-attachments/assets/221ea04d-2d5a-4320-bb4b-b490a19395a3



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The ninja's power drain now drains the correct amount of power.
