### PR TITLE
Blaster/Starflare Cells now fit in the Security Belts

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -397,6 +397,8 @@
       - Pribar
       - SpaceBladeSec
       - HandheldCriminalRecords
+      - BlasterCell
+      - StarflareCell
       # imp edit end
       components:
       - Stunbaton


### PR DESCRIPTION
## About the PR
It was brought to my attention that neither of these went in the belts and they frankly should.

## Why / Balance
These are effectively gun magazines so no reason they shouldn't.

## Technical details
Added two tags to the whitelist.

## Media
<img width="348" height="509" alt="image" src="https://github.com/user-attachments/assets/a0a757f3-f867-4564-8f1a-32ac32af0b3c" />

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Blaster and Starflare Cells fit in security belts now
