### PR TITLE
Synthblood death fix (#83)

### DIFF
--- a/Content.Server/_CD/Traits/SynthComponent.cs
+++ b/Content.Server/_CD/Traits/SynthComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Chemistry.Components;
 namespace Content.Server._CD.Traits;
 
 /// <summary>
@@ -11,4 +12,10 @@ public sealed partial class SynthComponent : Component
     /// </summary>
     [DataField]
     public float AlertChance = 0.3f;
+
+    /// <summary>
+    /// VDS - The reagent that replaces the synth's blood
+    /// </summary>
+    [DataField]
+    public Solution SynthBloodReagent = new([new("SynthBlood", 300)]);
 }

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -11,7 +11,7 @@ public sealed class SynthSystem : EntitySystem
 {
     // Begin DeltaV - make strings static readonly
     private static readonly ProtoId<TypingIndicatorPrototype> RobotTypingIndicator = "robot";
-    private static readonly ProtoId<ReagentPrototype> SynthBloodReagent = "SynthBlood";
+    // private static readonly ProtoId<ReagentPrototype> SynthBloodReagent = "SynthBlood"; // VDS - use solution in component instead.
     // End DeltaV
 
     [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
@@ -32,8 +32,8 @@ public sealed class SynthSystem : EntitySystem
         }
 
         // Give them synth blood. Ion storm notif is handled in that system
-        _bloodstream.ChangeBloodReagent(uid, SynthBloodReagent); // DeltaV - make strings static readonly
-
+        _bloodstream.ChangeBloodReagents(uid, component.SynthBloodReagent); // DeltaV - make strings static readonly 
+                                                                            // VDS - update to use new ChangeBloodReagents
         // Gives them the DamagedSiliconAccent component
         EnsureComp<DamagedSiliconAccentComponent>(uid, out var accent);
         accent.EnableChargeCorruption = false; //Disables corruption on low battery. This would always be active since non-silicons don't have a battery


### PR DESCRIPTION
## About the PR
One more try! A port of [PR #83](https://github.com/vermist-sector/vermist-dust/pull/83) from Vermist Dust, fixing an error brought about by the change in how bloodstreams work from upstream. 

## Why / Balance
Making things like they should be!

## Technical details
Very small changes in C# to ensure that the game doesn't instruct Synths to have 1u of blood.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [ ] I give permission for any changes to the repository made in this PR to be relicensed under MIT. (not my work - I can't decide this)
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->

:cl:
- fix: The Imp sector has finally updated their rulings on synthblood volume to function on par with the rest of the crew.
