### PR TITLE
Further map population range adjustments, less strict brackets

### DIFF
--- a/Resources/Prototypes/_Impstation/Maps/anthill.yml
+++ b/Resources/Prototypes/_Impstation/Maps/anthill.yml
@@ -3,7 +3,7 @@
   mapName: 'Pathway'
   mapPath: /Maps/_Impstation/anthill.yml
   minPlayers: 35
-  maxPlayers: 60
+  maxPlayers: 64
   stations:
     Pathway:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/bagel.yml
+++ b/Resources/Prototypes/_Impstation/Maps/bagel.yml
@@ -3,7 +3,7 @@
   mapName: 'Bagel Station'
   mapPath: /Maps/_Impstation/bagel.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Bagel:
       stationProto: StandardNanotrasenStation
@@ -43,7 +43,7 @@
             TechnicalAssistant: [ 4, 4 ]
             # medical - 8-12
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 1 ] 
+            MedicalDoctor: [ 4, 1 ]
             MedicalIntern: [ 4, 4 ]
             Paramedic: [ 1, 1 ]
             Psychologist: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/barratry.yml
+++ b/Resources/Prototypes/_Impstation/Maps/barratry.yml
@@ -4,7 +4,7 @@
   mapName: 'Barratry'
   mapPath: /Maps/_Impstation/barratry.yml # imp
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Barratry:
       stationProto: StandardNanotrasenStation
@@ -46,16 +46,16 @@
             TechnicalAssistant: [ 4, 4 ]
             # medical - 7-11
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ] 
+            MedicalDoctor: [ 4, 4 ]
             MedicalIntern: [ 2, 4 ]
-            Paramedic: [ 1, 1 ] 
+            Paramedic: [ 1, 1 ]
             # science - 8-9
             Borg: [ 2, 2 ]
             ResearchAssistant: [ 1, 1]
             Scientist: [ 5, 5 ]
             StationAi: [ 1, 1 ]
             # security - 10-14
-            Brigmedic: [ 1, 1 ] 
+            Brigmedic: [ 1, 1 ]
             Detective: [ 1, 1 ]
             Lawyer: [ 2, 2 ]
             SecurityCadet: [ 4, 4 ]

--- a/Resources/Prototypes/_Impstation/Maps/boat.yml
+++ b/Resources/Prototypes/_Impstation/Maps/boat.yml
@@ -3,7 +3,7 @@
   mapName: 'NTAS Whale'
   mapPath: /Maps/_Impstation/boat.yml
   minPlayers: 45
-  maxPlayers: 69 #map needs more job spawns to have a higher max pop
+  maxPlayers: 75
   stations:
     Boat:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/box.yml
+++ b/Resources/Prototypes/_Impstation/Maps/box.yml
@@ -3,7 +3,7 @@
   mapName: 'Box Station'
   mapPath: /Maps/_Impstation/icebox.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/cog.yml
+++ b/Resources/Prototypes/_Impstation/Maps/cog.yml
@@ -2,7 +2,8 @@
   id: CogImp
   mapName: 'Cog'
   mapPath: /Maps/_Impstation/cog.yml
-  minPlayers: 70
+  minPlayers: 45
+  maxPlayers: 75
   stations:
     Cog:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/core.yml
+++ b/Resources/Prototypes/_Impstation/Maps/core.yml
@@ -3,7 +3,7 @@
   mapName: 'Core'
   mapPath: /Maps/_Impstation/core.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Core:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/gate.yml
+++ b/Resources/Prototypes/_Impstation/Maps/gate.yml
@@ -2,7 +2,7 @@
   id: GateImp
   mapName: 'Gate Station'
   mapPath: /Maps/_Impstation/gate.yml
-  minPlayers: 70
+  minPlayers: 65
   stations:
     Gate:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
+++ b/Resources/Prototypes/_Impstation/Maps/hummingbird.yml
@@ -3,7 +3,7 @@
   mapName: 'Hummingbird Station'
   mapPath: /Maps/_Impstation/hummingbird.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Hummingbird:
       stationProto: StandardNanotrasenStation
@@ -16,7 +16,7 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/_Impstation/Shuttles/emergency_courser_hummingbird.yml
         - type: StationJobs
