### PR TITLE
Giving the Janitorial Welding Tool a purpose again

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -712,7 +712,7 @@
         - to: wall #imp edit
           steps:
             - tool: Derusting
-              doAfter: 4
+              doAfter: 2
 
     - node: reinforcedWallRust
       entity: WallReinforcedRust
@@ -728,7 +728,7 @@
         - to: reinforcedWall #imp edit
           steps:
             - tool: Derusting
-              doAfter: 4
+              doAfter: 2
 
     - node: techWall #imp
       entity: WallTech


### PR DESCRIPTION
## About the PR

In a recent upmerge, the doafter time for Welding and Brushing in the rusted wall's construction graph was lowered greatly. (https://github.com/space-wizards/space-station-14/pull/41518/)

However, our imp original Janitorial Welding Tools use a bespoke Derusting tool quality, the value for which was not adjusted to match following the upmerge. (https://github.com/impstation/imp-station-14/pull/2259)

I just went and changed that really quick.

## Why / Balance

The Janitorial Welding Tool is currently entirely pointless, as its doafter is the exact same length as the Wire Brush's, but it also has to expend fuel to do its job. This change brings it in line with other welding tools for the purpose of derusting.

## Technical details

Cut two numbers in half in a yaml file.

Originally I considered just giving the janitorial welding tool a speedModifier of 2 in order to accomplish the same effect, as I was worried changing the Derusting doafter time in the rusted wall construction graph might have unintended consequences, but ingame testing seems to indicate this isn't the case, and I'm fairly certain the Derusting tool quality is only used for this one item anyways.

## Media

https://github.com/user-attachments/assets/5269e1a0-fb34-426a-8014-f24d71a793fe




## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**

:cl:
- fix: Janitorial welding tools once again derust walls just as fast as other welding tools.
