### PR TITLE
make ai static better toggle

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -10,6 +10,7 @@
                 <CheckBox Name="ReducedMotionCheckBox" Text="{Loc 'ui-options-reduced-motion'}" />
                 <!-- Imp add -->
                 <CheckBox Name="DisableSinguloWarpingCheckBox" Text="{Loc 'ui-options-disable-singulo-warp'}" />
+                <CheckBox Name="DisableAiStaticCheckBox" Text="{Loc 'ui-options-disable-ai-static'}" />
                 <CheckBox Name="EnableColorNameCheckBox" Text="{Loc 'ui-options-enable-color-name'}" />
                 <CheckBox Name="ColorblindFriendlyCheckBox" Text="{Loc 'ui-options-colorblind-friendly'}" />
                 <ui:OptionSlider Name="ScreenShakeIntensitySlider" Title="{Loc 'ui-options-screen-shake-intensity'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionTextEdit(ImpCCVars.NotifierExamine, NotifierExamineTextEdit);//imp
 
         Control.AddOptionCheckBox(ImpCCVars.DisableSinguloWarping, DisableSinguloWarpingCheckBox); // imp
+        Control.AddOptionCheckBox(ImpCCVars.DisableAiStatic, DisableAiStaticCheckBox); // imp
         Control.AddOptionCheckBox(DCCVars.NoVisionFilters, DisableFiltersCheckBox); // dv
 
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -8,12 +8,15 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Robust.Shared.Configuration; // imp
+using Content.Shared._Impstation.CCVar; // imp
 
 namespace Content.Client.Silicons.StationAi;
 
 public sealed class StationAiOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> CameraStaticShader = "CameraStatic";
+    private static readonly ProtoId<ShaderPrototype> CameraStaticAccessibleShader = "CameraStaticAccessible"; // imp
     private static readonly ProtoId<ShaderPrototype> StencilMaskShader = "StencilMask";
     private static readonly ProtoId<ShaderPrototype> StencilDrawShader = "StencilDraw";
 
@@ -22,6 +25,7 @@ public sealed class StationAiOverlay : Overlay
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // imp
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
@@ -97,7 +101,11 @@ public sealed class StationAiOverlay : Overlay
             () =>
             {
                 worldHandle.SetTransform(invMatrix);
-                var shader = _proto.Index(CameraStaticShader).Instance();
+
+                // IMP EDIT- static toggle
+                var shader = _cfg.GetCVar(ImpCCVars.DisableAiStatic) ?
+                    _proto.Index(CameraStaticAccessibleShader).Instance() : // IMP END
+                    _proto.Index(CameraStaticShader).Instance();
                 worldHandle.UseShader(shader);
                 worldHandle.DrawRect(worldBounds, Color.White);
             },

--- a/Content.Shared/_Impstation/CCVar/ImpCCVars.cs
+++ b/Content.Shared/_Impstation/CCVar/ImpCCVars.cs
@@ -16,6 +16,12 @@ public sealed class ImpCCVars : CVars
         CVarDef.Create("accessibility.disable_singulo_warping", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
+    /// Replaces the AI static camera effect with a plain black gradient.
+    /// </summary>
+    public static readonly CVarDef<bool> DisableAiStatic =
+        CVarDef.Create("accessibility.disable_ai_static", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
     /// The number of shared moods to give thaven by default.
     /// </summary>
     public static readonly CVarDef<uint> ThavenSharedMoodCount =

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -367,6 +367,7 @@ ui-options-enable-color-name = Add colors to character names
 ui-options-colorblind-friendly = Colorblind friendly mode
 ui-options-reduced-motion = Reduce motion of visual effects
 ui-options-disable-singulo-warp = Disable the singularity's screen warping effect
+ui-options-disable-ai-static = Disable the static effect on the AI camera overlay
 ui-options-chat-window-opacity = Chat window opacity
 ui-options-screen-shake-intensity = Screen shake intensity
 ui-options-speech-bubble-text-opacity = Speech bubble text opacity

--- a/Resources/Prototypes/_Impstation/Shaders/shaders.yml
+++ b/Resources/Prototypes/_Impstation/Shaders/shaders.yml
@@ -23,3 +23,8 @@
   id: SalvoScan
   kind: source
   path: "/Textures/_Impstation/Shaders/salvo_scan.swsl"
+
+- type: shader
+  id: CameraStaticAccessible
+  kind: source
+  path: "/Textures/_Impstation/Shaders/camera_static_accessible.swsl"

--- a/Resources/Textures/_Impstation/Shaders/camera_static_accessible.swsl
+++ b/Resources/Textures/_Impstation/Shaders/camera_static_accessible.swsl
@@ -1,0 +1,6 @@
+void fragment() {
+    highp vec2 coords = FRAGCOORD.xy;
+    highp vec2 value = vec2(coords * SCREEN_PIXEL_SIZE);
+    highp vec3 color = vec3(0.0,value.x/3.0,value.x/2.0);
+    COLOR = vec4(0.1 * color,1.0);
+}


### PR DESCRIPTION
## About the PR
toggle in accessibility menu to turn off ai camera static

## Why / Balance
bad for photosensitivity
i know the shader is kinda dookie but someone can change it if they care. i dont know gwsl

## Technical details
new shader, new cvar, ternary operator 👍 

## Media

https://github.com/user-attachments/assets/18df017c-2cea-43e3-b9dd-f982126e5c23

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: A toggle in the Accessibility menu will now allow you to turn off the static in the AI camera overlay.
