### PR TITLE
Ungu changelog fix

### DIFF
--- a/Resources/Changelog/Impstation.yml
+++ b/Resources/Changelog/Impstation.yml
@@ -4128,9 +4128,10 @@
   - message: Ungu are a bit more susceptible to high body temperatures, as their guidebook
       entry suggested.
     type: Tweak
-  - message: Ungu's weakness to Heat damage from weapons has been reduced from 50%
-      to 30%
+  - message: Ungu's death threshold has been lowered to 200 damage from 250. Their crit threshold is unchanged.
     type: Tweak
+  - message: Ungu no longer take three times the suffocation damage as other species.
+    type: Fix
   id: 2604
   time: '2026-02-04T22:43:03.0000000+00:00'
   url: https://github.com/impstation/imp-station-14/pull/4076


### PR DESCRIPTION
## About the PR
Fixed the changelog from https://github.com/impstation/imp-station-14/pull/4076 saying ungu had their heat weakness reduced, replaced it with entries regarding their death threshold and asphyxiation changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->