### PR TITLE
Fix Suppy throwing asserts

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Decorations/suppy.yml
@@ -39,7 +39,6 @@
     - Maintenance
     - Engineering
   - type: Appearance
-  - type: Body # for letting someone use the pet carrier on it
   - type: Buckle
   - type: Climbing
   - type: Pullable
@@ -47,7 +46,7 @@
   - type: PointLight
     color: "#FFFF00"
     radius: 2
-    energy: 1.4
+    energy: 2.5
   - type: Grammar
     attributes:
       proper: true
@@ -65,6 +64,8 @@
   - type: Alerts
   - type: AnimatedEmotes
   - type: MobState #for deathgasp
+  - type: Physics
+    bodyType: KinematicController
   - type: InputMover
   - type: Input
     context: "human"


### PR DESCRIPTION
## About the PR
Added Physics component with KinematicController top Suppy. Also removed now unnecessary Body component and made his pointlight match suppermatter's.

## Why / Balance
Was throwing a debug assert after recent update to entities that are meant to be able to move when controlled by players. (See https://github.com/space-wizards/space-station-14/pull/37970)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

