### PR TITLE
Update Amber, Bagel, Cog, Hummingbird, Marathon, Plasma, Train (Lawvend, Service Attendant, misc updates)

### DIFF
--- a/Resources/Maps/_Impstation/amber.yml
+++ b/Resources/Maps/_Impstation/amber.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 03/10/2026 00:45:21
+  time: 05/20/2026 01:05:37
   entityCount: 25034
 maps:
 - 1
@@ -110328,11 +110328,6 @@ entities:
     - type: Transform
       pos: -5.5,-55.5
       parent: 2
-  - uid: 9253
-    components:
-    - type: Transform
-      pos: 2.5,-21.5
-      parent: 2
   - uid: 9255
     components:
     - type: Transform
@@ -116152,8 +116147,6 @@ entities:
     - type: Transform
       pos: 41.43434,-9.850339
       parent: 2
-- proto: HandheldHealthAnalyzerUnpowered
-  entities:
   - uid: 8500
     components:
     - type: Transform
@@ -133299,11 +133292,6 @@ entities:
     - type: Transform
       pos: -46.5,3.5
       parent: 2
-  - uid: 10969
-    components:
-    - type: Transform
-      pos: 2.5,-21.5
-      parent: 2
   - uid: 10998
     components:
     - type: Transform
@@ -136579,6 +136567,15 @@ entities:
           - Open
         - - On
           - Close
+    - type: Fixtures
+      fixtures: {}
+- proto: SignAnchor
+  entities:
+  - uid: 10969
+    components:
+    - type: Transform
+      pos: 2.5,-21.5
+      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: SignAnomaly
@@ -149774,6 +149771,11 @@ entities:
     components:
     - type: Transform
       pos: -28.5,24.5
+      parent: 2
+  - uid: 9253
+    components:
+    - type: Transform
+      pos: 2.5,-21.5
       parent: 2
   - uid: 9260
     components:

--- a/Resources/Maps/_Impstation/bagel.yml
+++ b/Resources/Maps/_Impstation/bagel.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 03/10/2026 00:27:12
-  entityCount: 25959
+  time: 05/20/2026 01:07:42
+  entityCount: 25960
 maps:
 - 1
 grids:
@@ -133909,6 +133909,15 @@ entities:
     - type: DeviceLinkSink
       invokeCounter: 2
     - type: ActiveSignalTimer
+    - type: Fixtures
+      fixtures: {}
+- proto: SignAnchor
+  entities:
+  - uid: 11010
+    components:
+    - type: Transform
+      pos: -14.5,36.5
+      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: SignAnomaly

--- a/Resources/Maps/_Impstation/hummingbird.yml
+++ b/Resources/Maps/_Impstation/hummingbird.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 03/10/2026 01:19:08
-  entityCount: 25390
+  time: 05/20/2026 01:14:05
+  entityCount: 25388
 maps:
 - 1
 grids:
@@ -51139,16 +51139,6 @@ entities:
     - type: Transform
       pos: 113.5,-38.5
       parent: 2
-  - uid: 7714
-    components:
-    - type: Transform
-      pos: 73.5,27.5
-      parent: 2
-  - uid: 7715
-    components:
-    - type: Transform
-      pos: 73.5,28.5
-      parent: 2
   - uid: 7716
     components:
     - type: Transform
@@ -51188,16 +51178,6 @@ entities:
     components:
     - type: Transform
       pos: 73.5,26.5
-      parent: 2
-  - uid: 7724
-    components:
-    - type: Transform
-      pos: 74.5,28.5
-      parent: 2
-  - uid: 7725
-    components:
-    - type: Transform
-      pos: 74.5,27.5
       parent: 2
   - uid: 7726
     components:
@@ -131534,6 +131514,13 @@ entities:
       parent: 2
 - proto: Screen
   entities:
+  - uid: 7725
+    components:
+    - type: Transform
+      pos: 29.5,-12.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 9679
     components:
     - type: Transform
@@ -131636,13 +131623,6 @@ entities:
     components:
     - type: Transform
       pos: 38.5,-0.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 19028
-    components:
-    - type: Transform
-      pos: 29.5,-10.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -134368,6 +134348,15 @@ entities:
           - Forward
         - - Off
           - Off
+    - type: Fixtures
+      fixtures: {}
+- proto: SignAnchor
+  entities:
+  - uid: 7724
+    components:
+    - type: Transform
+      pos: 29.5,-9.5
+      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: SignAnomaly
@@ -139429,6 +139418,13 @@ entities:
       parent: 2
 - proto: StationMap
   entities:
+  - uid: 7715
+    components:
+    - type: Transform
+      pos: 29.5,-10.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 18267
     components:
     - type: Transform
@@ -139440,13 +139436,6 @@ entities:
     components:
     - type: Transform
       pos: 52.5,-36.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 19999
-    components:
-    - type: Transform
-      pos: 29.5,-9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -163293,6 +163282,7 @@ entities:
       deviceLists:
       - 18695
       - 18693
+      - 7714
   - uid: 24038
     components:
     - type: Transform
@@ -163302,6 +163292,7 @@ entities:
       deviceLists:
       - 18695
       - 18693
+      - 7714
   - uid: 24039
     components:
     - type: Transform
@@ -163311,6 +163302,7 @@ entities:
       deviceLists:
       - 18695
       - 18693
+      - 7714
   - uid: 24040
     components:
     - type: Transform
@@ -163320,14 +163312,31 @@ entities:
       deviceLists:
       - 18695
       - 18693
+      - 7714
 - proto: WeaponEnergyTurretAIControlPanel
   entities:
+  - uid: 7714
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 56.5,-22.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 24039
+      - 24040
+      - 24038
+      - 24037
   - uid: 18515
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 56.5,-19.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - StationAi
+      - - ResearchDirector
     - type: DeviceList
       devices:
       - 24018
@@ -163361,6 +163370,10 @@ entities:
       rot: 3.141592653589793 rad
       pos: 52.5,-16.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - StationAi
+      - - ResearchDirector
     - type: DeviceList
       devices:
       - 24018
@@ -164070,7 +164083,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -224289.28
+      secondsUntilStateChange: -224606.42
       state: Opening
     - type: Airlock
       autoClose: False

--- a/Resources/Maps/_Impstation/marathon.yml
+++ b/Resources/Maps/_Impstation/marathon.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 268.0.0
+  engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/13/2026 00:19:03
-  entityCount: 23563
+  time: 05/20/2026 00:37:08
+  entityCount: 23551
 maps:
 - 1
 grids:
@@ -7531,6 +7531,7 @@ entities:
     - type: GridPathfinding
     - type: NavMap
     - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 3
@@ -10168,26 +10169,6 @@ entities:
     - type: Transform
       pos: -23.5,37.5
       parent: 2
-  - uid: 204
-    components:
-    - type: Transform
-      pos: -2.5,83.5
-      parent: 2
-  - uid: 205
-    components:
-    - type: Transform
-      pos: -3.5,83.5
-      parent: 2
-  - uid: 206
-    components:
-    - type: Transform
-      pos: 2.5,83.5
-      parent: 2
-  - uid: 207
-    components:
-    - type: Transform
-      pos: 1.5,83.5
-      parent: 2
 - proto: AirlockCaptainLocked
   entities:
   - uid: 208
@@ -10295,6 +10276,16 @@ entities:
       parent: 2
 - proto: AirlockCommandGlassLocked
   entities:
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 2.5,83.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -3.5,83.5
+      parent: 2
   - uid: 227
     components:
     - type: Transform
@@ -14011,26 +14002,12 @@ entities:
     - type: Transform
       pos: -58.5,-51.5
       parent: 2
