### PR TITLE
Fixed the Blaster Muzzle Flash

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Effects/muzzleflashes.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/Effects/muzzleflashes.yml
@@ -58,6 +58,7 @@
     - shader: unshaded
       map: ["enum.EffectLayers.Unshaded"]
       sprite: _Impstation/Objects/Weapons/Guns/Projectiles/muzzleflashes.rsi
+      state: energy
 
 - type: entity
   parent: MuzzleFlashEffect


### PR DESCRIPTION
## About the PR
Blasters (energy weapons with red projectiles) were not showing their muzzle flashes correctly. Discovered this while making an example video for Aurora Song of our sprites.

## Why / Balance
Single line change. The muzzle flash was neglected to have a state designated in its sprite component when things were being moved around.

## Technical details
Single line change.

## Media

https://github.com/user-attachments/assets/2719faca-87fa-4b92-a294-6ee6e6c1588b



## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl: DVD Player
- fix: Blaster projectiles (red energy weapons) now correctly show their muzzle flashes again.
