### PR TITLE
disguise the head revolutionary's encryption key box

### DIFF
--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Boxes/general.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: revolutionary encryption key box
-  parent: [BoxEncryptionKeyPassenger, Tier2Contraband]
+  name: cardboard box
+  parent: [BoxEncryptionKeyPassenger]
   id: BoxEncryptionKeyRevolution
-  description: Contains four encryption keys to communicate with your fellow revolutionaries. Use wisely.
+  description: A cardboard box for storing things.
   components:
   - type: Item
     size: Normal


### PR DESCRIPTION
## About the PR
the name and description of the head revolutionary's encryption key box were changed to match that of a generic cardboard box. the tier 2 contraband parenting was removed

## Why / Balance
the intent of this change is to make it so that holding the encryption key box is not an immediate giveaway to onlookers that one is a head revolutionary

## Technical details
very simply renaming the prototype, changing the description, and removing a parent

## Media
i don't think a screenshot is necessary here

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [ X ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: The revolutionary encryption key box is now cleverly disguised.

