### PR TITLE
What if three fellas could declare War?

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -472,7 +472,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             if (TryComp<RuleGridsComponent>(uid, out var grids) && Transform(ev.DeclaratorEntity).MapID != grids.Map)
                 continue;
 
-            var newStatus = GetWarCondition(nukeops, ev.Status);
+            var newStatus = GetWarCondition(nukeops, ev.Status, ev.DeclaratorEntity.Comp.IgnorePopCheck); // Imp Edit: ignorePopCheck
             ev.Status = newStatus;
             if (newStatus == WarConditionStatus.WarReady)
             {
@@ -480,7 +480,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 var timeRemain = nukeops.WarNukieArriveDelay + Timing.CurTime;
                 ev.DeclaratorEntity.Comp.ShuttleDisabledTime = timeRemain;
 
-                DistributeExtraTc((uid, nukeops));
+                DistributeExtraTc((uid, nukeops), ev.DeclaratorEntity.Comp.GiftedTC); // Imp edit, added GiftedTC
             }
         }
     }
@@ -490,12 +490,12 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     /// <summary>
     ///     Returns conditions for war declaration
     /// </summary>
-    public WarConditionStatus GetWarCondition(NukeopsRuleComponent nukieRule, WarConditionStatus? oldStatus)
+    public WarConditionStatus GetWarCondition(NukeopsRuleComponent nukieRule, WarConditionStatus? oldStatus, bool ignorePopCheck = false) // Imp Edit: ignorePopCheck
     {
         if (!nukieRule.CanEnableWarOps)
             return WarConditionStatus.NoWarUnknown;
 
-        if (EntityQuery<NukeopsRoleComponent>().Count() < nukieRule.WarDeclarationMinOps)
+        if (EntityQuery<NukeopsRoleComponent>().Count() < nukieRule.WarDeclarationMinOps && !ignorePopCheck) // Imp Edit: ignorePopCheck
             return WarConditionStatus.NoWarSmallCrew;
 
         if (nukieRule.LeftOutpost)
@@ -507,7 +507,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         return WarConditionStatus.YesWar;
     }
 
-    private void DistributeExtraTc(Entity<NukeopsRuleComponent> nukieRule)
+    private void DistributeExtraTc(Entity<NukeopsRuleComponent> nukieRule, int bonusTC) // Imp edit, added GiftedTC
     {
         var enumerator = EntityQueryEnumerator<StoreComponent>();
         while (enumerator.MoveNext(out var uid, out var component))
@@ -521,7 +521,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             if (Transform(uid).MapID != Transform(outpost).MapID) // Will receive bonus TC only on their start outpost
                 continue;
 
-            _store.TryAddCurrency(new() { { TelecrystalCurrencyPrototype, nukieRule.Comp.WarTcAmountPerNukie } }, uid, component);
+            _store.TryAddCurrency(new() { { TelecrystalCurrencyPrototype, bonusTC } }, uid, component);
 
             var msg = Loc.GetString("store-currency-war-boost-given", ("target", uid));
             _popupSystem.PopupEntity(msg, uid);

--- a/Content.Server/NukeOps/WarDeclaratorComponent.cs
+++ b/Content.Server/NukeOps/WarDeclaratorComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.GameTicking.Rules;
+using Content.Server.GameTicking.Rules;
 using Content.Shared.NukeOps;
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -60,6 +60,20 @@ public sealed partial class WarDeclaratorComponent : Component
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan ShuttleDisabledTime;
+
+    /// <summary>
+    /// How much TC declaring war will give
+    /// IMP
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int GiftedTC = 40;
+
+    /// <summary>
+    /// Do we ignore the check for if we can declare war at this pop?
+    /// IMP
+    /// </summary>
+    [DataField]
+    public bool IgnorePopCheck = false;
 
     [DataField]
     public WarConditionStatus? CurrentStatus;

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -97,6 +97,7 @@
     - NukieSpectralLocator # Imp special!!
   inhand:
   - NukeOpsDeclarationOfWar
+  - NukeOpsMiniDeclarationOfWar
 
 - type: chameleonOutfit
   id: NukeopsCommanderOutfit

--- a/Resources/Prototypes/_Impstation/Objects/Devices/Syndicate_gadgets/war_declarator.yml
+++ b/Resources/Prototypes/_Impstation/Objects/Devices/Syndicate_gadgets/war_declarator.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: NukeOpsDeclarationOfWar
+  id: NukeOpsMiniDeclarationOfWar
+  name: miniature war declarator
+  description: Use to send a declaration of hostilities to the target, delaying your shuttle departure while they prepare for your assault. Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a mild amount of bonus telecrystals. Must be used at start of mission, or your benefactors will lose interest.
+  components:
+    - type: WarDeclarator
+      message: war-declarator-default-message
+      giftedTC: 20
+      ignorePopCheck: true


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

Introducing the brand new Mini War Declarator! A War declarator that works no matter your team size! However it only gives each of you 20 TC rather than the normal 40 so you better be ready!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

If i get stuck into stealthops one more time i'm going to become a villain

Really though right now nukies at lowpop feel very pushed into stealth, they have the announcement console sure, but right now all that is is a hard mode button with no tradeoff and a significantly higher odds of losing.

On the opposite end, there's lots of rounds where people don't get to know it's nukies until the nuke arms or someone screams redshells on greens at which point everyone has to hastily prep. This does lead to fun crewside wins such as the legendary toolbox only victory, but a lot of the time it leads to rounds playing very similar to one another with the crew having to race the armoury and generally throw themselves at the operatives without any plan. It also has led to warops being more of a 30+ readied type of deal, which is a shame as warops is generally the gamemode where the crew gets to go wild and have fun.

## Technical details
<!-- Summary of code changes for easier review. -->

Moved the TC deciding over to the War Declarator rather than the Gamerule, allowing for admins to toy with the declarator

Admittedly there should be more of a work to split all this up as right now Nukie Commanders spawn with both declarators in hands due to how handing out gear in gamerules works (at least to my knowledge.) The regular declarator still respects playercount though so lowpop nukies can't do normal war

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl:
- add: Nuclear operatives crave more violence and as such have provided Commanders with a miniature war declarator for those smaller stations.
