### PR TITLE
shipyard Reach shuttle updates

### DIFF
--- a/Resources/Changelog/Impstation.yml
+++ b/Resources/Changelog/Impstation.yml
@@ -4128,9 +4128,10 @@
   - message: Ungu are a bit more susceptible to high body temperatures, as their guidebook
       entry suggested.
     type: Tweak
-  - message: Ungu's weakness to Heat damage from weapons has been reduced from 50%
-      to 30%
+  - message: Ungu's death threshold has been lowered to 200 damage from 250. Their crit threshold is unchanged.
     type: Tweak
+  - message: Ungu no longer take three times the suffocation damage as other species.
+    type: Fix
   id: 2604
   time: '2026-02-04T22:43:03.0000000+00:00'
   url: https://github.com/impstation/imp-station-14/pull/4076

--- a/Resources/Locale/en-US/_Impstation/pointing/pointing.ftl
+++ b/Resources/Locale/en-US/_Impstation/pointing/pointing.ftl
@@ -3,7 +3,7 @@
 imp-pointing-system-try-point-cannot-reach = You can't reach there!
 imp-pointing-system-point-at-self = You {$verb} at yourself.
 imp-pointing-system-point-at-other = You {$verb} at {THE($other)}.
-imp-pointing-system-point-at-self-others = {CAPITALIZE(THE($otherName))} {$verb} at imp-{REFLEXIVE($other)}.
+imp-pointing-system-point-at-self-others = {CAPITALIZE(THE($otherName))} {$verb} at {REFLEXIVE($other)}.
 imp-pointing-system-point-at-other-others = {CAPITALIZE(THE($otherName))} {$verb} at {THE($other)}.
 imp-pointing-system-point-at-you-other = {CAPITALIZE(THE($otherName))} {$verb} at you.
 imp-pointing-system-point-at-tile = You {$verb} at the {$tileName}.


### PR DESCRIPTION
## About the PR
updates the Reach shuttle, as purchasable from the shipyard console, to the current version of the map.

## Why / Balance
buying Reach from cargo's shipyard console spawns a noticeably older version of the map, bringing it up to date makes it a smoother experience overall with the maps improvements. major changes like the southern evac dock, genpop, and service area rework are easy to notice missing for what is the most expensive shuttle purchase.
the spawners, gear, and machines that dont belong on a purchasable shuttle (ex. the captain's locker, the chief engineer's magboots, nuke disk case) have been removed. the AME has been replaced with the previous 15kw generators as the main engine.

## Technical details
converted the most recent Reach map into a grid and removed the BecomesStation component.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: meatsmall, mothrii
- tweak: The Reach shuttle purchasable from the cargo shipyard console has been updated.