### PR TITLE
Chill out hotplate

### DIFF
--- a/Content.Server/Chemistry/Components/SolutionHeaterComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionHeaterComponent.cs
@@ -8,4 +8,10 @@ public sealed partial class SolutionHeaterComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float HeatPerSecond;
+
+    /// <summary>
+    /// Imp - The maximum temperature the heater will heat solutions to. Defaults to null.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float? MaxTemperature;
 }

--- a/Content.Server/Chemistry/EntitySystems/SolutionHeaterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionHeaterSystem.cs
@@ -89,6 +89,10 @@ public sealed class SolutionHeaterSystem : EntitySystem
                 var energy = heater.HeatPerSecond * frameTime;
                 foreach (var (_, soln) in _solutionContainer.EnumerateSolutions((heatingEntity, container)))
                 {
+                    // Imp - Max temperature for hotplates
+                    if (heater.MaxTemperature != null && soln.Comp.Solution.Temperature >= heater.MaxTemperature.Value)
+                        continue;
+                    // Imp
                     _solutionContainer.AddThermalEnergy(soln, energy);
                 }
             }

--- a/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
@@ -42,6 +42,7 @@
       shader: unshaded
   - type: SolutionHeater
     heatPerSecond: 160
+    maxTemperature: 1200 # Imp - Lavabeaker patch
   - type: ItemPlacer
     whitelist:
       components:


### PR DESCRIPTION
## About the PR
Adds a max temperature to hotplates.

## Why / Balance
Lavabeakers is an exploit, this is the patch. It doesn't fix the ChemMaster not equalizing temperatures so the exploit is still technically possible, but at least you can't do it accidentally anymore by leaving something on the hotplate for too long.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Hotplates can no longer heat solutions to temperatures that rival Goku's power level.
