### PR TITLE
Allow IgniteOnBuckle to work with Impstation bonfires

### DIFF
--- a/Content.Server/Buckle/Systems/IgniteOnBuckleSystem.cs
+++ b/Content.Server/Buckle/Systems/IgniteOnBuckleSystem.cs
@@ -28,6 +28,7 @@ public sealed class IgniteOnBuckleSystem : EntitySystem
         comp.FireStacks = ent.Comp.FireStacks;
         comp.MaxFireStacks = ent.Comp.MaxFireStacks;
         comp.IgniteTime = ent.Comp.IgniteTime;
+        comp.Strap = args.Strap; // Imp
     }
 
     private void ActiveOnInit(Entity<ActiveIgniteOnBuckleComponent> ent, ref MapInitEvent args)
@@ -56,6 +57,9 @@ public sealed class IgniteOnBuckleSystem : EntitySystem
 
             igniteComponent.NextIgniteTime += TimeSpan.FromSeconds(igniteComponent.IgniteTime);
             Dirty(uid, igniteComponent);
+
+            if (TryComp<FlammableComponent>(igniteComponent.Strap, out var flammable) && !flammable.OnFire) // Imp, check if strap is a flammable object and is on fire
+                continue;
 
             if (flammableComponent.FireStacks > igniteComponent.MaxFireStacks)
                 continue;

--- a/Content.Server/Buckle/Systems/IgniteOnBuckleSystem.cs
+++ b/Content.Server/Buckle/Systems/IgniteOnBuckleSystem.cs
@@ -58,7 +58,7 @@ public sealed class IgniteOnBuckleSystem : EntitySystem
             igniteComponent.NextIgniteTime += TimeSpan.FromSeconds(igniteComponent.IgniteTime);
             Dirty(uid, igniteComponent);
 
-            if (TryComp<FlammableComponent>(igniteComponent.Strap, out var flammable) && !flammable.OnFire) // Imp, check if strap is a flammable object and is on fire
+            if (TryComp<FlammableComponent>(igniteComponent.Strap, out var sourceFlammableComponent) && !sourceFlammableComponent.OnFire) // Imp, check if strap is a flammable object and is on fire
                 continue;
 
             if (flammableComponent.FireStacks > igniteComponent.MaxFireStacks)

--- a/Content.Shared/Buckle/Components/ActiveIgniteOnBuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/ActiveIgniteOnBuckleComponent.cs
@@ -38,4 +38,11 @@ public sealed partial class ActiveIgniteOnBuckleComponent : Component
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField, AutoNetworkedField]
     public TimeSpan NextIgniteTime = TimeSpan.Zero;
+
+    /// <summary>
+    /// Imp.
+    /// The source that the target is buckled to.
+    /// </summary>
+    [DataField]
+    public EntityUid Strap;
 }

--- a/Content.Shared/Buckle/Components/ActiveIgniteOnBuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/ActiveIgniteOnBuckleComponent.cs
@@ -43,6 +43,6 @@ public sealed partial class ActiveIgniteOnBuckleComponent : Component
     /// Imp.
     /// The source that the target is buckled to.
     /// </summary>
-    [DataField]
+    [ViewVariables(VVAccess.ReadOnly)]
     public EntityUid Strap;
 }

--- a/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
@@ -114,7 +114,7 @@
     position: Stand
     buckleOffset: "0, 0.4"
     buckleDoafterTime: 5
-  #- type: IgniteOnBuckle #imp edit, TODO: should be handled by Flammable from parent, but collision wonkiness prevents ignition on buckle, needs to be updated
+  - type: IgniteOnBuckle
   - type: Construction
     graph: Bonfire
     node: bonfireStake


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Disabled during upmerge due to not working with Impstation bonfires having flammability. Adds support to check the bonfire flammability.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Missed in upmerge.
## Technical details
<!-- Summary of code changes for easier review. -->
Same as about the PR. The check was added after the timer logic as it would rapidly light the person on fire since the time is stored and not updated while the strap is not on fire, meaning that once it was it would rapidly try to reach curTime by adding 1 second onto itself continuously. 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

https://github.com/user-attachments/assets/47fd212a-60a9-4e74-a0bc-78af6dd5a04c


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Bonfire with stake now works.