### PR TITLE
Gray liver actually processes alcohol

### DIFF
--- a/Resources/Prototypes/_Impstation/Body/Organs/gray.yml
+++ b/Resources/Prototypes/_Impstation/Body/Organs/gray.yml
@@ -222,23 +222,12 @@
 
 - type: entity
   id: OrganGrayLiver
-  parent: BaseGrayOrgan
+  parent: [BaseGrayOrgan, OrganHumanLiver]
   name: beobu
   description: "Jazee sipsun alcohol."
   components:
-  - type: Sprite
-    state: liver
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
-    maxReagents: 1
-    metabolizerTypes: [Human]
-    groups:
-    - id: Alcohol
-      rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
-  - type: Tag # goob edit
-    tags:
-    - Meat
-    - Organ
-    - Liver
+    metabolizerTypes: [ Human ]
 
 - type: entity
   id: OrganGrayKidneys


### PR DESCRIPTION
## About the PR
Ending gray prohibition, they can get drunk again

## Why / Balance
Bug fix

## Technical details
YAML. Gray liver is just a recolored renamed human liver. I left the metabolizer type line so that the merge conflict will be slightly easier with Dinner's pr hopefully?

## Media
<img width="184" height="162" alt="image" src="https://github.com/user-attachments/assets/e1fec48d-4c96-4cb2-a79f-c1a52d2e7f10" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Mysterious gray puking disease has been cured
