### PR TITLE
Dinos gib after death

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
@@ -150,12 +150,14 @@
         proto: DinoLootSpawner
         keysIn:
         - stageTwo
-      - type: Explosive
-        explosionType: Default
-        maxIntensity: 0.01
+      - type: ExplosionOnTrigger #maintaining kips beautiful mind
+        maxTileIntensity: 0.01
         intensitySlope: 1
         totalIntensity: 0.01
-      - type: ExplodeOnTrigger #this is just as a joke honestly
+        canCreateVacuum: false
+        keysIn:
+        - stageTwo
+      - type: GibOnTrigger
         keysIn:
         - stageTwo
 

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
@@ -711,8 +711,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      750: Dead
-      850: Critical
+      750: Critical
+      850: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       600: 0.8

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
@@ -150,14 +150,12 @@
         proto: DinoLootSpawner
         keysIn:
         - stageTwo
-      - type: ExplosionOnTrigger #maintaining kips beautiful mind
-        maxTileIntensity: 0.01
+      - type: Explosive
+        explosionType: Default
+        maxIntensity: 0.01
         intensitySlope: 1
         totalIntensity: 0.01
-        canCreateVacuum: false
-        keysIn:
-        - stageTwo
-      - type: GibOnTrigger
+      - type: ExplodeOnTrigger #this is just as a joke honestly
         keysIn:
         - stageTwo
 
@@ -256,6 +254,16 @@
       - Door
       tags:
       - Wall
+  - type: TwoStageTrigger
+    triggerDelay: 10.45
+    components:
+      - type: SpawnOnTrigger
+        proto: DinoLootSpawner
+        keysIn:
+        - stageTwo
+      - type: GibOnTrigger
+        keysIn:
+        - stageTwo
 
 # Small Dinosaurs
 


### PR DESCRIPTION
## About the PR
Dinos gib after death
The explosion can be removed safely if anyone cares. I haven't attended the recent dino wars is this a part of its identity now

## Why / Balance
Fixes bodies being deleted on death from dinosaurs with the devour action

## Technical details
Just adds gib on trigger. Changed the explosion to the prettier explosion trigger while I was there for smaller yaml nicies

## Media
theres like one million bullet casings in my localhost at this point so the video has noticeable lag. whatever. enjoy rot for clout

https://github.com/user-attachments/assets/a669762b-fc89-4a93-96ea-603f5662c4c0


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- fix: Dinosaurs that have devoured a person will no longer delete them on death
