### PR TITLE
Remove changes to PKA from  #2982

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -9,7 +9,7 @@
     sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
     size: Large
     shape:
-    - 0,0,1,1 # imp 2x2
+    - 0,0,2,1
   - type: GunWieldBonus
     minAngle: -43
     maxAngle: -43

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -552,7 +552,6 @@
   - type: TimedDespawn
     lifetime: 0.22 # roughly 5.5 tiles
   - type: GatheringProjectile
-  - type: PressureProjectile # DeltaV
 
 - type: entity
   id: BulletKineticShuttleWizden #imp - see the _Impstation directory for the version we use


### PR DESCRIPTION
## About the PR
Removes changes to wizden prototypes for PKA made in https://github.com/impstation/imp-station-14/pull/2982. Keeps the new systems that were merged with it.

## Why / Balance
Discussion around changing PKA damage was centered around other rebalances for salvage as means responding to changes made upstream, particularly health changes to salvage mobs. This was merged without any other changes that it would complement, which would also be a problem for some of our maps that have an atmosphere. It *also* only affected the base wizden prototypes, and since all of our gun prototypes are hard forked, this meant it didn't actually do anything in-game.

I've left the merged systems in case anyone wants to play around with it themselves.

## Technical details
Reverted changes to yaml.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: PKAs were not actually changed. We made it up.
