### PR TITLE
dionae and anomalocarids are more likely to be struck by lightning

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -159,7 +159,7 @@
   id: Card
   coefficients:
     Slash: 2.0
-    Piercing: 0.1 # Holes easily poked through, but do little to structural integrity 
+    Piercing: 0.1 # Holes easily poked through, but do little to structural integrity
     Heat: 3.0
 
 - type: damageModifierSet
@@ -202,7 +202,7 @@
     Blunt: 0.7
     Slash: 0.8
     Heat: 1.5
-    Shock: 1.2
+    # Shock: 1.2 # imp
 
 - type: damageModifierSet
   id: Moth # Slightly worse at everything but cold

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -119,6 +119,11 @@
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
   - type: Rootable
+  # imp edit start
+  - type: LightningTarget # dionae are as likely to be struck by lightning as a tesla coil
+    priority: 4
+    lightningExplode: false
+  # imp edit end
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/anomalocarid.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/anomalocarid.yml
@@ -219,6 +219,9 @@
           32:
             sprite: _Impstation/Mobs/Species/Anomalocarid/displacement.rsi
             state: back
+  - type: LightningTarget # lightning is more likely to strike the tallest thing in a location. so.
+    priority: 4
+    lightningExplode: false
   #- type: CosmicStarMarkOffset
   #  offset: 0, 0.375
 


### PR DESCRIPTION
## About the PR
this pr removes the shock weakness for diona in favor of instead making them extra likely to be targeted by a tesla. anomalocarids also get this because they're tall

## Why / Balance
funny, better in game representation of why trees are struck by lightning

## Technical details
all yaml. i should probably do a guidebook edit to mention this weakness because it does absolutely impact the playstyle of dionae and anomalocarid engineers

## Media

https://github.com/user-attachments/assets/bd69d99c-9d44-4fff-8111-14314ed76229


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Tall species now tend to work like a lightning rod...
