### PR TITLE
Duct spiders can use a VIM mech

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/duct_spider.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/duct_spider.yml
@@ -92,3 +92,5 @@
   - type: Tag
     tags:
     - VimPilot
+    - DoorBumpOpener
+    - FootstepSound


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

gives ductspiders the VimPilot tag

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
i think they should be allowed
## Technical details
<!-- Summary of code changes for easier review. -->
adds tags to the mob yml
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="483" height="262" alt="image" src="https://github.com/user-attachments/assets/38534d7e-f190-48bb-b434-558bab99face" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
- add: Duct spiders can now Pilot Vims!
