### PR TITLE
dolphin tweaks

### DIFF
--- a/Resources/Maps/_Impstation/lilboat.yml
+++ b/Resources/Maps/_Impstation/lilboat.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 03/20/2026 21:48:30
+  time: 03/20/2026 22:37:58
   entityCount: 8989
 maps:
 - 1
@@ -28460,8 +28460,8 @@ entities:
       pos: 39.5,-15.5
       parent: 2
     - type: GasMixer
-      inletTwoConcentration: 0.029999971
-      inletOneConcentration: 0.97
+      inletTwoConcentration: 0.78
+      inletOneConcentration: 0.22
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasOutletInjector


### PR DESCRIPTION
## About the PR
this PR makes a variety of small changes to dolphin. 

1. moved the bridge APC to the the bridge substation instead of the AI substation
2. fixed the security turnstiles
3. linked unlinked scrubbers and vents to their air alarms
4. added and linked an air alarm to the maintenance bar
5. fixed a typo on the morgue camera
6. added cameras to the engineering lobby + RTG room
7. added a red phone
8. added a Jonny spawner to the bathroom
9. added a few LV cables to reach unpowered lightbulbs
10. swapped the AI holopad and turret
11. added the lawvend and removed the law boards
12. swapped the enforcer safe for a rifle safe
13. added holopads to anomaly, armory, captain, clown/mime, cryo (med), engi front, HOP, library, and storeroom

## Why / Balance
bug fixes, requested changes

## Technical details
mapping

## Media
no relevant media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- tweak: Minor Dolphin changes and fixes.

