### PR TITLE
remove valentines

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -22,8 +22,7 @@ public sealed class CargoTest
     private static readonly HashSet<ProtoId<CargoProductPrototype>> Ignored =
     [
         // This is ignored because it is explicitly intended to be able to sell for more than it costs.
-        new("FunCrateGambling"),
-        new("CrateValentines") // imp edit - CrateValentines is ignored because it is available as a limited time event
+        new("FunCrateGambling")
     ];
 
     [Test]

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/snack.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/snack.yml
@@ -7,10 +7,6 @@
     FoodSnackPistachios: 3
     FoodSnackSus: 3
     FoodSnackSemki: 3
-    # imp edit start - valentines special
-    BoxChocolateHearts: 3
-    BoxConversationHeart: 3
-    # imp edit end
   contrabandInventory:
     FoodSnackSwirlLollipop: 2
     FoodSnackSyndi: 3

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_service.yml
@@ -28,16 +28,16 @@
   category: cargoproduct-category-name-service
   group: market
 
-- type: cargoProduct
-  name: romantic crate
-  id: CrateValentines
-  icon:
-    sprite: _Impstation/Objects/Fun/bouquet.rsi
-    state: icon
-  product: CrateValentinesFilled
-  cost: 750
-  category: cargoproduct-category-name-fun
-  group: market
+#- type: cargoProduct # come back next february
+#  name: romantic crate
+#  id: CrateValentines
+#  icon:
+#    sprite: _Impstation/Objects/Fun/bouquet.rsi
+#    state: icon
+#  product: CrateValentinesFilled
+#  cost: 750
+#  category: cargoproduct-category-name-fun
+#  group: market
 
 #- type: cargoProduct # come back next june
 #  name: anniversary crate


### PR DESCRIPTION
## About the PR
february is over so we are now shelving the most problematic cargo order in history

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
reverts changes to cargotest.cs, removes valentines inventory from getmore chocolate vendor, comments out the valentines crate as a cargo order

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [ ] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl:
- remove: Oops! We're outlawing Valentine's again.
