### PR TITLE
Fixed stun projectile goofs

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Bullets/magnum.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Bullets/magnum.yml
@@ -62,8 +62,15 @@
   parent: BaseBullet
   categories: [ HideSpawnMenu ]
   components:
+  - type: Sprite
+    sprite: _Impstation/Objects/Weapons/Guns/Projectiles/kineticprojectiles.rsi
+    layers:
+    - state: stunbullet
+      shader: unshaded
   - type: Projectile
     impactEffect: BulletImpactEffectKineticStun
     damage:
       types:
-        Blunt: 5
+        Shock: 3
+  - type: StaminaDamageOnCollide
+    damage: 30 #4 hits to stun

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Bullets/pistol35.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Bullets/pistol35.yml
@@ -61,4 +61,4 @@
       types:
         Shock: 2
   - type: StaminaDamageOnCollide
-    damage: 13 # 8 hits to stun
+    damage: 15 #7 hits to stun. Really 6.67 but unless you're receiving teamwork it's gonna be 7.


### PR DESCRIPTION
## About the PR
Must have happened when the hardforkening was done. Restored the stamina and shock damage of the stun magnum bullets, as well as the projectile sprite they should be using. I've also increased the stamina damage on the Freelancer's stun shots just a smidge to give some wiggle room, but any more and it just becomes as good as a disabler if not better (which we do not want).

## Why / Balance
The Freelancer and Magnum stun shots are not meant to be good enough that you can just use them for arrests. They're for roleplay purposes, as well as being support shots, warning shots, or tools to at least put someone into a slowdown so you can make a getaway. Needing a full magazine to stun with the Freelancer was maybe really not good, so the best I can do is put it to 7 shots to stun (13 stamina damage -> 15 stamina damage). This puts it into a place where it can stun faster than a magnum but you do not have the same wiggle room that a magnum has. If I were to raise the stamina damage of those bullets any more I would need to make the Freelancer shoot slower.

## Technical details
Only YAML. Just some missing components and a line change.

## Media

https://github.com/user-attachments/assets/0bcf610a-1300-401c-afcb-df5f97c91613



## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl: DVD Player
- tweak: The Freelancer's .35 Stun shots are now slightly better at stunning. Very slightly.
- fix: .45 Stun now properly works as it did before.