-- proto: ArtistCircuitBoard
-  entities:
-  - uid: 764
-    components:
-    - type: Transform
-      pos: -3.5786777,64.67137
-      parent: 2
 - proto: Ash
   entities:
   - uid: 765
     components:
     - type: Transform
       pos: -28.507416,-46.550377
-      parent: 2
-- proto: AsimovCircuitBoard
-  entities:
-  - uid: 766
-    components:
-    - type: Transform
-      pos: -3.4068027,64.40575
       parent: 2
 - proto: AsteroidRock
   entities:
@@ -52997,6 +52974,11 @@ entities:
         moles:
           Oxygen: 3.4430928
           Nitrogen: 12.952587
+  - uid: 8670
+    components:
+    - type: Transform
+      pos: -3.5,62.5
+      parent: 2
 - proto: ClosetL3JanitorFilled
   entities:
   - uid: 8266
@@ -53533,6 +53515,11 @@ entities:
       parent: 2
 - proto: ClothingHandsGlovesColorYellow
   entities:
+  - uid: 766
+    components:
+    - type: Transform
+      pos: -3.444458,63.50408
+      parent: 2
   - uid: 8331
     components:
     - type: Transform
@@ -54810,13 +54797,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -50.5,59.5
       parent: 2
-- proto: CommandmentCircuitBoard
-  entities:
-  - uid: 8549
-    components:
-    - type: Transform
-      pos: -3.7193027,63.17137
-      parent: 2
 - proto: CommsComputerCircuitboard
   entities:
   - uid: 8550
@@ -55669,13 +55649,6 @@ entities:
     components:
     - type: Transform
       pos: -44.601845,67.62289
-      parent: 2
-- proto: CorporateCircuitBoard
-  entities:
-  - uid: 8670
-    components:
-    - type: Transform
-      pos: -3.4849277,64.54637
       parent: 2
 - proto: CowToolboxFilled
   entities:
@@ -64805,13 +64778,6 @@ entities:
       parent: 2
     - type: FaxMachine
       name: Captain
-- proto: FigureSpawner
-  entities:
-  - uid: 9991
-    components:
-    - type: Transform
-      pos: -75.5,-63.5
-      parent: 2
 - proto: filingCabinet
   entities:
   - uid: 9992
@@ -68795,13 +68761,6 @@ entities:
     components:
     - type: Transform
       pos: -15.130933,9.804543
-      parent: 2
-- proto: GameMasterCircuitBoard
-  entities:
-  - uid: 10474
-    components:
-    - type: Transform
-      pos: -3.6880527,63.936996
       parent: 2
 - proto: GasAnalyzer
   entities:
@@ -105607,6 +105566,13 @@ entities:
     - type: Transform
       pos: 45.499237,25.550482
       parent: 2
+- proto: LawVend
+  entities:
+  - uid: 8549
+    components:
+    - type: Transform
+      pos: -3.5,64.5
+      parent: 2
 - proto: Lighter
   entities:
   - uid: 15795
@@ -105625,13 +105591,6 @@ entities:
     components:
     - type: Transform
       pos: -63.5,-57.5
-      parent: 2
-- proto: LiveLetLiveCircuitBoard
-  entities:
-  - uid: 15798
-    components:
-    - type: Transform
-      pos: -3.5786777,63.79637
       parent: 2
 - proto: LockableButtonArmory
   entities:
@@ -107002,6 +106961,13 @@ entities:
     - type: Transform
       pos: 28.488785,-1.4569497
       parent: 2
+- proto: MechFigurineSpawner50
+  entities:
+  - uid: 9991
+    components:
+    - type: Transform
+      pos: -75.5,-63.5
+      parent: 2
 - proto: MedicalAssembler
   entities:
   - uid: 23442
@@ -107582,26 +107548,12 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: NTDefaultCircuitBoard
-  entities:
-  - uid: 15998
-    components:
-    - type: Transform
-      pos: -3.4380527,63.655746
-      parent: 2
 - proto: NuclearBomb
   entities:
   - uid: 15999
     components:
     - type: Transform
       pos: 5.5,43.5
-      parent: 2
-- proto: NutimovCircuitBoard
-  entities:
-  - uid: 16000
-    components:
-    - type: Transform
-      pos: -3.3286777,63.51512
       parent: 2
 - proto: OatSeeds
   entities:
@@ -107913,13 +107865,6 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: PaladinCircuitBoard
-  entities:
-  - uid: 16049
-    components:
-    - type: Transform
-      pos: -3.5161777,62.811996
-      parent: 2
 - proto: Paper
   entities:
   - uid: 120
@@ -108798,6 +108743,13 @@ entities:
     components:
     - type: Transform
       pos: 40.559143,-53.538166
+      parent: 2
+- proto: PlushieSpawner50
+  entities:
+  - uid: 19721
+    components:
+    - type: Transform
+      pos: 13.5,6.5
       parent: 2
 - proto: PonderingOrb
   entities:
@@ -119264,13 +119216,6 @@ entities:
     - type: Transform
       pos: -40.52716,56.50407
       parent: 2
-- proto: RobocopCircuitBoard
-  entities:
-  - uid: 17908
-    components:
-    - type: Transform
-      pos: -3.4224277,62.624496
-      parent: 2
 - proto: SalvageMagnet
   entities:
   - uid: 17909
@@ -119435,6 +119380,11 @@ entities:
       fixtures: {}
 - proto: Screwdriver
   entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -3.522583,63.675957
+      parent: 2
   - uid: 17932
     components:
     - type: Transform
@@ -124494,7 +124444,7 @@ entities:
     - type: Transform
       pos: 19.53292,7.7526426
       parent: 2
-- proto: SpacemenFigureSpawner
+- proto: SpacemenFigurineSpawner90
   entities:
   - uid: 18641
     components:
@@ -125582,13 +125532,6 @@ entities:
     components:
     - type: Transform
       pos: -28.5,-50.5
-      parent: 2
-- proto: StationEfficiencyCircuitBoard
-  entities:
-  - uid: 18806
-    components:
-    - type: Transform
-      pos: -3.3443027,62.45262
       parent: 2
 - proto: StationMap
   entities:
@@ -128399,6 +128342,12 @@ entities:
       parent: 2
 - proto: Table
   entities:
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,63.5
+      parent: 2
   - uid: 564
     components:
     - type: Transform
@@ -130160,12 +130109,6 @@ entities:
     - type: Transform
       pos: 4.5,-28.5
       parent: 2
-  - uid: 19464
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,64.5
-      parent: 2
   - uid: 19465
     components:
     - type: Transform
@@ -130265,18 +130208,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-27.5
-      parent: 2
-  - uid: 19485
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,63.5
-      parent: 2
-  - uid: 19486
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,62.5
       parent: 2
   - uid: 19487
     components:
@@ -131551,13 +131482,6 @@ entities:
     components:
     - type: Transform
       pos: -25.44764,39.398945
-      parent: 2
-- proto: ToySpawner
-  entities:
-  - uid: 19721
-    components:
-    - type: Transform
-      pos: 13.5,6.5
       parent: 2
 - proto: TrashBag
   entities:
@@ -148339,18 +148263,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.5,42.5
       parent: 2
-  - uid: 22856
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,62.5
-      parent: 2
-  - uid: 22857
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,63.5
-      parent: 2
   - uid: 22858
     components:
     - type: Transform
@@ -149052,6 +148964,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,41.5
+      parent: 2
+  - uid: 764
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,63.5
       parent: 2
   - uid: 985
     components:

