### PR TITLE
ungu and allulalo are now complex lifeforms

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
@@ -6,7 +6,6 @@
   abstract: true
   components:
   - type: GoobAbsorbable
-    biomassRestored: 1.0
   - type: Hunger
     baseDecayRate: 0.02 # 30% ish more than default
   - type: Thirst

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/ungu.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/ungu.yml
@@ -100,7 +100,6 @@
       Dead: 0
     baseDecayRate: 0.0124 # 3/4 as fast as a human
   - type: GoobAbsorbable
-    biomassRestored: 0.8 # im so full of ungu yum
   - type: Thirst
   - type: Icon
     sprite: _Impstation/Mobs/Species/Ungu/parts.rsi


### PR DESCRIPTION
## About the PR
ungu were giving 20% less biomass for ling absorption compared to other playable species, which has rammys

i also killed the biomass line for allu because i dont think it was causing problems (code checks for if `biomassRestored` is under 1 and this is exactly 1) but it is now in line with all other roundstart species

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
2 line deletion

ftr for prospective people trapped grappling with goobAbsorbable: defining a `biomassRestored` that is less than 1 means that something will not count as a player for changeling biomass purposes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Ungu and Allulalo are now complex lifeforms, legally speaking.
