### PR TITLE
chef loadout fix

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -20,8 +20,8 @@
 - type: startingGear
   id: ChefGear
   equipment:
-    shoes: ClothingShoesChef
-    id: ChefPDA
+  #  shoes: ClothingShoesChef # imp, loadout choice
+  #  id: ChefPDA # imp, loadout choice
     ears: ClothingHeadsetService
     belt: ClothingBeltChefFilled
   #storage:


### PR DESCRIPTION
## About the PR
no double shoes and pda

## Technical details
commented upstream ones out

## Media
<img width="895" height="347" alt="image" src="https://github.com/user-attachments/assets/a0a17b68-cff7-480c-9144-5c2734ce7626" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
- fix: Chefs no longer start with extra shoes and PDAs