--- a/Resources/Maps/_Impstation/plasma.yml
+++ b/Resources/Maps/_Impstation/plasma.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/21/2026 01:15:39
-  entityCount: 26746
+  time: 05/20/2026 02:35:22
+  entityCount: 26778
 maps:
 - 1
 grids:
@@ -111,7 +111,7 @@ entities:
           version: 7
         -5,-5:
           ind: -5,-5
-          tiles: BwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAEABwAAAAAAAAcAAAAAAACDAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAABwAAAAABAAcAAAAACQAHAAAAAAAABwAAAAACAAcAAAAABQAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAIABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAADAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAACDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAABwCDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAUABwAAAAAAAAcAAAAAAAAHAAAAAAAAgwAAAAAAAAcAAAAACwAHAAAAAAAABwAAAAABAAcAAAAACwAHAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAABwAHAAAAAAAABwAAAAAHAIMAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAwAHAAAAAAAABwAAAAAAAAcAAAAABQAHAAAAAAAABwAAAAAFAAcAAAAAAACDAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAAcAAAAAAQCDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAMAAcAAAAAAAAHAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAABAAcAAAAAAAAHAAAAAAAABwAAAAAKAAcAAAAAAAAHAAAAAAAABwAAAAAJAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAAIAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAgABwAAAAAAAAcAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAYABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAABwAAAAAAAAcAAAAACAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAEABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAHAAcAAAAABQAHAAAAAAAABwAAAAAIAAcAAAAAAAAHAAAAAAwABwAAAAAAAAcAAAAABQAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAcABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAHAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAADAAcAAAAAAAAHAAAAAAAABwAAAAAEAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAA==
+          tiles: BwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAEABwAAAAAAAAcAAAAAAACDAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAABwAAAAABAAcAAAAACQAHAAAAAAAABwAAAAACAAcAAAAABQAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAIABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAADAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAACDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAABwCDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAUABwAAAAAAAAcAAAAAAAAHAAAAAAAAgwAAAAAAAAcAAAAACwAHAAAAAAAABwAAAAABAAcAAAAACwAHAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAABwAHAAAAAAAABwAAAAAHAIMAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAwAHAAAAAAAABwAAAAAAAAcAAAAABQAHAAAAAAAABwAAAAAFAAcAAAAAAACDAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAAcAAAAAAQCDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAMAAcAAAAAAAAHAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAABAAcAAAAAAAAHAAAAAAAABwAAAAAKAAcAAAAAAAAHAAAAAAAABwAAAAAJAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAAAHAAAAAAAABwAAAAAIAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAYABwAAAAAAAAcAAAAAAAACAAAAAAAAAgAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAABwAAAAAAAAcAAAAACAAHAAAAAAAABwAAAAAAAAcAAAAAAAACAAAAAAAAAgAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAHAAcAAAAABQAHAAAAAAAABwAAAAAIAAcAAAAAAAAHAAAAAAwABwAAAAAAAAcAAAAABQAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAcABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAHAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAADAAcAAAAAAAAHAAAAAAAABwAAAAAEAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAIMAAAAAAACDAAAAAAAAgwAAAAAAAA==
           version: 7
         -2,-1:
           ind: -2,-1
@@ -1771,6 +1771,7 @@ entities:
             7737: -68,-50
             7817: -53,-67
             7821: -62,-68
+            8298: -74,-69
         - node:
             color: '#FFFFFFFF'
             id: BushCTwo
@@ -7725,7 +7726,8 @@ entities:
           -17,-18:
             1: 2
           -17,-16:
-            1: 64764
+            1: 64628
+            2: 136
           -16,-17:
             1: 53239
           -8,-4:
@@ -7878,12 +7880,12 @@ entities:
           -22,3:
             1: 65357
           -22,0:
-            2: 238
+            3: 238
             1: 3584
           -22,4:
             1: 65535
           -22,-1:
-            2: 20479
+            3: 20479
           -21,1:
             1: 43263
           -21,2:
@@ -7895,7 +7897,7 @@ entities:
             1: 36044
           -21,-1:
             1: 34952
-            2: 819
+            3: 819
           -20,0:
             1: 4565
           -20,1:
@@ -7978,7 +7980,7 @@ entities:
             1: 21969
           -21,-2:
             1: 34955
-            2: 13056
+            3: 13056
           -20,-1:
             1: 21845
           -19,-4:
@@ -8034,15 +8036,15 @@ entities:
             1: 36864
           -23,-2:
             1: 409
-            2: 34816
+            3: 34816
           -23,-1:
-            2: 2184
+            3: 2184
           -22,-4:
             1: 65520
           -22,-3:
             1: 65092
           -22,-2:
-            2: 65280
+            3: 65280
             1: 14
           -24,-15:
             1: 65280
@@ -8104,17 +8106,17 @@ entities:
             1: 48056
           -12,-8:
             1: 15
-            2: 30464
+            3: 30464
           -12,-9:
             1: 62702
           -13,-8:
             1: 13
-            2: 60928
+            3: 60928
           -12,-7:
-            2: 127
+            3: 127
             1: 28672
           -13,-7:
-            2: 1263
+            3: 1263
             1: 28672
           -12,-6:
             1: 30711
@@ -8756,19 +8758,19 @@ entities:
             1: 65520
           -28,-1:
             1: 255
-            3: 61440
+            4: 61440
           -29,-1:
             1: 4351
-            3: 49152
+            4: 49152
           -27,-3:
             1: 57343
           -27,-2:
             1: 56796
           -27,-1:
             1: 2269
-            3: 4096
+            4: 4096
           -27,0:
-            3: 4369
+            4: 4369
             1: 52428
           -26,-3:
             1: 32755
@@ -8779,29 +8781,29 @@ entities:
           -26,0:
             1: 30711
           -28,0:
-            4: 13104
-            3: 17472
+            5: 13104
+            4: 17472
           -28,1:
             0: 240
-            3: 28672
+            4: 28672
           -29,1:
             0: 128
             1: 4369
-            3: 17476
+            4: 17476
           -28,2:
-            3: 61559
+            4: 61559
           -29,2:
-            3: 50244
+            4: 50244
             1: 4369
           -28,3:
             1: 65520
           -28,4:
             1: 4095
           -27,1:
-            3: 4369
+            4: 4369
             1: 52428
           -27,2:
-            3: 4369
+            4: 4369
             1: 52428
           -27,3:
             1: 54612
@@ -8913,12 +8915,12 @@ entities:
             1: 65522
           -32,-1:
             1: 255
-            3: 28672
+            4: 28672
           -33,-1:
             1: 255
-            3: 61440
+            4: 61440
           -32,0:
-            3: 4116
+            4: 4116
             0: 17472
           -31,-3:
             1: 65535
@@ -8938,30 +8940,30 @@ entities:
             1: 65535
           -29,0:
             1: 4369
-            3: 17412
+            4: 17412
             0: 64
           -33,0:
-            3: 53713
+            4: 53713
           -32,1:
-            3: 4112
+            4: 4112
             0: 17476
           -33,1:
-            3: 53713
+            4: 53713
           -32,2:
-            5: 16
-            6: 4096
+            6: 16
+            7: 4096
             0: 17476
           -33,2:
-            5: 192
-            6: 49152
-            3: 4369
+            6: 192
+            7: 49152
+            4: 4369
           -32,3:
-            7: 16
-            3: 29696
+            8: 16
+            4: 29696
             0: 68
           -33,3:
-            7: 192
-            3: 61713
+            8: 192
+            4: 61713
           -32,4:
             1: 228
           -31,1:
@@ -9168,7 +9170,7 @@ entities:
             1: 221
           -37,0:
             0: 34952
