### PR TITLE
adds eclipse to relevant tests

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -137,6 +137,7 @@ namespace Content.IntegrationTests.Tests
             "CogImp",
             "CoreImp",
             "E1M1",
+            "Eclipse",
             "ElkridgeImp",
             "GateImp",
             "Hummingbird",
@@ -156,7 +157,6 @@ namespace Content.IntegrationTests.Tests
             "Monarch",
 
             // DEROTATED:
-            //"Eclipse",
             //"Luna",
             //"Refsdal",
             //"reHash",

--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -49,6 +49,7 @@ public sealed class StationPowerTests
         "CogImp",
         "CoreImp",
         //"E1M1",
+        "Eclipse",
         "ElkridgeImp",
         "GateImp",
         "Hummingbird",
@@ -68,7 +69,6 @@ public sealed class StationPowerTests
         "Monarch",
 
         // DEROTATED:
-        //"Eclipse",
         //"Luna",
         //"Refsdal",
         //"reHash",


### PR DESCRIPTION
## About the PR
eclipse was causing map related test fails

## Why / Balance
eclipse need tests too

## Technical details

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [ ] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
not player facing
