### PR TITLE
Draw pressure regulators above catwalks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -187,6 +187,7 @@
     visibleLayers:
     - enum.SubfloorLayers.FirstLayer
   - type: Sprite
+    drawdepth: FloorObjects #imp
     sprite: Structures/Piping/Atmospherics/pump.rsi
     layers:
     - sprite: Structures/Piping/Atmospherics/pipe.rsi


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Inlet pressure regulators should show up above catwalks like other atmos devices.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Brings it in line with other pumps/atmos devices as changed in #2096 . You do need to left click these things.

## Technical details
<!-- Summary of code changes for easier review. -->
One line YAML

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="427" height="565" alt="image" src="https://github.com/user-attachments/assets/1e1e5aba-0d75-4bc3-b796-bb9cc5009b6f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Inlet pressure regulators are no longer hidden under catwalks.
