### PR TITLE
Decapoids no longer FUCKING DIE

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -463,6 +463,7 @@
             Heat: 3
 # imp edits start, vapour breathers
       - !type:Oxygenate
+        scaling: true
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Decapoid, Thaven ] # thaven can breathe all gases safely


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
change was missed in upstream merge. lets let decapoids live ok?
## Technical details
<!-- Summary of code changes for easier review. -->
Was missing a new field added to oxygenate! easy peasy fix
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Decapoids no longer FUCKING DIE
