### PR TITLE
Zombification restored to cellular

### DIFF
--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Cellular", 0.2 }, // imp "Poison", 0.3 > cellular 0.2
+            { "Cellular", 0.3 }, // imp "Poison", 0.3 > cellular 0.3
         }
     };
 


### PR DESCRIPTION
## About the PR
poison > cellular

## Why / Balance
I believe this was changed on accident in an upmerge.
Hive changed this in pr #393, and it was a good change because zombification is too easy to treat as poison. Also species resistances makes it messy. Since then, upstream has increased the amount from 0.2 to 0.4 and then back down to 0.3 and tweaked the grace period from 0 to 2. I went ahead and just increased our value as well rather than also change the grace period back to 0, but that can be reverted as well if desired.

## Technical details
1 line change

## Media
<img width="690" height="409" alt="image" src="https://github.com/user-attachments/assets/2414bfc4-cd04-4d57-92f7-8c9e29c8489a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://youtu.be/kqj7b59D85Y) and [Coding Standards](https://youtu.be/kqj7b59D85Y).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: The zombie infection deals cellular damage again
