### PR TITLE
fix cost of hos jumpskirt in uniform printer

### DIFF
--- a/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
@@ -28,7 +28,7 @@
   result: ClothingUniformJumpsuitSecGrey
 
 - type: latheRecipe
-  parent: BaseJumpsuitRecipe
+  parent: BaseCommandJumpsuitRecipe # imp
   id: ClothingUniformJumpskirtHoSGrey
   result: ClothingUniformJumpskirtHoSGrey
 


### PR DESCRIPTION
## About the PR
it didnt cost durathread and now it does

## Why / Balance
it had the wrong parent

## Technical details
its parented to command clothing now yay

## Media
<img width="821" height="164" alt="image" src="https://github.com/user-attachments/assets/1125a2a3-3d77-4a0b-9811-0fd59d4bb88f" />
it used to be like this but now its not.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: the head of security's grey jumpskirt now correctly has the same cost as other command uniforms.
