### PR TITLE
Tegloose

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegGeneratorComponent.cs
+++ b/Content.Server/Power/Generation/Teg/TegGeneratorComponent.cs
@@ -14,10 +14,25 @@ public sealed partial class TegGeneratorComponent : Component
     /// </summary>
     /// <remarks>
     /// A value of 0.9 means that 90% of energy transferred goes to electricity.
+    /// IMP ADD: This value will modulate over time depending on the TEG's internal heat.
     /// </remarks>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("thermalEfficiency")]
     public float ThermalEfficiency = 0.65f;
+
+    /// <summary>
+    ///     IMP ADD:
+    ///     The base value to be used as thermal efficiency.
+    /// </summary>
+    [DataField]
+    public float BaseThermalEfficiency = 0.65f;
+
+    /// <summary>
+    ///     IMP ADD:
+    ///     The minimum thermal efficiency this TEG is capable of.
+    /// </summary>
+    [DataField]
+    public float MinThermalEfficiency = 0.2f;
 
     /// <summary>
     /// Simple factor that scales effective electricity generation.
@@ -82,22 +97,17 @@ public sealed partial class TegGeneratorComponent : Component
     [DataField]
     public float PowerSmoothingFactor = 0.2f;
 
-    // IMP ADD START HERE!
-    /// <summary>
-    ///     Base factor used to calculate temperature of ambient heat output.
-    /// </summary>
-    [DataField]
-    public float BaseAmbientHeatFactor = 5f;
+    // IMP ADD:
 
     /// <summary>
-    ///     Factor used to calculate temperature of ambient heat output. Modulates according to time the TEG has been producing power.
+    ///     Amount of internal heat the TEG has accumulated.
     /// </summary>
     [DataField]
-    public float AmbientHeatFactor = 5f;
+    public float InternalHeat = 0f;
 
     /// <summary>
-    ///     Time the TEG has spent producing power. Will exponentially affect the temperature of ambient heat output.
+    ///     Maximum amount of internal heat the TEG can accumulate.
     /// </summary>
     [DataField]
-    public float Uptime = 0f;
+    public float MaxInternalHeat = 10000f;
 }

--- a/Content.Server/Power/Generation/Teg/TegGeneratorComponent.cs
+++ b/Content.Server/Power/Generation/Teg/TegGeneratorComponent.cs
@@ -81,4 +81,23 @@ public sealed partial class TegGeneratorComponent : Component
     /// </summary>
     [DataField]
     public float PowerSmoothingFactor = 0.2f;
+
+    // IMP ADD START HERE!
+    /// <summary>
+    ///     Base factor used to calculate temperature of ambient heat output.
+    /// </summary>
+    [DataField]
+    public float BaseAmbientHeatFactor = 5f;
+
+    /// <summary>
+    ///     Factor used to calculate temperature of ambient heat output. Modulates according to time the TEG has been producing power.
+    /// </summary>
+    [DataField]
+    public float AmbientHeatFactor = 5f;
+
+    /// <summary>
+    ///     Time the TEG has spent producing power. Will exponentially affect the temperature of ambient heat output.
+    /// </summary>
+    [DataField]
+    public float Uptime = 0f;
 }

--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -112,8 +112,8 @@ public sealed class TegSystem : EntitySystem
                 args.PushMarkup(Loc.GetString("teg-generator-examine-power-max-output", ("power", supplier.MaxSupply)));
 
                 // IMP ADD: TEG AMBIENT HEAT
-                // locales in divisors of 7 minutes- maxes out at 35 minutes (5 diff strings).
-                var uptime = MathF.Min(MathF.Round(component.Uptime / 7), 35);
+                // 5 different strings, so we multiply fraction by 5.
+                var uptime = MathF.Round(component.InternalHeat / component.MaxInternalHeat * 5);
                 args.PushMarkup(Loc.GetString("teg-generator-examine-uptime", ("uptime", uptime)));
             }
         }
@@ -199,27 +199,40 @@ public sealed class TegSystem : EntitySystem
                 // A -> B
                 airA.Temperature -= transfer / cA;
                 airB.Temperature += outTransfer / cB;
+
+                // IMP ADD: TEGLOOSE, modify internal temperature
+                component.InternalHeat = MathF.Min(
+                    component.MaxInternalHeat,
+                    component.InternalHeat - (transfer / cA - outTransfer / cB));
             }
             else
             {
                 // B -> A
                 airA.Temperature += outTransfer / cA;
                 airB.Temperature -= transfer / cB;
+
+                // IMP ADD: TEGLOOSE, modify internal temperature
+                component.InternalHeat = MathF.Min(
+                    component.MaxInternalHeat,
+                    component.InternalHeat - (transfer / cB - outTransfer / cA));
             }
