### PR TITLE
Re-enable roundstart wizard as a major antag for Secret gamemode

### DIFF
--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -10,7 +10,7 @@
   id: Wizard
   name: roles-antag-wizard-name
   antagonist: true
-  # setPreference: true # Disabled as roundstart gamemode until reworked
+  setPreference: true #imp, disabled roundstart upstream
   playTimeTracker: AntagWizard # Imp
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -9,7 +9,7 @@
     Revolutionary: 0.05 # previously 0.05
     SpyVsSpy: 0.03 # imp
     Zombie: 0.04 # previously 0.05
-    #Wizard: 0.02 # previously 0.05, disabled roundstart upstream, whether we decide to keep it or not should be in separate pr
+    Wizard: 0.02 # previously 0.05, disabled roundstart upstream
     Zombieteors: 0.01 # imp - removed from upstream
     KesslerSyndrome: 0.01 # imp - removed from upstream
 


### PR DESCRIPTION
## About the PR
Mostly reverts https://github.com/space-wizards/space-station-14/pull/40983, re-enabling wizard as a roundsrtart major antag, but not as a minor antag, for the Secret gamemode.

## Why / Balance
Wizard was disabled upstream citing its largely unfinished and unbalanced state. I feel as though wizard as a gamemode is always going to have a large amount of disparity in how fun it is between rounds; a lot hinges on the performance of a single player. However, wizard is an iconic part of Space Station's history and nature as a chaotic game and even with it's flaws, I feel it's worth re-enabling as long as it stays rare.

The weight set here is what we had set for it previously, making it so Wizard has a 2% chance to roll as a gamemode. This keeps the sub-gamemode wizard disabled (but not the ghost role wizard) making it overall much rarer than it was before.

## Technical details
Couple lines of yaml.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Wizard has been re-enabled as a roundstart major antagonist.

