### PR TITLE
raptor and shramp mimes survive

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -84,6 +84,8 @@
     - Reptilian
     - Vulpkanin
     # imp below
+    - Allulalo
+    - Anomalocarid
     - Gray
     - Gastropoid
     - Thaven


### PR DESCRIPTION
## About the PR
two guys did not have survival boxes and now they do

## Why / Balance
fix

## Technical details
yaml

## Media
<img width="312" height="416" alt="image" src="https://github.com/user-attachments/assets/9e91e747-1f2d-492c-9f9a-f89a157b93ef" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- fix: Allulalo and anomalocarid mimes spawn with a survival box
