### PR TITLE
Shave off some time from between rounds

### DIFF
--- a/Resources/ConfigPresets/Impstation/impstation.toml
+++ b/Resources/ConfigPresets/Impstation/impstation.toml
@@ -6,7 +6,7 @@ soft_max_players = 100
 # default 120
 round_restart_time = 150
 # default 150
-lobbyduration = 450
+lobbyduration = 600
 
 [server]
 # TODO


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
 2:30 round end down from 5
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
15 minutes is a long time between rounds. 10 for lobby is good, 5 minutes for round end is a bit much.
## Technical details
<!-- Summary of code changes for easier review. -->
config
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak:  The time between rounds has been reduced to 10 minutes. 2:30 minutes round end and 7:30 minutes lobby time.


