### PR TITLE
Randomized Unidentified Corpse Species

### DIFF
--- a/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
+++ b/Content.Server/Humanoid/Components/RandomHumanoidAppearanceComponent.cs
@@ -56,4 +56,9 @@ public sealed partial class RandomHumanoidAppearanceComponent : Component
     /// If the square brackets are empty (i.e. if the List<Color> has no members,) the color of that marking will be randomized.
     /// </summary>
     [DataField] public Dictionary<string, List<Color>>? Markings = null;
+    /// <summary>
+    /// Before randomizing, selects a random species, if applicable.
+    /// Uses a blacklist.
+    /// </summary>
+    [DataField] public HashSet<string>? Species = null;
 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -82,6 +82,7 @@
   components:
   - type: RandomHumanoidAppearance
     randomizeName: false
+    species: [] # imp
   - type: Damageable
     damage:
       types:


### PR DESCRIPTION
## About the PR
What it says on the tin, unidentified corpses AKA salvage corpses have their species randomized now.

## Why / Balance
I feel like it should've been this way forever. I mean, why do only humans get to be an unidentified corpse? Has barely any gameplay effect. I guess salvage can get a bagpipe for free if they find a gray corpse.

## Technical details
Pretty minor changes. I used viableSpecies to track which species the corpse can roll as, which is why it can be a cookie, vulpakin, or goblin since those have the viableSpecies component.

## Media
<img width="1271" height="731" alt="image" src="https://github.com/user-attachments/assets/b845000a-e8d1-4243-a38a-71090b4c178c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Unidentified corpses are no longer exclusively human. Equality, yay!