-            3: 13104
+            4: 13104
           -36,1:
             0: 8955
             1: 20480
@@ -9368,7 +9370,7 @@ entities:
             0: 65535
           -38,0:
             0: 13107
-            3: 34944
+            4: 34944
           -32,-14:
             1: 20206
           -32,-12:
@@ -9770,6 +9772,11 @@ entities:
             Oxygen: 21.824879
             Nitrogen: 82.10312
         - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
+        - volume: 2500
           temperature: 235
           moles:
             Oxygen: 27.225372
@@ -9863,6 +9870,17 @@ entities:
     - type: Action
       originalIconColor: '#FFFFFFFF'
       container: 13506
+- proto: ActionToggleLight
+  entities:
+  - uid: 26775
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 26774
+    - type: Action
+      originalIconColor: '#FFFFFFFF'
+      container: 26774
 - proto: AirAlarm
   entities:
   - uid: 346
@@ -14766,6 +14784,11 @@ entities:
     - type: Transform
       pos: -22.5,20.5
       parent: 2
+  - uid: 13572
+    components:
+    - type: Transform
+      pos: -74.5,-67.5
+      parent: 2
 - proto: AirlockTheatreLocked
   entities:
   - uid: 3369
@@ -18313,11 +18336,6 @@ entities:
     - type: Transform
       pos: -80.5,-72.5
       parent: 2
-  - uid: 3725
-    components:
-    - type: Transform
-      pos: -80.5,-71.5
-      parent: 2
   - uid: 4098
     components:
     - type: Transform
@@ -18608,11 +18626,6 @@ entities:
     - type: Transform
       pos: -123.5,-28.5
       parent: 2
-  - uid: 7078
-    components:
-    - type: Transform
-      pos: -72.5,-67.5
-      parent: 2
   - uid: 7089
     components:
     - type: Transform
@@ -18622,11 +18635,6 @@ entities:
     components:
     - type: Transform
       pos: -75.5,-76.5
-      parent: 2
-  - uid: 7111
-    components:
-    - type: Transform
-      pos: -73.5,-68.5
       parent: 2
   - uid: 7113
     components:
@@ -18712,11 +18720,6 @@ entities:
     components:
     - type: Transform
       pos: -63.5,-70.5
-      parent: 2
-  - uid: 7750
-    components:
-    - type: Transform
-      pos: -73.5,-71.5
       parent: 2
   - uid: 7912
     components:
@@ -19403,11 +19406,6 @@ entities:
     - type: Transform
       pos: -10.5,-45.5
       parent: 2
-  - uid: 8888
-    components:
-    - type: Transform
-      pos: -73.5,-70.5
-      parent: 2
   - uid: 8894
     components:
     - type: Transform
@@ -19473,25 +19471,10 @@ entities:
     - type: Transform
       pos: -10.5,-48.5
       parent: 2
-  - uid: 9242
-    components:
-    - type: Transform
-      pos: -74.5,-70.5
-      parent: 2
-  - uid: 9243
-    components:
-    - type: Transform
-      pos: -73.5,-67.5
-      parent: 2
   - uid: 9256
     components:
     - type: Transform
       pos: -60.5,-69.5
-      parent: 2
-  - uid: 9259
-    components:
-    - type: Transform
-      pos: -74.5,-68.5
       parent: 2
   - uid: 9347
     components:
@@ -19602,11 +19585,6 @@ entities:
     components:
     - type: Transform
       pos: -51.5,-66.5
-      parent: 2
-  - uid: 9455
-    components:
-    - type: Transform
-      pos: -74.5,-69.5
       parent: 2
   - uid: 9485
     components:
@@ -20247,11 +20225,6 @@ entities:
     components:
     - type: Transform
       pos: -16.5,-51.5
-      parent: 2
-  - uid: 15342
-    components:
-    - type: Transform
-      pos: -76.5,-70.5
       parent: 2
   - uid: 15590
     components:
@@ -20963,11 +20936,6 @@ entities:
     - type: Transform
       pos: -64.5,-73.5
       parent: 2
-  - uid: 16729
-    components:
-    - type: Transform
-      pos: -74.5,-67.5
-      parent: 2
   - uid: 16734
     components:
     - type: Transform
@@ -21013,11 +20981,6 @@ entities:
     - type: Transform
       pos: -61.5,-68.5
       parent: 2
-  - uid: 16781
-    components:
-    - type: Transform
-      pos: -75.5,-70.5
-      parent: 2
   - uid: 16782
     components:
     - type: Transform
@@ -21047,11 +21010,6 @@ entities:
     components:
     - type: Transform
       pos: -64.5,-72.5
-      parent: 2
-  - uid: 16790
-    components:
-    - type: Transform
-      pos: -73.5,-69.5
       parent: 2
   - uid: 16791
     components:
@@ -21177,11 +21135,6 @@ entities:
     components:
     - type: Transform
       pos: -65.5,-67.5
-      parent: 2
-  - uid: 17544
-    components:
-    - type: Transform
-      pos: -71.5,-67.5
       parent: 2
   - uid: 17545
     components:
@@ -22400,11 +22353,6 @@ entities:
     - type: Transform
       pos: -74.5,-72.5
       parent: 2
-  - uid: 3686
-    components:
-    - type: Transform
-      pos: -75.5,-71.5
-      parent: 2
   - uid: 3699
     components:
     - type: Transform
@@ -22460,15 +22408,10 @@ entities:
     - type: Transform
       pos: -83.5,-70.5
       parent: 2
-  - uid: 3924
-    components:
-    - type: Transform
-      pos: -76.5,-71.5
-      parent: 2
   - uid: 3925
     components:
     - type: Transform
-      pos: -74.5,-71.5
+      pos: -73.5,-71.5
       parent: 2
   - uid: 3926
     components:
@@ -22610,11 +22553,6 @@ entities:
     - type: Transform
       pos: -83.5,-74.5
       parent: 2
-  - uid: 4764
-    components:
-    - type: Transform
-      pos: -75.5,-67.5
-      parent: 2
   - uid: 4804
     components:
     - type: Transform
@@ -22634,11 +22572,6 @@ entities:
     components:
     - type: Transform
       pos: -14.5,14.5
-      parent: 2
-  - uid: 5632
-    components:
-    - type: Transform
-      pos: -76.5,-69.5
       parent: 2
   - uid: 5970
     components:
@@ -22688,12 +22621,7 @@ entities:
   - uid: 6799
     components:
     - type: Transform
-      pos: -75.5,-68.5
-      parent: 2
-  - uid: 6846
-    components:
-    - type: Transform
-      pos: -75.5,-69.5
+      pos: -74.5,-71.5
       parent: 2
   - uid: 6908
     components:
@@ -22754,6 +22682,11 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-45.5
+      parent: 2
+  - uid: 7111
+    components:
+    - type: Transform
+      pos: -75.5,-71.5
       parent: 2
   - uid: 7176
     components:
@@ -23010,11 +22943,6 @@ entities:
     - type: Transform
       pos: -55.5,-68.5
       parent: 2
-  - uid: 9213
-    components:
-    - type: Transform
-      pos: -76.5,-67.5
-      parent: 2
   - uid: 9216
     components:
     - type: Transform
@@ -23024,6 +22952,11 @@ entities:
     components:
     - type: Transform
       pos: -109.5,-38.5
+      parent: 2
+  - uid: 9259
+    components:
+    - type: Transform
+      pos: -76.5,-71.5
       parent: 2
   - uid: 9295
     components:
@@ -23179,11 +23112,6 @@ entities:
     components:
     - type: Transform
       pos: -52.5,-68.5
