### PR TITLE
Deathmatch "Instant" Death (No More Crit)

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
@@ -43,4 +43,11 @@ public sealed partial class DeathMatchRuleComponent : Component
     /// </summary>
     [DataField("gear", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>)), ViewVariables(VVAccess.ReadWrite)]
     public string Gear = "DeathMatchGear";
+
+    /// <summary>
+    /// If true, lowers players' entities death thresholds to their critical thresholds because waiting to press
+    /// the succumb button sucks when you want to kill people. Imp addition.
+    /// </summary>
+    [DataField]
+    public bool InstantDeath = true;
 }

--- a/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
@@ -70,6 +70,14 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
 
             _point.EnsurePlayer(ev.Player.UserId, uid, point);
 
+            // imp edit start, make the Dead state count as the kill state instead of Critical, for instant deathmatch death
+            if (dm.InstantDeath)
+            {
+                if (TryComp<KillTrackerComponent>(mob, out var killTrackerComponent))
+                    killTrackerComponent.KillState = MobState.Dead;
+            }
+            // imp edit end
+
             ev.Handled = true;
             break;
         }

--- a/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
@@ -13,6 +13,8 @@ using Content.Shared.Storage;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Utility;
+using Content.Shared.Mobs; // imp
+using Content.Shared.Mobs.Systems; // imp
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -29,6 +31,7 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!; //imp
 
     public override void Initialize()
     {
@@ -54,6 +57,11 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
             var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(ev.Station, null, ev.Profile);
             DebugTools.AssertNotNull(mobMaybe);
             var mob = mobMaybe!.Value;
+
+            // imp edit start, set the death threshold to the critical threshold
+            if (dm.InstantDeath)
+                _mobThresholdSystem.SetMobStateThreshold(mob, _mobThresholdSystem.GetThresholdForState(mob, MobState.Critical), MobState.Dead);
+            // imp edit end
 
             _mind.TransferTo(newMind, mob);
             _outfitSystem.SetOutfit(mob, dm.Gear);

--- a/Content.Server/KillTracking/KillTrackerComponent.cs
+++ b/Content.Server/KillTracking/KillTrackerComponent.cs
@@ -1,13 +1,14 @@
 ﻿using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Robust.Shared.Network;
+using Content.Server.GameTicking.Rules; // imp
 
 namespace Content.Server.KillTracking;
 
 /// <summary>
 /// This is used for entities that track player damage sources and killers.
 /// </summary>
-[RegisterComponent, Access(typeof(KillTrackingSystem))]
+[RegisterComponent, Access(typeof(KillTrackingSystem), typeof(DeathMatchRuleSystem))] // imp edit, add ", typeof(DeathMatchRuleSystem)"
 public sealed partial class KillTrackerComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Set the death threshold to the critical threshold in deathmatch, so there's no more waiting in crit so you can press the succumb button.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't like how it feels currently and it's not like anyone's ever coming back up from crit in deathmatch, this gives everyone more time to be actively playing.

## Technical details
<!-- Summary of code changes for easier review. -->
Put a new datafield in `DeathMatchRuleComponent` and edited `DeathMatchRuleSystem` to set the entity's death threshold to their critical threshold if the datafield's true.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
https://github.com/user-attachments/assets/a4586015-0070-47a0-8fb5-507cc2cbf577

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl:
- tweak: You no longer go critical in Deathmatch mode.
