### PR TITLE
Add the thing I FORGOT in the zookeeper PR

### DIFF
--- a/Resources/Locale/en-US/_Impstation/spray-painter/spray-painter.ftl
+++ b/Resources/Locale/en-US/_Impstation/spray-painter/spray-painter.ftl
@@ -26,6 +26,7 @@ spray-painter-style-airlockstandard-reporter = Reporter
 spray-painter-style-airlockstandard-secmed = Sec/Med
 spray-painter-style-airlockstandard-service = Service
 spray-painter-style-airlockstandard-theatre = Theatre
+spray-painter-style-airlockstandard-zoo = Zoo
 
 spray-painter-style-airlockglass-armory = Armory
 spray-painter-style-airlockglass-bar = Bar
@@ -54,6 +55,7 @@ spray-painter-style-airlockglass-reporter = Reporter
 spray-painter-style-airlockglass-secmed = Sec/Med
 spray-painter-style-airlockglass-service = Service
 spray-painter-style-airlockglass-theatre = Theatre
+spray-painter-style-airlockglass-zoo = Zoo
 
 # Lockers
 spray-painter-style-locker-aa = Administrative Assistant
@@ -63,6 +65,7 @@ spray-painter-style-locker-griffy = Griffy
 spray-painter-style-locker-hd = Hospitality Director
 spray-painter-style-locker-janitor = Janitor
 spray-painter-style-locker-musician = Musician
+spray-painter-style-locker-zookeeper = Zookeeper
 
 spray-painter-style-closet-business = Business
 

--- a/Resources/Prototypes/Paintables/airlock_groups.yml
+++ b/Resources/Prototypes/Paintables/airlock_groups.yml
@@ -46,6 +46,7 @@
     secmed: AirlockSecurityMedical
     service: AirlockService
     theatre: AirlockTheatre
+    zoo: AirlockZoo
     # imp edit end
 
 - type: paintableGroup
@@ -95,4 +96,5 @@
     secmed: AirlockSecurityMedicalGlass
     service: AirlockServiceGlass
     theatre: AirlockTheatreGlass
+    zoo: AirlockZooGlass
     # imp edit end

--- a/Resources/Prototypes/Paintables/locker_groups.yml
+++ b/Resources/Prototypes/Paintables/locker_groups.yml
@@ -36,6 +36,7 @@
     HD: LockerHospitalityDirector
     janitor: LockerJanitor
     musician: LockerMusician
+    zookeeper: LockerZookeeper
     # imp edit end
 
 - type: paintableGroup


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
I ADDED the ZOOKEEPER doors and locker to the SPRAY PAINTER because I FORGET them
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

https://github.com/user-attachments/assets/19b20acb-caeb-4a24-aae3-66866ac84e36



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->
