### PR TITLE
Rearrange the atmos signs on packed

### DIFF
--- a/Resources/Maps/_Impstation/packed.yml
+++ b/Resources/Maps/_Impstation/packed.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 268.0.0
+  engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/11/2026 07:02:29
+  time: 04/03/2026 16:56:21
   entityCount: 15295
 maps:
 - 126
@@ -6275,6 +6275,7 @@ entities:
     - type: SpreaderGrid
     - type: NavMap
     - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
   - uid: 126
     components:
     - type: MetaData
@@ -7962,7 +7963,7 @@ entities:
       pos: 101.5,-19.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -32882.727
+      secondsUntilStateChange: -32986.555
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -70117,6 +70118,13 @@ entities:
     - type: Transform
       pos: -3.4634295,-18.46823
       parent: 2
+- proto: PlushieSpawner50
+  entities:
+  - uid: 8652
+    components:
+    - type: Transform
+      pos: 84.5,12.5
+      parent: 2
 - proto: PortableGeneratorJrPacman
   entities:
   - uid: 801
@@ -84384,13 +84392,6 @@ entities:
     - type: Transform
       pos: 40.655693,32.432835
       parent: 2
-- proto: ToySpawner
-  entities:
-  - uid: 8652
-    components:
-    - type: Transform
-      pos: 84.5,12.5
-      parent: 2
 - proto: TrashBag
   entities:
   - uid: 10811
@@ -96508,21 +96509,19 @@ entities:
       parent: 2
 - proto: WarningCO2
   entities:
-  - uid: 410
+  - uid: 417
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 47.5,-26.5
+      pos: 47.5,-28.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: WarningN2
   entities:
-  - uid: 409
+  - uid: 410
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 47.5,-22.5
+      pos: 47.5,-24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -96531,38 +96530,34 @@ entities:
   - uid: 415
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 47.5,-24.5
+      pos: 47.5,-26.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: WarningPlasma
   entities:
-  - uid: 417
+  - uid: 409
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 47.5,-30.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-- proto: WarningTritium
-  entities:
-  - uid: 381
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,-32.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: WarningWaste
   entities:
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 47.5,-34.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: WarningWaterVapor
+  entities:
   - uid: 351
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 47.5,-28.5
+      pos: 47.5,-30.5
       parent: 2
     - type: Fixtures
       fixtures: {}


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
I changed the atmos signs up so that the sign is over the corresponding pump. Also that the water vapor tank uses the h2o sign and waste uses the waste sign
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
every time i play atmos on packed i see this and get mad.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->