### PR TITLE
hunt fixes blast

### DIFF
--- a/Content.Client/_Impstation/Heretic/Overlays/SerpentFocusSystem.cs
+++ b/Content.Client/_Impstation/Heretic/Overlays/SerpentFocusSystem.cs
@@ -48,14 +48,10 @@ public sealed class SerpentFocusSystem : Client.Overlays.EquipmentHudSystem<Serp
         var lightRadius = 0f;
         foreach (var comp in args.Components)
         {
-            if (!comp.IsActive && (comp.PulseTime <= 0f || comp.PulseAccumulator >= comp.PulseTime))
+            if (!comp.IsActive)
                 continue;
 
             if (tvComp == null)
-                tvComp = comp;
-            else if (!tvComp.DrawOverlay && comp.DrawOverlay)
-                tvComp = comp;
-            else if (tvComp.DrawOverlay == comp.DrawOverlay && tvComp.PulseTime > 0f && comp.PulseTime <= 0f)
                 tvComp = comp;
 
             lightRadius = MathF.Max(lightRadius, comp.LightRadius);
@@ -63,14 +59,12 @@ public sealed class SerpentFocusSystem : Client.Overlays.EquipmentHudSystem<Serp
 
         _serpentOverlay.ResetLight(false);
         UpdateSerpentOverlay(tvComp, lightRadius);
-        UpdateOverlay(tvComp);
     }
 
     protected override void DeactivateInternal()
     {
         base.DeactivateInternal();
 
-        UpdateOverlay(null);
         UpdateSerpentOverlay(null, 0f);
     }
 

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -190,7 +190,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
             if (hereticComp.Power >= 2)
                 ApplyGraspEffect(args.User, target, hereticComp);
 
-            if (hereticComp.Power >= 4 && HasComp<StatusEffectsComponent>(target))
+            if (hereticComp.Power >= 4 && HasComp<StatusEffectsComponent>(target) && hereticComp.MainPath != "Hunt")
             {
                 var markComp = EnsureComp<HereticCombatMarkComponent>(target);
                 markComp.Path = hereticComp.MainPath;

--- a/Resources/Prototypes/_Impstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Impstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -262,8 +262,6 @@
   components:
   - type: Physics
     bodyType: Static
-  - type: Visibility
-    layer: 69 #sigh
   - type: Fixtures
     fixtures:
       fix1:
@@ -317,6 +315,7 @@
     layers:
     - state: icon
   - type: Item
+    size: Normal
   - type: Clothing
     slots:
       - NECK
@@ -329,6 +328,7 @@
   - type: ToggleClothing
     action: ActionToggleSkaptodonCloak
     disableOnUnequip: true
+    mustEquip: true
   - type: ComponentToggler
     parent: true
     components:


### PR DESCRIPTION
## About the PR
tons of misc fixes to the new hunt path stuff

## Why / Balance
the game is good when it works

## Technical details
cut out a bunch of vestigial code in the SerpentFocus overlay, added a check to not do marks for hunt path users, deleted the number 69

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The serpent's focus ability should be more functional.
- fix: Hunt heretics' grasp will no longer put a big ERROR on the target.
- tweak: The Skaptodon Cloak is now slightly bigger.
- tweak: Eldritch Towers are now visible to everyone.