-      parent: 2
-  - uid: 13572
-    components:
-    - type: Transform
-      pos: -71.5,-68.5
       parent: 2
   - uid: 13660
     components:
@@ -23344,11 +23272,6 @@ entities:
     components:
     - type: Transform
       pos: -22.5,-64.5
-      parent: 2
-  - uid: 16219
-    components:
-    - type: Transform
-      pos: -71.5,-69.5
       parent: 2
   - uid: 16230
     components:
@@ -24860,6 +24783,11 @@ entities:
     - type: Transform
       pos: -55.504875,-37.181557
       parent: 2
+  - uid: 26759
+    components:
+    - type: Transform
+      pos: -75.6196,-69.35985
+      parent: 2
 - proto: BarSignComboCafe
   entities:
   - uid: 9228
@@ -24900,18 +24828,6 @@ entities:
     components:
     - type: Transform
       pos: -118.34879,31.563398
-      parent: 2
-- proto: BaseChemistryEmptyVial
-  entities:
-  - uid: 881
-    components:
-    - type: Transform
-      pos: -94.74149,-71.37663
-      parent: 2
-  - uid: 2159
-    components:
-    - type: Transform
-      pos: -94.53837,-71.20476
       parent: 2
 - proto: BaseComputer
   entities:
@@ -64668,6 +64584,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -96.5,-40.5
       parent: 2
+  - uid: 6846
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -75.5,-68.5
+      parent: 2
   - uid: 9537
     components:
     - type: Transform
@@ -65312,6 +65234,18 @@ entities:
     - type: Transform
       pos: -36.404404,-30.261925
       parent: 2
+- proto: ChemistryEmptyVial
+  entities:
+  - uid: 881
+    components:
+    - type: Transform
+      pos: -94.74149,-71.37663
+      parent: 2
+  - uid: 2159
+    components:
+    - type: Transform
+      pos: -94.53837,-71.20476
+      parent: 2
 - proto: ChemistryHotplate
   entities:
   - uid: 3949
@@ -65377,10 +65311,85 @@ entities:
     - type: Transform
       pos: -62.51284,-4.350784
       parent: 2
+  - uid: 17544
+    components:
+    - type: Transform
+      pos: -73.16138,-68.62286
+      parent: 2
+  - uid: 18367
+    components:
+    - type: Transform
+      pos: -73.41138,-68.18536
+      parent: 2
   - uid: 23445
     components:
     - type: Transform
       pos: -134.43372,-1.2921429
+      parent: 2
+  - uid: 26751
+    components:
+    - type: Transform
+      pos: -73.38013,-68.93536
+      parent: 2
+  - uid: 26754
+    components:
+    - type: Transform
+      pos: -73.69263,-68.88849
+      parent: 2
+  - uid: 26755
+    components:
+    - type: Transform
+      pos: -73.47388,-68.68536
+      parent: 2
+  - uid: 26756
+    components:
+    - type: Transform
+      pos: -73.7395,-68.60724
+      parent: 2
+  - uid: 26763
+    components:
+    - type: Transform
+      pos: -73.70825,-68.18536
+      parent: 2
+  - uid: 26764
+    components:
+    - type: Transform
+      pos: -73.28638,-68.12286
+      parent: 2
+  - uid: 26765
+    components:
+    - type: Transform
+      pos: -73.47388,-68.60724
+      parent: 2
+  - uid: 26766
+    components:
+    - type: Transform
+      pos: -73.427,-68.43536
+      parent: 2
+  - uid: 26767
+    components:
+    - type: Transform
+      pos: -73.2395,-68.59161
+      parent: 2
+  - uid: 26768
+    components:
+    - type: Transform
+      pos: -73.52075,-68.81036
+      parent: 2
+  - uid: 26769
+    components:
+    - type: Transform
+      pos: -73.64575,-68.71661
+      parent: 2
+  - uid: 26770
+    components:
+    - type: Transform
+      pos: -73.6145,-68.21661
+      parent: 2
+  - uid: 26771
+    components:
+    - type: Transform
+      pos: -73.28638,-68.85724
       parent: 2
 - proto: CigarGoldCase
   entities:
@@ -68424,6 +68433,14 @@ entities:
     - type: Transform
       pos: -64.5,-63.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 16449
     components:
     - type: Transform
@@ -68471,6 +68488,26 @@ entities:
     - type: Transform
       pos: -95.5,33.5
       parent: 2
+  - uid: 22112
+    components:
+    - type: Transform
+      pos: -73.5,-69.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 26403
+          - 26747
+          - 26748
+          - 26749
+          - 26750
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
   - uid: 24495
     components:
     - type: Transform
@@ -68480,11 +68517,6 @@ entities:
     components:
     - type: Transform
       pos: -134.5,15.5
-      parent: 2
-  - uid: 26403
-    components:
-    - type: Transform
-      pos: -64.5,-62.5
       parent: 2
 - proto: CrateMaterialGlass
   entities:
@@ -68605,6 +68637,13 @@ entities:
     - type: Transform
       pos: -44.5,-58.5
       parent: 2
+- proto: CratePermaEscapeLights
+  entities:
+  - uid: 4764
+    components:
+    - type: Transform
+      pos: -74.5,-69.5
+      parent: 2
 - proto: CrateScienceSecure
   entities:
   - uid: 26444
@@ -68632,13 +68671,6 @@ entities:
     components:
     - type: Transform
       pos: -14.5,-2.5
-      parent: 2
-- proto: CrateServiceSecure
-  entities:
-  - uid: 18367
-    components:
-    - type: Transform
-      pos: -68.5,-20.5
       parent: 2
 - proto: CrateSurgery
   entities:
@@ -68680,6 +68712,13 @@ entities:
       name: Mothroach Grave Marker
     - type: Transform
       pos: -129.5,18.5
+      parent: 2
+- proto: CrayonBox
+  entities:
+  - uid: 26760
+    components:
+    - type: Transform
+      pos: -75.44469,-69.44472
       parent: 2
 - proto: Crematorium
   entities:
@@ -69767,6 +69806,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -119.5,-50.5
       parent: 2
+  - uid: 8481
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -93.5,8.5
+      parent: 2
   - uid: 8600
     components:
     - type: Transform
@@ -70404,6 +70449,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -101.5,-16.5
       parent: 2
+  - uid: 23221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -102.5,8.5
+      parent: 2
   - uid: 23321
     components:
     - type: Transform
@@ -70420,11 +70471,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-59.5
-      parent: 2
-  - uid: 25553
-    components:
-    - type: Transform
-      pos: -102.5,16.5
       parent: 2
 - proto: DisposalJunction
   entities:
@@ -70875,6 +70921,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -76.5,-56.5
+      parent: 2
+  - uid: 3393
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -94.5,8.5
       parent: 2
   - uid: 3706
     components:
@@ -71778,7 +71830,8 @@ entities:
   - uid: 7516
     components:
     - type: Transform
-      pos: -102.5,13.5
+      rot: -1.5707963267948966 rad
+      pos: -101.5,8.5
       parent: 2
   - uid: 7566
     components:
@@ -72499,10 +72552,10 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -126.5,-47.5
       parent: 2
-  - uid: 8481
+  - uid: 8543
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: -100.5,8.5
       parent: 2
   - uid: 8549
@@ -72541,8 +72594,8 @@ entities:
   - uid: 9088
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -101.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -97.5,8.5
       parent: 2
   - uid: 9152
     components:
@@ -72577,8 +72630,8 @@ entities:
   - uid: 9247
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -99.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -98.5,8.5
       parent: 2
   - uid: 9365
     components:
@@ -76009,16 +76062,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -66.5,-29.5
       parent: 2
