### PR TITLE
Fix artifact & advanced node scanner bugs

### DIFF
--- a/Content.Shared/Bed/Components/HealOnBuckleComponent.cs
+++ b/Content.Shared/Bed/Components/HealOnBuckleComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Bed.Components
         /// <summary>
         /// Damage to apply to entities that are strapped to this entity.
         /// </summary>
-        [DataField(required: true)]
+        [DataField(required: true), AutoNetworkedField] //IMP: AutoNetworkedField - fixes client nullreference with XAEApplyComponentsSystem
         public DamageSpecifier Damage = default!;
 
         /// <summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -522,11 +522,11 @@ public abstract partial class SharedXenoArtifactSystem
                 switch (Comp<AnalysisConsoleComponent>(biasComp.Provider).BiasDirection)
                 {
                     case BiasDirection.Shallow:
-                        if (successorNodes.Count > 0)
+                        if (predecessorNodes.Count > 0)
                             directNodes = predecessorNodes;
                         break;
                     default:
-                        if (predecessorNodes.Count > 0)
+                        if (successorNodes.Count > 0)
                             directNodes = successorNodes;
                         break;
                 }

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Actions;
 using Content.Shared.Popups;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
+using Content.Shared.Xenoarchaeology.Equipment.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
@@ -71,6 +72,11 @@ public abstract partial class SharedXenoArtifactSystem : EntitySystem
         Dirty(ent);
     }
 
+    /// <summary>
+    /// IMP!! Updates an artifacts knowledge of what advanced node scanner is (or that there isn't) linked to the artifact's pad.
+    /// </summary>
+    /// <param name="ent"> The artifact </param>
+    /// <param name="advancedNodeScanner"> the advanced node scanner entity, can be null</param>
     // IMP
     public void SetAdvancedNodeScanner(Entity<XenoArtifactComponent> ent, EntityUid? advancedNodeScanner)
     {

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEApplyComponentsSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEApplyComponentsSystem.cs
@@ -41,6 +41,7 @@ public sealed class XAEApplyComponentsSystem : BaseXAESystem<XAEApplyComponentsC
 
             var clone = EntityManager.ComponentFactory.GetComponent(registry.Value);
             AddComp(artifact, clone);
+            Dirty(artifact); //IMP: fix clients not knowing internal data of components (e.g healOnBuckle)
         }
     }
 }

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactAnalyzerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactAnalyzerSystem.cs
@@ -142,7 +142,7 @@ public abstract class SharedArtifactAnalyzerSystem : EntitySystem
             }
         }
 
