### PR TITLE
Projectile Speed Standardization and fixing the M-1's Lethal Spread

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Blasters/baseblasters.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Blasters/baseblasters.yml
@@ -24,6 +24,7 @@
   - type: Clothing
     sprite: _Impstation/Objects/Weapons/Guns/Blasters/temp_gun.rsi
   - type: Gun
+    projectileSpeed: 25
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Blasters/commsecblasters.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Blasters/commsecblasters.yml
@@ -17,6 +17,7 @@
   - type: Clothing
     sprite: _Impstation/Objects/Weapons/Guns/Blasters/energy_shotgun.rsi
   - type: Gun
+    projectileSpeed: 25
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/eshotgun.ogg
   - type: BatteryAmmoProvider
@@ -71,6 +72,7 @@
   - type: StealTarget
     stealGroup: WeaponEnergyMagnum
   - type: Gun
+    projectileSpeed: 25
     fireRate: 1.5
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/blasterrevolver.ogg

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Blasters/secblasters.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Blasters/secblasters.yml
@@ -24,6 +24,7 @@
     size: Ginormous
   - type: GunRequiresWield
   - type: Gun
+    projectileSpeed: 25
     fireRate: 0.5
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/blastercannon.ogg
@@ -65,6 +66,7 @@
     sprite: _Impstation/Objects/Weapons/Guns/Blasters/advblaster.rsi
   - type: Appearance
   - type: Gun
+    projectileSpeed: 25
     fireRate: 1.75
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/blasterpist.ogg
@@ -98,6 +100,7 @@
   - type: Clothing
     sprite: _Impstation/Objects/Weapons/Guns/Blasters/temp_gun.rsi
   - type: Gun
+    projectileSpeed: 25
     fireRate: 1
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
@@ -141,6 +144,7 @@
     steps: 5
     zeroVisible: true
   - type: Gun
+    projectileSpeed: 25
     fireRate: 2.5
     selectedMode: SemiAuto
     availableModes:
@@ -198,6 +202,7 @@
     minAngle: -14
     maxAngle: -16
   - type: Gun
+    projectileSpeed: 25
     minAngle: 16
     maxAngle: 36
     angleIncrease: 2

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/basedisablers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/basedisablers.yml
@@ -24,6 +24,7 @@
   - type: Clothing
     sprite: _Impstation/Objects/Weapons/Guns/Disablers/disabler_smg.rsi
   - type: Gun
+    projectileSpeed: 25
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: PacifismAllowedGun
@@ -54,6 +55,7 @@
     steps: 5
     zeroVisible: false
   - type: Gun
+    projectileSpeed: 25
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: BatteryAmmoProvider

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/crewdisablers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/crewdisablers.yml
@@ -59,6 +59,7 @@
     steps: 4
     zeroVisible: true
   - type: Gun
+    projectileSpeed: 25
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/antiquedisabler.ogg
   - type: BatteryAmmoProvider

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/researchdisablers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/researchdisablers.yml
@@ -76,6 +76,7 @@
     proto: BulletDisablerSmg
     fireCost: 33
   - type: Gun
+    projectileSpeed: 25
     selectedMode: FullAuto
     fireRate: 4
     availableModes:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/seclinkdisablers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/seclinkdisablers.yml
@@ -38,6 +38,7 @@
     sprite: _Impstation/Objects/Weapons/Guns/Disablers/clowndisabler.rsi
   - type: Appearance
   - type: Gun
+    projectileSpeed: 25
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/clowndisabler.ogg
 
@@ -98,6 +99,7 @@
     steps: 6
     zeroVisible: true
   - type: Gun
+    projectileSpeed: 25
     minAngle: 2
     maxAngle: 15
     angleIncrease: 3

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/tasers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Disablers/tasers.yml
@@ -20,6 +20,7 @@
     slots:
     - Belt
   - type: Gun
+    projectileSpeed: 25
     fireRate: 0.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser.ogg
@@ -40,6 +41,7 @@
   description: A low-capacity, energy-based stun gun used by elite security teams to disable even the toughest of targets.
   components:
   - type: Gun
