### PR TITLE
ninja inventory tweaks

### DIFF
--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -29,9 +29,10 @@
     belt: EnergyKatanaStun # imp
   inhand:
     - JetpackBlackFilled
+  # begin imp edit, replaced toolset with omnitool and added smoke grenades
   storage:
     back: # belt holds katana so satchel has the tools for sabotaging things
-    #- Crowbar #imp, replaced toolset minus welder with omnitool
+    #- Crowbar 
     #- Wrench
     #- Screwdriver
     #- Wirecutter
@@ -42,6 +43,7 @@
     - SmokeGrenade
     - SmokeGrenade
     - SmokeGrenade
+  # end imp edit
 
 - type: chameleonOutfit
   id: NinjaChameleonOutfit


### PR DESCRIPTION
## About the PR
this PR changes the ninja's starting inventory by adding smoke grenades and replacing the set of tools with an omnitool.

## Why / Balance
the goal here is to both add to the ninja's kit and encourage use of that kit. swapping the tools for the omnitool will discourage tool use because it's inconvenient and loud. hopefully this will encourage ninjas to use teleports and glove hacking instead, with an added benefit of freeing up inventory space. smoke grenades are fun to use and reinforce the ninja's "stealthy, but not too stealthy" identity.
 
## Technical details
commented out tools, added omnitool and 4 smoke grenades to the ninja's inventory.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: The Spider Clan now supplies agents with smoke bombs.
- tweak: The Spider Clan has acquired a patent for advanced tool storage technology.

