### PR TITLE
Make Night Oppas actually exist

### DIFF
--- a/Resources/Prototypes/_Impstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/events.yml
@@ -125,6 +125,14 @@
     reoccurrenceDelay: 20
     minimumPlayers: 10
     duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointGhostOppa
+      min: 1
+      max: 1
+      pickPlayer: false
 
 # syndicate infiltrator
 - type: entity


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Made it so that night oppas can spawn.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Night Oppas have apparently been broken ever since they were added and were just unable to spawn naturally.
(I checked and it's always been like this so everyone who said they have seen night oppas lied... Or just saw admin ones idk)
## Technical details
<!-- Summary of code changes for easier review. -->
Added the code that chooses where night oppas spawn.
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Night Oppas are no longer extinct!

