### PR TITLE
brings hemorrage trait to parity with otherstatus effect traits

### DIFF
--- a/Content.Shared/_Impstation/Traits/Assorted/HemorrhageSystem.cs
+++ b/Content.Shared/_Impstation/Traits/Assorted/HemorrhageSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Body.Events;
+using Content.Shared.StatusEffectNew;
 
 namespace Content.Shared._Impstation.Traits.Assorted;
 
@@ -6,11 +7,13 @@ public sealed class HemophiliaSystem : EntitySystem
 {
     public override void Initialize()
     {
-        SubscribeLocalEvent<HemorrhageComponent, BleedModifierEvent>(OnBleedModifier);
+        SubscribeLocalEvent<HemorrhageComponent, StatusEffectRelayedEvent<BleedModifierEvent>>(OnBleedModifier);
     }
 
-    private void OnBleedModifier(Entity<HemorrhageComponent> ent, ref BleedModifierEvent args)
+    private void OnBleedModifier(Entity<HemorrhageComponent> ent, ref StatusEffectRelayedEvent<BleedModifierEvent> args)
     {
-        args.BleedAmount *= ent.Comp.BleedAmountCoefficient;
+        var ev = args.Args;
+        ev.BleedAmount *= ent.Comp.BleedAmountCoefficient;
+        args.Args = ev;
     }
 }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
changed the hemorrhage trait system to have parity with similar traits such as hemophilia

## Technical details
<!-- Summary of code changes for easier review. -->
use `StatusEffectRelayedEvent<BleedModifierEvent>` instead of just `BleedModifierEvent`. I'm not sure why other traits and statuseffects use this but its probably prudent to follow suit.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