-  - uid: 14832
-    components:
-    - type: Transform
-      pos: -102.5,11.5
-      parent: 2
-  - uid: 14839
-    components:
-    - type: Transform
-      pos: -102.5,10.5
-      parent: 2
   - uid: 14845
     components:
     - type: Transform
@@ -76141,7 +76184,8 @@ entities:
   - uid: 15241
     components:
     - type: Transform
-      pos: -102.5,12.5
+      rot: -1.5707963267948966 rad
+      pos: -95.5,8.5
       parent: 2
   - uid: 15242
     components:
@@ -76533,6 +76577,12 @@ entities:
     components:
     - type: Transform
       pos: -104.5,-21.5
+      parent: 2
+  - uid: 21766
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -96.5,8.5
       parent: 2
   - uid: 21783
     components:
@@ -77475,11 +77525,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -97.5,-10.5
       parent: 2
-  - uid: 23221
-    components:
-    - type: Transform
-      pos: -102.5,9.5
-      parent: 2
   - uid: 23244
     components:
     - type: Transform
@@ -77548,14 +77593,18 @@ entities:
   - uid: 24349
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -97.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -99.5,8.5
+      parent: 2
+  - uid: 24670
+    components:
+    - type: Transform
+      pos: -93.5,13.5
       parent: 2
   - uid: 24675
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -98.5,8.5
+      pos: -93.5,12.5
       parent: 2
   - uid: 24824
     components:
@@ -77611,15 +77660,20 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -72.5,-25.5
       parent: 2
+  - uid: 25553
+    components:
+    - type: Transform
+      pos: -93.5,11.5
+      parent: 2
   - uid: 26426
     components:
     - type: Transform
-      pos: -102.5,15.5
+      pos: -93.5,10.5
       parent: 2
   - uid: 26427
     components:
     - type: Transform
-      pos: -102.5,14.5
+      pos: -93.5,9.5
       parent: 2
 - proto: DisposalPipeBroken
   entities:
@@ -77630,15 +77684,6 @@ entities:
       parent: 2
 - proto: DisposalRouter
   entities:
-  - uid: 8543
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -102.5,8.5
-      parent: 2
-    - type: DisposalRouter
-      tags:
-      - Mail
   - uid: 14444
     components:
     - type: Transform
@@ -77741,8 +77786,7 @@ entities:
       parent: 2
     - type: DisposalRouter
       tags:
-      - Cargo
-      - Mail
+      - Supply
   - uid: 16901
     components:
     - type: Transform
@@ -78088,17 +78132,10 @@ entities:
     - type: Transform
       pos: -111.5,-14.5
       parent: 2
-  - uid: 24521
+  - uid: 24553
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -103.5,16.5
-      parent: 2
-  - uid: 24670
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -96.5,8.5
+      pos: -93.5,14.5
       parent: 2
 - proto: DisposalUnit
   entities:
@@ -78507,6 +78544,13 @@ entities:
     - type: Transform
       pos: -70.27978,-37.364647
       parent: 2
+- proto: DrinkBeerBottleFull
+  entities:
+  - uid: 26778
+    components:
+    - type: Transform
+      pos: -73.632675,-68.21034
+      parent: 2
 - proto: DrinkBeerCan
   entities:
   - uid: 2376
@@ -78523,6 +78567,22 @@ entities:
     components:
     - type: Transform
       pos: -129.38156,-28.58283
+      parent: 2
+- proto: DrinkBottleBeer
+  entities:
+  - uid: 26772
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -73.4895,-68.81036
+      parent: 2
+- proto: DrinkBottleGildlager
+  entities:
+  - uid: 26762
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -73.4321,-68.4536
       parent: 2
 - proto: DrinkBottleOfNothingFull
   entities:
@@ -79342,10 +79402,10 @@ entities:
     - type: Transform
       pos: -138.5,-7.5
       parent: 2
-  - uid: 21766
+  - uid: 24521
     components:
     - type: Transform
-      pos: -96.5,9.5
+      pos: -96.5,8.5
       parent: 2
   - uid: 26326
     components:
@@ -83579,6 +83639,25 @@ entities:
     - type: Transform
       pos: -92.49603,7.5641766
       parent: 2
+  - uid: 26774
+    components:
+    - type: Transform
+      pos: -76.39691,-68.49159
+      parent: 2
+    - type: HandheldLight
+      toggleActionEntity: 26775
+    - type: ContainerContainer
+      containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 26775
+    - type: ActionsContainer
 - proto: FlashlightSeclite
   entities:
   - uid: 5905
@@ -130365,13 +130444,6 @@ entities:
       parent: 2
 - proto: MailingUnit
   entities:
-  - uid: 3393
-    components:
-    - type: Transform
-      pos: -103.5,16.5
-      parent: 2
-    - type: MailingUnit
-      tag: Cargo
   - uid: 3680
     components:
     - type: Transform
@@ -130417,6 +130489,16 @@ entities:
     - type: Configuration
       config:
         tag: Science
+  - uid: 14839
+    components:
+    - type: Transform
+      pos: -93.5,14.5
+      parent: 2
+    - type: MailingUnit
+      tag: Supply
+    - type: Configuration
+      config:
+        tag: Supply
   - uid: 15286
     components:
     - type: Transform
@@ -130452,13 +130534,6 @@ entities:
     - type: Configuration
       config:
         tag: Security
-  - uid: 24553
-    components:
-    - type: Transform
-      pos: -96.5,8.5
-      parent: 2
-    - type: MailingUnit
-      tag: Mail
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 20643
@@ -130532,6 +130607,23 @@ entities:
     - type: Transform
       pos: -138.5,24.5
       parent: 2
+- proto: Matchbox
+  entities:
+  - uid: 26777
+    components:
+    - type: Transform
+      pos: -76.28844,-68.31972
+      parent: 2
+- proto: MaterialCardboard
+  entities:
+  - uid: 26747
+    components:
+    - type: Transform
+      parent: 22112
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 22112
 - proto: MaterialCloth
   entities:
   - uid: 9130
@@ -130539,6 +130631,14 @@ entities:
     - type: Transform
       pos: -52.435898,-61.550594
       parent: 2
+  - uid: 26748
+    components:
+    - type: Transform
+      parent: 22112
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 22112
 - proto: MaterialWoodPlank
   entities:
   - uid: 22391
@@ -130546,6 +130646,14 @@ entities:
     - type: Transform
       pos: -8.5,-31.5
       parent: 2
+  - uid: 26750
+    components:
+    - type: Transform
+      parent: 22112
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 22112
 - proto: MaterialWoodPlank10
   entities:
   - uid: 22077
@@ -130874,6 +130982,13 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -69.5,-23.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 26757
+    components:
+    - type: Transform
+      pos: -75.5,-67.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -131889,6 +132004,11 @@ entities:
     components:
     - type: Transform
       pos: -100.5,-20.5
+      parent: 2
+  - uid: 26761
+    components:
+    - type: Transform
+      pos: -75.5,-69.5
       parent: 2
 - proto: PaperBin5
   entities:
@@ -133345,6 +133465,11 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-10.5
+      parent: 2
+  - uid: 14832
+    components:
+    - type: Transform
+      pos: -103.5,16.5
       parent: 2
   - uid: 18575
     components:
@@ -136311,6 +136436,18 @@ entities:
     - type: Transform
       pos: -98.5,11.5
       parent: 2
+  - uid: 26752
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -74.5,-69.5
+      parent: 2
+  - uid: 26753
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -73.5,-66.5
+      parent: 2
 - proto: PoweredStrobeLightEmpty
   entities:
   - uid: 3985
