### PR TITLE
Re-add the battery ammo provider to power cells.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -41,6 +41,11 @@
           Full: {visible: true, state: o2}
           Neither: {visible: true, state: o1}
           Empty: {visible: false}
+#Imp The following component is needed here for the Svalinn to work. DO NOT REMOVE. If you wanna know why ask DVD Player.
+  - type: BatteryAmmoProvider
+    proto: RedLightLaser
+    fireCost: 50
+#Imp end of edits.
 
 - type: entity
   name: potato battery


### PR DESCRIPTION
## About the PR
Fixed the Svalinn so it works again.

## Why / Balance
Some time ago upstream removed the battery ammo providers from power cells and tied the ammo provider to the Svalinn itself so that what laser prototype the gun uses was determined exclusively on the gun. I reverted this change, because an addition I made to the Uplink shop was a special power cell that makes the Svalinn almost 3x as strong as it is, something that would not be possible with upstream's system for the Svalinn.

Anyways, at some point in upstream merging that component was removed from the cells again, so I've added it back in with a more detailed #imp comment on why so hopefully this doesn't happen again.

## Technical details
I just add a component back in.

## Media
https://github.com/user-attachments/assets/5df36a8b-7e60-4daf-8d2d-3a1e6aec498a

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: The Svalinn will shoots its dinky red lasers once more
