### PR TITLE
Fix pipe wrenching stacking delays

### DIFF
--- a/Content.Shared/Construction/Components/AnchorableComponent.cs
+++ b/Content.Shared/Construction/Components/AnchorableComponent.cs
@@ -33,6 +33,7 @@ namespace Content.Shared.Construction.Components
         /// Currently only used for AtmosUnsafeAnchorSystem
         /// </remarks>
         [DataField]
+        [ViewVariables(VVAccess.ReadOnly)]
         public float AdditionalDelay = 0f;
         // IMP ADD END
     }

--- a/Content.Shared/Construction/Components/AnchorableComponent.cs
+++ b/Content.Shared/Construction/Components/AnchorableComponent.cs
@@ -32,7 +32,6 @@ namespace Content.Shared.Construction.Components
         /// <remarks>
         /// Currently only used for AtmosUnsafeAnchorSystem
         /// </remarks>
-        [DataField]
         [ViewVariables(VVAccess.ReadOnly)]
         public float AdditionalDelay = 0f;
         // IMP ADD END

--- a/Content.Shared/Construction/Components/AnchorableComponent.cs
+++ b/Content.Shared/Construction/Components/AnchorableComponent.cs
@@ -24,6 +24,17 @@ namespace Content.Shared.Construction.Components
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField]
         public float Delay = 1f;
+
+        // IMP ADD START
+        /// <summary>
+        /// Extra delay when anchoring or unanchoring. Resets to 0 when anchoring is complete or cancelled.
+        /// </summary>
+        /// <remarks>
+        /// Currently only used for AtmosUnsafeAnchorSystem
+        /// </remarks>
+        [DataField]
+        public float AdditionalDelay = 0f;
+        // IMP ADD END
     }
 
     [Flags]

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -284,7 +284,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         else
             RaiseLocalEvent(uid, (UnanchorAttemptEvent)attempt);
 
-        anchorable.AdditionalDelay += attempt.Delay; // imp: Add to AdditionalDelay instead of base Delay
+        anchorable.AdditionalDelay = attempt.Delay; // imp: Use AdditionalDelay instead of adding to base Delay
 
         return !attempt.Cancelled;
     }

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         // Log unanchor attempt (server only)
         _adminLogger.Add(LogType.Anchor, LogImpact.Low, $"{ToPrettyString(userUid):user} is trying to unanchor {ToPrettyString(uid):entity} from {transform.Coordinates:targetlocation}");
 
-        _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryUnanchorCompletedEvent());
+        _tool.UseTool(usingUid, userUid, uid, anchorable.Delay + anchorable.AdditionalDelay, usingTool.Qualities, new TryUnanchorCompletedEvent()); // imp: Add AdditionalDelay
     }
 
     private void OnInteractUsing(EntityUid uid, AnchorableComponent anchorable, InteractUsingEvent args)
@@ -116,6 +116,8 @@ public sealed partial class AnchorableSystem : EntitySystem
 
     private void OnUnanchorComplete(EntityUid uid, AnchorableComponent component, TryUnanchorCompletedEvent args)
     {
+        component.AdditionalDelay = 0f; // imp: Reset additional delay even if it's cancelled
+
         if (args.Cancelled || args.Used is not { } used)
             return;
 
@@ -136,6 +138,8 @@ public sealed partial class AnchorableSystem : EntitySystem
 
     private void OnAnchorComplete(EntityUid uid, AnchorableComponent component, TryAnchorCompletedEvent args)
     {
+        component.AdditionalDelay = 0f; // imp: Reset additional delay even if it's cancelled
+
         if (args.Cancelled || args.Used is not { } used)
             return;
 
@@ -248,7 +252,7 @@ public sealed partial class AnchorableSystem : EntitySystem
             return;
         }
 
-        _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryAnchorCompletedEvent());
+        _tool.UseTool(usingUid, userUid, uid, anchorable.Delay + anchorable.AdditionalDelay, usingTool.Qualities, new TryAnchorCompletedEvent()); // imp: Add AdditionalDelay
     }
 
     private bool Valid(
@@ -280,7 +284,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         else
             RaiseLocalEvent(uid, (UnanchorAttemptEvent)attempt);
 
-        anchorable.Delay += attempt.Delay;
+        anchorable.AdditionalDelay += attempt.Delay; // imp: Add to AdditionalDelay instead of base Delay
 
         return !attempt.Cancelled;
     }

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -116,8 +116,6 @@ public sealed partial class AnchorableSystem : EntitySystem
 
     private void OnUnanchorComplete(EntityUid uid, AnchorableComponent component, TryUnanchorCompletedEvent args)
     {
-        component.AdditionalDelay = 0f; // imp: Reset additional delay even if it's cancelled
-
         if (args.Cancelled || args.Used is not { } used)
             return;
 
@@ -138,8 +136,6 @@ public sealed partial class AnchorableSystem : EntitySystem
 
     private void OnAnchorComplete(EntityUid uid, AnchorableComponent component, TryAnchorCompletedEvent args)
     {
-        component.AdditionalDelay = 0f; // imp: Reset additional delay even if it's cancelled
-
         if (args.Cancelled || args.Used is not { } used)
             return;
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Attempting to unanchor pressurized pipes causes a warning to appear and adds a delay to the unanchoring doafter. However, every attempt adds to the delay and it stacks forever. This PR fixes the logic so that the additional delay is not "remembered" by the pipe forever.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It seems unintentional and is incredibly annoying. The only way I've found to get rid of the issue in gameplay is by welding the pipe and making a new one. 

## Technical details
<!-- Summary of code changes for easier review. -->
When a `BaseAnchoredAttemptEvent` is raised, the code can specify an additional `Delay` (this is only used in `AtmosUnsafeUnanchorSystem`). When the event is checked, `AnchorableComponent`'s base delay has the `BaseAnchoredAttemptEvent.Delay` added on with no concern of reverting it back to its original value. 

I've added an `AdditionalDelay` field to `AnchorableComponent`, which is modified instead of the base `Delay` field. When the code needs the total time required, the two are added together. When un/anchoring is complete or cancelled, `AdditionalDelay` is reset to 0.

I have no idea if this is a good implementation, but it works.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
Old behavior:

https://github.com/user-attachments/assets/ece8807e-2667-449f-8208-c708a79ba3c7

New behavior:

https://github.com/user-attachments/assets/f28bc916-5f94-4adb-96dd-d6e7548aecc7

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl:
- fix: Pressurized pipes no longer get harder to wrench the more you try.