@@ -137420,10 +137557,10 @@ entities:
     - type: Transform
       pos: -134.5,32.5
       parent: 2
-  - uid: 6261
+  - uid: 3686
     components:
     - type: Transform
-      pos: -76.5,-68.5
+      pos: -80.5,-71.5
       parent: 2
   - uid: 7473
     components:
@@ -137505,6 +137642,16 @@ entities:
     components:
     - type: Transform
       pos: -116.5,18.5
+      parent: 2
+  - uid: 26758
+    components:
+    - type: Transform
+      pos: -73.5,-70.5
+      parent: 2
+  - uid: 26776
+    components:
+    - type: Transform
+      pos: -76.5,-67.5
       parent: 2
 - proto: RandomPosterContraband
   entities:
@@ -148215,12 +148362,7 @@ entities:
   - uid: 22110
     components:
     - type: Transform
-      pos: -64.5,-31.5
-      parent: 2
-  - uid: 22112
-    components:
-    - type: Transform
-      pos: -64.5,-33.5
+      pos: -75.5,-68.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
@@ -148348,6 +148490,26 @@ entities:
     - type: Transform
       pos: -72.21315,-18.151472
       parent: 2
+- proto: SprayPainter
+  entities:
+  - uid: 26403
+    components:
+    - type: Transform
+      parent: 22112
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 22112
+- proto: SprayPainterAmmo
+  entities:
+  - uid: 26749
+    components:
+    - type: Transform
+      parent: 22112
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 22112
 - proto: StairDark
   entities:
   - uid: 3867
@@ -148483,6 +148645,13 @@ entities:
       parent: 2
 - proto: StationMap
   entities:
+  - uid: 7750
+    components:
+    - type: Transform
+      pos: -73.5,-67.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 11725
     components:
     - type: Transform
@@ -153513,6 +153682,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -66.5,-32.5
       parent: 2
+  - uid: 15342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -75.5,-69.5
+      parent: 2
   - uid: 15684
     components:
     - type: Transform
@@ -153529,6 +153704,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -77.5,-33.5
+      parent: 2
+  - uid: 16219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -76.5,-68.5
       parent: 2
   - uid: 16506
     components:
@@ -154101,6 +154282,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -46.5,-2.5
+      parent: 2
+- proto: ToolboxArtisticFilled
+  entities:
+  - uid: 26773
+    components:
+    - type: Transform
+      pos: -76.47504,-68.19472
       parent: 2
 - proto: ToolboxElectrical
   entities:
@@ -168184,6 +168372,11 @@ entities:
     - type: Transform
       pos: -71.5,-78.5
       parent: 2
+  - uid: 3725
+    components:
+    - type: Transform
+      pos: -71.5,-69.5
+      parent: 2
   - uid: 3727
     components:
     - type: Transform
@@ -168243,6 +168436,12 @@ entities:
     components:
     - type: Transform
       pos: -71.5,-33.5
+      parent: 2
+  - uid: 3924
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -73.5,-70.5
       parent: 2
   - uid: 3945
     components:
@@ -168314,10 +168513,21 @@ entities:
     - type: Transform
       pos: -96.5,26.5
       parent: 2
+  - uid: 6261
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -76.5,-70.5
+      parent: 2
   - uid: 6886
     components:
     - type: Transform
       pos: -75.5,-58.5
+      parent: 2
+  - uid: 7078
+    components:
+    - type: Transform
+      pos: -73.5,-67.5
       parent: 2
   - uid: 7084
     components:
@@ -168749,6 +168959,12 @@ entities:
     - type: Transform
       pos: -20.5,-46.5
       parent: 2
+  - uid: 8888
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -74.5,-70.5
+      parent: 2
   - uid: 8926
     components:
     - type: Transform
@@ -168833,6 +169049,23 @@ entities:
     components:
     - type: Transform
       pos: -20.5,-43.5
+      parent: 2
+  - uid: 9213
+    components:
+    - type: Transform
+      pos: -71.5,-68.5
+      parent: 2
+  - uid: 9242
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -76.5,-69.5
+      parent: 2
+  - uid: 9243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -75.5,-70.5
       parent: 2
   - uid: 9271
     components:
@@ -168933,6 +169166,11 @@ entities:
     components:
     - type: Transform
       pos: -100.5,3.5
+      parent: 2
+  - uid: 9455
+    components:
+    - type: Transform
+      pos: -75.5,-67.5
       parent: 2
   - uid: 9463
     components:
@@ -170501,10 +170739,26 @@ entities:
     - type: Transform
       pos: -68.5,-61.5
       parent: 2
+  - uid: 16729
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -76.5,-67.5
+      parent: 2
   - uid: 16733
     components:
     - type: Transform
       pos: -65.5,-17.5
+      parent: 2
+  - uid: 16781
+    components:
+    - type: Transform
+      pos: -71.5,-67.5
+      parent: 2
+  - uid: 16790
+    components:
+    - type: Transform
+      pos: -72.5,-67.5
       parent: 2
   - uid: 16799
     components:
@@ -172211,7 +172465,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -232811.05
+      secondsUntilStateChange: -234242.84
       state: Opening
     - type: Airlock
       autoClose: False
@@ -173117,6 +173371,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -90.5,-24.5
+      parent: 2
+  - uid: 5632
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -76.5,-68.5
       parent: 2
   - uid: 5727
     components:

--- a/Resources/Maps/_Impstation/train.yml
+++ b/Resources/Maps/_Impstation/train.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/21/2026 01:05:53
-  entityCount: 20061
+  time: 05/20/2026 01:48:16
+  entityCount: 20053
 maps:
 - 1
 grids:
@@ -11878,28 +11878,12 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: ArtistCircuitBoard
-  entities:
-  - uid: 503
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.51749,-305.3535
-      parent: 2
 - proto: Ashtray
   entities:
   - uid: 19462
     components:
     - type: Transform
       pos: 12.836552,-211.53426
-      parent: 2
-- proto: AsimovCircuitBoard
-  entities:
-  - uid: 504
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.189365,-305.33786
       parent: 2
 - proto: AsteroidRock
   entities:
@@ -42308,14 +42292,6 @@ entities:
     - type: Transform
       pos: -15.5,-75.5
       parent: 2
-- proto: CommandmentCircuitBoard
-  entities:
-  - uid: 5617
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.126865,-309.5439
-      parent: 2
 - proto: CommsComputerCircuitboard
   entities:
   - uid: 13026
@@ -42914,14 +42890,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-254.5
-      parent: 2
-- proto: CorporateCircuitBoard
-  entities:
-  - uid: 5685
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.626865,-305.55676
       parent: 2
 - proto: CowToolboxFilled
   entities:
@@ -57563,14 +57531,6 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: GameMasterCircuitBoard
-  entities:
-  - uid: 7302
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.11124,-305.4942
-      parent: 2
 - proto: GasAnalyzer
   entities:
   - uid: 18624
@@ -90699,6 +90659,13 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: LawVend
+  entities:
+  - uid: 11696
+    components:
+    - type: Transform
+      pos: 21.5,-309.5
+      parent: 2
 - proto: LeavesCannabis
   entities:
   - uid: 11691
@@ -90724,14 +90691,6 @@ entities:
     components:
     - type: Transform
       pos: -13.643399,-246.28522
-      parent: 2
-- proto: LiveLetLiveCircuitBoard
-  entities:
-  - uid: 11696
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.07999,-305.6193
       parent: 2
 - proto: LockableButtonAtmospherics
   entities:
@@ -93003,14 +92962,6 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: NTDefaultCircuitBoard
-  entities:
-  - uid: 11975
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.689365,-305.32224
-      parent: 2
 - proto: NuclearBomb
   entities:
   - uid: 11976