+    projectileSpeed: 25
     fireRate: 0.5
     soundGunshot:
       path: /Audio/Effects/tesla_collapse.ogg # The wrath of god...

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/FuelGuns/basefuelguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/FuelGuns/basefuelguns.yml
@@ -95,6 +95,7 @@
     sprite: _Impstation/Objects/Weapons/Guns/FuelGuns/adder.rsi
     size: Small
   - type: Gun
+    projectileSpeed: 25
     clumsyProof: false
     cameraRecoilScalar: 1
     fireRate: 4

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/FuelGuns/echionguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/FuelGuns/echionguns.yml
@@ -59,6 +59,7 @@
     shape:
     - 0,0,3,1
   - type: Gun
+    projectileSpeed: 25
     clumsyProof: false
     cameraRecoilScalar: 1
     fireRate: 5.3

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Energy/blasterbolts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Energy/blasterbolts.yml
@@ -44,7 +44,7 @@
   name: lethal laser barrage
   id: BulletLaserSpreadNarrow
   categories: [ HideSpawnMenu ]
-  parent: BaseBulletLaser
+  parent: BulletLaserHeavy
   components:
   - type: ProjectileSpread
     proto: BulletLaserHeavy
@@ -55,7 +55,7 @@
   name: wide laser barrage
   id: BulletLaserSpread
   categories: [ HideSpawnMenu ]
-  parent: BaseBulletLaser
+  parent: BulletLaser
   components:
   - type: ProjectileSpread
     proto: BulletLaser

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/30rifles.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/30rifles.yml
@@ -18,7 +18,6 @@
     sprite: _Impstation/Objects/Weapons/Guns/Rifles/daito.rsi
   - type: GunRequiresWield
   - type: Gun
-    projectileSpeed: 35
     fireRate: 3
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Snipers/60snipers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Snipers/60snipers.yml
@@ -15,7 +15,6 @@
     sprite: _Impstation/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: GunRequiresWield
   - type: Gun
-    projectileSpeed: 35
     fireRate: 0.4
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/goldzipper.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Special/goldzipper.yml
@@ -24,6 +24,7 @@
     steps: 5
     zeroVisible: true
   - type: Gun
+    projectileSpeed: 25
     fireRate: 2
     soundGunshot:
       path: /Audio/_Impstation/Weapons/Guns/Gunshots/goldlaser.ogg


### PR DESCRIPTION
## About the PR
Upstream changed what the default projectile speed for guns is, and I had made a couple shoot faster than normal but not THIS fast so now those were made retroactively slower. I also standardized energy projectiles to have 25 as their speed, to give them another detail that sets their feel apart from bullets. Also I learned some cursed knowledge about spread projectiles forcing one of their pellets/bolts to be what the spread is parented off of so I had to fix that for the M-1.

## Why / Balance
There was reason to have the Daito and Lindwyrm shoot faster bullets than normal guns, but now that guns use the maximum speed there's no way to have that without them being like, hitscan or something, and having them shoot slower bullets certainly makes zero sense.

I've also made blasters/disablers/echion-guns have a standard projectile speed of 25 (kinetic speed is 40). This is very much a video-game-y inspired move to make, as a lot of especially older games have blaster energy weapons shoot slower projectiles than the kinetic ones. It's a detail that sets these weapons apart from kinetic bullets. It's also a broad enough spectrum of weapon types that you will see this difference that I'm not afraid of it being a friction point with player expectation-- they can come to expect energy weapons as a whole to shoot slower projectiles than bullets, rather than one or two guns shooting weirdly slower projectiles.

It's also what the standard default speed was before for disablers and such, so I'm not worried about it being a broader hit on balance with those, as nothing is technically being nerfed.

## Technical details
I had to apply projectile speed manually to every gun that had a gun component for the energy weapons. If a prototype has a gun component at all, it overrides this detail from the parent and puts it back to the default if you don't specify the speed again. I also had to change the M-1's lethal spread prototype's parent to the projectile it's making a spread of, because having the parent be anything else will always make one of those projectiles in the spread that of the spread's parent rather than all of them just being specified prototype in the component.

## Media

https://github.com/user-attachments/assets/1cc7a2d1-a5f0-486b-b17b-91153198ca4c



## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: Gun projectile speeds have been standardized!
- fix: All four projectiles in the M-1's lethal spread are now the same.
