### PR TITLE
fireaxe damage nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -21,7 +21,7 @@
       types:
         # axes are kinda like sharp hammers, you know?
         Blunt: 5
-        Slash: 10
+        Slash: 5 #imp
         Structural: 10
     soundHit:
       collection: MetalThud
@@ -29,7 +29,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Slash: 10
+        Slash: 5 #imp
         Structural: 40
   - type: Item
     size: Ginormous


### PR DESCRIPTION
## About the PR
this PR reduces the slash damage on the crew fireaxe

## Why / Balance
there is no need for a weapon that's mapped in every atmospherics department and bridge to be dealing that much damage. previously, when wielded, the fireaxe did 25 damage (5 blunt 20 slash). this PR changes it to do 15 when wielded (5 blunt, 10 slash). the structural damage was not changed.

## Technical details
2 numbers in yml tweaked

## Media
no relevant media

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.


**Changelog**
:cl:
- tweak: Nanotrasen-issue fireaxes are a little duller.

