### PR TITLE
change default postmortem instructions

### DIFF
--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -147,7 +147,7 @@ public sealed partial class PlayerProvidedCharacterRecords
             year: 0,
             allergies: "None",
             drugAllergies: "None",
-            postmortemInstructions: "Return home",
+            postmortemInstructions: "None given",
             medicalEntries: new List<RecordEntry>(),
             securityEntries: new List<RecordEntry>(),
             employmentEntries: new List<RecordEntry>()


### PR DESCRIPTION
## About the PR
changed the default postmortem instructions given to characters from "return home" to "none given."

## Why / Balance
as postmortem instructions are supposed to be an rp prompt, "return home" being the default acts as an extremely boring, closed prompt because it means most bodies will just be left in the morgue if medical staff are interested in engaging that rp prompt at all. 

## Technical details
one line change. this pr doesnt change the records of existing characters.

## Media
<img width="1524" height="350" alt="image" src="https://github.com/user-attachments/assets/75fa5e6a-3d05-4109-b637-0c5fb2af6e2e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: the default postmortem instructions for characters are now "none given" instead of "return home." chop up your dead coworkers to make sandwiches if you want!

