### PR TITLE
Seperate Cap ID from Locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -83,7 +83,7 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: LockerFillCaptainNoLaser
+        tableId: LockerFillCaptainNoLaserNoID # imp separate ID from locker
 
 # No Laser + Laser locker
 - type: entity
@@ -94,12 +94,12 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: LockerFillCaptainLaser
+        tableId: LockerFillCaptainLaserNoID # imp separate ID from locker
 
 # No Laser + Laser + Hardsuit locker
 - type: entity
   id: LockerCaptainFilledHardsuit
-  suffix: Filled, Hardsuit
+  suffix: Filled, Hardsuit, ID # imp
   parent: LockerCaptain
   components:
   - type: EntityTableContainerFill

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Lockers/heads.yml
@@ -22,3 +22,62 @@
     containers:
       entity_storage: !type:NestedSelector
         tableId: LockerFillHospitalityDirector
+
+# No laser table
+- type: entityTable
+  id: LockerFillCaptainNoLaserNoID
+  table: !type:AllSelector
+    children:
+    - id: CigarGoldCase
+      prob: 0.25
+    - id: ClothingBeltSheathFilled
+    - id: ClothingHeadsetAltCommand
+    - id: ClothingOuterArmorCaptainCarapace
+    - id: BoxCaptainCircuitboards
+    - id: DoorRemoteCustom
+    - id: MedalCase
+    - id: PinpointerNuclear
+    - id: PlushieNuke
+      prob: 0.1
+    - id: RubberStampCaptain
+    - id: SpaceCash1000
+    - id: WeaponDisabler
+    - id: ClothingEyesGlassesCommand
+    - id: HeadSkeleton # A skull to accompany your skeleton crew
+      conditions:
+      - !type:PlayerCountCondition
+        max: 15
+    - id: TicketPad
+    - id: PersonalAILearnerCommand
+    - id: PrinterDocFlatpack  # Corvax-Printer
+
+# No laser table + Laser table
+- type: entityTable
+  id: LockerFillCaptainLaserNoID
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: LockerFillCaptainNoLaserNoID
+    - id: WeaponAntiqueLaser
+
+# Has ID but no laser locker, used when the antique laser is placed in the special display crate
+- type: entity
+  id: LockerCaptainFilledNoLaserHasID
+  suffix: Filled, ID
+  parent: LockerCaptain
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillCaptainNoLaser
+
+# Has ID but no Laser + Laser locker
+- type: entity
+  id: LockerCaptainFilledHasID
+  suffix: Filled, ID, AntiqueLaser
+  parent: LockerCaptain
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillCaptainLaser


### PR DESCRIPTION
### Only merge this once mappers are ready for the cap ID to no longer spawn in the locker

## About the PR
<!-- What did you change? -->
Made some new loot tables for the cap locker that include no ID and also made a few lockers that still contain the ID just in case a cramped map needs it.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This should make it so loot tables automagically swap for mappers once they get the new cap ID spawners added to their maps
## Technical details
<!-- Summary of code changes for easier review. -->
All yaml edits
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="505" height="417" alt="CapLocker" src="https://github.com/user-attachments/assets/eb892f95-ee8b-4608-a0bd-2103756fe787" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: mkanke
- tweak: Captains ID no longer spawns in their locker