### PR TITLE
Disable Supermatter Air Alarm Auto Mode

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Structures/Specific/Atmospherics/supermatter.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Specific/Atmospherics/supermatter.yml
@@ -57,3 +57,5 @@
   components:
   - type: AccessReader
     access: [["Atmospherics"], ["Engineering"]]
+  - type: AirAlarm
+    autoMode: false


### PR DESCRIPTION
## About the PR
Disables auto mode on the supermatter air alarm.

## Why / Balance
Auto mode is really unintuitive and the easiest thing to overlook when setting up the supermatter. Engineers will still need to properly set up scrubber and vent settings, this just makes it less confusing to an engineer new to interacting with an air alarm for the first time.

## Technical details
Two line yaml change.


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The supermatter air alarm no longer starts with auto mode enabled.

