### PR TITLE
Embiggen Syndicate Satchels

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Back/satchel.yml
@@ -11,9 +11,16 @@
   parent: [ClothingBackpackSatchel, Tier1Contraband]
   id: ClothingBackpackSatchelSyndicate
   name: syndicate satchel
-  description:
+  description: A traitorous-looking satchel.
   components:
   - type: Sprite
     sprite: _Impstation/Clothing/Back/Satchels/syndicate.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.1
+  - type: Storage
+    grid:
+    - 1,0,2,0
+    - 0,1,2,3
+    - 4,0,7,3
+    - 9,0,10,0
+    - 9,1,11,3


### PR DESCRIPTION
## About the PR

Syndicate Backpacks and Syndicate Duffelbags both have more space than their non-contraband counterparts; but not the Syndicate Satchel. I fixed that. Also, I gave it a description, because it was lacking one.

## Why / Balance
Running around with really blatant contraband on you should be worth it, hence both the syndie backpack and duffel both having more storage space than standard (by 7 and 5 total slots, respectively). 

To make a nice little gradient, I gave the satchel 6 total extra slots, 3 on each of the little side sections. This ensures the most important inventory restrictions which distinguish them from backpacks or duffels remain- you can still only hold one large item, at the center of the storage space, and cannot fit any super-long guns like the shotguns in here. The largest mechanical difference is the ability to fit more than a single 3x3 item such as a survival box in your satchel, which I think is fine given- again- you're running around with blatant contraband on you. 

## Technical details
Gave `ClothingBackpackSatchelSyndicate` the Storage component with the following grid:

    - 1,0,2,0
    - 0,1,2,3
    - 4,0,7,3
    - 9,0,10,0
    - 9,1,11,3
 
Replaced an empty description field with "A traitorous-looking satchel.", to match the description conventions of the normal satchel and the syndicate backpack.

## Media

<img width="477" height="225" alt="Content Client_zNNudsfgGF" src="https://github.com/user-attachments/assets/ba7031ff-6a76-4e6c-a26c-cbdd3921e47a" />


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**

:cl:
- tweak: Syndicate satchels now have slightly larger storage capacity than their standard counterparts, as is already the case with Syndicate backpacks and duffel bags.
