### PR TITLE
Akurra is sized up

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/FuelGuns/plasma.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/FuelGuns/plasma.yml
@@ -105,6 +105,8 @@
   - type: Item
     sprite: _Impstation/Objects/Weapons/Guns/FuelGuns/akurra.rsi
     size: Large
+    shape:
+    - 0,0,3,1
   - type: Gun
     clumsyProof: false
     cameraRecoilScalar: 1


### PR DESCRIPTION
## About the PR
Made the Akurra twice as big as it was appearing.

## Why / Balance
The gun had the correct size listed in its item component, but it was getting the shape from its parent, the Adder (2x2). This is not intended, so I've made the Akurra correctly display as a 4x2 item.

## Technical details
two line change.

## Media
<img width="1936" height="1056" alt="image" src="https://github.com/user-attachments/assets/54691d29-c27c-4c69-9378-e5c28d52ee7b" />

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: The Akurra has Sized Up
