### PR TITLE
hide unbuyable store listings

### DIFF
--- a/Content.Client/Store/Ui/StoreMenu.xaml.cs
+++ b/Content.Client/Store/Ui/StoreMenu.xaml.cs
@@ -126,6 +126,9 @@ public sealed partial class StoreMenu : DefaultWindow
         if (!listing.Categories.Contains(CurrentCategory))
             return;
 
+        if (!listing.Buyable) // imp addition, hide unbuyable listings
+            return;
+
         var hasBalance = listing.CanBuyWith(Balance);
 
         var spriteSys = _entityManager.EntitySysManager.GetEntitySystem<SpriteSystem>();
@@ -262,6 +265,9 @@ public sealed partial class StoreMenu : DefaultWindow
         var allCategories = new List<StoreCategoryPrototype>();
         foreach (var listing in listings)
         {
+            if (!listing.Buyable) // imp addition, hide categories with no buyable listings
+                continue;
+
             foreach (var cat in listing.Categories)
             {
                 var proto = _prototypeManager.Index(cat);


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Made it so store listings that fail any conditions simply don't show up in the ui, instead of just saying unavailable and going to the bottom of the list.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
better organized this way. and it's easier to keep some surplus secrets if we want

## Technical details
<!-- Summary of code changes for easier review. -->
two if statements in `StoreMenu.xaml.cs`

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
https://github.com/user-attachments/assets/91411ff0-6b2b-4ccc-9ba1-25d12e917ba5

<img width="718" height="639" alt="image" src="https://github.com/user-attachments/assets/23167512-bf30-4365-9f7d-d82278aa946b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Unpurchasable items in the uplink are no longer visible.
