### PR TITLE
Make the evil skull a natural artifact

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/item_xenoartifacts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Xenoarchaeology/item_xenoartifacts.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: [ BaseItem, NaturalXenoArtifactItem ]
+  parent: NaturalXenoArtifactItem
   id: EvilSkullArtifactItem
   name: evil skull
   suffix: Hummingbird thief objective


### PR DESCRIPTION
## About the PR
Changes the evil skull (Hummingbird chapel item) from a reticulated artifact to a natural one.

## Why / Balance
I intended to do this when we original re-introduced old xeno artifacts, but never got around to it. Makes the effects of it in the hands of someone without an artifact analyzer less predictable, making it more likely to add a bit more chaos for whoever has it.

## Technical details
Changed the evil skull's parent, removed some redundant pieces of yaml from its prototype.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- tweak: Hummingbird's evil skull is now functions as a natural artifact instead of a reticulated one, making it a bit more unpredictable.