### PR TITLE
pixel-precise thaven clothing offsets

### DIFF
--- a/Resources/Prototypes/_Impstation/InventoryTemplates/thaven_inventory_template.yml
+++ b/Resources/Prototypes/_Impstation/InventoryTemplates/thaven_inventory_template.yml
@@ -34,14 +34,14 @@
       uiWindowPos: 0,2
       strippingWindowPos: 0,1
       displayName: Neck
-      offset: 0, 0.03
+      offset: 0, 0.03125 # 1 pixel up
     - name: mask
       slotTexture: mask
       slotFlags: MASK
       uiWindowPos: 1,2
       strippingWindowPos: 1,1
       displayName: Mask
-      offset: 0, 0.0655
+      offset: 0, 0.0625 # 2 pixels up
     - name: eyes
       slotTexture: glasses
       slotFlags: EYES
@@ -49,7 +49,7 @@
       uiWindowPos: 0,3
       strippingWindowPos: 0,0
       displayName: Eyes
-      offset: 0, 0.08
+      offset: 0, 0.0625 # 2 pixels up
     - name: ears
       slotTexture: ears
       slotFlags: EARS
@@ -57,14 +57,14 @@
       uiWindowPos: 2,2
       strippingWindowPos: 2,0
       displayName: Ears
-      offset: 0, 0.0615
+      offset: 0, 0.0625 # 2 pixels up
     - name: head
       slotTexture: head
       slotFlags: HEAD
       uiWindowPos: 1,3
       strippingWindowPos: 1,0
       displayName: Head
-      offset: 0, 0.06
+      offset: 0, 0.0625 # 2 pixels up
     - name: pocket1
       slotTexture: pocket
       fullTextureName: template_small


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
the thaven clothing offsets were slightly edited to make them pixel accurate, almost every offset is basically identical, excluding eyes which were strangely half a pixel above where it feels like they should be. this meant that sharkminnow eye markings were visible under the glasses. so i moved them down a bit so they're exactly 2 pixels up.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
looks better :)

## Technical details
<!-- Summary of code changes for easier review. -->
changed the offsets in `thaven_inventory_template.yml`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
<img width="352" height="256" alt="image" src="https://github.com/user-attachments/assets/5f30d2b2-09e3-4495-bf69-a6223c30e6ae" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Thaven clothing offsets have been slightly changed.
