### PR TITLE
Cigar case can only store tiny items

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
@@ -38,6 +38,7 @@
   - type: Storage
     grid:
     - 0,0,3,1
+    maxItemSize: Tiny # imp
   - type: Item
     sprite: Objects/Consumable/Smokeables/Cigars/case.rsi
     size: Normal


### PR DESCRIPTION
## About the PR
Cigar cases now have a maximum size of 'Tiny' meaning they cannot store items of size small or larger

## Why / Balance
This is kind of a continuation of #1606.
An admin noticed you can do this with cigar cases:
<img width="295" height="210" alt="image" src="https://github.com/user-attachments/assets/ff9f87d1-9f4e-462a-82fe-5bc101d93bbc" />

Based on the previous PR i feel like it just makes sense for this to be mechanically enforced.

## Media
<img width="400" height="242" alt="image" src="https://github.com/user-attachments/assets/cf28f4fd-9177-4f3b-bd90-5cd085c048dd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- remove: Cigar cases can no longer store items bigger than cigars.
