### PR TITLE
marching band uniform not contraband no more

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -487,7 +487,7 @@
     sprite: _Impstation/Clothing/Uniforms/Jumpsuit/cmo_scrubs.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseCommandContraband]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitMusicianMarchingBand
   name: musician's marching uniform
   description: For when you need to join the parade.


### PR DESCRIPTION
<img width="617" height="272" alt="thumb" src="https://github.com/user-attachments/assets/5522b3b0-3907-4105-a514-3b0377de793f" />

## About the PR
musician marching band uniform was command contraband
it was not supposed to be like that
i fixed          it

## Why / Balance
not supposed to be like that

## Technical details
one (1) line changed

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
:cl:
- fix: Musicians are now legally allowed to wear marching band uniforms.
