### PR TITLE
(pre-emptive pr) exped atmos pressure reduction

### DIFF
--- a/Resources/Prototypes/Procedural/salvage_mods.yml
+++ b/Resources/Prototypes/Procedural/salvage_mods.yml
@@ -138,7 +138,7 @@
   desc: salvage-air-mod-breathable-atmosphere
   gases:
     - 21.824779 # oxygen
-    - 82.10312 # nitrogen
+    - 21.824779 # nitrogen - imp pka support: 82.10312 -> 21.824779
 
 - type: salvageAirMod
   id: Sleepy
@@ -146,7 +146,7 @@
   desc: salvage-air-mod-dangerous-atmosphere
   gases:
     - 21.824779 # oxygen
-    - 72.10312 # nitrogen
+    - 11.824779 # nitrogen - imp pka support: 72.10312 -> 11.824779
     - 0
     - 0
     - 0
@@ -166,7 +166,7 @@
   desc: salvage-air-mod-dangerous-atmosphere
   gases:
     - 21.824779 # oxygen
-    - 77.10312 # nitrogen
+    - 17.10312 # nitrogen - imp pka support: 77.10312 -> 17.10312
     - 10 # carbon dioxide
   biomes:
     - Caves
@@ -182,7 +182,7 @@
   gases:
     - 21.824779 # oxygen
     - 0
-    - 82.10312 # carbon dioxide
+    - 21.824779 # carbon dioxide - imp pka support: 82.10312 -> 21.824779
   biomes:
     - Caves
     - Snow
@@ -196,7 +196,7 @@
     - 0
     - 0
     - 0
-    - 103.927899 # plasma
+    - 43.649558 # plasma - imp pka support: 103.927899 -> 43.649558
   biomes:
     - Caves
     - Lava
@@ -209,7 +209,7 @@
     - 21.824779 # oxygen
     - 0
     - 0
-    - 82.10312 # plasma
+    - 21.824779 # plasma - imp pka support: 82.10312 -> 21.824779
   biomes:
     - Caves
     - Lava


### PR DESCRIPTION
## About the PR
this is a pre-emptive pr ready to go if the recently-merged #2982 becomes an issue for salvagers on expeditions. expedition atmospheres have been reduced to roughly ~44% of the pressure they previously had to get under the "half of one atmosphere" requirement that the system introduced. this does _not_ address atmosphere on maps like box

## Why / Balance
the pka is a salvager's tool of the trade and should be sufficient weaponry for expeditions. or they could raid the armory, thats cool too

## Technical details
the total pressure is based entirely off the `Breathable` `salvageAirMod`: to ensure those are still breathable for nitrogen-breathing species, the mole count of oxygen was copy-pasted into nitrogen. this total pressure was then used as a target for the other `salvageAirMod` prototypes, with oxygen remaining untouched across those. this does mean nitrogen-breathing species might can lack enough moles in the atmosphere to be able to breathe, but these are dangerous gas environments anyways and should already be handled with internals

## Media
<img width="1763" height="1122" alt="image" src="https://github.com/user-attachments/assets/96ebf773-f073-4e3f-b2a7-12c222ab93a7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Expeditions have had their atmospheric pressure reduced to accomodate for PKA pressure sensitivity.
