### PR TITLE
allow usage of research disks on r&d computer

### DIFF
--- a/Content.Server/Research/Disk/ResearchDiskSystem.cs
+++ b/Content.Server/Research/Disk/ResearchDiskSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Research.Prototypes;
 using Content.Server.Research.Systems;
 using Content.Shared.Research.Components;
 using Robust.Shared.Prototypes;
+using Content.Server.Research.Components; // imp
 
 namespace Content.Server.Research.Disk
 {
@@ -24,6 +25,21 @@ namespace Content.Server.Research.Disk
         {
             if (!args.CanReach)
                 return;
+
+
+            // imp start
+            if (HasComp<ResearchConsoleComponent>(args.Target))
+            {
+                if (!_research.TryGetClientServer(args.Target.Value, out var serverEnt, out var clientServer))
+                    return;
+
+                _research.ModifyServerPoints(serverEnt.Value, component.Points, clientServer);
+                _popupSystem.PopupEntity(Loc.GetString("research-disk-inserted", ("points", component.Points)), args.Target.Value, args.User);
+                QueueDel(uid);
+                args.Handled = true;
+                return;
+            }
+            // imp end
 
             if (!TryComp<ResearchServerComponent>(args.Target, out var server))
                 return;

--- a/Content.Server/Research/Disk/ResearchDiskSystem.cs
+++ b/Content.Server/Research/Disk/ResearchDiskSystem.cs
@@ -6,6 +6,8 @@ using Content.Server.Research.Systems;
 using Content.Shared.Research.Components;
 using Robust.Shared.Prototypes;
 using Content.Server.Research.Components; // imp
+using Robust.Shared.Audio; // imp
+using Robust.Shared.Audio.Systems; // imp
 
 namespace Content.Server.Research.Disk
 {
@@ -14,6 +16,10 @@ namespace Content.Server.Research.Disk
         [Dependency] private readonly IPrototypeManager _prototype = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly ResearchSystem _research = default!;
+        [Dependency] private readonly SharedAudioSystem _audio = default!; // imp
+
+        private static readonly SoundPathSpecifier ApproveSound = new("/Audio/Effects/Cargo/ping.ogg"); // imp
+
         public override void Initialize()
         {
             base.Initialize();
@@ -35,6 +41,7 @@ namespace Content.Server.Research.Disk
 
                 _research.ModifyServerPoints(serverEnt.Value, component.Points, clientServer);
                 _popupSystem.PopupEntity(Loc.GetString("research-disk-inserted", ("points", component.Points)), args.Target.Value, args.User);
+                _audio.PlayPvs(ApproveSound, uid);
                 QueueDel(uid);
                 args.Handled = true;
                 return;


### PR DESCRIPTION
## About the PR
made it so research disks can be used on awesome computer. does not allow techdisks.

## Why / Balance
having to gain access to the physical server is kind of nothingburger and leads to problems on lowpop rounds when nobody has access to the thing. bit of a nerf to sci traitors that need access to the server but its still pretty easy to just ask a borg, my reasoning below

<img width="1056" height="65" alt="image" src="https://github.com/user-attachments/assets/f798d015-53dd-4224-a5e9-bd0e7e180c8e" />

## Technical details
few edits to ResearchDiskSystem.cs. think i patched all the logic holes but a double check would be nice.

## Media

https://github.com/user-attachments/assets/b79449a0-8869-406e-83c7-953e11ddb9b3


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

:cl:
- tweak: You can now insert Research Disks into the R&D console.