-          availableJobs: # Total of 66 nice jobs roundstart, max of 77 inc. latejoins and trainees.
+          availableJobs: # Total of 66 jobs roundstart, max of 77 inc. latejoins and trainees.
             # command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]

--- a/Resources/Prototypes/_Impstation/Maps/luna.yml
+++ b/Resources/Prototypes/_Impstation/Maps/luna.yml
@@ -3,7 +3,7 @@
   mapName: 'Embryo'
   mapPath: /Maps/_Impstation/luna.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Luna:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/marathon.yml
+++ b/Resources/Prototypes/_Impstation/Maps/marathon.yml
@@ -3,7 +3,7 @@
   mapName: 'Marathon Station'
   mapPath: /Maps/_Impstation/marathon.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Marathon:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/oasis.yml
+++ b/Resources/Prototypes/_Impstation/Maps/oasis.yml
@@ -2,7 +2,7 @@
   id: OasisImp
   mapName: 'Oasis'
   mapPath: /Maps/_Impstation/oasis.yml
-  minPlayers: 70
+  minPlayers: 65
   stations:
     Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/plasma.yml
+++ b/Resources/Prototypes/_Impstation/Maps/plasma.yml
@@ -2,8 +2,8 @@
   id: PlasmaImp
   mapName: 'Plasma'
   mapPath: /Maps/_Impstation/plasma.yml
-  minPlayers: 35
-  maxPlayers: 69
+  minPlayers: 45
+  maxPlayers: 75 #everyone talks about how damn big this map is, so let's try this
   stations:
     Plasma:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/submarine.yml
+++ b/Resources/Prototypes/_Impstation/Maps/submarine.yml
@@ -3,7 +3,7 @@
   id: Submarine
   mapName: 'Submarine'
   mapPath: /Maps/_Impstation/submarine.yml
-  minPlayers: 70
+  minPlayers: 65
   maxPlayers: 100
   stations:
     Submarine:

--- a/Resources/Prototypes/_Impstation/Maps/train.yml
+++ b/Resources/Prototypes/_Impstation/Maps/train.yml
@@ -5,7 +5,7 @@
   maxRandomOffset: 0
   randomRotation: false
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Train:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/union.yml
+++ b/Resources/Prototypes/_Impstation/Maps/union.yml
@@ -3,7 +3,7 @@
   mapName: 'Union'
   mapPath: /Maps/_Impstation/union.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Union:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Impstation/Maps/whisper.yml
+++ b/Resources/Prototypes/_Impstation/Maps/whisper.yml
@@ -2,7 +2,7 @@
   id: Whisper
   mapName: 'Whisper'
   mapPath: /Maps/_Impstation/whisper.yml
-  minPlayers: 35
+  minPlayers: 25
   maxPlayers: 60
   stations:
     Whisper:

--- a/Resources/Prototypes/_Impstation/Maps/xeno.yml
+++ b/Resources/Prototypes/_Impstation/Maps/xeno.yml
@@ -3,7 +3,7 @@
   mapName: 'Xeno'
   mapPath: /Maps/_Impstation/xeno.yml
   minPlayers: 35
-  maxPlayers: 69
+  maxPlayers: 64
   stations:
     Xeno:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
Followup to https://github.com/impstation/imp-station-14/pull/3501, adjusting map population ranges further.

Current population range brackets have been adjusted:
Min pop: 0 - 7
Low pop: 8 - 34
Mid pop: 34 - 64 (from 34 - 69)
High pop: 65 - 100 (from 70 - 100)

I had partially originally created the original PR to accommodate the server's max pop being increased to 100 so that high pop maps would roll more consistently. However, it really hasn't played out that way, since we haven't really consistently been hitting those population numbers. Reducing the minimum population of highpop maps down to 65 better reflects how they were before. This also goes back on making maps strictly fit into these brackets, so several maps now have overlap between two brackets, namely Whisper, Cog, Whale, and Plasma (people keep saying how big this map is).

<img width="3414" height="2592" alt="mapranges" src="https://github.com/user-attachments/assets/f03e5dab-7af7-4cb2-b7a1-530161a8d036" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Map population ranges have been tweaked. Maps in the high-pop bracket will now roll at 65 players. Plasma, Cog, and Whale roll between 45 - 75 players. Whisper rolls between 25 - 60 players.