### PR TITLE
fix soap not being able to clean decals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -68,6 +68,8 @@
   - type: CleansForensics
   - type: Residue
     residueAdjective: residue-slippery
+  - type: CleansDecals # imp
+    solution: soap
 
 - type: entity
   parent: BaseSoap
@@ -80,8 +82,6 @@
       map: ["enum.SolutionContainerLayers.Fill"]
   - type: Residue
     residueColor: residue-green
-  - type: CleansDecals # imp
-    solution: soap
 
 - type: entity
   parent: BaseSoap


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Fixed a bug where soap couldn't clean decals anymore after the most recent upmerge.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
One of the upstream PRs we got during the upmerge included a BaseSoap prototype. the CleansDecals component was never migrated to it meaning only one soap prototype could clean decals.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
https://github.com/user-attachments/assets/60e23177-50a3-457f-9520-c7466dbf3d94

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Soap can clean decals again.
