### PR TITLE
rarer claymores in maintenance loot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -21,7 +21,7 @@
       types:
         # axes are kinda like sharp hammers, you know?
         Blunt: 5
-        Slash: 5 #imp
+        Slash: 10
         Structural: 10
     soundHit:
       collection: MetalThud
@@ -29,7 +29,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Slash: 5 #imp
+        Slash: 10
         Structural: 40
   - type: Item
     size: Ginormous


### PR DESCRIPTION
## About the PR
this PR makes claymores less common in maintenance lockers

## Why / Balance
for how cool and dangerous the claymore is, it is far too common. it's not rare for there to be multiple claymores showing up in one round on mid-high pop maps

## Technical details
commented the claymore out of the maints weapon pool (weight: 95) it is currently in and moved it to the other (weight: 5) pool

## Media
no relevant media

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.


**Changelog**
:cl:
- tweak: Claymores are no longer infesting maintenance passageways.
