### PR TITLE
Type-25 Adjustments

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1103,9 +1103,9 @@
     - proto: BulletLaserMagnum
       fireCost: 175 #imp
     - proto: BulletBlasterFlare #imp - was BulletLaserWindowPiercingMagnum
-      fireCost: 87.5 #imp
-    - proto: BulletMagnumDisabler #imp
       fireCost: 116 #imp
+    - proto: BulletMagnumDisabler #imp
+      fireCost: 175 #imp
   - type: BatterySelfRecharger #imp reduced the recharge delay and the recharge rate
     autoRecharge: true
     autoRechargeRate: 35 #imp - was 48

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/blasterbolts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/blasterbolts.yml
@@ -198,7 +198,7 @@
     muzzleFlash: MuzzleFlashEffectGoldLaser
   - type: AmbientSound
     enabled: true
-    volume: -10
+    volume: -15
     range: 5
     sound:
       path: /Audio/_Impstation/Machines/echion.ogg
@@ -207,8 +207,8 @@
   - type: PointLight
     enabled: true
     color: "#ffa223"
-    radius: 10.0
-    energy: 6.0
+    radius: 5
+    energy: 3.0
   - type: Projectile
     deleteOnCollide: false
     damage:


### PR DESCRIPTION
## About the PR
It's been some time in the field, and some changes were in order. Nothing super dramatic, though. I mean the flare change is a bit dramatic but it's not gonna kill anything.

## Why / Balance
The flare shot was way too effective as a flare, ultimately, and maybe cost a little too little per shot. Additionally, the disabler mode was at the strength of the regular disabler magnum, but more shots, self-recharging, and a slightly faster rate of fire. It needed to be toned down a bit. Here are the changes below:

- Flare Shot's brightness and radius have been cut in half
- Flare Shot firing cost increased so you get 9 shots instead of 12 on a full battery
- Disabler Shot's firing cost increased so you get 6 shots instead of 9 on a full battery

## Technical details
All YAML baby

## Media

https://github.com/user-attachments/assets/b298bf71-e3d9-41e0-9882-c1dc717317eb


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The  T-25's flare shot has been reduced in brightness and the ammo counts of it, and the disabler shot, have been adjusted.
