### PR TITLE
PSA: The PSA is better now

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Security/psa.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Security/psa.yml
@@ -23,17 +23,17 @@
   - type: ItemToggle
   - type: ProximityBeeper
   - type: ProximityDetector
-    range: 8
+    range: 10
     components:
     - type: Stealth
   - type: Beeper
     isMuted: true
-    minBeepInterval: 1.00
+    minBeepInterval: 0.25
     maxBeepInterval: 1.00
     beepSound:
       path: "/Audio/_Impstation/Items/detectorbeep.ogg"
       params:
-        maxDistance: 1
+        maxDistance: 5
         volume: -8
 
 - type: entity
@@ -42,7 +42,7 @@
   suffix: Powered
   components:
   - type: PowerCellDraw
-    drawRate: 6
+    drawRate: 3
     useCharge: 0
   - type: ToggleCellDraw
 


### PR DESCRIPTION
## About the PR
Stat changes to the PSA! Nothing too fancy.

## Why / Balance
The tool Nobody Uses. Giving it a buff to see how this works for usage. If the buff puts it in a place where people use it and it feels fair for the antagonist, then a job well done. If it's made useful but it doesn't feel fair in practice, then likely this thing will be Killed. Consider this a bit of an experiment.

Increased the range from 8 tiles to 10 tiles, the beeping gets faster the closer you are now, doubled the battery life (2 minutes active on a medium cell to 4 minutes active on a medium cell), but made its audio travel further so cloaked antags have a chance to know what's up (5 tile radius for the beep).

## Technical details
YAML.

## Media

https://github.com/user-attachments/assets/8712259c-5ff5-4fd7-8e12-24e5206e55aa


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl: DVD Player
- tweak: The Portable Sensor Array has been buffed
