### PR TITLE
remove service headset from lawdrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
@@ -14,7 +14,7 @@
     ClothingUniformJumpsuitLawyerGood: 1
     ClothingUniformJumpskirtLawyerGood: 1
     ClothingShoesBootsLaceup: 2
-    # ClothingHeadsetService: 2 imp, not service
+    ClothingHeadsetGrey: 2 #imp, not service
     ClothingNeckLawyerbadge: 1 #imp, 2 > 1
     ClothingNeckProsecutorbadge: 1 #imp
     ClothingNeckDefenseAttorneyBadge: 1 #imp


### PR DESCRIPTION
## About the PR
see title. replaces with passenger headsets.

## Why / Balance
its not supposed to be there... theyre not in service... i coulda sworn i checked the lawdrobe inventory when i was looking through shit to fix for #2380 and i guess that got missed

they're passenger headsets so now the lawyer can give headsets to prisoners lacking comms.

## Technical details
1 line yam

## Media
<img width="424" height="271" alt="image" src="https://github.com/user-attachments/assets/5cbeac29-84aa-4e26-96bf-0bd257ca4fc3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: the lawyer no longer has smuggled service headsets in the lawdrobe.
