### PR TITLE
replaced bug

### DIFF
--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/Packs/service.yml
@@ -207,7 +207,7 @@
   recipes:
   - BalloonSyn
   - FoamBlade
-  - PlushieBug
+  - PlushieImp
   - PlushieCaptain
   - PlushieGhost
   - PlushieGnomeChild

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/prizecounter.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/prizecounter.yml
@@ -258,11 +258,6 @@
 
 - type: latheRecipe
   parent: PrizeCounterPlushieExpensive
-  id: PlushieImp
-  result: PlushieImp
-
-- type: latheRecipe
-  parent: PrizeCounterPlushieExpensive
   id: PlushieCaptain
   result: PlushieCaptain
 

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/prizecounter.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/prizecounter.yml
@@ -258,8 +258,8 @@
 
 - type: latheRecipe
   parent: PrizeCounterPlushieExpensive
-  id: PlushieBug
-  result: PlushieBug
+  id: PlushieImp
+  result: PlushieImp
 
 - type: latheRecipe
   parent: PrizeCounterPlushieExpensive

--- a/Resources/migration_imp.yml
+++ b/Resources/migration_imp.yml
@@ -156,3 +156,7 @@ JermovCircuitBoard: null
 # 2026-03-19
 #removes painting "the sleeping gypsy"
 PaintingSleepingGypsy: RandomPainting
+
+# 2026-06-14
+# changed mapped bug plushies with imp plushies
+PlushieBug: PlushieImp


### PR DESCRIPTION
## About the PR
replaced all 'easily accesible' bugplushies with imp plushies, including those crafted in service lathes and prize counters, as well as added a migration to change them all with imp

## Why / Balance
i have to be honest. bugplush has been the conversation topic multiple times in discord channels having players constantly bicker about the "mascotability" of doop's bug in the game and as much as i love her, i do agree that we could stand to have a little less readily available bug. this pr replaces all 'easy access bugs' with the imp from impstation

this does not mean bug has been removed, she's still in prize ball + other plushie tables. she was simply reallocated to a nicer less wet cardboard box not in the rain

## Technical details
single-line id changes in service lathe bugs and added bug > mira in migration_imp

## Media
<img width="790" height="604" alt="image" src="https://github.com/user-attachments/assets/f480eee1-d2b8-4903-b7c5-b2a4e1d6f7c9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- tweak: CentComm has reportedly and arbitrarily thrown away all of the weird pink plushies for some weird stoner plushies.