### PR TITLE
Add a nuke pinpointer to the Vault freezer

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -394,6 +394,7 @@
     - id: SpaceCash1000
     - id: BeachBall
     - id: BikeHorn
+    - id: PinpointerNuclear # imp
 
 - type: entity
   id: LockerFreezerVaultFilled


### PR DESCRIPTION
## About the PR

This will require any existing mapped pinpointers in station vaults be removed before it can be merged, so I'm putting it up as a draft for now. 

## Why / Balance

From discussion in the mapping channel on discord.
At present, there is no standardization regarding if a spare pinpointer is mapped in station vaults or not. Some maps have it, some maps do not, it is a complete tossup. With the nuclear disk case being merged, it can now be much trickier for someone to find out where the nuke disk is located.

Adding one to the filled vault freezer prototype ensures that a second pinpointer is always present on station without having to make any additions to existing maps (unless some vaults are also missing the freezer), which provides more gameplay opportunities for antags and crew even if it would not come up often.

This will require mapped nuke pinpointers being removed from vaults where present and also confirmation that there are not any other spare pinpointers mapped; the Captain's locker and the Vault freezer should be the only places to obtain one without special circumstances (e.g. Nuclear Operatives)

## Technical details
Added `-ID: PinpointerNuclear` to the `LockerFillVault` entityTable in `Resources/Prototypes/Catalog/Fills/Lockers/heads.yml`, with an # imp comment.

## Media

<img width="556" height="454" alt="Content Client_El8cBSIfBR" src="https://github.com/user-attachments/assets/3b1abfe9-98a2-490f-83de-46569c7f5f14" />


## Requirements
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.

**Changelog**

:cl:
- tweak: The Vault freezer now contains a spare pinpointer for the nuke disk.

