### PR TITLE
remove generated books from bookshelves

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -14,9 +14,9 @@
   table: !type:AllSelector
     children:
     # Randomly generated books
-    - id: BookRandomStory
-      amount: !type:RangeNumberSelector
-        range: 0, 8
+    #- id: BookRandomStory # imp edit, random book removal
+    #  amount: !type:RangeNumberSelector
+    #    range: 0, 8
     # Guidebooks
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector
@@ -25,7 +25,7 @@
     # Handwritten books
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector
-        range: 0, 3
+        range: 0, 11  # imp edit, 3 -> 11 due to random book removal
       tableId: RandomHandwrittenBookTable
     #imp, safe spellbooks
     - !type:NestedSelector
@@ -109,7 +109,7 @@
   id: RandomBookTable
   table: !type:GroupSelector
     children:
-    - id: BookRandomStory
+    #- id: BookRandomStory # imp edit, random book removal
     - !type:NestedSelector
       tableId: RandomGuidebookTable
     - !type:NestedSelector

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Books/cryptid_bookshelf.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Books/cryptid_bookshelf.yml
@@ -28,17 +28,13 @@
   id: CryptidBookshelfEntityTable
   table: !type:AllSelector
     children:
-    # Randomly generated books
-    - id: BookRandomStory
-      amount: !type:RangeNumberSelector
-        range: 0, 8
     # Guidebooks
     - !type:NestedSelector
       tableId: RandomGuidebookTable
     # Handwritten books
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector
-        range: 0, 3
+        range: 0, 11
       tableId: RandomHandwrittenBookTable
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector
@@ -53,7 +49,6 @@
   id: RandomMagicalBookTable
   table: !type:GroupSelector
     children:
-    - id: BookRandomStory
     - id: BlinkBook
       weight: 0.01
     - id: FireballSpellbook
@@ -73,7 +68,6 @@
   id: RandomHereticBookTable
   table: !type:GroupSelector
     children:
-    - id: BookRandomStory
     - id: EldritchTome
       weight: 0.5
     - id: CodexCicatrix
@@ -83,7 +77,6 @@
   id: CryptidRandomBookTable
   table: !type:GroupSelector
     children:
-    - id: BookRandomStory
     - !type:NestedSelector
       tableId: RandomGuidebookTable
     - !type:NestedSelector


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
made it so randomly generated books don't spawn in bookshelves (and the book return teleporter). also increased the amount of handwritten books so the amount of books you get is the same

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
they take up space and removing them lets us show off our custom books better

## Technical details
<!-- Summary of code changes for easier review. -->
very minor yml entitytable edits

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="439" height="189" alt="image" src="https://github.com/user-attachments/assets/0f47c530-fbe3-4742-ab5a-0113e967dd63" />

our beautiful handwritten books

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Randomly generated books can no longer be found in bookshelves and the book return teleporter.
