### PR TITLE
AI is borg supervisor

### DIFF
--- a/Resources/Locale/en-US/_Impstation/job/job-supervisors.ftl
+++ b/Resources/Locale/en-US/_Impstation/job/job-supervisors.ftl
@@ -1,1 +1,2 @@
-job-supervisors-hd = Hospitality Director
+job-supervisors-hd = the Hospitality Director
+job-supervisors-ai = the Station AI

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -28,6 +28,6 @@
       time: 40h # imp, was 10h
   canBeAntag: false
   icon: JobIconBorg
-  supervisors: job-supervisors-rd
+  supervisors: job-supervisors-ai # imp edit, lawsync
   jobEntity: PlayerBorgBattery
   applyTraits: false


### PR DESCRIPTION
## About the PR
Changed borg supervisor from RD to AI

## Why / Balance
Lawsync & remnant from when the RD had binary comms

For the record. I didn't want to PR a rules change as a non admin but I do wish we had explicit wording from this section of wizden rules:
<img width="858" height="276" alt="image" src="https://github.com/user-attachments/assets/9efb8a92-6529-44a5-aa5e-4313df41ec87" />

I would normally argue this falls under other rules like roleplay a normal person (want to keep your job > listen to your boss), but borgs present a bit of a gray space for this. It would even be nice to add AI into the chain of command page and make it clearer that they're considered command here, but I figure that direction should come from admins.

## Technical details
yaml

## Media
<img width="452" height="104" alt="image" src="https://github.com/user-attachments/assets/6ef3215c-5706-40e5-8ced-11a918c4e4bb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl:
- tweak: The Station AI is listed as crew borg's job supervisor instead of the Research Director