### PR TITLE
add a detach handler function to the notifier examine component

### DIFF
--- a/Content.Shared/_Impstation/NotifierExamine/NotifierExamineSystem.cs
+++ b/Content.Shared/_Impstation/NotifierExamine/NotifierExamineSystem.cs
@@ -21,6 +21,7 @@ public sealed class NotifierExamineSystem : EntitySystem
 
         SubscribeLocalEvent<NotifierExamineComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<NotifierExamineComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<NotifierExamineComponent, PlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<NotifierExamineComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbs);
     }
 
@@ -31,6 +32,13 @@ public sealed class NotifierExamineSystem : EntitySystem
 
         ent.Comp.Active = true;
         ent.Comp.Content = _netCfg.GetClientCVar(args.Player.Channel, ImpCCVars.NotifierExamine);
+        Dirty(ent.Owner, ent.Comp);
+    }
+
+    private void OnPlayerDetached(Entity<NotifierExamineComponent> ent, ref PlayerDetachedEvent args)
+    {
+        ent.Comp.Active = false;
+        ent.Comp.Content = "";
         Dirty(ent.Owner, ent.Comp);
     }
     private void OnGetExamineVerbs(Entity<NotifierExamineComponent> ent, ref GetVerbsEvent<ExamineVerb> args)


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Adds a handler for players being detached from an entity for the notifier
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In cases where a player died or went ssd it didn't really matter but when someone takes over an entity another player controlled e.g a mouse and such it remains. i don't really like this so the notifier turns off with no player. 

I was going to bundle this with a bunch of cleanup. but that involves database stuff which is a headache and i feel like this should have been there in the first place so it gets to go early.
## Technical details
<!-- Summary of code changes for easier review. -->
adds an on player detach function to notifierexaminesystem

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The accessibility notifier no longer stays when a player exits an entity

