### PR TITLE
add the mime chaplain gear to loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -526,6 +526,7 @@
   - ChaplainMaskClayshaper # imp
   - ChaplainMaskFire # imp
   - ChaplainClown # imp
+  - ChaplainSilentMask # imp
 
 - type: loadoutGroup
   id: ChaplainJumpsuit
@@ -555,6 +556,7 @@
   - ChaplainHoodie
   - ChaplainOuterMoon # imp
   - ChaplainHonkrobes # imp
+  - ChaplainSilentRobes # imp
 
 - type: loadoutGroup
   id: ChaplainNeck

--- a/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/mime_prestige.yml
+++ b/Resources/Prototypes/_Impstation/Loadouts/Miscellaneous/mime_prestige.yml
@@ -1,0 +1,24 @@
+﻿- type: loadoutEffectGroup
+  id: MimeExpertTimer
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobMime
+      time: 30h
+
+- type: loadout
+  id: ChaplainSilentMask
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MimeExpertTimer
+  equipment:
+    mask: ClothingMaskSilent
+
+- type: loadout
+  id: ChaplainSilentRobes
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MimeExpertTimer
+  equipment:
+    outerClothing: ClothingOuterSilent


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Added the mask of the silent and the robes of the silent to the chaplain loadout as 30 hour prestige mime items.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They're already available from hacked PietyVends like the clown chaplain items, may as well make them avaiable in the loadout like the clown stuff.

## Technical details
<!-- Summary of code changes for easier review. -->
Added an expert mime timer (30 hours) and loadout prototypes.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="807" height="548" alt="image" src="https://github.com/user-attachments/assets/9138e12b-deed-4a58-ba58-6ced3b9bb36f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Expert mimes can now start with silent chaplain clothing.
