### PR TITLE
disable content warning in debug builds

### DIFF
--- a/Content.Shared/_Funkystation/CCVars/CCVars.Funky.cs
+++ b/Content.Shared/_Funkystation/CCVars/CCVars.Funky.cs
@@ -9,11 +9,19 @@ namespace Content.Shared._Funkystation.CCVars;
 [CVarDefs]
 public sealed class CCVars_Funky
 {
+    // imp start. Automatically disable content warnings in debug builds.
+#if DEBUG 
+    private static bool _cwOnBuildType;
+#else
+    private static bool _cwOnBuildType = true;
+#endif
+    // imp end
+
     /// <summary>
     /// If the content warning should be displayed.
     /// </summary>
     public static readonly CVarDef<bool> ContentWarningDisplay =
-        CVarDef.Create("cw.display", true, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("cw.display", _cwOnBuildType, CVar.SERVER | CVar.REPLICATED); // imp. Automatically disable content warnings in debug builds.
 
     /// <summary>
     /// If ignoring the content warning should kick you from the server.


### PR DESCRIPTION
## About the PR
added a compiler conditional to disable content warnings in builds with the "DEBUG" flag.

## Why / Balance
if you're running a dev environment you have likely already played the game some. dont make sense to have the warning here. especially because it has a button that will close the client if you click wrong accidentally

## Technical details
slight modification to funky cw.display cvar. added debug compiler conditional to switch between false/true (debug/other).

i considered just removing the gameplay state from contentwarninguicontroller but idk if that would cause issues somewhere else, 
so this was easier. 

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->
