### PR TITLE
Changed the Title of the Window for the Bounty Hunter Tool Box

### DIFF
--- a/Resources/Locale/en-US/_Impstation/bountyhunter/bountyhunter.ftl
+++ b/Resources/Locale/en-US/_Impstation/bountyhunter/bountyhunter.ftl
@@ -21,6 +21,8 @@ roles-antag-bounty-hunter-objective = Hunt down your target and get paid.
 
 bounty-hunter-roundend-name = Bounty Hunter
 
+bounty-hunter-backpack-window-title = Bounty Hunter Background
+
 bounty-hunter-category-raider-name = Raider
 bounty-hunter-category-raider-description =
     You aren't a fan of subtlety.

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Bounty Hunter/bounty_hunter_items.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Bounty Hunter/bounty_hunter_items.yml
@@ -7,6 +7,7 @@
   components:
   - type: ThiefUndeterminedBackpack
     maxSelectedSets: 2
+    toolName: bounty-hunter-backpack-window-title
     possibleSets:
     - BountyHunterRaider
     - BountyHunterHardsuit


### PR DESCRIPTION
## About the PR
I was doing some testing with bounty hunters, and I noticed that the UI says Thieving Kit.
I have updated the UI to use something different when the source is from a Bounty Hunter Toolbox.
Hopefully this toolbox gets rated 11/10 in the next toolbox rating video.

## Why / Balance
Added a title to the Bounty Hunter UI so that it doesn't say Thieving Kit anymore. 
It looks nicer. It doesn't affect balance, but it affected my ability to play bounty hunter.

## Technical details
bountyhunter.ftl includes a new entry for the title of the window
BountyHunterGear includes a toolName that matches what is in the bountyhunter.ftl

## Media
<img width="701" height="246" alt="Screenshot 2026-05-06 212539" src="https://github.com/user-attachments/assets/2f8b916e-de0e-4b19-a2e7-e113e9dbb95e" />
<img width="2141" height="1246" alt="Screenshot 2026-05-06 212729" src="https://github.com/user-attachments/assets/4ceebfe4-5ff2-4e53-80bb-424c220ff11e" />


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.


## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
cl:
- tweak: fixed the UI Title Name for Bounty Hunter Toolbox