### PR TITLE
Deprecate EVA airlocks, migrate them to Command locked airlocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -36,7 +36,7 @@
       board: [ DoorElectronicsServiceTheatre ]
 
 - type: entity
-  parent: AirlockChapel #imp editeLocked
+  parent: AirlockChapel #imp edit
   id: AirlockChapelLocked
   suffix: Chapel, Locked
   components:
@@ -442,6 +442,7 @@
   parent: AirlockCommand
   id: AirlockEVALocked
   suffix: EVA, Locked
+  categories: [ HideSpawnMenu ] #imp edit, deprecated in favor of Command airlocks with imp map forking
   components:
   - type: ContainerFill
     containers:
@@ -843,6 +844,7 @@
   parent: AirlockCommandGlassLocked
   id: AirlockEVAGlassLocked
   suffix: EVA, Locked
+  categories: [ HideSpawnMenu ] #imp edit, deprecated in favor of Command airlocks with imp map forking
   components:
   - type: ContainerFill
     containers:

--- a/Resources/migration_imp.yml
+++ b/Resources/migration_imp.yml
@@ -134,3 +134,8 @@ ComputerFundingAllocation: ComputerFundingAllocationBroken
 # 2025-11-20
 # upstream merge replacement prototypes
 CrayonRainbowInfinite: CrayonInfinite
+
+# 2025-12-27
+# standardize EVA rooms to command access, we should have done this a year ago when we initially hard forked maps but c'est la vie
+AirlockEVALocked: AirlockCommandLocked
+AirlockEVAGlassLocked: AirlockCommandGlassLocked


### PR DESCRIPTION
## About the PR
Hides EVA airlocks from the spawn menu and migrates them to Command locked airlocks.

## Why / Balance
When we hard forked maps a year ago, we had decided on Command locked airlocks to be the standard for EVA rooms. This helps enforce that standard.

## Technical details
Hid two entities from entity spawner and added two entries to migration_imp.yml.

## Media

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/099da68a-83ff-4361-8296-5b02cb4815bc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
