### PR TITLE
 rename 'imminent doom' to 'stationwide destruction' 

### DIFF
--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1636,7 +1636,7 @@
 - type: entity
   id: XenoArtifactSingularity #IMP swapped the id of this and the tesla because they were incorrect??
   parent: BaseOneTimeXenoArtifactEffect
-  description: Station-wide destruction #IMP desc changed
+  description: Stationwide destruction #IMP desc changed
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1651,7 +1651,7 @@
 - type: entity
   id: XenoArtifactTesla #IMP swapped the id of this and the singulo because they were incorrect??
   parent: BaseOneTimeXenoArtifactEffect
-  description: Station-wide destruction #IMP desc changed
+  description: Stationwide destruction #IMP desc changed
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true

--- a/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
+++ b/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
@@ -486,7 +486,7 @@
 - type: entity
   id: XenoArtifactSupermatter
   parent: BaseOneTimeXenoArtifactEffect
-  description: Station-wide destruction
+  description: Stationwide destruction
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true


### PR DESCRIPTION
## About the PR
Renamed "imminent doom" effect to "stationwide destruction"

## Why / Balance
Was confusing and caused Impstation veterans to assume it wasn't a SWD node. Also it ruined my gridwide knockdown "Stationwide disruption" joke

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Stationwide destruction artifact effects are once again called "Stationwide destruction", instead of "imminent doom".