### PR TITLE
Wildering Mirror buff

### DIFF
--- a/Resources/Prototypes/_Impstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Impstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -29,7 +29,7 @@
           eldritch-book-icon3: ""
           eldritch-book-icon4: ""
           eldritch-book-icon5: ""
-          eldritch-book-icon6: ""          
+          eldritch-book-icon6: ""
   - type: HereticKnowledgeItem
   - type: PointLight
     radius: 1.5
@@ -38,11 +38,11 @@
   - type: Tag
     tags:
       - Book
-    
+
 - type: entity
   id: RealityTear
   name: reality tear
-  description: It hurts your head to look at. 
+  description: It hurts your head to look at.
   components:
   - type: TimedDespawn
     lifetime: 10
@@ -57,7 +57,7 @@
     sprite: _Goobstation/Heretic/reality_fracture.rsi
     state: icon_harvested
   - type: Clickable
-  
+
 - type: entity
   parent: EldritchTome
   id: DebugEldritchTome
@@ -69,7 +69,7 @@
     pointGain: 999
     useTimeSeconds: 1
 
-- type: entity 
+- type: entity
   parent: [ BaseItem, TierXContraband ]
   id: HereticBookSensor
   name: seeker's heart
@@ -94,7 +94,7 @@
         maxDistance: 1
         volume: -2
 
-- type: entity 
+- type: entity
   id: AlwaysPoweredHellLight
   parent: MarkerBase
   name: hellworldlight
@@ -113,7 +113,7 @@
       - sprite: Structures/Wallmounts/Lighting/light_tube.rsi
         state: base
 
-- type: entity 
+- type: entity
   id: HellSpawnPointMarker
   parent: MarkerBase
   name: hellworldtarget
@@ -151,6 +151,12 @@
       reflects:
         - Energy
       spread: 330
+    - type: Clothing
+      sprite: Clothing/Belt/sheath.rsi
+      slots: [belt]
+      equipSound:
+        path: /Audio/Items/belt_equip.ogg
+      quickEquip: false
 
 - type: entity
   name: frangiclave


### PR DESCRIPTION
## About the PR
The Wildering mirror now fits onto your belt slot instead of only being an inhand item

Still need to make sprites for the equipped mirror for clarity, so draft for now.
## Why / Balance
This allows the heretic to use the wildering mirror's 60% energy deflect without holding it in one of their hands.
Heretic is very reliant on having both hands and using the mirror thus requires a lot of annoying inventory juggling, making this item more actually usable gives heretic a single usable tool against (some) stuns

## Technical details
Yaml
+ 1 WIP sprite

## Media
no

## Requirements
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: The Heretic's Wildering Mirror can now be equipped on the belt slot while still granting 60% energy deflection.
