### PR TITLE
Boar and Banana Deer Accents Yay!

### DIFF
--- a/Resources/Locale/en-US/_Impstation/accent/animals.ftl
+++ b/Resources/Locale/en-US/_Impstation/accent/animals.ftl
@@ -77,3 +77,9 @@ accent-words-babyanom-3 = Blbl...
 accent-words-babyanom-4 = Blblbl?
 accent-words-babyanom-5 = Brbl.
 accent-words-babyanom-6 = Klklkl!
+
+# Boar
+accent-words-boar-1 = Grunt.
+accent-words-boar-2 = Screegh.
+accent-words-boar-3 = Snrf.
+accent-words-boar-4 = Snort.

--- a/Resources/Locale/en-US/_Impstation/accent/animals.ftl
+++ b/Resources/Locale/en-US/_Impstation/accent/animals.ftl
@@ -83,3 +83,4 @@ accent-words-boar-1 = Grunt.
 accent-words-boar-2 = Screegh.
 accent-words-boar-3 = Snrf.
 accent-words-boar-4 = Snort.
+accent-words-boar-5 = Squeal.

--- a/Resources/Prototypes/_Impstation/Accents/full_replacements.yml
+++ b/Resources/Prototypes/_Impstation/Accents/full_replacements.yml
@@ -126,3 +126,21 @@
   - accent-words-zombie-8
   - accent-words-zombie-9
   - accent-words-zombie-10
+
+- type: accent
+  id: boar
+  fullReplacements:
+  - accent-words-boar-1
+  - accent-words-boar-2
+  - accent-words-boar-3
+  - accent-words-boar-4
+
+- type: accent
+  id: bananadeer
+  fullReplacements:
+  - accent-words-bananadeer-1
+  - accent-words-bananadeer-2
+  - accent-words-bananadeer-3
+  - accent-words-bananadeer-4
+  - accent-words-bananadeer-5
+  - accent-words-bananadeer-6

--- a/Resources/Prototypes/_Impstation/Accents/full_replacements.yml
+++ b/Resources/Prototypes/_Impstation/Accents/full_replacements.yml
@@ -134,6 +134,7 @@
   - accent-words-boar-2
   - accent-words-boar-3
   - accent-words-boar-4
+  - accent-words-boar-5
 
 - type: accent
   id: bananadeer

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/banana_deer.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/banana_deer.yml
@@ -67,6 +67,8 @@
       path: /Audio/_Impstation/Animals/bananadeer_eee.ogg
     interactFailureSound:
       path: /Audio/_Impstation/Animals/bananadeer_euh.ogg
+  - type: ReplacementAccent
+    accent: bananadeer
   - type: Speech
     speechSounds: BananaDeer
     speechVerb: Goat

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/animals.yml
@@ -74,7 +74,7 @@
     - type: Hunger
       baseDecayRate: 0.3
     - type: Thirst
-      baseDecayRate: 0.05
+      baseDecayRate: 0.04 # previously 0.05 but getting too thirsty makes them slow
     - type: YoungKodepiiaRetaliation
       attackMemoryLength: 15
     - type: GoobAbsorbable
@@ -112,6 +112,11 @@
       interactSuccessSpawn: EffectHearts
       interactSuccessSound:
         path: /Audio/Animals/pig_oink.ogg
+    - type: ReplacementAccent
+      accent: boar
+    - type: Speech
+      speechSounds: Ungu # goooood speech noise
+      speechVerb: Bros # all they do is grunt
     - type: SentienceTarget
       flavorKind: station-event-random-sentience-flavor-organic
       weight: 0.05


### PR DESCRIPTION
## About the PR
Adds a full replacement accent and speech sounds for boar & implements the unused banana deer accent.

## Why / Balance
Banana deer and boar both become ghost roles fairly regularly (deer have a chance any time they spawn and boar can get hit by random sentience events) and it's weird that they can speak without using cognizine. This brings them in line with other animal ghost roles!

Also decreases the rate at which boar thirst decays so it's the same as most other animals.

## Technical details
My YAMLs...

If you're thinking "hey the thirst change seems kind of out-of-place in this accent and sounds PR" it's because I was consulting with the person who made boars on boar onomatopoeia and they were like "hey while you're in there can you fix the thirst thing" so I did.

## Media
<img width="307" height="160" alt="bananadeer accent" src="https://github.com/user-attachments/assets/10b7ac20-8941-4276-aee8-e6d197303d0b" />
<img width="222" height="77" alt="boar accent" src="https://github.com/user-attachments/assets/33ca6603-ab6d-4896-b1ca-a709dc0f0d90" />

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [ ] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl:
- fix: Boar have forsaken humanoid language and begun grunting and snuffling more.
- fix: Banana deer have had their PhDs revoked and can no longer speak in full sentences.
