### PR TITLE
fix frontier assembler offsets

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
@@ -189,7 +189,7 @@
     sprite: _NF/Structures/Machines/assembler.rsi
     drawdepth: SmallObjects
     snapCardinals: true
-    offset: "0.0,0.0"
+    offset: "0.0,0.0" #imp
     layers:
     - state: assembler
       map: ["enum.MicrowaveVisualizerLayers.Base"]
@@ -246,7 +246,7 @@
   - type: Sprite
     sprite: _NF/Structures/Machines/medical_assembler.rsi
     snapCardinals: true
-    offset: "0.0,0.0"
+    offset: "0.0,0.0" #imp
     layers:
     - state: mediwave-base
       map: ["enum.MicrowaveVisualizerLayers.Base"]


### PR DESCRIPTION
## About the PR
set the offsets of the frontier assemblers to 0, 0. includes food-o-mat and medical assembler.

## Why / Balance
they were both inheriting the microwave offset which looked quite strange and made them both look very off-centered.

## Media
<img width="712" height="422" alt="Screenshot 2025-12-10 155628" src="https://github.com/user-attachments/assets/764ef0fa-bb57-4688-bc79-9c35f318cad5" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- fix: fixed a bad sprite offset on the Medical Assembler and Food-O-Mat
