### PR TITLE
Remove the fugitive time requirement

### DIFF
--- a/Resources/Prototypes/_DV/Roles/Antags/fugitive.yml
+++ b/Resources/Prototypes/_DV/Roles/Antags/fugitive.yml
@@ -4,8 +4,8 @@
   antagonist: true
   playTimeTracker: AntagFugitive
   objective: roles-antag-fugitive-objective
-  # imp edit: comment out sec requirement
   # keep these in sync with the spawner
+  # imp edit: comment out sec requirement
   #requirements:
   #- !type:DepartmentTimeRequirement
   #  department: Security


### PR DESCRIPTION
## About the PR
fugitive requires 1 hour of sec time, which i don't really understand. it's a very low impact antag that's great for new antag players, i don't think locking it off is great. 

## Technical details
i tested it and it seemed to work but it's possible i missed something


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Fugitive no longer requires 1 hour of sec time to play.