+
+            // IMP ADD: TEGLOOSE
+            // clamp to 0
+            component.InternalHeat = MathF.Max(component.InternalHeat, 0);
+
+            // modify thermal efficiency based on internal temperature, clamped to base value & min efficiency
+            // a TEG can never get more efficient, but it can get less efficient!
+            component.ThermalEfficiency = MathF.Max(component.MinThermalEfficiency, MathF.Min(
+                component.BaseThermalEfficiency,
+                component.BaseThermalEfficiency * (component.InternalHeat / component.MaxInternalHeat)));
+            // END IMP ADD
         }
 
         component.LastGeneration = electricalEnergy;
 
         // Turn energy (at atmos tick rate) into wattage.
         var power = electricalEnergy / args.dt;
-
-        // IMP ADD- TEG AMBIENT HEAT
-        if (power > 0f)
-            component.Uptime += args.dt;
-        else
-            component.Uptime = MathF.Max(component.Uptime - args.dt * component.BaseAmbientHeatFactor, 0f);
-        AmbientHeat((uid, component), power);
-        // END IMP
 
         // Add ramp factor. This magics slight power into existence, but allows us to ramp up.
         // Also apply an exponential moving average to smooth out fluttering, as it was causing
@@ -239,25 +252,6 @@ public sealed class TegSystem : EntitySystem
         _atmosphere.Merge(outletB.Air, airB);
 
         UpdateAppearance(uid, component, powerReceiver, tegGroup);
-    }
-
-    // IMP ADD
-    /// <summary>
-    ///     Adds temperature to the atmosphere of the TEG generator entity, scaling based on the amount of power produced.
-    /// </summary>
-    /// <remarks>
-    ///     All the math here is really arbitrary. sorry im not a numbers pervert -mq
-    /// </remarks>
-    private void AmbientHeat(Entity<TegGeneratorComponent> ent, float power)
-    {
-        // if this method is running, then we have already fully built and powered the TEG. no need to check that.
-        ent.Comp.AmbientHeatFactor = MathF.Pow(ent.Comp.BaseAmbientHeatFactor, ent.Comp.Uptime / 100f);
-
-        var temp = power / 100f * ent.Comp.AmbientHeatFactor;
-        var mix = _atmosphere.GetContainingMixture(ent.Owner, true, true);
-
-        if (mix is not null)
-            _atmosphere.AddHeat(mix, temp);
     }
 
     private void UpdateAppearance(

--- a/Resources/Locale/en-US/_Impstation/power/teg.ftl
+++ b/Resources/Locale/en-US/_Impstation/power/teg.ftl
@@ -1,0 +1,11 @@
+teg-circulator-examine-flow-rate = The flow rate meter indicates [color=lightblue]{$flowRate} moles/s[/color].
+
+# uptime: measure in increments of 7 minutes, up to 35.
+teg-generator-examine-uptime = {$uptime ->
+    *[0] It's stone-cold.
+    [1] It's stone-cold.
+    [2] It's not very warm.
+    [3] It's heating up.
+    [4] It's warm!
+    [5] It's boiling hot!
+}

--- a/Resources/Locale/en-US/power/teg.ftl
+++ b/Resources/Locale/en-US/power/teg.ftl
@@ -1,6 +1,3 @@
 ﻿teg-generator-examine-power = It's currently supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-power-max-output = It's capable of supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-connection = To function, a [color=white]circulator[/color] must be attached on both sides.
-
-# imp add flow rate
-teg-circulator-examine-flow-rate = The flow rate meter indicates [color=lightblue]{$flowRate} moles/s[/color].


### PR DESCRIPTION
# NOTE THE NUMBERS ON THIS HAVE NOT BEEN BALANCED!!! THIS IS A PROOF OF CONCEPT!!!

## About the PR
The TEG will now function as a radiator, adding heat to its environment proportional to the amount of power generated.
The longer you leave the TEG running, the more heat it will add. You can examine the TEG to get a sense of how long it's been running.
If your TEG's been running for a while, you'll need to turn it off to let it cool again.

TODO: balancing, guidebook

## Why / Balance
The TEG is basically free power with zero risk. You just have to set it up, and then it obsoletes engineering's job for the entire shift.
Adding a degree of maintenance to the TEG is good :)

## Technical details
- Moved some FTLs
- Added datafields to the generator component tracking uptime and heat factor. uptime is modified every atmos tick.
- A whole lot of math and methods to add heat to the TEG's environment. The heat factor will never go below 0, but it will reduce heat when powered off at a rate of 5x what it accumulates. We will need to balance this shit probably

## Media
None yet

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added TEGloose.