@@ -93025,14 +92976,6 @@ entities:
     components:
     - type: Transform
       pos: 5.5,-66.5
-      parent: 2
-- proto: NutimovCircuitBoard
-  entities:
-  - uid: 11978
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.658115,-305.41605
       parent: 2
 - proto: OperatingTable
   entities:
@@ -93136,14 +93079,6 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: PaladinCircuitBoard
-  entities:
-  - uid: 11995
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.51749,-309.41882
-      parent: 2
 - proto: Paper
   entities:
   - uid: 5342
@@ -94088,6 +94023,20 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: PottedPlant11
+  entities:
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 22.5,-305.5
+      parent: 2
+- proto: PottedPlant15
+  entities:
+  - uid: 5617
+    components:
+    - type: Transform
+      pos: 22.5,-309.5
+      parent: 2
 - proto: PottedPlant7
   entities:
   - uid: 15990
@@ -101537,14 +101486,6 @@ entities:
     - type: Transform
       pos: 5.6054945,-335.5165
       parent: 2
-- proto: RobocopCircuitBoard
-  entities:
-  - uid: 13334
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.564365,-309.57516
-      parent: 2
 - proto: RollerBedSpawnFolded
   entities:
   - uid: 8641
@@ -105242,13 +105183,6 @@ entities:
     - type: Transform
       pos: 5.5,-304.5
       parent: 2
-- proto: SpawnPointAdminAssistant
-  entities:
-  - uid: 18996
-    components:
-    - type: Transform
-      pos: 6.5,-5.5
-      parent: 2
 - proto: SpawnPointAtmos
   entities:
   - uid: 13754
@@ -105306,10 +105240,10 @@ entities:
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 13761
+  - uid: 7302
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      pos: 6.5,-5.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
@@ -106005,14 +105939,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-263.5
-      parent: 2
-- proto: StationEfficiencyCircuitBoard
-  entities:
-  - uid: 13847
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.001865,-309.41882
       parent: 2
 - proto: StationMap
   entities:
@@ -109141,11 +109067,6 @@ entities:
     - type: Transform
       pos: 21.5,-299.5
       parent: 2
-  - uid: 14234
-    components:
-    - type: Transform
-      pos: 21.5,-309.5
-      parent: 2
   - uid: 14235
     components:
     - type: Transform
@@ -110187,6 +110108,11 @@ entities:
     - type: Transform
       pos: 6.5066996,-115.193634
       parent: 2
+  - uid: 13761
+    components:
+    - type: Transform
+      pos: 23.522459,-305.48752
+      parent: 2
   - uid: 14370
     components:
     - type: Transform
@@ -110260,6 +110186,11 @@ entities:
       parent: 2
 - proto: ToolboxMechanicalFilled
   entities:
+  - uid: 5685
+    components:
+    - type: Transform
+      pos: 23.459959,-305.2844
+      parent: 2
   - uid: 10070
     components:
     - type: Transform
@@ -127889,74 +127820,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 16.5,-156.5
       parent: 2
-  - uid: 17260
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-309.5
-      parent: 2
-  - uid: 17261
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-309.5
-      parent: 2
-  - uid: 17262
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-309.5
-      parent: 2
-  - uid: 17263
-    components:
-    - type: Transform
-      pos: 22.5,-305.5
-      parent: 2
-  - uid: 17264
-    components:
-    - type: Transform
-      pos: 23.5,-305.5
-      parent: 2
-  - uid: 17265
-    components:
-    - type: Transform
-      pos: 21.5,-305.5
-      parent: 2
-  - uid: 17267
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-309.5
-      parent: 2
-  - uid: 17268
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,-309.5
-      parent: 2
-  - uid: 17269
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-310.5
-      parent: 2
-  - uid: 17270
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-305.5
-      parent: 2
-  - uid: 17271
-    components:
-    - type: Transform
-      pos: 22.5,-304.5
-      parent: 2
-  - uid: 17272
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,-305.5
-      parent: 2
   - uid: 18626
     components:
     - type: Transform
@@ -127982,6 +127845,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-7.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 22.5,-305.5
       parent: 2
   - uid: 913
     components:
@@ -128067,6 +127935,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,-350.5
       parent: 2
+  - uid: 11975
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 23.5,-309.5
+      parent: 2
+  - uid: 11978
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-309.5
+      parent: 2
+  - uid: 11995
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-309.5
+      parent: 2
   - uid: 12056
     components:
     - type: Transform
@@ -128084,6 +127970,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-71.5
+      parent: 2
+  - uid: 13334
+    components:
+    - type: Transform
+      pos: 23.5,-305.5
       parent: 2
   - uid: 13392
     components:
@@ -128107,10 +127998,50 @@ entities:
     - type: Transform
       pos: -10.5,-189.5
       parent: 2
+  - uid: 13847
+    components:
+    - type: Transform
+      pos: 22.5,-304.5
+      parent: 2
+  - uid: 14234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-310.5
+      parent: 2
   - uid: 16854
     components:
     - type: Transform
       pos: 6.5,-210.5
+      parent: 2
+  - uid: 17260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-309.5
+      parent: 2
+  - uid: 17261
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-309.5
+      parent: 2
+  - uid: 17262
+    components:
+    - type: Transform
+      pos: 21.5,-305.5
+      parent: 2
+  - uid: 17263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-305.5
+      parent: 2
+  - uid: 17264
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-305.5
       parent: 2
   - uid: 17273
     components:

--- a/Resources/Maps/_Impstation/train.yml
+++ b/Resources/Maps/_Impstation/train.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/20/2026 01:48:16
-  entityCount: 20053
+  time: 05/20/2026 02:39:38
+  entityCount: 20054
 maps:
 - 1
 grids:
@@ -102480,6 +102480,15 @@ entities:
     - type: DeviceLinkSink
       invokeCounter: 2
     - type: ActiveSignalTimer
+    - type: Fixtures
+      fixtures: {}
+- proto: SignAnchor
+  entities:
+  - uid: 17265
+    components:
+    - type: Transform
+      pos: 19.5,-262.5
+      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: SignAnomaly

--- a/Resources/Prototypes/_Impstation/Maps/plasma.yml
+++ b/Resources/Prototypes/_Impstation/Maps/plasma.yml
@@ -18,7 +18,7 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_plasma.yml
         - type: StationJobs
-          availableJobs: #Total of 69 nice jobs roundstart, max of 85 inc. latejoins and trainees.
+          availableJobs: #Total of 70 jobs roundstart, max of 86 inc. latejoins and trainees.
             #command - 8
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
@@ -28,7 +28,7 @@
             HeadOfSecurity: [ 1, 1 ]
             HospitalityDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            # service - 17
+            # service - 18
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
@@ -39,6 +39,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
+            ServiceWorker: [ 1, 1 ]
             # engineering - 8-12
             AtmosphericTechnician: [ 4, 4 ]
             StationEngineer: [ 4, 4 ]


### PR DESCRIPTION
## About the PR
Amber, Bagel, Cog, Hummingbird, Marathon, Plasma, and Train have been updated to use the new station anchor sign.

Marathon, Plasma, and Train have been updated to use the lawvend instead of mapped law boards.

Hummingbird has been updated to fix a few duplicate carpets mapped on top of each other.

Plasma has been updated to include a spawn for Service Attendant, with 1 slot enabled. Cargo and Mail now also share a single mail unit to address an issue with mail being sent from cargo being spit back at itself.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- add: Marathon, Plasma, and Train now have a lawvend mapped in their AI core.
- add: Plasma now has one Service Attendant slot enabled on it.

