### PR TITLE
Minor Drozd Changes

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/MachineGuns/35machineguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/MachineGuns/35machineguns.yml
@@ -146,17 +146,18 @@
     - type: Gun
       minAngle: 21
       maxAngle: 32
+      angleDecay: 20
       fireRate: 6
       burstFireRate: 12
       soundGunshot:
         path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
       availableModes:
-      - Burst
       - FullAuto
+      - Burst
       - SemiAuto
       shotsPerBurst: 3
       burstCooldown: 0.25
-      selectedMode: Burst
+      selectedMode: FullAuto
     - type: ItemSlots
       slots:
         gun_magazine:


### PR DESCRIPTION
## About the PR
Set the default firing mode to full auto and increased the angle delay a little so maintaining accurate shots with burst mode feels more practical.

## Why / Balance
The Drozd's burst mode has felt awkward to use and doesn't have much practical use when full-auto is right there and is easier to handle. The exact number for the angle decay was increased from 16 to 20, so a 25% increase. Not huge, but it's easier to tap the trigger for a burst and maintain a tight pattern for that burst when you do.

## Technical details
Just a couple line changes.

## Media

https://github.com/user-attachments/assets/1cf5bb32-c5b1-43a6-ad50-651b99add876


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl: DVD Player
- tweak: The Drozd is now default to full-auto, and will recover its accuracy a little quicker.
