### PR TITLE
Remove black and white vision effect from sacrifice effects

### DIFF
--- a/Resources/Locale/en-US/_Impstation/Heretic/heretic/sacrificeeffects.ftl
+++ b/Resources/Locale/en-US/_Impstation/Heretic/heretic/sacrificeeffects.ftl
@@ -1,4 +1,3 @@
-heretic-sac-effect-lantern = The world is but a shadow, and you have seen the light by which it is cast. Now, you are among the shadows again, and the world seems grey like shadows ought to be.
 heretic-sac-effect-moth = Your brain is buzzing. Your mind is tangled within itself. Everything is where it should be. Nothing is in its place.
 heretic-sac-effect-grail = Your blood, like water, has been used to slake the thirst of another. Your blood, like water, flows unfettered.
 heretic-sac-effect-heart = The drumbeat in your chest beats wildly. It shall not slow, no matter what pain might be inflicted upon it.

--- a/Resources/Prototypes/_Impstation/Heretic/Heretic/sacrifice_effects.yml
+++ b/Resources/Prototypes/_Impstation/Heretic/Heretic/sacrifice_effects.yml
@@ -1,10 +1,4 @@
 - type: hereticSacrificeEffect
-  id: SacEffectLantern
-  components:
-  - type: BlackAndWhiteOverlay
-  message: heretic-sac-effect-lantern
-
-- type: hereticSacrificeEffect
   id: SacEffectMoth
   components:
   - type: ScrambledAccent
@@ -49,4 +43,3 @@
     maxDurationOfIncident: 30
     minDurationOfIncident: 10
   message: heretic-sac-effect-knock
-  


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Removed the associated prototype and ftl line
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Visual filters like this are prone to causing accessibility issues in players. As was reported by a player yesterday. Unavoidable visual effects such as this should be avoided.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl: sev7ves
- remove: Removed black and white vision from the pool of possible sacrifice effects.


