### PR TITLE
maybe fix weird anomalocarid kidney test fail

### DIFF
--- a/Resources/Prototypes/_Impstation/Body/Organs/anomalocarid.yml
+++ b/Resources/Prototypes/_Impstation/Body/Organs/anomalocarid.yml
@@ -296,7 +296,7 @@
   - type: EmitSoundOnThrow
     sound: /Audio/Weapons/bolathrow.ogg
   - type: EmitSoundOnLand
-    sound: /Audio/Effects/snap.ogg
+    sound: /Audio/Effects/gib3.ogg
   - type: Damageable #for the ensnaring behavior
     damageContainer: Inorganic
   - type: Destructible


### PR DESCRIPTION
## About the PR
okay so basically anomalocarid kidneys were causing random test fails. i don't actually know why, but maybe it's because they weren't destructible like normal bolas, which don't cause test fails. so i made them destructible. this might not do anything at all but maybe it'll work

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
