### PR TITLE
Decapoid Silicon Lawsync Patch

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/decapoid_silicons.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/decapoid_silicons.yml
@@ -157,6 +157,7 @@
     - FootstepSound
     - SiliconEmotes
     - EmagImmune
+    - DecapoidSilicon
   - type: Emoting
   - type: GuideHelp
     guides:
@@ -285,6 +286,8 @@
     - DoorBumpOpener
     - FootstepSound
     - SiliconEmotes
+    - EmagImmune
+    - DecapoidSilicon
   - type: BorgChassis
     maxModules: 3
     hasMindState: tcktck_e
@@ -426,6 +429,8 @@
     - SiliconEmotes
     - HudMedical
     - HudSecurity
+    - EmagImmune
+    - DecapoidSilicon
   - type: BorgChassis
     maxModules: 3
     hasMindState: tckut_e
@@ -500,6 +505,7 @@
     - SiliconEmotes
     - Bot
     - Unimplantable
+    - DecapoidSilicon
   - type: TypingIndicator #in case someone admin controls one
     proto: robot
   - type: Speech

--- a/Resources/Prototypes/_Impstation/Objects/Specific/Robotics/synchronizer.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Specific/Robotics/synchronizer.yml
@@ -14,5 +14,7 @@
       components:
       - Replicator
       - Drone
+      tags:
+      - DecapoidSilicon
   - type: StealTarget
     stealGroup: SiliconSynchronizerRd

--- a/Resources/Prototypes/_Impstation/tags.yml
+++ b/Resources/Prototypes/_Impstation/tags.yml
@@ -435,3 +435,5 @@
 - type: Tag
   id: WeldingTool
 
+- type: Tag
+  id: DecapoidSilicon


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

prevents decapoid silicons (tcktck and tck'ut) from being synced to NT laws
also fixes their tags to make them actually emagimmune

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

the empire would invade if they found out

## Technical details
<!-- Summary of code changes for easier review. -->

literally just adds a tag.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
