### PR TITLE
Increase Arcade Machine Payout range from 5-8 to 10-15

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -190,8 +190,8 @@
   suffix: Filled
   components:
   - type: SpaceVillainArcade
-    rewardMinAmount: 5
-    rewardMaxAmount: 8
+    rewardMinAmount: 10 # imp edit - increasing the minimum and maximum reward from 5 and 8 to 10 and 15 to let players get more rewards, as the machines drop tickets now
+    rewardMaxAmount: 15
 
 - type: entity
   id: BlockGameArcade


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
I doubled the amount of payouts SpaceVillain can have

## Why / Balance
Since ticket drop amounts are randomized sometimes you get a 5 win machine and end up with 50 tickets which is not enough to get some items.

## Technical details
1 line yml change.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->
**Changelog**
<!-- soup wtf did you do this changelog -->
:cl:
- fix: The Space Villain Machines have had their ticket rolls replaced with double-sized ones
