### PR TITLE
Svalinn Removed from Default Protolathe (and moved elsewhere!)

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -49,7 +49,6 @@
   recipes:
   - WeaponPistolCHIMP
   - WeaponForceGun
-  - WeaponLaserSvalinn # imp, T2
   - WeaponProtoKineticAccelerator
   - PKAUpgradeDamage
   - PKAUpgradeRange

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -137,6 +137,7 @@
   recipes:
   - Truncheon
   - WeaponAdvancedLaser
+  - WeaponLaserSvalinn
   - WeaponLaserCannon
   - WeaponLaserCarbine
   - WeaponXrayCannon

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/autolathe.yml
@@ -20,6 +20,7 @@
   id: ImpAutoEmagged
   recipes:
   - CombatKnife
+  - WeaponLaserSvalinn
   - RiotShield
   - MagazineCobraEmpty
   - MagazineBasiliskEmpty

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/protolathe.yml
@@ -30,6 +30,7 @@
   recipes:
     - FullAutoConversionKit
     - HyperBurstConversionKit
+    - WeaponLaserSvalinn
     - MagazineDMRIncendiary
     - MagazineDMRUranium
     - MagazineLPistolIncendiary


### PR DESCRIPTION
## About the PR
Removes the Svalinn from the default Protolathe list of recipes, moves it to the Security Techfab, and adds it as a recipe on an emagged protolathe and autolathe.

## Why / Balance
I was hoping that there wouldn't be issues with self-seccing/self-antagging from scientists by having this recipe as something that shows up in the protolathe by default, especially considering how weak it is, but it's been a problem. Rather than having this unwritten and unspoken expectation of scientists to "don't print this even though you can", I've moved it to places where it can still be used by crews and antagonists alike but in a manner that makes more sense.

## Technical details
Four line changes in yaml.

## Media

https://github.com/user-attachments/assets/d34dbc0b-ded2-49ab-bfb9-bca149aadef2



## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl: DVD Player
- tweak: The Svalinn can no longer be printed in a Protolathe that hasn't been emagged, but can printed at a SecFab and an emagged Autolathe now.
