### PR TITLE
xenoborgs trying to roll doesnt kill a round anymore

### DIFF
--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -79,7 +79,7 @@
   - type: RuleGrids
   - type: GameRule
     minPlayers: 40
-    cancelPresetOnTooFewPlayers: False # imp
+    cancelPresetOnTooFewPlayers: false # imp
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/mothership.yml
   - type: AntagMultipleRoleSpawner


### PR DESCRIPTION
## About the PR
did you know i knew how to solve this because heretics had this problem. which could mean anything

## Why / Balance
causes a round to return to lobby for no good reason

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Xenoborgs no longer cause a round to fail to start.