-        if (HasComp<AdvancedNodeScannerComponent>(args.Source))
+        if (!TryComp<AdvancedNodeScannerComponent>(args.Source, out var ansComp))
         {
             ent.Comp.AdvancedNodeScanner = args.Source;
             Dirty(ent);
@@ -164,9 +164,12 @@ public abstract class SharedArtifactAnalyzerSystem : EntitySystem
 
     private void OnLinkAttemptAnalyzer(Entity<ArtifactAnalyzerComponent> ent, ref LinkAttemptEvent args)
     {
-        // IMP EDIT the if statement
-        if ((ent.Comp.Console != null && HasComp<AnalysisConsoleComponent>(args.Source)) || (ent.Comp.AdvancedNodeScanner != null && HasComp<AdvancedNodeScannerComponent>(args.Source)))
-            args.Cancel(); // can only link to one device of a type at a time
+        //IMP, bypass this cancel if linking to advanced node scanner
+        if (HasComp<AdvancedNodeScannerComponent>(args.Source))
+            return;
+
+        if (ent.Comp.Console != null)
+            args.Cancel(); // can only link to one console at a time
     }
 
     private void OnPortDisconnectedConsole(Entity<AnalysisConsoleComponent> ent, ref PortDisconnectedEvent args)
@@ -181,7 +184,7 @@ public abstract class SharedArtifactAnalyzerSystem : EntitySystem
 
     private void OnPortDisconnectedAnalyzer(Entity<ArtifactAnalyzerComponent> ent, ref PortDisconnectedEvent args)
     {
-        if (args.Port != ent.Comp.LinkingPort || ent.Comp.Console == null) //We'll handle the advanced node scanner case in SharedAdvancedNodeScannerSystem //IMP only the comment is imp
+        if (args.Port != ent.Comp.LinkingPort || ent.Comp.Console == null)
             return;
 
         ent.Comp.Console = null;

--- a/Content.Shared/_Impstation/Xenoarchaeology/Equipment/SharedAdvancedNodeScannerSystem.cs
+++ b/Content.Shared/_Impstation/Xenoarchaeology/Equipment/SharedAdvancedNodeScannerSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
@@ -15,6 +16,7 @@ namespace Content.Shared.Xenoarchaeology.Equipment;
 /// </summary>
 public abstract class SharedAdvancedNodeScannerSystem : EntitySystem
 {
+    [Dependency] private readonly SharedDeviceLinkSystem _linkSystem = default!;
     [Dependency] private readonly SharedPowerReceiverSystem _powerReceiver = default!;
     [Dependency] private readonly SharedXenoArtifactSystem _artifact = default!;
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
@@ -27,12 +29,23 @@ public abstract class SharedAdvancedNodeScannerSystem : EntitySystem
         SubscribeLocalEvent<AdvancedNodeScannerComponent, NewLinkEvent>(OnNewLink);
         SubscribeLocalEvent<AdvancedNodeScannerComponent, PortDisconnectedEvent>(OnPortDisconnected);
         SubscribeLocalEvent<AdvancedNodeScannerComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<AdvancedNodeScannerComponent, LinkAttemptEvent>(OnLinkAttempt);
+
         SubscribeLocalEvent<XenoArtifactComponent, ArtifactUnlockingFinishedEvent>(OnUnlockingFinished);
     }
 
     private void OnMapInit(EntityUid uid, AdvancedNodeScannerComponent comp, MapInitEvent args)
     {
-        UpdateANSLinkAppearance((uid, comp), comp.AnalyzerEntity is not null);
+        UpdateAdvancedNodeScannerLinkAppearance((uid, comp), comp.AnalyzerEntity is not null);
+    }
+
+    /// <summary>
+    /// Can only connect advanced node scanner to the artifact analyzer!
+    /// </summary>
+    private void OnLinkAttempt(EntityUid uid, AdvancedNodeScannerComponent comp, LinkAttemptEvent args)
+    {
+        if (!HasComp<ArtifactAnalyzerComponent>(args.Sink))
+            args.Cancel();
     }
 
     /// <summary>
@@ -40,35 +53,64 @@ public abstract class SharedAdvancedNodeScannerSystem : EntitySystem
     /// the analyzer's knowledge of the advanced node scanner,
     /// the artifact ON the analyzer pad's knowledge of the advanced node scanner
     /// and turns on the "linked light".
-    /// The console is handled in the Analyzer's side of things
     /// </summary>
     private void OnNewLink(Entity<AdvancedNodeScannerComponent> ent, ref NewLinkEvent args)
     {
         if (!TryComp<ArtifactAnalyzerComponent>(args.Sink, out var analyzer))
             return;
 
-        ent.Comp.AnalyzerEntity = args.Sink;
-        analyzer.AdvancedNodeScanner = ent;
-
-        // Turn the 'linked' light on
-        UpdateANSLinkAppearance(ent, true);
-
-        if (analyzer.CurrentArtifact is { } artifact && TryComp<XenoArtifactComponent>(artifact, out var artifactComp))
+        // Make previously linked analyzer (if any) forget
+        if (ent.Comp.AnalyzerEntity != null && ent.Comp.AnalyzerEntity != args.Sink)
         {
-            _artifact.SetAdvancedNodeScanner((artifact, artifactComp), ent.Owner);
-            Dirty(artifact, artifactComp);
+            _linkSystem.RemoveSinkFromSource(ent.Owner, ent.Comp.AnalyzerEntity.Value);
         }
 
-        Dirty(args.Sink, analyzer);
+        // If the new analyzer is currently connected to another A.N.S, no it isn't
+        if (analyzer.AdvancedNodeScanner != null && analyzer.AdvancedNodeScanner != ent)
+        {
+            _linkSystem.RemoveSinkFromSource(analyzer.AdvancedNodeScanner.Value, args.Sink);
+        }
+
+        ent.Comp.AnalyzerEntity = args.Sink;
+        UpdateAdvancedNodeScannerLinkChains((args.Sink, analyzer), ent);
+
+        // Turn the 'linked' light on
+        UpdateAdvancedNodeScannerLinkAppearance(ent, true);
+
         Dirty(ent);
     }
 
     /// <summary>
-    /// erases the advanced node scanner's knowledge of the analyzer it is unlinking from,
-    /// the analyzer's knowledge of the advanced node scanner,
-    /// the artifact ON the analyzer pad's knowledge of the advanced node scanner
-    /// and turns off the "linked light"
-    /// We also clear the analysis console's knowledge of advanced node scanner.
+    /// Helper function to provide analyzer, console, and artifact with Advanced Node Scanner info, including null.
+    /// </summary>
+    private void UpdateAdvancedNodeScannerLinkChains(Entity<ArtifactAnalyzerComponent> analyzer,
+        Entity<AdvancedNodeScannerComponent>? ans)
+    {
+        // Analyzer
+        analyzer.Comp.AdvancedNodeScanner = ans;
+        Dirty(analyzer);
+
+        // artifact
+        if (analyzer.Comp.CurrentArtifact is { } artifact && TryComp<XenoArtifactComponent>(artifact, out var artifactComp))
+        {
+            _artifact.SetAdvancedNodeScanner((artifact, artifactComp), ans);
+            Dirty(artifact, artifactComp);
+        }
+
+        // console
+        if (analyzer.Comp.Console is { } console && TryComp<AnalysisConsoleComponent>(console, out var consoleComp))
+        {
+            consoleComp.AdvancedNodeScanner = ans;
+            Dirty(console, consoleComp);
+        }
+    }
+
+    /// <summary>
+    /// erases the advanced node scanner's knowledge of the analyzer it is unlinking from
+    /// 1. the analyzer's knowledge of the advanced node scanner
+    /// 2. the artifact ON the analyzer pad's knowledge of the advanced node scanner
+    /// 3.and turns off the "linked light"
+    /// 4. We also clear the analysis console's knowledge of advanced node scanner
     /// </summary>
     private void OnPortDisconnected(Entity<AdvancedNodeScannerComponent> ent, ref PortDisconnectedEvent args)
     {
@@ -77,23 +119,10 @@ public abstract class SharedAdvancedNodeScannerSystem : EntitySystem
 
         if (TryComp<ArtifactAnalyzerComponent>(analyzerEntity, out var analyzer))
         {
-            analyzer.AdvancedNodeScanner = null;
-            Dirty(analyzerEntity, analyzer);
-
-            if (analyzer.Console is { } console && TryComp<AnalysisConsoleComponent>(analyzer.Console, out var analysisConsoleComponent))
-            {
-                analysisConsoleComponent.AdvancedNodeScanner = null;
-                Dirty(console, analysisConsoleComponent);
-            }
-
-            if (analyzer.CurrentArtifact is { } artifact && TryComp<XenoArtifactComponent>(artifact, out var artifactComp))
-            {
-                _artifact.SetAdvancedNodeScanner((artifact, artifactComp), null);
-                Dirty(artifact, artifactComp);
-            }
+            UpdateAdvancedNodeScannerLinkChains((analyzerEntity, analyzer), null);
         }
         // Turn the 'linked' light off
-        UpdateANSLinkAppearance(ent, false);
+        UpdateAdvancedNodeScannerLinkAppearance(ent, false);
 
         ent.Comp.AnalyzerEntity = null;
         Dirty(ent);
@@ -102,7 +131,7 @@ public abstract class SharedAdvancedNodeScannerSystem : EntitySystem
     /// <summary>
     /// Updates the appearance of the advanced node scanner - turns the 'linked' light on or off.
     /// </summary>
-    private void UpdateANSLinkAppearance(Entity<AdvancedNodeScannerComponent> ent, bool linked)
+    private void UpdateAdvancedNodeScannerLinkAppearance(Entity<AdvancedNodeScannerComponent> ent, bool linked)
     {
         if (!TryComp<AppearanceComponent>(ent.Owner, out var appearance))
             return;

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -432,7 +432,7 @@
       - !type:XenoArchDepthCondition # imp addition
         depths: [ 3, 4, 5 ]
     - id: XenoArtifactBed
-      weight: 15.0 # imp edit
+      weight: 10.0 # imp edit
       conditions:
       - !type:XenoArchDepthCondition # imp addition
         depths: [ 1, 2, 3 ]


### PR DESCRIPTION
## About the PR
Fixed client errors when sleeping in artifact bed.
Fix issues when linking advanced node scanner to 2nd analyzer, or analyzer to 2nd advanced node scanner. Now they are jealous!

## Why / Balance
Bugfixes

## Technical details
Artifact bed issue => Client error, dirtied the component & added autonetworkfield to the damage specifier
Advanced node scanner => Reworked how they link slightly, moved most A.N.S linking stuff to SharedAdvancedNodeScannerSystem. New links cause the linked analyzer's previous link to die, and linked A.N.S's previous link to die.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- fix: Fixed client errors when sleeping in artifact bed.
- fix: Fix issues when linking advanced node scanner to 2nd analyzer, or analyzer to 2nd advanced node scanner. Now they are jealous