### PR TITLE
Captain's ID Spawners for Saltern & Schooner

### DIFF
--- a/Resources/Maps/_Impstation/saltern.yml
+++ b/Resources/Maps/_Impstation/saltern.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/29/2026 22:23:11
-  entityCount: 14804
+  time: 06/23/2026 21:08:18
+  entityCount: 14812
 maps:
 - 658
 grids:
@@ -6196,7 +6196,6 @@ entities:
   - uid: 592
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,17.5
       parent: 31
 - proto: AirlockChemistryLocked
@@ -6225,7 +6224,6 @@ entities:
   - uid: 11635
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,38.5
       parent: 31
 - proto: AirlockCommandGlassLocked
@@ -6303,7 +6301,6 @@ entities:
   - uid: 4006
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,16.5
       parent: 31
 - proto: AirlockEngineeringGlassLocked
@@ -6394,7 +6391,6 @@ entities:
   - uid: 2050
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,8.5
       parent: 31
   - uid: 2637
@@ -6425,13 +6421,11 @@ entities:
   - uid: 5125
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,42.5
       parent: 31
   - uid: 8943
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,2.5
       parent: 31
   - uid: 9592
@@ -6442,7 +6436,6 @@ entities:
   - uid: 9986
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-11.5
       parent: 31
 - proto: AirlockExternal
@@ -6462,7 +6455,6 @@ entities:
   - uid: 9229
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,-26.5
       parent: 31
 - proto: AirlockExternalGlass
@@ -6863,13 +6855,11 @@ entities:
   - uid: 3175
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-4.5
       parent: 31
   - uid: 3219
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-2.5
       parent: 31
 - proto: AirlockGlass
@@ -7122,7 +7112,6 @@ entities:
   - uid: 1169
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,-30.5
       parent: 31
 - proto: AirlockMaint
@@ -7214,7 +7203,6 @@ entities:
   - uid: 119
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-18.5
       parent: 31
   - uid: 543
@@ -7265,7 +7253,6 @@ entities:
   - uid: 2354
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,-12.5
       parent: 31
   - uid: 2454
@@ -7286,25 +7273,21 @@ entities:
   - uid: 7378
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -33.5,9.5
       parent: 31
   - uid: 9220
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-13.5
       parent: 31
   - uid: 9402
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-31.5
       parent: 31
   - uid: 9445
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-33.5
       parent: 31
   - uid: 9671
@@ -7332,19 +7315,16 @@ entities:
   - uid: 7944
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,-6.5
       parent: 31
   - uid: 9516
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-18.5
       parent: 31
   - uid: 12998
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-21.5
       parent: 31
 - proto: AirlockMaintReporterLocked
@@ -7422,13 +7402,11 @@ entities:
   - uid: 606
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-15.5
       parent: 31
   - uid: 1475
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-15.5
       parent: 31
 - proto: AirlockMedicalMorgueMaintLocked
@@ -7436,7 +7414,6 @@ entities:
   - uid: 10479
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-18.5
       parent: 31
 - proto: AirlockQuartermasterGlassLocked
@@ -7728,7 +7705,6 @@ entities:
   - uid: 4911
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,4.5
       parent: 31
     - type: DeviceNetwork
@@ -7738,7 +7714,6 @@ entities:
   - uid: 4921
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-26.5
       parent: 31
   - uid: 5476
@@ -7753,7 +7728,6 @@ entities:
   - uid: 5507
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,41.5
       parent: 31
     - type: DeviceNetwork
@@ -7896,7 +7870,6 @@ entities:
   - uid: 10534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-27.5
       parent: 31
     - type: DeviceNetwork
@@ -7927,7 +7900,6 @@ entities:
   - uid: 12105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,42.5
       parent: 31
     - type: DeviceNetwork
@@ -29423,14 +29395,6 @@ entities:
     - type: Transform
       pos: 12.503073,-3.393904
       parent: 31
-- proto: CaptainIDCard
-  entities:
-  - uid: 4684
-    components:
-    - type: Transform
-      rot: -6.283185307179586 rad
-      pos: 10.532338,24.489452
-      parent: 31
 - proto: CarbonDioxideCanister
   entities:
   - uid: 56
@@ -29455,37 +29419,31 @@ entities:
   - uid: 290
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,21.5
       parent: 31
   - uid: 1376
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,21.5
       parent: 31
   - uid: 2081
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 31
   - uid: 2250
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 31
   - uid: 2251
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 31
   - uid: 3117
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 31
   - uid: 4058
@@ -29506,13 +29464,11 @@ entities:
   - uid: 4736
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 31
   - uid: 4878
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 31
   - uid: 6466
@@ -29523,7 +29479,6 @@ entities:
   - uid: 6606
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-7.5
       parent: 31
   - uid: 7091
@@ -29614,97 +29569,81 @@ entities:
   - uid: 8271
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,22.5
       parent: 31
   - uid: 8919
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-5.5
       parent: 31
   - uid: 8920
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-6.5
       parent: 31
   - uid: 8921
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-7.5
       parent: 31
   - uid: 8923
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-7.5
       parent: 31
   - uid: 8924
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-6.5
       parent: 31
   - uid: 8925
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-6.5
       parent: 31
   - uid: 8926
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-5.5
       parent: 31
   - uid: 8927
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-5.5
       parent: 31
   - uid: 8928
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-4.5
       parent: 31
   - uid: 8929
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-4.5
       parent: 31
   - uid: 8931
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-5.5
       parent: 31
   - uid: 8932
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-6.5
       parent: 31
   - uid: 8933
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-7.5
       parent: 31
   - uid: 10321
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-8.5
       parent: 31
   - uid: 10322
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-8.5
       parent: 31
   - uid: 11039
@@ -29732,97 +29671,81 @@ entities:
   - uid: 7360
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-7.5
       parent: 31
   - uid: 7361
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-6.5
       parent: 31
   - uid: 7362
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-6.5
       parent: 31
   - uid: 7363
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-7.5
       parent: 31
   - uid: 12904
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-35.5
       parent: 31
   - uid: 12905
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-34.5
       parent: 31
   - uid: 12906
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-33.5
       parent: 31
   - uid: 12907
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-35.5
       parent: 31
   - uid: 12908
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-34.5
       parent: 31
   - uid: 12909
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-33.5
       parent: 31
   - uid: 12910
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-35.5
       parent: 31
   - uid: 12911
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-34.5
       parent: 31
   - uid: 12912
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-33.5
       parent: 31
   - uid: 12913
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-33.5
       parent: 31
   - uid: 12914
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-34.5
       parent: 31
   - uid: 12915
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-35.5
       parent: 31
 - proto: CarpetBlue
@@ -29845,7 +29768,6 @@ entities:
   - uid: 568
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,-10.5
       parent: 31
   - uid: 989
@@ -29896,7 +29818,6 @@ entities:
   - uid: 4922
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,-10.5
       parent: 31
   - uid: 5121
@@ -29912,13 +29833,11 @@ entities:
   - uid: 7463
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,-9.5
       parent: 31
   - uid: 8344
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,-9.5
       parent: 31
   - uid: 11074
@@ -29951,25 +29870,21 @@ entities:
   - uid: 4155
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-29.5
       parent: 31
   - uid: 4721
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-30.5
       parent: 31
   - uid: 4722
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-29.5
       parent: 31
   - uid: 4780
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-30.5
       parent: 31
   - uid: 8726
@@ -30132,19 +30047,16 @@ entities:
   - uid: 2175
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 31
   - uid: 2196
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 31
   - uid: 2306
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 31
   - uid: 2945
@@ -30160,7 +30072,6 @@ entities:
   - uid: 3213
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 31
   - uid: 4864
@@ -30171,19 +30082,16 @@ entities:
   - uid: 4975
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 31
   - uid: 4981
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-0.5
       parent: 31
   - uid: 5091
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 31
   - uid: 5142
@@ -30194,7 +30102,6 @@ entities:
   - uid: 5143
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 31
   - uid: 6242
@@ -30235,7 +30142,6 @@ entities:
   - uid: 8229
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 31
   - uid: 8239
@@ -30246,43 +30152,36 @@ entities:
   - uid: 8795
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 31
   - uid: 8839
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 31
   - uid: 9042
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 31
   - uid: 9213
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 31
   - uid: 9221
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 31
   - uid: 9333
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 31
   - uid: 9759
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-1.5
       parent: 31
   - uid: 9761
@@ -30293,49 +30192,41 @@ entities:
   - uid: 10042
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,8.5
       parent: 31
   - uid: 10043
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,9.5
       parent: 31
   - uid: 10055
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,10.5
       parent: 31
   - uid: 11076
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 31
   - uid: 11078
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 31
   - uid: 11079
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 31
   - uid: 11080
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 31
   - uid: 11082
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 31
   - uid: 11388
@@ -30395,13 +30286,11 @@ entities:
   - uid: 1698
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-23.5
       parent: 31
   - uid: 2087
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-23.5
       parent: 31
   - uid: 9935
@@ -30464,7 +30353,6 @@ entities:
   - uid: 2847
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-19.5
       parent: 31
   - uid: 3931
@@ -30485,25 +30373,21 @@ entities:
   - uid: 4782
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-20.5
       parent: 31
   - uid: 4854
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-18.5
       parent: 31
   - uid: 4972
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-18.5
       parent: 31
   - uid: 5734
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-18.5
       parent: 31
   - uid: 6471
@@ -30514,25 +30398,21 @@ entities:
   - uid: 8450
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-20.5
       parent: 31
   - uid: 9312
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-20.5
       parent: 31
   - uid: 9376
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-19.5
       parent: 31
   - uid: 11273
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-19.5
       parent: 31
 - proto: Catwalk
@@ -44859,13 +44739,11 @@ entities:
   - uid: 1584
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,25.5
       parent: 31
   - uid: 1601
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-0.5
       parent: 31
     - type: DeviceNetwork
@@ -44875,7 +44753,6 @@ entities:
   - uid: 2115
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-15.5
       parent: 31
     - type: DeviceNetwork
@@ -44947,7 +44824,6 @@ entities:
   - uid: 4908
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,0.5
       parent: 31
     - type: DeviceNetwork
@@ -44998,25 +44874,21 @@ entities:
   - uid: 6458
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-36.5
       parent: 31
   - uid: 6858
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,24.5
       parent: 31
   - uid: 7464
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-38.5
       parent: 31
   - uid: 9881
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,-3.5
       parent: 31
     - type: DeviceNetwork
@@ -45050,7 +44922,6 @@ entities:
   - uid: 12687
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -31.5,-8.5
       parent: 31
     - type: DeviceNetwork
@@ -45061,7 +44932,6 @@ entities:
   - uid: 12688
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-7.5
       parent: 31
     - type: DeviceNetwork
@@ -45073,7 +44943,6 @@ entities:
   - uid: 12690
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-16.5
       parent: 31
     - type: DeviceNetwork
@@ -45083,7 +44952,6 @@ entities:
   - uid: 12691
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-12.5
       parent: 31
     - type: DeviceNetwork
@@ -45095,7 +44963,6 @@ entities:
   - uid: 12693
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-7.5
       parent: 31
     - type: DeviceNetwork
@@ -45107,7 +44974,6 @@ entities:
   - uid: 12694
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-3.5
       parent: 31
     - type: DeviceNetwork
@@ -45119,7 +44985,6 @@ entities:
   - uid: 12695
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-7.5
       parent: 31
     - type: DeviceNetwork
@@ -45130,7 +44995,6 @@ entities:
   - uid: 12696
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-9.5
       parent: 31
     - type: DeviceNetwork
@@ -45140,7 +45004,6 @@ entities:
   - uid: 12697
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-9.5
       parent: 31
     - type: DeviceNetwork
@@ -45152,7 +45015,6 @@ entities:
   - uid: 12701
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-12.5
       parent: 31
     - type: DeviceNetwork
@@ -45162,7 +45024,6 @@ entities:
   - uid: 12718
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,-6.5
       parent: 31
     - type: DeviceNetwork
@@ -45182,7 +45043,6 @@ entities:
   - uid: 12736
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,20.5
       parent: 31
     - type: DeviceNetwork
@@ -45192,7 +45052,6 @@ entities:
   - uid: 12737
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,17.5
       parent: 31
     - type: DeviceNetwork
@@ -45204,7 +45063,6 @@ entities:
   - uid: 12740
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,19.5
       parent: 31
     - type: DeviceNetwork
@@ -45214,7 +45072,6 @@ entities:
   - uid: 12742
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,22.5
       parent: 31
     - type: DeviceNetwork
@@ -45224,7 +45081,6 @@ entities:
   - uid: 12743
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,27.5
       parent: 31
     - type: DeviceNetwork
@@ -45254,7 +45110,6 @@ entities:
   - uid: 12760
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,12.5
       parent: 31
     - type: DeviceNetwork
@@ -45264,7 +45119,6 @@ entities:
   - uid: 12761
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,6.5
       parent: 31
     - type: DeviceNetwork
@@ -45274,7 +45128,6 @@ entities:
   - uid: 12762
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,6.5
       parent: 31
     - type: DeviceNetwork
@@ -45284,7 +45137,6 @@ entities:
   - uid: 12769
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,2.5
       parent: 31
     - type: DeviceNetwork
@@ -45294,7 +45146,6 @@ entities:
   - uid: 12771
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,12.5
       parent: 31
     - type: DeviceNetwork
@@ -45304,7 +45155,6 @@ entities:
   - uid: 12778
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,14.5
       parent: 31
     - type: DeviceNetwork
@@ -45314,7 +45164,6 @@ entities:
   - uid: 12779
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,12.5
       parent: 31
     - type: DeviceNetwork
@@ -45324,7 +45173,6 @@ entities:
   - uid: 12787
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-5.5
       parent: 31
     - type: DeviceNetwork
@@ -45353,7 +45201,6 @@ entities:
   - uid: 12825
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-18.5
       parent: 31
     - type: DeviceNetwork
@@ -45363,7 +45210,6 @@ entities:
   - uid: 12828
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-18.5
       parent: 31
     - type: DeviceNetwork
@@ -45390,7 +45236,6 @@ entities:
   - uid: 12853
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,-27.5
       parent: 31
     - type: DeviceNetwork
@@ -45400,7 +45245,6 @@ entities:
   - uid: 12861
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-24.5
       parent: 31
     - type: DeviceNetwork
@@ -45410,7 +45254,6 @@ entities:
   - uid: 12862
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-31.5
       parent: 31
     - type: DeviceNetwork
@@ -45420,7 +45263,6 @@ entities:
   - uid: 12863
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-30.5
       parent: 31
     - type: DeviceNetwork
@@ -45430,7 +45272,6 @@ entities:
   - uid: 13068
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-17.5
       parent: 31
     - type: DeviceNetwork
@@ -45442,7 +45283,6 @@ entities:
   - uid: 13069
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-21.5
       parent: 31
     - type: DeviceNetwork
@@ -45608,7 +45448,6 @@ entities:
   - uid: 160
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,5.5
       parent: 31
     - type: DeviceNetwork
@@ -45620,7 +45459,6 @@ entities:
   - uid: 275
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,16.5
       parent: 31
     - type: DeviceNetwork
@@ -45632,7 +45470,6 @@ entities:
   - uid: 727
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 55.5,-4.5
       parent: 31
     - type: DeviceNetwork
@@ -45673,7 +45510,6 @@ entities:
   - uid: 1160
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,-9.5
       parent: 31
     - type: DeviceNetwork
@@ -45693,7 +45529,6 @@ entities:
   - uid: 1372
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-1.5
       parent: 31
     - type: DeviceNetwork
@@ -45716,7 +45551,6 @@ entities:
   - uid: 1520
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,-25.5
       parent: 31
     - type: DeviceNetwork
@@ -45725,7 +45559,6 @@ entities:
   - uid: 1526
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,-24.5
       parent: 31
     - type: DeviceNetwork
@@ -45734,7 +45567,6 @@ entities:
   - uid: 1561
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,17.5
       parent: 31
     - type: DeviceNetwork
@@ -45754,13 +45586,11 @@ entities:
   - uid: 1917
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,22.5
       parent: 31
   - uid: 2167
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,29.5
       parent: 31
     - type: DeviceNetwork
@@ -45791,7 +45621,6 @@ entities:
   - uid: 3419
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,3.5
       parent: 31
     - type: DeviceNetwork
@@ -45803,7 +45632,6 @@ entities:
   - uid: 3428
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-33.5
       parent: 31
     - type: DeviceNetwork
@@ -45823,7 +45651,6 @@ entities:
   - uid: 3724
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,-27.5
       parent: 31
     - type: DeviceNetwork
@@ -45833,7 +45660,6 @@ entities:
   - uid: 3729
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-18.5
       parent: 31
     - type: DeviceNetwork
@@ -45844,7 +45670,6 @@ entities:
   - uid: 3765
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,-23.5
       parent: 31
     - type: DeviceNetwork
@@ -45853,7 +45678,6 @@ entities:
   - uid: 3857
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-23.5
       parent: 31
     - type: DeviceNetwork
@@ -45863,7 +45687,6 @@ entities:
   - uid: 3866
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-25.5
       parent: 31
     - type: DeviceNetwork
@@ -46031,25 +45854,21 @@ entities:
   - uid: 4120
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,18.5
       parent: 31
   - uid: 4160
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,18.5
       parent: 31
   - uid: 4161
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,18.5
       parent: 31
   - uid: 4210
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-29.5
       parent: 31
     - type: DeviceNetwork
@@ -46058,13 +45877,11 @@ entities:
   - uid: 4215
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-38.5
       parent: 31
   - uid: 4346
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,38.5
       parent: 31
     - type: DeviceNetwork
@@ -46109,7 +45926,6 @@ entities:
   - uid: 4617
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,-19.5
       parent: 31
     - type: DeviceNetwork
@@ -46121,7 +45937,6 @@ entities:
   - uid: 4718
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-19.5
       parent: 31
     - type: DeviceNetwork
@@ -46133,7 +45948,6 @@ entities:
   - uid: 4912
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,17.5
       parent: 31
     - type: DeviceNetwork
@@ -46241,7 +46055,6 @@ entities:
   - uid: 6585
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,29.5
       parent: 31
     - type: DeviceNetwork
@@ -46304,7 +46117,6 @@ entities:
   - uid: 6952
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,2.5
       parent: 31
   - uid: 6957
@@ -46315,7 +46127,6 @@ entities:
   - uid: 6959
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,9.5
       parent: 31
     - type: DeviceNetwork
@@ -46325,7 +46136,6 @@ entities:
   - uid: 6960
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-6.5
       parent: 31
   - uid: 7096
@@ -46369,7 +46179,6 @@ entities:
   - uid: 7325
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,-8.5
       parent: 31
     - type: DeviceNetwork
@@ -46402,7 +46211,6 @@ entities:
   - uid: 7460
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 31
     - type: DeviceNetwork
@@ -46414,7 +46222,6 @@ entities:
   - uid: 7519
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,2.5
       parent: 31
     - type: DeviceNetwork
@@ -46424,7 +46231,6 @@ entities:
   - uid: 7899
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,0.5
       parent: 31
     - type: DeviceNetwork
@@ -46475,7 +46281,6 @@ entities:
   - uid: 8433
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,18.5
       parent: 31
   - uid: 8810
@@ -46590,7 +46395,6 @@ entities:
   - uid: 9416
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-3.5
       parent: 31
     - type: DeviceNetwork
@@ -46624,13 +46428,11 @@ entities:
   - uid: 9782
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-36.5
       parent: 31
   - uid: 9783
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,-36.5
       parent: 31
   - uid: 9959
@@ -46758,7 +46560,6 @@ entities:
   - uid: 9988
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-12.5
       parent: 31
     - type: DeviceNetwork
@@ -46769,7 +46570,6 @@ entities:
   - uid: 9989
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 31
     - type: DeviceNetwork
@@ -46780,7 +46580,6 @@ entities:
   - uid: 9990
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-12.5
       parent: 31
     - type: DeviceNetwork
@@ -46791,7 +46590,6 @@ entities:
   - uid: 9994
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 31
     - type: DeviceNetwork
@@ -46802,7 +46600,6 @@ entities:
   - uid: 9995
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,1.5
       parent: 31
     - type: DeviceNetwork
@@ -46850,7 +46647,6 @@ entities:
   - uid: 10245
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-8.5
       parent: 31
     - type: DeviceNetwork
@@ -46862,7 +46658,6 @@ entities:
   - uid: 10246
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-8.5
       parent: 31
     - type: DeviceNetwork
@@ -47101,7 +46896,6 @@ entities:
   - uid: 12038
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,6.5
       parent: 31
     - type: DeviceNetwork
@@ -47167,7 +46961,6 @@ entities:
   - uid: 12715
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-1.5
       parent: 31
     - type: DeviceNetwork
@@ -47179,7 +46972,6 @@ entities:
   - uid: 12738
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,22.5
       parent: 31
     - type: DeviceNetwork
@@ -47191,7 +46983,6 @@ entities:
   - uid: 12744
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,25.5
       parent: 31
     - type: DeviceNetwork
@@ -47203,7 +46994,6 @@ entities:
   - uid: 12752
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,25.5
       parent: 31
     - type: DeviceNetwork
@@ -47215,7 +47005,6 @@ entities:
   - uid: 12753
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,24.5
       parent: 31
     - type: DeviceNetwork
@@ -47227,7 +47016,6 @@ entities:
   - uid: 12757
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,34.5
       parent: 31
     - type: DeviceNetwork
@@ -47238,7 +47026,6 @@ entities:
   - uid: 12767
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,8.5
       parent: 31
     - type: DeviceNetwork
@@ -47250,7 +47037,6 @@ entities:
   - uid: 12768
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,6.5
       parent: 31
     - type: DeviceNetwork
@@ -47262,7 +47048,6 @@ entities:
   - uid: 12770
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,11.5
       parent: 31
     - type: DeviceNetwork
@@ -47274,7 +47059,6 @@ entities:
   - uid: 12774
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,9.5
       parent: 31
     - type: DeviceNetwork
@@ -47307,7 +47091,6 @@ entities:
   - uid: 12852
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,-21.5
       parent: 31
     - type: DeviceNetwork
@@ -47319,7 +47102,6 @@ entities:
   - uid: 12856
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-25.5
       parent: 31
     - type: DeviceNetwork
@@ -47331,7 +47113,6 @@ entities:
   - uid: 12859
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-26.5
       parent: 31
     - type: DeviceNetwork
@@ -47343,7 +47124,6 @@ entities:
   - uid: 12860
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-27.5
       parent: 31
     - type: DeviceNetwork
@@ -47375,7 +47155,6 @@ entities:
   - uid: 13104
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,-17.5
       parent: 31
     - type: DeviceNetwork
@@ -47415,7 +47194,6 @@ entities:
   - uid: 14523
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,42.5
       parent: 31
     - type: DeviceNetwork
@@ -47425,7 +47203,6 @@ entities:
   - uid: 14524
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,8.5
       parent: 31
     - type: DeviceNetwork
@@ -47436,7 +47213,6 @@ entities:
   - uid: 14525
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,10.5
       parent: 31
     - type: DeviceNetwork
@@ -47447,7 +47223,6 @@ entities:
   - uid: 14526
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,0.5
       parent: 31
     - type: DeviceNetwork
@@ -47458,7 +47233,6 @@ entities:
   - uid: 14527
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-2.5
       parent: 31
     - type: DeviceNetwork
@@ -47469,7 +47243,6 @@ entities:
   - uid: 14528
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-5.5
       parent: 31
     - type: DeviceNetwork
@@ -47480,7 +47253,6 @@ entities:
   - uid: 14529
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-8.5
       parent: 31
     - type: DeviceNetwork
@@ -47491,7 +47263,6 @@ entities:
   - uid: 14530
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,-18.5
       parent: 31
     - type: DeviceNetwork
@@ -47500,7 +47271,6 @@ entities:
   - uid: 14531
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-18.5
       parent: 31
     - type: DeviceNetwork
@@ -47509,7 +47279,6 @@ entities:
   - uid: 14532
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-23.5
       parent: 31
     - type: DeviceNetwork
@@ -47518,7 +47287,6 @@ entities:
   - uid: 14533
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-24.5
       parent: 31
     - type: DeviceNetwork
@@ -47527,7 +47295,6 @@ entities:
   - uid: 14534
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-25.5
       parent: 31
     - type: DeviceNetwork
@@ -65556,7 +65323,6 @@ entities:
   - uid: 77
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-14.5
       parent: 31
   - uid: 95
@@ -65617,7 +65383,6 @@ entities:
   - uid: 291
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,21.5
       parent: 31
   - uid: 295
@@ -65628,13 +65393,11 @@ entities:
   - uid: 362
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,19.5
       parent: 31
   - uid: 364
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,19.5
       parent: 31
   - uid: 469
@@ -65660,7 +65423,6 @@ entities:
   - uid: 670
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,12.5
       parent: 31
   - uid: 751
@@ -65671,7 +65433,6 @@ entities:
   - uid: 757
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,-14.5
       parent: 31
   - uid: 772
@@ -65722,7 +65483,6 @@ entities:
   - uid: 1131
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,6.5
       parent: 31
   - uid: 1180
@@ -65743,7 +65503,6 @@ entities:
   - uid: 1215
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-10.5
       parent: 31
   - uid: 1225
@@ -65774,91 +65533,76 @@ entities:
   - uid: 1307
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,21.5
       parent: 31
   - uid: 1308
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,21.5
       parent: 31
   - uid: 1312
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 31
   - uid: 1315
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,21.5
       parent: 31
   - uid: 1319
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,21.5
       parent: 31
   - uid: 1324
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-4.5
       parent: 31
   - uid: 1327
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,21.5
       parent: 31
   - uid: 1328
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,21.5
       parent: 31
   - uid: 1329
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,21.5
       parent: 31
   - uid: 1333
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,21.5
       parent: 31
   - uid: 1336
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,19.5
       parent: 31
   - uid: 1344
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,19.5
       parent: 31
   - uid: 1346
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,19.5
       parent: 31
   - uid: 1347
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,19.5
       parent: 31
   - uid: 1352
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,19.5
       parent: 31
   - uid: 1357
@@ -65869,43 +65613,36 @@ entities:
   - uid: 1362
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,19.5
       parent: 31
   - uid: 1369
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,19.5
       parent: 31
   - uid: 1375
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,19.5
       parent: 31
   - uid: 1380
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,19.5
       parent: 31
   - uid: 1382
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,19.5
       parent: 31
   - uid: 1386
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,19.5
       parent: 31
   - uid: 1416
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-10.5
       parent: 31
   - uid: 1417
@@ -65921,7 +65658,6 @@ entities:
   - uid: 1436
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-8.5
       parent: 31
   - uid: 1447
@@ -65942,7 +65678,6 @@ entities:
   - uid: 1455
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,17.5
       parent: 31
   - uid: 1460
@@ -65963,31 +65698,26 @@ entities:
   - uid: 1487
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,19.5
       parent: 31
   - uid: 1488
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 55.5,19.5
       parent: 31
   - uid: 1489
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,19.5
       parent: 31
   - uid: 1490
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,19.5
       parent: 31
   - uid: 1513
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,19.5
       parent: 31
   - uid: 1522
@@ -65998,7 +65728,6 @@ entities:
   - uid: 1528
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-9.5
       parent: 31
   - uid: 1529
@@ -66024,7 +65753,6 @@ entities:
   - uid: 1604
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-8.5
       parent: 31
   - uid: 1629
@@ -66115,7 +65843,6 @@ entities:
   - uid: 1887
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-7.5
       parent: 31
   - uid: 1891
@@ -66161,7 +65888,6 @@ entities:
   - uid: 2140
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-11.5
       parent: 31
   - uid: 2149
@@ -66192,7 +65918,6 @@ entities:
   - uid: 2197
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-5.5
       parent: 31
   - uid: 2200
@@ -66233,13 +65958,11 @@ entities:
   - uid: 2461
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,19.5
       parent: 31
   - uid: 2495
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 55.5,21.5
       parent: 31
   - uid: 2498
@@ -66280,19 +66003,16 @@ entities:
   - uid: 2543
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,26.5
       parent: 31
   - uid: 2552
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,26.5
       parent: 31
   - uid: 2558
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,26.5
       parent: 31
   - uid: 2608
@@ -66303,25 +66023,21 @@ entities:
   - uid: 2618
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-5.5
       parent: 31
   - uid: 2630
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,26.5
       parent: 31
   - uid: 2643
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,19.5
       parent: 31
   - uid: 2660
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,21.5
       parent: 31
   - uid: 2677
@@ -66367,25 +66083,21 @@ entities:
   - uid: 3463
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 31
   - uid: 3464
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-6.5
       parent: 31
   - uid: 3471
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-5.5
       parent: 31
   - uid: 3486
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-8.5
       parent: 31
   - uid: 3504
@@ -66461,7 +66173,6 @@ entities:
   - uid: 4386
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-26.5
       parent: 31
   - uid: 4393
@@ -66477,13 +66188,11 @@ entities:
   - uid: 4399
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,1.5
       parent: 31
   - uid: 4403
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,3.5
       parent: 31
   - uid: 4445
@@ -66514,7 +66223,6 @@ entities:
   - uid: 4532
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-22.5
       parent: 31
   - uid: 4595
@@ -66550,7 +66258,6 @@ entities:
   - uid: 4612
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-26.5
       parent: 31
   - uid: 4614
@@ -66601,7 +66308,6 @@ entities:
   - uid: 4702
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,18.5
       parent: 31
   - uid: 4844
@@ -66617,7 +66323,6 @@ entities:
   - uid: 5066
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,8.5
       parent: 31
   - uid: 5071
@@ -66683,7 +66388,6 @@ entities:
   - uid: 5957
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,14.5
       parent: 31
   - uid: 6025
@@ -66724,13 +66428,11 @@ entities:
   - uid: 6275
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 31
   - uid: 6280
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,24.5
       parent: 31
   - uid: 6287
@@ -66741,19 +66443,16 @@ entities:
   - uid: 6288
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,24.5
       parent: 31
   - uid: 6301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,7.5
       parent: 31
   - uid: 6319
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,8.5
       parent: 31
   - uid: 6322
@@ -66774,7 +66473,6 @@ entities:
   - uid: 6341
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,6.5
       parent: 31
   - uid: 6357
@@ -66800,19 +66498,16 @@ entities:
   - uid: 6361
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 31
   - uid: 6363
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 31
   - uid: 6365
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,8.5
       parent: 31
   - uid: 6366
@@ -66823,7 +66518,6 @@ entities:
   - uid: 6369
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,6.5
       parent: 31
   - uid: 6382
@@ -66859,7 +66553,6 @@ entities:
   - uid: 6528
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,29.5
       parent: 31
   - uid: 6557
@@ -66895,13 +66588,11 @@ entities:
   - uid: 6744
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 59.5,24.5
       parent: 31
   - uid: 6812
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-42.5
       parent: 31
   - uid: 6838
@@ -66917,7 +66608,6 @@ entities:
   - uid: 6908
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,23.5
       parent: 31
   - uid: 6958
@@ -67033,13 +66723,11 @@ entities:
   - uid: 7038
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-22.5
       parent: 31
   - uid: 7039
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,-22.5
       parent: 31
   - uid: 7044
@@ -67055,7 +66743,6 @@ entities:
   - uid: 7358
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,15.5
       parent: 31
   - uid: 7375
@@ -67066,7 +66753,6 @@ entities:
   - uid: 7376
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,23.5
       parent: 31
   - uid: 7425
@@ -67077,31 +66763,26 @@ entities:
   - uid: 7431
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,31.5
       parent: 31
   - uid: 7447
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-32.5
       parent: 31
   - uid: 7448
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-32.5
       parent: 31
   - uid: 7449
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-32.5
       parent: 31
   - uid: 7450
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,-32.5
       parent: 31
   - uid: 7472
@@ -67237,37 +66918,31 @@ entities:
   - uid: 8108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,0.5
       parent: 31
   - uid: 8109
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,1.5
       parent: 31
   - uid: 8110
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,2.5
       parent: 31
   - uid: 8111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,3.5
       parent: 31
   - uid: 8112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,4.5
       parent: 31
   - uid: 8132
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,-14.5
       parent: 31
   - uid: 8147
@@ -67278,19 +66953,16 @@ entities:
   - uid: 8155
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,-13.5
       parent: 31
   - uid: 8156
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,-11.5
       parent: 31
   - uid: 8157
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,-9.5
       parent: 31
   - uid: 8162
@@ -67301,13 +66973,11 @@ entities:
   - uid: 8216
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,-26.5
       parent: 31
   - uid: 8217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-24.5
       parent: 31
   - uid: 8222
@@ -67328,19 +66998,16 @@ entities:
   - uid: 8305
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-29.5
       parent: 31
   - uid: 8309
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-32.5
       parent: 31
   - uid: 8310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-33.5
       parent: 31
   - uid: 8329
@@ -67521,13 +67188,11 @@ entities:
   - uid: 8601
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-32.5
       parent: 31
   - uid: 8807
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,34.5
       parent: 31
   - uid: 8819
@@ -67548,19 +67213,16 @@ entities:
   - uid: 8946
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 31
   - uid: 8947
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,2.5
       parent: 31
   - uid: 8948
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 31
   - uid: 9027
@@ -67636,7 +67298,6 @@ entities:
   - uid: 9291
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-30.5
       parent: 31
   - uid: 9321
@@ -67647,19 +67308,16 @@ entities:
   - uid: 9331
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 31
   - uid: 9332
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,2.5
       parent: 31
   - uid: 9380
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,4.5
       parent: 31
   - uid: 9408
@@ -67720,31 +67378,26 @@ entities:
   - uid: 9515
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 49.5,-12.5
       parent: 31
   - uid: 9525
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-41.5
       parent: 31
   - uid: 9535
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 50.5,-12.5
       parent: 31
   - uid: 9536
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-12.5
       parent: 31
   - uid: 9598
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-14.5
       parent: 31
   - uid: 9658
@@ -67775,19 +67428,16 @@ entities:
   - uid: 9692
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-40.5
       parent: 31
   - uid: 9693
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-42.5
       parent: 31
   - uid: 9700
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-30.5
       parent: 31
   - uid: 9723
@@ -67798,19 +67448,16 @@ entities:
   - uid: 9805
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-34.5
       parent: 31
   - uid: 9806
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-35.5
       parent: 31
   - uid: 9807
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-36.5
       parent: 31
   - uid: 9808
@@ -67896,13 +67543,11 @@ entities:
   - uid: 9889
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,13.5
       parent: 31
   - uid: 9933
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,24.5
       parent: 31
   - uid: 9934
@@ -67923,7 +67568,6 @@ entities:
   - uid: 9949
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-14.5
       parent: 31
   - uid: 9951
@@ -67949,13 +67593,11 @@ entities:
   - uid: 10065
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,33.5
       parent: 31
   - uid: 10080
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,28.5
       parent: 31
   - uid: 10226
@@ -67966,7 +67608,6 @@ entities:
   - uid: 10372
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,14.5
       parent: 31
   - uid: 10388
@@ -68032,13 +67673,11 @@ entities:
   - uid: 11409
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-2.5
       parent: 31
   - uid: 11410
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-6.5
       parent: 31
   - uid: 11472
@@ -68139,7 +67778,6 @@ entities:
   - uid: 11616
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,35.5
       parent: 31
   - uid: 11620
@@ -68160,43 +67798,36 @@ entities:
   - uid: 11665
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,37.5
       parent: 31
   - uid: 11666
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,38.5
       parent: 31
   - uid: 11667
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,39.5
       parent: 31
   - uid: 11751
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,37.5
       parent: 31
   - uid: 11752
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,36.5
       parent: 31
   - uid: 11753
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,35.5
       parent: 31
   - uid: 11878
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,28.5
       parent: 31
   - uid: 11939
@@ -68222,61 +67853,51 @@ entities:
   - uid: 11944
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,52.5
       parent: 31
   - uid: 11951
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,52.5
       parent: 31
   - uid: 11952
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,52.5
       parent: 31
   - uid: 11955
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,51.5
       parent: 31
   - uid: 11956
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,50.5
       parent: 31
   - uid: 11957
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,48.5
       parent: 31
   - uid: 11958
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,49.5
       parent: 31
   - uid: 11959
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,48.5
       parent: 31
   - uid: 11960
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,48.5
       parent: 31
   - uid: 11969
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,29.5
       parent: 31
   - uid: 11972
@@ -68287,31 +67908,26 @@ entities:
   - uid: 11973
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,27.5
       parent: 31
   - uid: 11974
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,31.5
       parent: 31
   - uid: 11976
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,31.5
       parent: 31
   - uid: 11977
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,31.5
       parent: 31
   - uid: 11978
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,30.5
       parent: 31
   - uid: 11982
@@ -68382,13 +67998,11 @@ entities:
   - uid: 12031
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 54.5,-21.5
       parent: 31
   - uid: 12032
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 54.5,-27.5
       parent: 31
   - uid: 12033
@@ -68559,7 +68173,6 @@ entities:
   - uid: 13982
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 63.5,21.5
       parent: 31
 - proto: GrilleBroken
@@ -69250,73 +68863,61 @@ entities:
   - uid: 11945
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,52.5
       parent: 31
   - uid: 11946
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,52.5
       parent: 31
   - uid: 11947
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,52.5
       parent: 31
   - uid: 11948
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,52.5
       parent: 31
   - uid: 11949
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,52.5
       parent: 31
   - uid: 11950
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,52.5
       parent: 31
   - uid: 11961
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,48.5
       parent: 31
   - uid: 11962
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,48.5
       parent: 31
   - uid: 11963
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,48.5
       parent: 31
   - uid: 11970
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,31.5
       parent: 31
   - uid: 11971
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,31.5
       parent: 31
   - uid: 11975
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,31.5
       parent: 31
   - uid: 12591
@@ -69965,31 +69566,26 @@ entities:
   - uid: 2253
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-13.5
       parent: 31
   - uid: 5655
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-13.5
       parent: 31
   - uid: 9695
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-42.5
       parent: 31
   - uid: 9696
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-41.5
       parent: 31
   - uid: 9697
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-40.5
       parent: 31
 - proto: HospitalCurtainsOpen
@@ -70864,6 +70460,61 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 28.678698,9.469505
       parent: 31
+- proto: LinkedCaptainIDCardSpawner
+  entities:
+  - uid: 14807
+    components:
+    - type: Transform
+      pos: -2.5,-36.5
+      parent: 31
+  - uid: 14810
+    components:
+    - type: Transform
+      pos: -5.5,45.5
+      parent: 31
+  - uid: 14812
+    components:
+    - type: Transform
+      pos: 57.5,-1.5
+      parent: 31
+- proto: LinkedCaptainIDCardSpawner2
+  entities:
+  - uid: 14806
+    components:
+    - type: Transform
+      pos: 55.5,-11.5
+      parent: 31
+  - uid: 14808
+    components:
+    - type: Transform
+      pos: -11.5,18.5
+      parent: 31
+  - uid: 14811
+    components:
+    - type: Transform
+      pos: 13.5,26.5
+      parent: 31
+- proto: LinkedCaptainIDCardSpawner3
+  entities:
+  - uid: 14809
+    components:
+    - type: Transform
+      pos: -11.5,48.5
+      parent: 31
+- proto: LinkedCaptainIDCardSpawner4
+  entities:
+  - uid: 4684
+    components:
+    - type: Transform
+      pos: 10.5,24.5
+      parent: 31
+- proto: LinkedCaptainIDCardSpawner5
+  entities:
+  - uid: 14805
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 31
 - proto: LiquidNitrogenCanister
   entities:
   - uid: 8790
@@ -71475,7 +71126,6 @@ entities:
   - uid: 11230
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-14.5
       parent: 31
 - proto: MaintenanceWeaponSpawner
@@ -76331,31 +75981,26 @@ entities:
   - uid: 13461
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,28.5
       parent: 31
   - uid: 13703
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,-7.5
       parent: 31
   - uid: 13705
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-7.5
       parent: 31
   - uid: 13778
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,-42.5
       parent: 31
   - uid: 13789
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-38.5
       parent: 31
 - proto: RandomCableHVSpawner
@@ -76363,73 +76008,61 @@ entities:
   - uid: 2971
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-31.5
       parent: 31
   - uid: 2973
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,-31.5
       parent: 31
   - uid: 3108
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,24.5
       parent: 31
   - uid: 3109
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,24.5
       parent: 31
   - uid: 3383
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-35.5
       parent: 31
   - uid: 3388
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-38.5
       parent: 31
   - uid: 3391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-28.5
       parent: 31
   - uid: 3392
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,-28.5
       parent: 31
   - uid: 3393
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-29.5
       parent: 31
   - uid: 3394
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-30.5
       parent: 31
   - uid: 3396
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-31.5
       parent: 31
   - uid: 3418
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-34.5
       parent: 31
 - proto: RandomDrinkGlass
@@ -76722,7 +76355,6 @@ entities:
   - uid: 1414
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,23.5
       parent: 31
   - uid: 4382
@@ -76748,7 +76380,6 @@ entities:
   - uid: 5212
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,-18.5
       parent: 31
   - uid: 6487
@@ -76794,13 +76425,11 @@ entities:
   - uid: 7608
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-14.5
       parent: 31
   - uid: 7625
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-16.5
       parent: 31
   - uid: 7628
@@ -76836,7 +76465,6 @@ entities:
   - uid: 9415
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-17.5
       parent: 31
   - uid: 9469
@@ -76847,13 +76475,11 @@ entities:
   - uid: 10663
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-10.5
       parent: 31
   - uid: 10761
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,-11.5
       parent: 31
   - uid: 11028
@@ -76864,7 +76490,6 @@ entities:
   - uid: 11231
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-11.5
       parent: 31
   - uid: 14786
@@ -77004,7 +76629,6 @@ entities:
   - uid: 1535
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,17.5
       parent: 31
   - uid: 2194
@@ -77027,13 +76651,11 @@ entities:
   - uid: 15
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-10.5
       parent: 31
   - uid: 17
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,19.5
       parent: 31
   - uid: 79
@@ -77044,13 +76666,11 @@ entities:
   - uid: 209
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,19.5
       parent: 31
   - uid: 238
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,19.5
       parent: 31
   - uid: 307
@@ -77066,43 +76686,36 @@ entities:
   - uid: 361
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,19.5
       parent: 31
   - uid: 369
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,19.5
       parent: 31
   - uid: 371
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,19.5
       parent: 31
   - uid: 373
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,19.5
       parent: 31
   - uid: 375
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,19.5
       parent: 31
   - uid: 377
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,19.5
       parent: 31
   - uid: 380
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,19.5
       parent: 31
   - uid: 410
@@ -77138,7 +76751,6 @@ entities:
   - uid: 587
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-19.5
       parent: 31
   - uid: 651
@@ -77214,13 +76826,11 @@ entities:
   - uid: 1341
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,15.5
       parent: 31
   - uid: 1349
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-5.5
       parent: 31
   - uid: 1381
@@ -77246,7 +76856,6 @@ entities:
   - uid: 1423
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,15.5
       parent: 31
   - uid: 1435
@@ -77302,13 +76911,11 @@ entities:
   - uid: 1686
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,1.5
       parent: 31
   - uid: 1689
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-4.5
       parent: 31
   - uid: 1736
@@ -77349,13 +76956,11 @@ entities:
   - uid: 1945
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,6.5
       parent: 31
   - uid: 1972
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,18.5
       parent: 31
   - uid: 1976
@@ -77366,7 +76971,6 @@ entities:
   - uid: 1991
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,8.5
       parent: 31
   - uid: 2000
@@ -77392,7 +76996,6 @@ entities:
   - uid: 2044
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 31
   - uid: 2052
@@ -77403,13 +77006,11 @@ entities:
   - uid: 2069
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,26.5
       parent: 31
   - uid: 2172
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-6.5
       parent: 31
   - uid: 2174
@@ -77420,7 +77021,6 @@ entities:
   - uid: 2177
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,26.5
       parent: 31
   - uid: 2185
@@ -77436,67 +77036,56 @@ entities:
   - uid: 2227
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,19.5
       parent: 31
   - uid: 2262
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 55.5,19.5
       parent: 31
   - uid: 2263
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 31
   - uid: 2277
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,12.5
       parent: 31
   - uid: 2280
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,14.5
       parent: 31
   - uid: 2299
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,19.5
       parent: 31
   - uid: 2319
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 31
   - uid: 2337
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-5.5
       parent: 31
   - uid: 2339
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,19.5
       parent: 31
   - uid: 2345
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,19.5
       parent: 31
   - uid: 2419
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-8.5
       parent: 31
   - uid: 2445
@@ -77512,13 +77101,11 @@ entities:
   - uid: 2453
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,26.5
       parent: 31
   - uid: 2456
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,26.5
       parent: 31
   - uid: 2459
@@ -77584,7 +77171,6 @@ entities:
   - uid: 2567
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,19.5
       parent: 31
   - uid: 2599
@@ -77595,91 +77181,76 @@ entities:
   - uid: 2626
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 31
   - uid: 2636
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,19.5
       parent: 31
   - uid: 2640
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,19.5
       parent: 31
   - uid: 2645
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,19.5
       parent: 31
   - uid: 2648
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,19.5
       parent: 31
   - uid: 3135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,8.5
       parent: 31
   - uid: 3421
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-30.5
       parent: 31
   - uid: 3469
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-11.5
       parent: 31
   - uid: 3470
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-9.5
       parent: 31
   - uid: 3518
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-10.5
       parent: 31
   - uid: 3560
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-2.5
       parent: 31
   - uid: 3562
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 49.5,-6.5
       parent: 31
   - uid: 3563
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 48.5,-6.5
       parent: 31
   - uid: 3567
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-6.5
       parent: 31
   - uid: 3568
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-6.5
       parent: 31
   - uid: 3769
@@ -77690,7 +77261,6 @@ entities:
   - uid: 3851
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-7.5
       parent: 31
   - uid: 3864
@@ -77741,7 +77311,6 @@ entities:
   - uid: 4041
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,6.5
       parent: 31
   - uid: 4051
@@ -77762,13 +77331,11 @@ entities:
   - uid: 4254
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,20.5
       parent: 31
   - uid: 4255
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,21.5
       parent: 31
   - uid: 4320
@@ -77784,19 +77351,16 @@ entities:
   - uid: 4398
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,3.5
       parent: 31
   - uid: 4515
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,-26.5
       parent: 31
   - uid: 4516
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-24.5
       parent: 31
   - uid: 4522
@@ -77807,19 +77371,16 @@ entities:
   - uid: 4577
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-22.5
       parent: 31
   - uid: 4578
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-22.5
       parent: 31
   - uid: 4583
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-26.5
       parent: 31
   - uid: 4627
@@ -77905,7 +77466,6 @@ entities:
   - uid: 4933
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,1.5
       parent: 31
   - uid: 4940
@@ -77951,7 +77511,6 @@ entities:
   - uid: 5664
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-5.5
       parent: 31
   - uid: 5706
@@ -77992,13 +77551,11 @@ entities:
   - uid: 6372
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,6.5
       parent: 31
   - uid: 6373
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 31
   - uid: 6381
@@ -78019,19 +77576,16 @@ entities:
   - uid: 6417
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 54.5,-21.5
       parent: 31
   - uid: 6425
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 54.5,-27.5
       parent: 31
   - uid: 6446
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,37.5
       parent: 31
   - uid: 6463
@@ -78042,7 +77596,6 @@ entities:
   - uid: 6480
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,0.5
       parent: 31
   - uid: 6495
@@ -78058,25 +77611,21 @@ entities:
   - uid: 6632
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,4.5
       parent: 31
   - uid: 6634
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,2.5
       parent: 31
   - uid: 6645
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,29.5
       parent: 31
   - uid: 6828
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,3.5
       parent: 31
   - uid: 6859
@@ -78092,13 +77641,11 @@ entities:
   - uid: 6907
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,24.5
       parent: 31
   - uid: 6950
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,35.5
       parent: 31
   - uid: 6972
@@ -78219,13 +77766,11 @@ entities:
   - uid: 7029
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-26.5
       parent: 31
   - uid: 7069
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,-22.5
       parent: 31
   - uid: 7118
@@ -78236,7 +77781,6 @@ entities:
   - uid: 7326
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-8.5
       parent: 31
   - uid: 7336
@@ -78247,25 +77791,21 @@ entities:
   - uid: 7443
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-32.5
       parent: 31
   - uid: 7444
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-32.5
       parent: 31
   - uid: 7445
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-32.5
       parent: 31
   - uid: 7446
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,-32.5
       parent: 31
   - uid: 7473
@@ -78286,7 +77826,6 @@ entities:
   - uid: 7582
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,36.5
       parent: 31
   - uid: 7818
@@ -78392,7 +77931,6 @@ entities:
   - uid: 8085
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,-14.5
       parent: 31
   - uid: 8125
@@ -78403,19 +77941,16 @@ entities:
   - uid: 8142
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,-13.5
       parent: 31
   - uid: 8143
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,-11.5
       parent: 31
   - uid: 8144
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,-9.5
       parent: 31
   - uid: 8151
@@ -78511,7 +78046,6 @@ entities:
   - uid: 8546
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-32.5
       parent: 31
   - uid: 8556
@@ -78602,7 +78136,6 @@ entities:
   - uid: 9383
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,4.5
       parent: 31
   - uid: 9384
@@ -78643,19 +78176,16 @@ entities:
   - uid: 9526
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-40.5
       parent: 31
   - uid: 9585
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-42.5
       parent: 31
   - uid: 9608
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-20.5
       parent: 31
   - uid: 9645
@@ -78686,7 +78216,6 @@ entities:
   - uid: 9694
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-41.5
       parent: 31
   - uid: 9708
@@ -78702,7 +78231,6 @@ entities:
   - uid: 9932
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,23.5
       parent: 31
   - uid: 10007
@@ -78718,13 +78246,11 @@ entities:
   - uid: 10079
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,28.5
       parent: 31
   - uid: 10303
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-8.5
       parent: 31
   - uid: 10352
@@ -78750,19 +78276,16 @@ entities:
   - uid: 10613
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,-14.5
       parent: 31
   - uid: 10616
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-14.5
       parent: 31
   - uid: 10617
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-14.5
       parent: 31
   - uid: 11124
@@ -78783,13 +78306,11 @@ entities:
   - uid: 11411
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-6.5
       parent: 31
   - uid: 11413
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-2.5
       parent: 31
   - uid: 11469
@@ -78800,13 +78321,11 @@ entities:
   - uid: 11658
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,28.5
       parent: 31
   - uid: 11873
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,27.5
       parent: 31
   - uid: 12525
@@ -84296,19 +83815,16 @@ entities:
   - uid: 10620
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,-8.5
       parent: 31
   - uid: 10621
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,-8.5
       parent: 31
   - uid: 10622
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-8.5
       parent: 31
 - proto: TableFrame
@@ -85457,13 +84973,11 @@ entities:
   - uid: 1444
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 31
   - uid: 1445
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,2.5
       parent: 31
 - proto: ToiletEmpty
@@ -86287,7 +85801,6 @@ entities:
   - uid: 9
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,19.5
       parent: 31
   - uid: 54
@@ -86298,7 +85811,6 @@ entities:
   - uid: 70
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-20.5
       parent: 31
   - uid: 83
@@ -86399,361 +85911,301 @@ entities:
   - uid: 322
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,22.5
       parent: 31
   - uid: 323
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,23.5
       parent: 31
   - uid: 324
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,24.5
       parent: 31
   - uid: 325
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,23.5
       parent: 31
   - uid: 326
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,22.5
       parent: 31
   - uid: 327
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,24.5
       parent: 31
   - uid: 329
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,25.5
       parent: 31
   - uid: 330
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,25.5
       parent: 31
   - uid: 331
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,25.5
       parent: 31
   - uid: 334
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,25.5
       parent: 31
   - uid: 340
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,25.5
       parent: 31
   - uid: 341
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,25.5
       parent: 31
   - uid: 342
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,25.5
       parent: 31
   - uid: 344
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,25.5
       parent: 31
   - uid: 345
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,25.5
       parent: 31
   - uid: 347
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,25.5
       parent: 31
   - uid: 348
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,25.5
       parent: 31
   - uid: 349
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,25.5
       parent: 31
   - uid: 350
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,25.5
       parent: 31
   - uid: 352
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,25.5
       parent: 31
   - uid: 353
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,22.5
       parent: 31
   - uid: 354
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,25.5
       parent: 31
   - uid: 355
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,25.5
       parent: 31
   - uid: 357
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,24.5
       parent: 31
   - uid: 358
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,21.5
       parent: 31
   - uid: 359
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,25.5
       parent: 31
   - uid: 363
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,21.5
       parent: 31
   - uid: 365
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,21.5
       parent: 31
   - uid: 367
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,19.5
       parent: 31
   - uid: 368
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,21.5
       parent: 31
   - uid: 370
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,21.5
       parent: 31
   - uid: 372
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,21.5
       parent: 31
   - uid: 374
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,21.5
       parent: 31
   - uid: 378
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,21.5
       parent: 31
   - uid: 379
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,21.5
       parent: 31
   - uid: 381
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,22.5
       parent: 31
   - uid: 382
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,20.5
       parent: 31
   - uid: 383
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,23.5
       parent: 31
   - uid: 384
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,22.5
       parent: 31
   - uid: 386
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,23.5
       parent: 31
   - uid: 387
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,24.5
       parent: 31
   - uid: 388
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,22.5
       parent: 31
   - uid: 389
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,23.5
       parent: 31
   - uid: 390
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,24.5
       parent: 31
   - uid: 391
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,22.5
       parent: 31
   - uid: 392
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,23.5
       parent: 31
   - uid: 393
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,24.5
       parent: 31
   - uid: 394
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,22.5
       parent: 31
   - uid: 395
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,23.5
       parent: 31
   - uid: 396
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,24.5
       parent: 31
   - uid: 397
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,22.5
       parent: 31
   - uid: 398
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,23.5
       parent: 31
   - uid: 399
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,24.5
       parent: 31
   - uid: 403
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,23.5
       parent: 31
   - uid: 405
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,24.5
       parent: 31
   - uid: 406
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,25.5
       parent: 31
   - uid: 407
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,21.5
       parent: 31
   - uid: 408
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,25.5
       parent: 31
   - uid: 412
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,24.5
       parent: 31
   - uid: 473
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,46.5
       parent: 31
   - uid: 497
@@ -86804,7 +86256,6 @@ entities:
   - uid: 633
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,-14.5
       parent: 31
   - uid: 637
@@ -86820,7 +86271,6 @@ entities:
   - uid: 645
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,20.5
       parent: 31
   - uid: 652
@@ -86831,7 +86281,6 @@ entities:
   - uid: 674
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,9.5
       parent: 31
   - uid: 690
@@ -86897,7 +86346,6 @@ entities:
   - uid: 745
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 46.5,-12.5
       parent: 31
   - uid: 747
@@ -86928,7 +86376,6 @@ entities:
   - uid: 830
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,9.5
       parent: 31
   - uid: 853
@@ -86999,7 +86446,6 @@ entities:
   - uid: 910
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,16.5
       parent: 31
   - uid: 951
@@ -87120,13 +86566,11 @@ entities:
   - uid: 1243
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,22.5
       parent: 31
   - uid: 1249
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,24.5
       parent: 31
   - uid: 1254
@@ -87142,7 +86586,6 @@ entities:
   - uid: 1263
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,18.5
       parent: 31
   - uid: 1270
@@ -87153,7 +86596,6 @@ entities:
   - uid: 1275
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,18.5
       parent: 31
   - uid: 1277
@@ -87179,7 +86621,6 @@ entities:
   - uid: 1305
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,21.5
       parent: 31
   - uid: 1314
@@ -87195,13 +86636,11 @@ entities:
   - uid: 1332
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,18.5
       parent: 31
   - uid: 1338
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,15.5
       parent: 31
   - uid: 1343
@@ -87217,7 +86656,6 @@ entities:
   - uid: 1366
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,20.5
       parent: 31
   - uid: 1377
@@ -87228,19 +86666,16 @@ entities:
   - uid: 1387
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,23.5
       parent: 31
   - uid: 1410
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-7.5
       parent: 31
   - uid: 1411
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,19.5
       parent: 31
   - uid: 1413
@@ -87256,25 +86691,21 @@ entities:
   - uid: 1431
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,22.5
       parent: 31
   - uid: 1439
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,20.5
       parent: 31
   - uid: 1449
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,15.5
       parent: 31
   - uid: 1456
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,17.5
       parent: 31
   - uid: 1461
@@ -87305,7 +86736,6 @@ entities:
   - uid: 1540
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,16.5
       parent: 31
   - uid: 1545
@@ -87326,7 +86756,6 @@ entities:
   - uid: 1588
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,20.5
       parent: 31
   - uid: 1600
@@ -87642,7 +87071,6 @@ entities:
   - uid: 1806
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,17.5
       parent: 31
   - uid: 1815
@@ -87858,7 +87286,6 @@ entities:
   - uid: 1889
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,17.5
       parent: 31
   - uid: 1892
@@ -87944,7 +87371,6 @@ entities:
   - uid: 1916
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,20.5
       parent: 31
   - uid: 1920
@@ -88035,7 +87461,6 @@ entities:
   - uid: 1940
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,10.5
       parent: 31
   - uid: 1943
@@ -88056,7 +87481,6 @@ entities:
   - uid: 1951
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,17.5
       parent: 31
   - uid: 1952
@@ -88072,7 +87496,6 @@ entities:
   - uid: 1966
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,25.5
       parent: 31
   - uid: 1970
@@ -88138,7 +87561,6 @@ entities:
   - uid: 1997
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,16.5
       parent: 31
   - uid: 2004
@@ -88149,13 +87571,11 @@ entities:
   - uid: 2009
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,25.5
       parent: 31
   - uid: 2012
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 55.5,25.5
       parent: 31
   - uid: 2013
@@ -88166,7 +87586,6 @@ entities:
   - uid: 2014
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,25.5
       parent: 31
   - uid: 2040
@@ -88202,13 +87621,11 @@ entities:
   - uid: 2055
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,26.5
       parent: 31
   - uid: 2056
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,30.5
       parent: 31
   - uid: 2092
@@ -88314,7 +87731,6 @@ entities:
   - uid: 2169
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-4.5
       parent: 31
   - uid: 2184
@@ -88335,13 +87751,11 @@ entities:
   - uid: 2210
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 54.5,-2.5
       parent: 31
   - uid: 2214
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-8.5
       parent: 31
   - uid: 2220
@@ -88422,13 +87836,11 @@ entities:
   - uid: 2266
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 31
   - uid: 2270
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,25.5
       parent: 31
   - uid: 2271
@@ -88449,7 +87861,6 @@ entities:
   - uid: 2282
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,11.5
       parent: 31
   - uid: 2284
@@ -88480,7 +87891,6 @@ entities:
   - uid: 2316
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,10.5
       parent: 31
   - uid: 2324
@@ -88496,7 +87906,6 @@ entities:
   - uid: 2328
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,22.5
       parent: 31
   - uid: 2333
@@ -88512,13 +87921,11 @@ entities:
   - uid: 2336
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 31
   - uid: 2348
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,10.5
       parent: 31
   - uid: 2350
@@ -88529,7 +87936,6 @@ entities:
   - uid: 2360
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,10.5
       parent: 31
   - uid: 2374
@@ -88545,7 +87951,6 @@ entities:
   - uid: 2401
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,22.5
       parent: 31
   - uid: 2406
@@ -88581,7 +87986,6 @@ entities:
   - uid: 2475
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,19.5
       parent: 31
   - uid: 2476
@@ -88602,7 +88006,6 @@ entities:
   - uid: 2489
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,22.5
       parent: 31
   - uid: 2490
@@ -88628,7 +88031,6 @@ entities:
   - uid: 2544
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,26.5
       parent: 31
   - uid: 2555
@@ -88639,13 +88041,11 @@ entities:
   - uid: 2560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 30.5,19.5
       parent: 31
   - uid: 2564
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,24.5
       parent: 31
   - uid: 2569
@@ -88671,13 +88071,11 @@ entities:
   - uid: 2622
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-4.5
       parent: 31
   - uid: 2624
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,19.5
       parent: 31
   - uid: 2625
@@ -88718,7 +88116,6 @@ entities:
   - uid: 2662
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-6.5
       parent: 31
   - uid: 2678
@@ -88799,7 +88196,6 @@ entities:
   - uid: 3472
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-6.5
       parent: 31
   - uid: 3480
@@ -88815,31 +88211,26 @@ entities:
   - uid: 3500
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-6.5
       parent: 31
   - uid: 3511
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-18.5
       parent: 31
   - uid: 3514
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-18.5
       parent: 31
   - uid: 3515
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-18.5
       parent: 31
   - uid: 3516
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-6.5
       parent: 31
   - uid: 3517
@@ -88850,49 +88241,41 @@ entities:
   - uid: 3519
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 21.5,-3.5
       parent: 31
   - uid: 3520
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-3.5
       parent: 31
   - uid: 3521
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-3.5
       parent: 31
   - uid: 3522
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-3.5
       parent: 31
   - uid: 3523
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-3.5
       parent: 31
   - uid: 3524
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-4.5
       parent: 31
   - uid: 3525
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-5.5
       parent: 31
   - uid: 3526
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-7.5
       parent: 31
   - uid: 3535
@@ -88908,13 +88291,11 @@ entities:
   - uid: 3539
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-18.5
       parent: 31
   - uid: 3543
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-3.5
       parent: 31
   - uid: 3544
@@ -88925,7 +88306,6 @@ entities:
   - uid: 3545
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-13.5
       parent: 31
   - uid: 3546
@@ -88961,13 +88341,11 @@ entities:
   - uid: 3556
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-18.5
       parent: 31
   - uid: 3557
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,-3.5
       parent: 31
   - uid: 3565
@@ -88988,7 +88366,6 @@ entities:
   - uid: 3703
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -33.5,-17.5
       parent: 31
   - uid: 3739
@@ -89049,7 +88426,6 @@ entities:
   - uid: 3858
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,-24.5
       parent: 31
   - uid: 3878
@@ -89065,7 +88441,6 @@ entities:
   - uid: 3896
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-13.5
       parent: 31
   - uid: 3925
@@ -89076,13 +88451,11 @@ entities:
   - uid: 3983
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -61.5,-24.5
       parent: 31
   - uid: 4010
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,-23.5
       parent: 31
   - uid: 4117
@@ -89093,7 +88466,6 @@ entities:
   - uid: 4144
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,7.5
       parent: 31
   - uid: 4154
@@ -89224,7 +88596,6 @@ entities:
   - uid: 4234
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,11.5
       parent: 31
   - uid: 4257
@@ -89645,7 +89016,6 @@ entities:
   - uid: 4716
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,9.5
       parent: 31
   - uid: 4717
@@ -89866,7 +89236,6 @@ entities:
   - uid: 5158
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,46.5
       parent: 31
   - uid: 5177
@@ -89907,7 +89276,6 @@ entities:
   - uid: 5184
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,11.5
       parent: 31
   - uid: 5193
@@ -89928,7 +89296,6 @@ entities:
   - uid: 5215
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,11.5
       parent: 31
   - uid: 5252
@@ -89989,7 +89356,6 @@ entities:
   - uid: 5314
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,45.5
       parent: 31
   - uid: 5609
@@ -90015,7 +89381,6 @@ entities:
   - uid: 5665
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,12.5
       parent: 31
   - uid: 5672
@@ -90071,7 +89436,6 @@ entities:
   - uid: 5894
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,23.5
       parent: 31
   - uid: 5917
@@ -90092,7 +89456,6 @@ entities:
   - uid: 5983
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-8.5
       parent: 31
   - uid: 5984
@@ -90103,7 +89466,6 @@ entities:
   - uid: 6028
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 31
   - uid: 6181
@@ -90114,7 +89476,6 @@ entities:
   - uid: 6200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-12.5
       parent: 31
   - uid: 6203
@@ -90150,7 +89511,6 @@ entities:
   - uid: 6212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,9.5
       parent: 31
   - uid: 6215
@@ -90171,7 +89531,6 @@ entities:
   - uid: 6235
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,11.5
       parent: 31
   - uid: 6236
@@ -90182,7 +89541,6 @@ entities:
   - uid: 6243
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,10.5
       parent: 31
   - uid: 6244
@@ -90213,7 +89571,6 @@ entities:
   - uid: 6283
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,9.5
       parent: 31
   - uid: 6284
@@ -90249,13 +89606,11 @@ entities:
   - uid: 6296
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,10.5
       parent: 31
   - uid: 6298
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,11.5
       parent: 31
   - uid: 6326
@@ -90266,19 +89621,16 @@ entities:
   - uid: 6333
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,11.5
       parent: 31
   - uid: 6334
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,15.5
       parent: 31
   - uid: 6348
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,15.5
       parent: 31
   - uid: 6349
@@ -90289,25 +89641,21 @@ entities:
   - uid: 6350
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,16.5
       parent: 31
   - uid: 6352
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,17.5
       parent: 31
   - uid: 6353
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,9.5
       parent: 31
   - uid: 6376
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,13.5
       parent: 31
   - uid: 6383
@@ -90323,7 +89671,6 @@ entities:
   - uid: 6387
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,-11.5
       parent: 31
   - uid: 6388
@@ -90334,13 +89681,11 @@ entities:
   - uid: 6389
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,7.5
       parent: 31
   - uid: 6390
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-12.5
       parent: 31
   - uid: 6394
@@ -90376,19 +89721,16 @@ entities:
   - uid: 6407
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -64.5,-23.5
       parent: 31
   - uid: 6408
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,26.5
       parent: 31
   - uid: 6416
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,21.5
       parent: 31
   - uid: 6432
@@ -90399,13 +89741,11 @@ entities:
   - uid: 6433
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,22.5
       parent: 31
   - uid: 6438
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,38.5
       parent: 31
   - uid: 6441
@@ -90421,7 +89761,6 @@ entities:
   - uid: 6450
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,21.5
       parent: 31
   - uid: 6454
@@ -90432,25 +89771,21 @@ entities:
   - uid: 6455
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,11.5
       parent: 31
   - uid: 6457
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,11.5
       parent: 31
   - uid: 6459
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,11.5
       parent: 31
   - uid: 6460
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 31
   - uid: 6468
@@ -90526,7 +89861,6 @@ entities:
   - uid: 6609
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,30.5
       parent: 31
   - uid: 6612
@@ -90687,7 +90021,6 @@ entities:
   - uid: 7028
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,36.5
       parent: 31
   - uid: 7034
@@ -90718,7 +90051,6 @@ entities:
   - uid: 7053
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,-13.5
       parent: 31
   - uid: 7060
@@ -90759,7 +90091,6 @@ entities:
   - uid: 7150
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,46.5
       parent: 31
   - uid: 7157
@@ -90795,7 +90126,6 @@ entities:
   - uid: 7231
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,45.5
       parent: 31
   - uid: 7333
@@ -90906,7 +90236,6 @@ entities:
   - uid: 7547
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,38.5
       parent: 31
   - uid: 7551
@@ -90942,7 +90271,6 @@ entities:
   - uid: 7592
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-31.5
       parent: 31
   - uid: 7601
@@ -90968,7 +90296,6 @@ entities:
   - uid: 7685
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,21.5
       parent: 31
   - uid: 7688
@@ -91004,7 +90331,6 @@ entities:
   - uid: 7908
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-25.5
       parent: 31
   - uid: 7968
@@ -91015,13 +90341,11 @@ entities:
   - uid: 7973
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,27.5
       parent: 31
   - uid: 8023
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,29.5
       parent: 31
   - uid: 8024
@@ -91057,7 +90381,6 @@ entities:
   - uid: 8086
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,-13.5
       parent: 31
   - uid: 8107
@@ -91133,19 +90456,16 @@ entities:
   - uid: 8152
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -59.5,-24.5
       parent: 31
   - uid: 8153
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-24.5
       parent: 31
   - uid: 8154
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,-24.5
       parent: 31
   - uid: 8160
@@ -91181,7 +90501,6 @@ entities:
   - uid: 8241
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,20.5
       parent: 31
   - uid: 8287
@@ -91197,7 +90516,6 @@ entities:
   - uid: 8307
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-23.5
       parent: 31
   - uid: 8311
@@ -91208,25 +90526,21 @@ entities:
   - uid: 8312
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-19.5
       parent: 31
   - uid: 8317
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-17.5
       parent: 31
   - uid: 8365
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-17.5
       parent: 31
   - uid: 8366
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-30.5
       parent: 31
   - uid: 8368
@@ -91237,7 +90551,6 @@ entities:
   - uid: 8372
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-17.5
       parent: 31
   - uid: 8381
@@ -91253,13 +90566,11 @@ entities:
   - uid: 8400
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,23.5
       parent: 31
   - uid: 8401
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,23.5
       parent: 31
   - uid: 8402
@@ -91270,19 +90581,16 @@ entities:
   - uid: 8416
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-26.5
       parent: 31
   - uid: 8438
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-25.5
       parent: 31
   - uid: 8449
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-19.5
       parent: 31
   - uid: 8452
@@ -91293,7 +90601,6 @@ entities:
   - uid: 8453
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-20.5
       parent: 31
   - uid: 8455
@@ -91314,19 +90621,16 @@ entities:
   - uid: 8459
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-21.5
       parent: 31
   - uid: 8462
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-22.5
       parent: 31
   - uid: 8463
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-24.5
       parent: 31
   - uid: 8464
@@ -91347,7 +90651,6 @@ entities:
   - uid: 8469
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-23.5
       parent: 31
   - uid: 8470
@@ -91388,25 +90691,21 @@ entities:
   - uid: 8489
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-19.5
       parent: 31
   - uid: 8493
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-17.5
       parent: 31
   - uid: 8494
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-17.5
       parent: 31
   - uid: 8495
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-17.5
       parent: 31
   - uid: 8516
@@ -91592,7 +90891,6 @@ entities:
   - uid: 8757
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-17.5
       parent: 31
   - uid: 8760
@@ -91603,25 +90901,21 @@ entities:
   - uid: 8766
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-17.5
       parent: 31
   - uid: 8770
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-28.5
       parent: 31
   - uid: 8771
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-23.5
       parent: 31
   - uid: 8774
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-24.5
       parent: 31
   - uid: 8806
@@ -91657,7 +90951,6 @@ entities:
   - uid: 9106
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,14.5
       parent: 31
   - uid: 9118
@@ -91668,13 +90961,11 @@ entities:
   - uid: 9144
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-29.5
       parent: 31
   - uid: 9168
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-28.5
       parent: 31
   - uid: 9182
@@ -91700,7 +90991,6 @@ entities:
   - uid: 9192
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-28.5
       parent: 31
   - uid: 9193
@@ -91711,7 +91001,6 @@ entities:
   - uid: 9203
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-26.5
       parent: 31
   - uid: 9205
@@ -91722,19 +91011,16 @@ entities:
   - uid: 9253
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-30.5
       parent: 31
   - uid: 9258
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-31.5
       parent: 31
   - uid: 9274
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-36.5
       parent: 31
   - uid: 9275
@@ -91815,7 +91101,6 @@ entities:
   - uid: 9329
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -34.5,19.5
       parent: 31
   - uid: 9345
@@ -91921,13 +91206,11 @@ entities:
   - uid: 9450
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-37.5
       parent: 31
   - uid: 9453
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-37.5
       parent: 31
   - uid: 9467
@@ -91938,25 +91221,21 @@ entities:
   - uid: 9468
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-43.5
       parent: 31
   - uid: 9470
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-43.5
       parent: 31
   - uid: 9471
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-43.5
       parent: 31
   - uid: 9472
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-43.5
       parent: 31
   - uid: 9475
@@ -92037,7 +91316,6 @@ entities:
   - uid: 9589
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,23.5
       parent: 31
   - uid: 9611
@@ -92133,43 +91411,36 @@ entities:
   - uid: 9803
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-37.5
       parent: 31
   - uid: 9857
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,-14.5
       parent: 31
   - uid: 9872
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-39.5
       parent: 31
   - uid: 9892
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -33.5,19.5
       parent: 31
   - uid: 9924
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,19.5
       parent: 31
   - uid: 9940
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,22.5
       parent: 31
   - uid: 9944
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,-15.5
       parent: 31
   - uid: 10019
@@ -92190,55 +91461,46 @@ entities:
   - uid: 10081
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,28.5
       parent: 31
   - uid: 10082
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,25.5
       parent: 31
   - uid: 10083
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,25.5
       parent: 31
   - uid: 10084
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,25.5
       parent: 31
   - uid: 10085
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,25.5
       parent: 31
   - uid: 10086
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,28.5
       parent: 31
   - uid: 10105
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,23.5
       parent: 31
   - uid: 10118
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,-14.5
       parent: 31
   - uid: 10128
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-14.5
       parent: 31
   - uid: 10131
@@ -92259,7 +91521,6 @@ entities:
   - uid: 10169
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,19.5
       parent: 31
   - uid: 10209
@@ -92280,7 +91541,6 @@ entities:
   - uid: 10220
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,15.5
       parent: 31
   - uid: 10244
@@ -92306,13 +91566,11 @@ entities:
   - uid: 10384
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,20.5
       parent: 31
   - uid: 10386
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,19.5
       parent: 31
   - uid: 10411
@@ -92328,7 +91586,6 @@ entities:
   - uid: 10473
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,28.5
       parent: 31
   - uid: 10474
@@ -92344,13 +91601,11 @@ entities:
   - uid: 10520
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,26.5
       parent: 31
   - uid: 10529
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-36.5
       parent: 31
   - uid: 10557
@@ -92361,19 +91616,16 @@ entities:
   - uid: 10560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-36.5
       parent: 31
   - uid: 10593
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,-11.5
       parent: 31
   - uid: 10689
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-36.5
       parent: 31
   - uid: 10708
@@ -92389,7 +91641,6 @@ entities:
   - uid: 10986
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-36.5
       parent: 31
   - uid: 10994
@@ -92420,7 +91671,6 @@ entities:
   - uid: 11291
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,14.5
       parent: 31
   - uid: 11303
@@ -92486,7 +91736,6 @@ entities:
   - uid: 11561
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,42.5
       parent: 31
   - uid: 11562
@@ -92502,37 +91751,31 @@ entities:
   - uid: 11564
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,42.5
       parent: 31
   - uid: 11566
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,38.5
       parent: 31
   - uid: 11567
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,41.5
       parent: 31
   - uid: 11568
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,34.5
       parent: 31
   - uid: 11569
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,34.5
       parent: 31
   - uid: 11570
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,38.5
       parent: 31
   - uid: 11575
@@ -92543,13 +91786,11 @@ entities:
   - uid: 11576
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,34.5
       parent: 31
   - uid: 11577
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,38.5
       parent: 31
   - uid: 11580
@@ -92560,13 +91801,11 @@ entities:
   - uid: 11599
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,44.5
       parent: 31
   - uid: 11600
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,43.5
       parent: 31
   - uid: 11602
@@ -92582,43 +91821,36 @@ entities:
   - uid: 11606
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,44.5
       parent: 31
   - uid: 11607
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,43.5
       parent: 31
   - uid: 11608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,42.5
       parent: 31
   - uid: 11609
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,41.5
       parent: 31
   - uid: 11610
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,40.5
       parent: 31
   - uid: 11611
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,39.5
       parent: 31
   - uid: 11612
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,38.5
       parent: 31
   - uid: 11615
@@ -92629,7 +91861,6 @@ entities:
   - uid: 11625
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,44.5
       parent: 31
   - uid: 11626
@@ -92640,7 +91871,6 @@ entities:
   - uid: 11627
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,34.5
       parent: 31
   - uid: 11628
@@ -92671,7 +91901,6 @@ entities:
   - uid: 11637
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,38.5
       parent: 31
   - uid: 11638
@@ -92702,7 +91931,6 @@ entities:
   - uid: 11645
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,36.5
       parent: 31
   - uid: 11646
@@ -92713,19 +91941,16 @@ entities:
   - uid: 11648
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,39.5
       parent: 31
   - uid: 11649
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,38.5
       parent: 31
   - uid: 11651
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,38.5
       parent: 31
   - uid: 11655
@@ -92736,7 +91961,6 @@ entities:
   - uid: 11656
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,34.5
       parent: 31
   - uid: 11657
@@ -92747,13 +91971,11 @@ entities:
   - uid: 11660
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,42.5
       parent: 31
   - uid: 11661
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,45.5
       parent: 31
   - uid: 11673
@@ -92774,13 +91996,11 @@ entities:
   - uid: 11677
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,35.5
       parent: 31
   - uid: 11678
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,34.5
       parent: 31
   - uid: 11680
@@ -92791,79 +92011,66 @@ entities:
   - uid: 11682
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,37.5
       parent: 31
   - uid: 11691
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,37.5
       parent: 31
   - uid: 11716
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,44.5
       parent: 31
   - uid: 11718
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,42.5
       parent: 31
   - uid: 11785
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,45.5
       parent: 31
   - uid: 11790
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,45.5
       parent: 31
   - uid: 11791
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,46.5
       parent: 31
   - uid: 11792
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,47.5
       parent: 31
   - uid: 11793
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,48.5
       parent: 31
   - uid: 11794
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,47.5
       parent: 31
   - uid: 11795
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,48.5
       parent: 31
   - uid: 11804
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,49.5
       parent: 31
   - uid: 11806
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,49.5
       parent: 31
   - uid: 11874
@@ -92874,13 +92081,11 @@ entities:
   - uid: 11886
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,31.5
       parent: 31
   - uid: 11968
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,30.5
       parent: 31
   - uid: 12002
@@ -92891,55 +92096,46 @@ entities:
   - uid: 12016
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,42.5
       parent: 31
   - uid: 12017
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,42.5
       parent: 31
   - uid: 12018
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,43.5
       parent: 31
   - uid: 12043
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,45.5
       parent: 31
   - uid: 12044
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,31.5
       parent: 31
   - uid: 12045
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,32.5
       parent: 31
   - uid: 12046
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,33.5
       parent: 31
   - uid: 12047
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,34.5
       parent: 31
   - uid: 12048
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,34.5
       parent: 31
   - uid: 12178
@@ -92960,7 +92156,6 @@ entities:
   - uid: 12735
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,16.5
       parent: 31
   - uid: 13274
@@ -93011,7 +92206,6 @@ entities:
   - uid: 120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,17.5
       parent: 31
   - uid: 139
@@ -93027,7 +92221,6 @@ entities:
   - uid: 165
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,1.5
       parent: 31
   - uid: 202
@@ -93043,13 +92236,11 @@ entities:
   - uid: 343
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,2.5
       parent: 31
   - uid: 400
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-12.5
       parent: 31
   - uid: 404
@@ -93165,13 +92356,11 @@ entities:
   - uid: 803
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,17.5
       parent: 31
   - uid: 804
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,17.5
       parent: 31
   - uid: 827
@@ -93182,7 +92371,6 @@ entities:
   - uid: 851
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,-20.5
       parent: 31
   - uid: 875
@@ -93423,7 +92611,6 @@ entities:
   - uid: 1441
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-20.5
       parent: 31
   - uid: 1458
@@ -93434,7 +92621,6 @@ entities:
   - uid: 1471
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-14.5
       parent: 31
   - uid: 1534
@@ -93535,7 +92721,6 @@ entities:
   - uid: 1743
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,23.5
       parent: 31
   - uid: 1768
@@ -93586,13 +92771,11 @@ entities:
   - uid: 1835
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,26.5
       parent: 31
   - uid: 2002
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,17.5
       parent: 31
   - uid: 2008
@@ -93838,7 +93021,6 @@ entities:
   - uid: 2142
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-16.5
       parent: 31
   - uid: 2145
@@ -93849,7 +93031,6 @@ entities:
   - uid: 2162
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,0.5
       parent: 31
   - uid: 2224
@@ -93890,7 +93071,6 @@ entities:
   - uid: 2252
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-2.5
       parent: 31
   - uid: 2254
@@ -93926,13 +93106,11 @@ entities:
   - uid: 2260
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-20.5
       parent: 31
   - uid: 2265
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,-18.5
       parent: 31
   - uid: 2267
@@ -93958,7 +93136,6 @@ entities:
   - uid: 2295
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-17.5
       parent: 31
   - uid: 2320
@@ -93994,13 +93171,11 @@ entities:
   - uid: 2351
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -30.5,-12.5
       parent: 31
   - uid: 2352
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-12.5
       parent: 31
   - uid: 2359
@@ -94011,7 +93186,6 @@ entities:
   - uid: 2362
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-17.5
       parent: 31
   - uid: 2364
@@ -94052,7 +93226,6 @@ entities:
   - uid: 2372
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-12.5
       parent: 31
   - uid: 2373
@@ -94148,7 +93321,6 @@ entities:
   - uid: 2429
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-23.5
       parent: 31
   - uid: 2430
@@ -94159,7 +93331,6 @@ entities:
   - uid: 2431
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,8.5
       parent: 31
   - uid: 2435
@@ -94195,13 +93366,11 @@ entities:
   - uid: 2449
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-23.5
       parent: 31
   - uid: 2450
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-24.5
       parent: 31
   - uid: 2468
@@ -94237,7 +93406,6 @@ entities:
   - uid: 2503
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-27.5
       parent: 31
   - uid: 2581
@@ -94248,7 +93416,6 @@ entities:
   - uid: 2598
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-8.5
       parent: 31
   - uid: 2620
@@ -94264,7 +93431,6 @@ entities:
   - uid: 2665
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-13.5
       parent: 31
   - uid: 3405
@@ -94275,115 +93441,96 @@ entities:
   - uid: 3416
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,-19.5
       parent: 31
   - uid: 3461
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-7.5
       parent: 31
   - uid: 3462
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-11.5
       parent: 31
   - uid: 3468
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-6.5
       parent: 31
   - uid: 3479
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-14.5
       parent: 31
   - uid: 3499
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-7.5
       parent: 31
   - uid: 3501
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-7.5
       parent: 31
   - uid: 3505
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-16.5
       parent: 31
   - uid: 3507
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-17.5
       parent: 31
   - uid: 3510
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-18.5
       parent: 31
   - uid: 3528
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-12.5
       parent: 31
   - uid: 3529
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-12.5
       parent: 31
   - uid: 3531
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-12.5
       parent: 31
   - uid: 3532
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-12.5
       parent: 31
   - uid: 3534
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-13.5
       parent: 31
   - uid: 3538
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-12.5
       parent: 31
   - uid: 3541
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-14.5
       parent: 31
   - uid: 3542
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-13.5
       parent: 31
   - uid: 3595
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-23.5
       parent: 31
   - uid: 3623
@@ -94394,13 +93541,11 @@ entities:
   - uid: 3873
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-4.5
       parent: 31
   - uid: 3875
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,23.5
       parent: 31
   - uid: 3915
@@ -94411,7 +93556,6 @@ entities:
   - uid: 3926
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-24.5
       parent: 31
   - uid: 3955
@@ -94427,13 +93571,11 @@ entities:
   - uid: 3993
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-26.5
       parent: 31
   - uid: 4021
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-5.5
       parent: 31
   - uid: 4064
@@ -94519,13 +93661,11 @@ entities:
   - uid: 4091
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-22.5
       parent: 31
   - uid: 4094
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-21.5
       parent: 31
   - uid: 4128
@@ -94546,13 +93686,11 @@ entities:
   - uid: 4211
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-3.5
       parent: 31
   - uid: 4212
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-3.5
       parent: 31
   - uid: 4221
@@ -94563,7 +93701,6 @@ entities:
   - uid: 4246
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-23.5
       parent: 31
   - uid: 4295
@@ -94589,7 +93726,6 @@ entities:
   - uid: 4353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-19.5
       parent: 31
   - uid: 4458
@@ -94615,7 +93751,6 @@ entities:
   - uid: 4558
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-13.5
       parent: 31
   - uid: 4609
@@ -94646,7 +93781,6 @@ entities:
   - uid: 4741
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,25.5
       parent: 31
   - uid: 4742
@@ -94672,7 +93806,6 @@ entities:
   - uid: 4778
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-24.5
       parent: 31
   - uid: 4836
@@ -94683,13 +93816,11 @@ entities:
   - uid: 4847
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-21.5
       parent: 31
   - uid: 4853
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-21.5
       parent: 31
   - uid: 4857
@@ -94705,13 +93836,11 @@ entities:
   - uid: 4885
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-19.5
       parent: 31
   - uid: 4905
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-19.5
       parent: 31
   - uid: 4928
@@ -94757,7 +93886,6 @@ entities:
   - uid: 5192
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,38.5
       parent: 31
   - uid: 5211
@@ -94788,7 +93916,6 @@ entities:
   - uid: 5929
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-21.5
       parent: 31
   - uid: 6240
@@ -94799,13 +93926,11 @@ entities:
   - uid: 6422
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,17.5
       parent: 31
   - uid: 6423
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,16.5
       parent: 31
   - uid: 6524
@@ -94886,13 +94011,11 @@ entities:
   - uid: 7598
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-10.5
       parent: 31
   - uid: 7607
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-10.5
       parent: 31
   - uid: 7952
@@ -94913,13 +94036,11 @@ entities:
   - uid: 8218
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,25.5
       parent: 31
   - uid: 8253
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,24.5
       parent: 31
   - uid: 8301
@@ -94945,7 +94066,6 @@ entities:
   - uid: 8718
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-30.5
       parent: 31
   - uid: 8817
@@ -94961,7 +94081,6 @@ entities:
   - uid: 8881
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-2.5
       parent: 31
   - uid: 8945
@@ -94977,13 +94096,11 @@ entities:
   - uid: 9097
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-7.5
       parent: 31
   - uid: 9112
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-6.5
       parent: 31
   - uid: 9119
@@ -95014,7 +94131,6 @@ entities:
   - uid: 9204
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,-5.5
       parent: 31
   - uid: 9228
@@ -95030,7 +94146,6 @@ entities:
   - uid: 9255
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-13.5
       parent: 31
   - uid: 9256
@@ -95086,13 +94201,11 @@ entities:
   - uid: 9346
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,-5.5
       parent: 31
   - uid: 9347
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,-5.5
       parent: 31
   - uid: 9373
@@ -95113,13 +94226,11 @@ entities:
   - uid: 9518
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,-5.5
       parent: 31
   - uid: 9519
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-5.5
       parent: 31
   - uid: 9566
@@ -95175,19 +94286,16 @@ entities:
   - uid: 9839
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-10.5
       parent: 31
   - uid: 9863
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,-21.5
       parent: 31
   - uid: 9866
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -33.5,8.5
       parent: 31
   - uid: 9916
@@ -95198,7 +94306,6 @@ entities:
   - uid: 9942
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,22.5
       parent: 31
   - uid: 9946
@@ -95219,7 +94326,6 @@ entities:
   - uid: 9987
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-13.5
       parent: 31
   - uid: 10013
@@ -95235,7 +94341,6 @@ entities:
   - uid: 10034
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-18.5
       parent: 31
   - uid: 10036
@@ -95256,19 +94361,16 @@ entities:
   - uid: 10129
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-11.5
       parent: 31
   - uid: 10353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-19.5
       parent: 31
   - uid: 10359
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-10.5
       parent: 31
   - uid: 10368
@@ -95279,7 +94381,6 @@ entities:
   - uid: 10370
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,12.5
       parent: 31
   - uid: 10401
@@ -95300,7 +94401,6 @@ entities:
   - uid: 10406
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-37.5
       parent: 31
   - uid: 10407
@@ -95316,7 +94416,6 @@ entities:
   - uid: 10476
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-6.5
       parent: 31
   - uid: 10521
@@ -95337,43 +94436,36 @@ entities:
   - uid: 10581
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-10.5
       parent: 31
   - uid: 10597
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,-13.5
       parent: 31
   - uid: 10598
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 40.5,-11.5
       parent: 31
   - uid: 10599
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,-11.5
       parent: 31
   - uid: 10600
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,-11.5
       parent: 31
   - uid: 10602
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,-11.5
       parent: 31
   - uid: 10603
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,-10.5
       parent: 31
   - uid: 10810
@@ -95429,7 +94521,6 @@ entities:
   - uid: 12248
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-4.5
       parent: 31
   - uid: 12250
@@ -95577,7 +94668,6 @@ entities:
   - uid: 10274
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-16.5
       parent: 31
   - uid: 10385
@@ -96337,13 +95427,11 @@ entities:
   - uid: 997
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 31
   - uid: 1002
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 31
   - uid: 1190
@@ -96404,25 +95492,21 @@ entities:
   - uid: 2155
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,11.5
       parent: 31
   - uid: 2409
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,2.5
       parent: 31
   - uid: 3744
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-14.5
       parent: 31
   - uid: 3795
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,-14.5
       parent: 31
   - uid: 4242
@@ -96463,7 +95547,6 @@ entities:
   - uid: 9277
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-31.5
       parent: 31
   - uid: 10635
@@ -96474,13 +95557,11 @@ entities:
   - uid: 10829
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,11.5
       parent: 31
   - uid: 12889
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-31.5
       parent: 31
 - proto: WindowDirectional

--- a/Resources/Maps/_Impstation/woodship.yml
+++ b/Resources/Maps/_Impstation/woodship.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/29/2026 21:49:40
-  entityCount: 10875
+  time: 06/23/2026 21:02:49
+  entityCount: 10890
 maps:
 - 1
 grids:
@@ -5438,19 +5438,16 @@ entities:
   - uid: 7050
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-3.5
       parent: 2
   - uid: 7051
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,-3.5
       parent: 2
   - uid: 7052
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-4.5
       parent: 2
   - uid: 8247
@@ -5471,7 +5468,6 @@ entities:
   - uid: 133
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,14.5
       parent: 2
   - uid: 1587
@@ -5484,13 +5480,11 @@ entities:
   - uid: 1685
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,38.5
       parent: 2
   - uid: 1697
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,41.5
       parent: 2
 - proto: AirlockBrigGlassLocked
@@ -5543,7 +5537,6 @@ entities:
   - uid: 2084
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,32.5
       parent: 2
 - proto: AirlockChemistryGlassLocked
@@ -5559,7 +5552,6 @@ entities:
   - uid: 3043
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,17.5
       parent: 2
 - proto: AirlockChiefEngineerGlassLocked
@@ -5574,7 +5566,6 @@ entities:
   - uid: 3485
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,14.5
       parent: 2
 - proto: AirlockCommandGlassLocked
@@ -5651,13 +5642,11 @@ entities:
   - uid: 285
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 2
   - uid: 392
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,11.5
       parent: 2
   - uid: 1831
@@ -5675,7 +5664,6 @@ entities:
   - uid: 2002
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-10.5
       parent: 2
   - uid: 2136
@@ -5711,13 +5699,11 @@ entities:
   - uid: 5770
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,31.5
       parent: 2
   - uid: 5875
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,32.5
       parent: 2
 - proto: AirlockExternal
@@ -5725,13 +5711,11 @@ entities:
   - uid: 4011
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,49.5
       parent: 2
   - uid: 4791
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-0.5
       parent: 2
   - uid: 8770
@@ -5777,7 +5761,6 @@ entities:
   - uid: 9310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 52.5,15.5
       parent: 2
   - uid: 10671
@@ -5790,7 +5773,6 @@ entities:
   - uid: 55
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 2
     - type: DeviceLinkSink
@@ -5803,7 +5785,6 @@ entities:
   - uid: 264
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-1.5
       parent: 2
     - type: DeviceLinkSink
@@ -5816,7 +5797,6 @@ entities:
   - uid: 2000
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-9.5
       parent: 2
     - type: DeviceLinkSink
@@ -5829,7 +5809,6 @@ entities:
   - uid: 2007
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-8.5
       parent: 2
     - type: DeviceLinkSink
@@ -6047,7 +6026,6 @@ entities:
   - uid: 4330
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,28.5
       parent: 2
     - type: DeviceLinkSink
@@ -6090,7 +6068,6 @@ entities:
   - uid: 8322
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,30.5
       parent: 2
     - type: DeviceLinkSink
@@ -6110,7 +6087,6 @@ entities:
   - uid: 3004
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,42.5
       parent: 2
 - proto: AirlockGlass
@@ -6133,7 +6109,6 @@ entities:
   - uid: 4740
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,58.5
       parent: 2
 - proto: AirlockHeadOfSecurityGlassLocked
@@ -6162,13 +6137,11 @@ entities:
   - uid: 1698
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,40.5
       parent: 2
   - uid: 1717
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,38.5
       parent: 2
   - uid: 4601
@@ -6194,13 +6167,11 @@ entities:
   - uid: 1662
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,38.5
       parent: 2
   - uid: 1666
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,40.5
       parent: 2
   - uid: 5176
@@ -6221,7 +6192,6 @@ entities:
   - uid: 1914
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,32.5
       parent: 2
 - proto: AirlockMaintAtmoLocked
@@ -6236,7 +6206,6 @@ entities:
   - uid: 4078
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,30.5
       parent: 2
     - type: AccessReader
@@ -6244,7 +6213,6 @@ entities:
   - uid: 4279
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,45.5
       parent: 2
 - proto: AirlockMaintChemLocked
@@ -6252,7 +6220,6 @@ entities:
   - uid: 3660
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,19.5
       parent: 2
 - proto: AirlockMaintCommandLocked
@@ -6312,13 +6279,11 @@ entities:
   - uid: 1800
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,38.5
       parent: 2
   - uid: 1804
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,38.5
       parent: 2
     - type: AccessReader
@@ -6326,7 +6291,6 @@ entities:
   - uid: 1827
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,46.5
       parent: 2
     - type: AccessReader
@@ -6351,13 +6315,11 @@ entities:
   - uid: 1982
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,43.5
       parent: 2
   - uid: 1999
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,15.5
       parent: 2
   - uid: 2130
@@ -6405,7 +6367,6 @@ entities:
   - uid: 5111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,49.5
       parent: 2
   - uid: 5712
@@ -6418,13 +6379,11 @@ entities:
   - uid: 5746
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,36.5
       parent: 2
   - uid: 8455
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,35.5
       parent: 2
   - uid: 9224
@@ -6509,7 +6468,6 @@ entities:
   - uid: 5394
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,29.5
       parent: 2
 - proto: AirlockQuartermasterGlassLocked
@@ -6604,7 +6562,6 @@ entities:
   - uid: 8368
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-13.5
       parent: 2
 - proto: AirSensor
@@ -6644,7 +6601,6 @@ entities:
   - uid: 3208
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,12.5
       parent: 2
   - uid: 3288
@@ -6723,7 +6679,6 @@ entities:
   - uid: 6637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,18.5
       parent: 2
     - type: DeviceNetwork
@@ -6732,7 +6687,6 @@ entities:
   - uid: 6639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,32.5
       parent: 2
     - type: DeviceNetwork
@@ -6741,7 +6695,6 @@ entities:
   - uid: 6641
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,28.5
       parent: 2
     - type: DeviceNetwork
@@ -6750,13 +6703,11 @@ entities:
   - uid: 6642
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,30.5
       parent: 2
   - uid: 6643
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,30.5
       parent: 2
     - type: DeviceNetwork
@@ -6765,7 +6716,6 @@ entities:
   - uid: 6645
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 44.5,16.5
       parent: 2
     - type: DeviceNetwork
@@ -6774,7 +6724,6 @@ entities:
   - uid: 6646
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,14.5
       parent: 2
     - type: DeviceNetwork
@@ -6868,7 +6817,6 @@ entities:
   - uid: 9533
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,40.5
       parent: 2
     - type: DeviceNetwork
@@ -6901,7 +6849,6 @@ entities:
   - uid: 10616
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,5.5
       parent: 2
     - type: DeviceNetwork
@@ -6912,7 +6859,6 @@ entities:
   - uid: 5115
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,43.5
       parent: 2
     - type: DeviceNetwork
@@ -7836,73 +7782,61 @@ entities:
   - uid: 1533
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,23.5
       parent: 2
   - uid: 1534
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,23.5
       parent: 2
   - uid: 1535
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,23.5
       parent: 2
   - uid: 1536
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,21.5
       parent: 2
   - uid: 1537
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,21.5
       parent: 2
   - uid: 1538
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,21.5
       parent: 2
   - uid: 1539
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,19.5
       parent: 2
   - uid: 1540
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,19.5
       parent: 2
   - uid: 1541
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,19.5
       parent: 2
   - uid: 1542
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,23.5
       parent: 2
   - uid: 1543
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,23.5
       parent: 2
   - uid: 1544
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,23.5
       parent: 2
   - uid: 5474
@@ -8342,19 +8276,16 @@ entities:
   - uid: 1524
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,21.5
       parent: 2
   - uid: 1525
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,21.5
       parent: 2
   - uid: 1526
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,21.5
       parent: 2
 - proto: AtmosFixOxygenMarker
@@ -8362,19 +8293,16 @@ entities:
   - uid: 1521
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,19.5
       parent: 2
   - uid: 1522
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,19.5
       parent: 2
   - uid: 1523
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,19.5
       parent: 2
 - proto: AtmosFixPlasmaMarker
@@ -8382,19 +8310,16 @@ entities:
   - uid: 1530
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,25.5
       parent: 2
   - uid: 1531
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,25.5
       parent: 2
   - uid: 1532
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,25.5
       parent: 2
 - proto: AtmosFixVoxMarker
@@ -8454,19 +8379,16 @@ entities:
   - uid: 1527
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,25.5
       parent: 2
   - uid: 1528
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,25.5
       parent: 2
   - uid: 1529
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,25.5
       parent: 2
 - proto: Autolathe
@@ -18890,6 +18812,41 @@ entities:
     - type: Transform
       pos: -14.5,1.5
       parent: 2
+  - uid: 10876
+    components:
+    - type: Transform
+      pos: -0.5,72.5
+      parent: 2
+  - uid: 10884
+    components:
+    - type: Transform
+      pos: -0.5,73.5
+      parent: 2
+  - uid: 10885
+    components:
+    - type: Transform
+      pos: -0.5,74.5
+      parent: 2
+  - uid: 10886
+    components:
+    - type: Transform
+      pos: 0.5,74.5
+      parent: 2
+  - uid: 10887
+    components:
+    - type: Transform
+      pos: 1.5,74.5
+      parent: 2
+  - uid: 10888
+    components:
+    - type: Transform
+      pos: 1.5,73.5
+      parent: 2
+  - uid: 10889
+    components:
+    - type: Transform
+      pos: 1.5,72.5
+      parent: 2
 - proto: CableHVStack
   entities:
   - uid: 984
@@ -22530,13 +22487,6 @@ entities:
     - type: Transform
       pos: 20.180689,25.4468
       parent: 2
-- proto: CaptainIDCard
-  entities:
-  - uid: 5518
-    components:
-    - type: Transform
-      pos: 1.4727774,65.795715
-      parent: 2
 - proto: CarbonDioxideCanister
   entities:
   - uid: 1250
@@ -22600,25 +22550,21 @@ entities:
   - uid: 8890
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,25.5
       parent: 2
   - uid: 8891
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,26.5
       parent: 2
   - uid: 8892
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,26.5
       parent: 2
   - uid: 8893
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,25.5
       parent: 2
 - proto: CarpetGreen
@@ -22651,7 +22597,6 @@ entities:
   - uid: 4168
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,31.5
       parent: 2
   - uid: 4205
@@ -22689,13 +22634,11 @@ entities:
   - uid: 8894
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,24.5
       parent: 2
   - uid: 8895
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,25.5
       parent: 2
 - proto: CarpetPurple
@@ -26022,25 +25965,21 @@ entities:
   - uid: 135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 2
   - uid: 149
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 2
   - uid: 179
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,0.5
       parent: 2
   - uid: 181
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 2
   - uid: 411
@@ -26396,7 +26335,6 @@ entities:
   - uid: 1218
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,18.5
       parent: 2
   - uid: 1222
@@ -26427,19 +26365,16 @@ entities:
   - uid: 1233
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,34.5
       parent: 2
   - uid: 1243
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,34.5
       parent: 2
   - uid: 1244
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,34.5
       parent: 2
   - uid: 1249
@@ -26465,43 +26400,36 @@ entities:
   - uid: 1808
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,71.5
       parent: 2
   - uid: 1830
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,63.5
       parent: 2
   - uid: 1832
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,62.5
       parent: 2
   - uid: 1833
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,63.5
       parent: 2
   - uid: 1835
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,70.5
       parent: 2
   - uid: 1881
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,71.5
       parent: 2
   - uid: 1883
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,71.5
       parent: 2
   - uid: 1930
@@ -26512,7 +26440,6 @@ entities:
   - uid: 1932
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-4.5
       parent: 2
   - uid: 2025
@@ -26788,37 +26715,31 @@ entities:
   - uid: 2452
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,64.5
       parent: 2
   - uid: 2486
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-16.5
       parent: 2
   - uid: 2487
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-17.5
       parent: 2
   - uid: 2488
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-18.5
       parent: 2
   - uid: 2489
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-18.5
       parent: 2
   - uid: 2490
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-17.5
       parent: 2
   - uid: 2491
@@ -26894,31 +26815,26 @@ entities:
   - uid: 2605
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,8.5
       parent: 2
   - uid: 2821
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,66.5
       parent: 2
   - uid: 2957
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,58.5
       parent: 2
   - uid: 2959
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,58.5
       parent: 2
   - uid: 2961
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,57.5
       parent: 2
   - uid: 3227
@@ -26939,7 +26855,6 @@ entities:
   - uid: 3467
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,16.5
       parent: 2
   - uid: 3502
@@ -27015,49 +26930,41 @@ entities:
   - uid: 3881
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,16.5
       parent: 2
   - uid: 3951
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,10.5
       parent: 2
   - uid: 3956
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,15.5
       parent: 2
   - uid: 3957
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,16.5
       parent: 2
   - uid: 3959
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,18.5
       parent: 2
   - uid: 3960
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,19.5
       parent: 2
   - uid: 3967
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,25.5
       parent: 2
   - uid: 3968
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,26.5
       parent: 2
   - uid: 3977
@@ -27078,55 +26985,46 @@ entities:
   - uid: 4007
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,70.5
       parent: 2
   - uid: 4021
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,70.5
       parent: 2
   - uid: 4030
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,60.5
       parent: 2
   - uid: 4031
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,65.5
       parent: 2
   - uid: 4033
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,64.5
       parent: 2
   - uid: 4036
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,69.5
       parent: 2
   - uid: 4037
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,68.5
       parent: 2
   - uid: 4038
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,66.5
       parent: 2
   - uid: 4039
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,65.5
       parent: 2
   - uid: 4072
@@ -27137,13 +27035,11 @@ entities:
   - uid: 4073
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,60.5
       parent: 2
   - uid: 4074
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,58.5
       parent: 2
   - uid: 4075
@@ -27174,7 +27070,6 @@ entities:
   - uid: 4578
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-15.5
       parent: 2
   - uid: 4706
@@ -27185,67 +27080,56 @@ entities:
   - uid: 4747
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,68.5
       parent: 2
   - uid: 4748
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,69.5
       parent: 2
   - uid: 4778
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,58.5
       parent: 2
   - uid: 4803
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,59.5
       parent: 2
   - uid: 4805
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,67.5
       parent: 2
   - uid: 4806
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,66.5
       parent: 2
   - uid: 4808
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,64.5
       parent: 2
   - uid: 4812
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,59.5
       parent: 2
   - uid: 4815
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,64.5
       parent: 2
   - uid: 4816
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,65.5
       parent: 2
   - uid: 4818
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,67.5
       parent: 2
   - uid: 4820
@@ -27291,19 +27175,16 @@ entities:
   - uid: 5336
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,16.5
       parent: 2
   - uid: 5346
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,12.5
       parent: 2
   - uid: 5405
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,20.5
       parent: 2
   - uid: 5425
@@ -27314,25 +27195,21 @@ entities:
   - uid: 5441
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,62.5
       parent: 2
   - uid: 5479
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,72.5
       parent: 2
   - uid: 5480
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,70.5
       parent: 2
   - uid: 5484
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,72.5
       parent: 2
   - uid: 5728
@@ -27383,13 +27260,11 @@ entities:
   - uid: 5863
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,16.5
       parent: 2
   - uid: 5873
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,28.5
       parent: 2
   - uid: 5895
@@ -27430,7 +27305,6 @@ entities:
   - uid: 5966
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,19.5
       parent: 2
   - uid: 5971
@@ -27561,19 +27435,16 @@ entities:
   - uid: 6074
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,10.5
       parent: 2
   - uid: 6078
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,16.5
       parent: 2
   - uid: 6079
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 43.5,16.5
       parent: 2
   - uid: 6133
@@ -27594,7 +27465,6 @@ entities:
   - uid: 6160
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,24.5
       parent: 2
   - uid: 6176
@@ -27615,13 +27485,11 @@ entities:
   - uid: 6302
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,12.5
       parent: 2
   - uid: 6337
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,7.5
       parent: 2
   - uid: 6347
@@ -27662,7 +27530,6 @@ entities:
   - uid: 6833
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,12.5
       parent: 2
   - uid: 6840
@@ -27673,13 +27540,11 @@ entities:
   - uid: 7053
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,-3.5
       parent: 2
   - uid: 7054
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,-4.5
       parent: 2
   - uid: 7092
@@ -27690,25 +27555,21 @@ entities:
   - uid: 7110
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,25.5
       parent: 2
   - uid: 7121
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,52.5
       parent: 2
   - uid: 7129
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,52.5
       parent: 2
   - uid: 7178
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 36.5,30.5
       parent: 2
   - uid: 7180
@@ -27719,7 +27580,6 @@ entities:
   - uid: 7181
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 36.5,28.5
       parent: 2
   - uid: 7192
@@ -27730,7 +27590,6 @@ entities:
   - uid: 7322
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,56.5
       parent: 2
   - uid: 7442
@@ -27741,7 +27600,6 @@ entities:
   - uid: 7457
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,17.5
       parent: 2
   - uid: 7462
@@ -27752,43 +27610,36 @@ entities:
   - uid: 7498
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,18.5
       parent: 2
   - uid: 7721
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,22.5
       parent: 2
   - uid: 7773
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,33.5
       parent: 2
   - uid: 7847
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,31.5
       parent: 2
   - uid: 7957
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,7.5
       parent: 2
   - uid: 7961
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,29.5
       parent: 2
   - uid: 8018
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,8.5
       parent: 2
   - uid: 8021
@@ -27799,7 +27650,6 @@ entities:
   - uid: 8043
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,10.5
       parent: 2
   - uid: 8048
@@ -27815,13 +27665,11 @@ entities:
   - uid: 8090
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,18.5
       parent: 2
   - uid: 8103
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,20.5
       parent: 2
   - uid: 8105
@@ -27837,7 +27685,6 @@ entities:
   - uid: 8197
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,30.5
       parent: 2
   - uid: 8215
@@ -27878,55 +27725,46 @@ entities:
   - uid: 8403
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,33.5
       parent: 2
   - uid: 8424
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,57.5
       parent: 2
   - uid: 8447
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,57.5
       parent: 2
   - uid: 8450
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,57.5
       parent: 2
   - uid: 8458
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,28.5
       parent: 2
   - uid: 8459
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,30.5
       parent: 2
   - uid: 8460
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,29.5
       parent: 2
   - uid: 8503
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,8.5
       parent: 2
   - uid: 8504
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,28.5
       parent: 2
   - uid: 8524
@@ -27957,7 +27795,6 @@ entities:
   - uid: 8594
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,34.5
       parent: 2
   - uid: 8738
@@ -28008,19 +27845,16 @@ entities:
   - uid: 8918
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,32.5
       parent: 2
   - uid: 8921
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,57.5
       parent: 2
   - uid: 8925
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,55.5
       parent: 2
   - uid: 8948
@@ -28031,19 +27865,16 @@ entities:
   - uid: 8956
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-15.5
       parent: 2
   - uid: 9152
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 2
   - uid: 9167
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,56.5
       parent: 2
   - uid: 9297
@@ -28389,55 +28220,46 @@ entities:
   - uid: 9838
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,52.5
       parent: 2
   - uid: 9842
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,50.5
       parent: 2
   - uid: 9843
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,48.5
       parent: 2
   - uid: 9844
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,44.5
       parent: 2
   - uid: 9845
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,42.5
       parent: 2
   - uid: 9846
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,40.5
       parent: 2
   - uid: 9908
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,58.5
       parent: 2
   - uid: 9982
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,17.5
       parent: 2
   - uid: 10010
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,19.5
       parent: 2
   - uid: 10028
@@ -28448,13 +28270,11 @@ entities:
   - uid: 10048
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,47.5
       parent: 2
   - uid: 10056
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,48.5
       parent: 2
   - uid: 10170
@@ -35502,7 +35322,6 @@ entities:
   - uid: 840
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 2
     - type: DeviceNetwork
@@ -35513,7 +35332,6 @@ entities:
   - uid: 841
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,14.5
       parent: 2
     - type: DeviceNetwork
@@ -35524,7 +35342,6 @@ entities:
   - uid: 844
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,11.5
       parent: 2
     - type: DeviceNetwork
@@ -35533,7 +35350,6 @@ entities:
   - uid: 845
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,15.5
       parent: 2
 - proto: FirelockEdge
@@ -35800,7 +35616,6 @@ entities:
   - uid: 47
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,29.5
       parent: 2
     - type: DeviceNetwork
@@ -35830,7 +35645,6 @@ entities:
   - uid: 714
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-9.5
       parent: 2
     - type: DeviceNetwork
@@ -35839,7 +35653,6 @@ entities:
   - uid: 843
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 2
     - type: DeviceNetwork
@@ -35849,7 +35662,6 @@ entities:
   - uid: 848
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 2
     - type: DeviceNetwork
@@ -35860,43 +35672,36 @@ entities:
   - uid: 1950
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-2.5
       parent: 2
   - uid: 1951
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,0.5
       parent: 2
   - uid: 1952
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-2.5
       parent: 2
   - uid: 1953
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-6.5
       parent: 2
   - uid: 1954
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-6.5
       parent: 2
   - uid: 1955
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 2
   - uid: 2408
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,0.5
       parent: 2
     - type: DeviceNetwork
@@ -35908,7 +35713,6 @@ entities:
   - uid: 2850
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-9.5
       parent: 2
     - type: DeviceNetwork
@@ -35918,25 +35722,21 @@ entities:
   - uid: 2859
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-2.5
       parent: 2
   - uid: 2860
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,3.5
       parent: 2
   - uid: 2861
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,9.5
       parent: 2
   - uid: 2864
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-9.5
       parent: 2
     - type: DeviceNetwork
@@ -36007,7 +35807,6 @@ entities:
   - uid: 3143
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,0.5
       parent: 2
     - type: DeviceNetwork
@@ -36019,7 +35818,6 @@ entities:
   - uid: 3516
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,15.5
       parent: 2
     - type: DeviceNetwork
@@ -36030,7 +35828,6 @@ entities:
   - uid: 3518
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,17.5
       parent: 2
     - type: DeviceNetwork
@@ -36041,7 +35838,6 @@ entities:
   - uid: 3519
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,14.5
       parent: 2
     - type: DeviceNetwork
@@ -36051,7 +35847,6 @@ entities:
   - uid: 3520
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,14.5
       parent: 2
     - type: DeviceNetwork
@@ -36061,7 +35856,6 @@ entities:
   - uid: 3521
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,12.5
       parent: 2
     - type: DeviceNetwork
@@ -36071,7 +35865,6 @@ entities:
   - uid: 3522
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,12.5
       parent: 2
     - type: DeviceNetwork
@@ -36081,7 +35874,6 @@ entities:
   - uid: 3922
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,18.5
       parent: 2
     - type: DeviceNetwork
@@ -36093,7 +35885,6 @@ entities:
   - uid: 3923
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,18.5
       parent: 2
     - type: DeviceNetwork
@@ -36105,7 +35896,6 @@ entities:
   - uid: 3924
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,18.5
       parent: 2
     - type: DeviceNetwork
@@ -36117,7 +35907,6 @@ entities:
   - uid: 3925
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,26.5
       parent: 2
     - type: DeviceNetwork
@@ -36129,7 +35918,6 @@ entities:
   - uid: 3926
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,26.5
       parent: 2
     - type: DeviceNetwork
@@ -36141,7 +35929,6 @@ entities:
   - uid: 3927
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,26.5
       parent: 2
     - type: DeviceNetwork
@@ -36162,7 +35949,6 @@ entities:
   - uid: 4514
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,37.5
       parent: 2
     - type: DeviceNetwork
@@ -36173,7 +35959,6 @@ entities:
   - uid: 4515
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,36.5
       parent: 2
     - type: DeviceNetwork
@@ -36184,7 +35969,6 @@ entities:
   - uid: 4516
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,49.5
       parent: 2
     - type: DeviceNetwork
@@ -36196,7 +35980,6 @@ entities:
   - uid: 4517
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,49.5
       parent: 2
     - type: DeviceNetwork
@@ -36208,7 +35991,6 @@ entities:
   - uid: 4518
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,42.5
       parent: 2
     - type: DeviceNetwork
@@ -36220,7 +36002,6 @@ entities:
   - uid: 4521
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,27.5
       parent: 2
     - type: DeviceNetwork
@@ -36231,7 +36012,6 @@ entities:
   - uid: 4522
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,27.5
       parent: 2
     - type: DeviceNetwork
@@ -36242,7 +36022,6 @@ entities:
   - uid: 4701
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,35.5
       parent: 2
     - type: DeviceNetwork
@@ -36358,7 +36137,6 @@ entities:
   - uid: 6373
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,24.5
       parent: 2
     - type: DeviceNetwork
@@ -36368,7 +36146,6 @@ entities:
   - uid: 6374
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,26.5
       parent: 2
     - type: DeviceNetwork
@@ -36379,7 +36156,6 @@ entities:
   - uid: 6375
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,26.5
       parent: 2
     - type: DeviceNetwork
@@ -36390,7 +36166,6 @@ entities:
   - uid: 6376
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,26.5
       parent: 2
     - type: DeviceNetwork
@@ -36401,7 +36176,6 @@ entities:
   - uid: 6378
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,26.5
       parent: 2
     - type: DeviceNetwork
@@ -36410,7 +36184,6 @@ entities:
   - uid: 6382
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,17.5
       parent: 2
     - type: DeviceNetwork
@@ -36421,7 +36194,6 @@ entities:
   - uid: 6383
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,15.5
       parent: 2
     - type: DeviceNetwork
@@ -36431,7 +36203,6 @@ entities:
   - uid: 6384
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,15.5
       parent: 2
     - type: DeviceNetwork
@@ -36582,7 +36353,6 @@ entities:
   - uid: 7625
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,28.5
       parent: 2
     - type: DeviceNetwork
@@ -36592,7 +36362,6 @@ entities:
   - uid: 7652
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,29.5
       parent: 2
     - type: DeviceNetwork
@@ -36621,7 +36390,6 @@ entities:
   - uid: 8225
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,49.5
       parent: 2
     - type: DeviceNetwork
@@ -36633,7 +36401,6 @@ entities:
   - uid: 8226
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,48.5
       parent: 2
     - type: DeviceNetwork
@@ -36644,7 +36411,6 @@ entities:
   - uid: 8227
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,43.5
       parent: 2
     - type: DeviceNetwork
@@ -36655,7 +36421,6 @@ entities:
   - uid: 8228
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,42.5
       parent: 2
     - type: DeviceNetwork
@@ -36675,7 +36440,6 @@ entities:
   - uid: 9001
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,32.5
       parent: 2
     - type: DeviceNetwork
@@ -36685,7 +36449,6 @@ entities:
   - uid: 9002
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,32.5
       parent: 2
     - type: DeviceNetwork
@@ -36695,7 +36458,6 @@ entities:
   - uid: 9003
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,29.5
       parent: 2
     - type: DeviceNetwork
@@ -36706,7 +36468,6 @@ entities:
   - uid: 9004
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,32.5
       parent: 2
     - type: DeviceNetwork
@@ -36716,7 +36477,6 @@ entities:
   - uid: 9005
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,30.5
       parent: 2
     - type: DeviceNetwork
@@ -36726,7 +36486,6 @@ entities:
   - uid: 9008
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,45.5
       parent: 2
     - type: DeviceNetwork
@@ -36736,7 +36495,6 @@ entities:
   - uid: 9009
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,46.5
       parent: 2
     - type: DeviceNetwork
@@ -36746,7 +36504,6 @@ entities:
   - uid: 9010
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,38.5
       parent: 2
     - type: DeviceNetwork
@@ -36755,7 +36512,6 @@ entities:
   - uid: 9011
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,46.5
       parent: 2
     - type: DeviceNetwork
@@ -36765,7 +36521,6 @@ entities:
   - uid: 9012
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,49.5
       parent: 2
     - type: DeviceNetwork
@@ -36775,7 +36530,6 @@ entities:
   - uid: 9013
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,52.5
       parent: 2
     - type: DeviceNetwork
@@ -36786,7 +36540,6 @@ entities:
   - uid: 9014
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,52.5
       parent: 2
     - type: DeviceNetwork
@@ -36796,7 +36549,6 @@ entities:
   - uid: 9015
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,54.5
       parent: 2
     - type: DeviceNetwork
@@ -36805,7 +36557,6 @@ entities:
   - uid: 9016
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,58.5
       parent: 2
     - type: DeviceNetwork
@@ -36815,7 +36566,6 @@ entities:
   - uid: 9017
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,56.5
       parent: 2
     - type: DeviceNetwork
@@ -36826,7 +36576,6 @@ entities:
   - uid: 9018
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,54.5
       parent: 2
     - type: DeviceNetwork
@@ -36837,7 +36586,6 @@ entities:
   - uid: 9019
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,56.5
       parent: 2
     - type: DeviceNetwork
@@ -36848,7 +36596,6 @@ entities:
   - uid: 9020
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,58.5
       parent: 2
     - type: DeviceNetwork
@@ -36858,7 +36605,6 @@ entities:
   - uid: 9021
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,66.5
       parent: 2
     - type: DeviceNetwork
@@ -36868,7 +36614,6 @@ entities:
   - uid: 9022
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,66.5
       parent: 2
     - type: DeviceNetwork
@@ -36878,7 +36623,6 @@ entities:
   - uid: 9023
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,52.5
       parent: 2
     - type: DeviceNetwork
@@ -36888,7 +36632,6 @@ entities:
   - uid: 9024
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 2
     - type: DeviceNetwork
@@ -36898,7 +36641,6 @@ entities:
   - uid: 9025
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,15.5
       parent: 2
     - type: DeviceNetwork
@@ -36907,7 +36649,6 @@ entities:
   - uid: 9026
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-9.5
       parent: 2
     - type: DeviceNetwork
@@ -36916,7 +36657,6 @@ entities:
   - uid: 9027
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-4.5
       parent: 2
     - type: DeviceNetwork
@@ -36926,7 +36666,6 @@ entities:
   - uid: 9029
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,1.5
       parent: 2
     - type: DeviceNetwork
@@ -36936,7 +36675,6 @@ entities:
   - uid: 9032
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,19.5
       parent: 2
     - type: DeviceNetwork
@@ -36945,7 +36683,6 @@ entities:
   - uid: 9034
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,7.5
       parent: 2
     - type: DeviceNetwork
@@ -36955,7 +36692,6 @@ entities:
   - uid: 9035
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,13.5
       parent: 2
     - type: DeviceNetwork
@@ -36965,7 +36701,6 @@ entities:
   - uid: 9036
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 2
     - type: DeviceNetwork
@@ -36975,7 +36710,6 @@ entities:
   - uid: 9037
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,17.5
       parent: 2
     - type: DeviceNetwork
@@ -36984,7 +36718,6 @@ entities:
   - uid: 9038
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,16.5
       parent: 2
     - type: DeviceNetwork
@@ -36993,7 +36726,6 @@ entities:
   - uid: 9044
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,14.5
       parent: 2
     - type: DeviceNetwork
@@ -37003,7 +36735,6 @@ entities:
   - uid: 9045
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,36.5
       parent: 2
     - type: DeviceNetwork
@@ -37013,7 +36744,6 @@ entities:
   - uid: 9048
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,38.5
       parent: 2
     - type: DeviceNetwork
@@ -37022,7 +36752,6 @@ entities:
   - uid: 9049
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,43.5
       parent: 2
     - type: DeviceNetwork
@@ -37032,7 +36761,6 @@ entities:
   - uid: 9050
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,49.5
       parent: 2
     - type: DeviceNetwork
@@ -37042,7 +36770,6 @@ entities:
   - uid: 9051
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,47.5
       parent: 2
     - type: DeviceNetwork
@@ -37051,7 +36778,6 @@ entities:
   - uid: 9089
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,35.5
       parent: 2
     - type: DeviceNetwork
@@ -37063,7 +36789,6 @@ entities:
   - uid: 9150
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,35.5
       parent: 2
     - type: DeviceNetwork
@@ -37074,7 +36799,6 @@ entities:
   - uid: 9151
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,35.5
       parent: 2
     - type: DeviceNetwork
@@ -37130,7 +36854,6 @@ entities:
   - uid: 9522
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,29.5
       parent: 2
     - type: DeviceNetwork
@@ -37141,7 +36864,6 @@ entities:
   - uid: 9524
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,29.5
       parent: 2
     - type: DeviceNetwork
@@ -37152,7 +36874,6 @@ entities:
   - uid: 9525
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,29.5
       parent: 2
     - type: DeviceNetwork
@@ -37163,7 +36884,6 @@ entities:
   - uid: 9531
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,36.5
       parent: 2
     - type: DeviceNetwork
@@ -37173,7 +36893,6 @@ entities:
   - uid: 9553
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,14.5
       parent: 2
     - type: DeviceNetwork
@@ -37183,7 +36902,6 @@ entities:
   - uid: 9557
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-4.5
       parent: 2
     - type: DeviceNetwork
@@ -37193,7 +36911,6 @@ entities:
   - uid: 9559
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-10.5
       parent: 2
     - type: DeviceNetwork
@@ -37202,7 +36919,6 @@ entities:
   - uid: 9560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-13.5
       parent: 2
     - type: DeviceNetwork
@@ -37212,7 +36928,6 @@ entities:
   - uid: 9561
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-10.5
       parent: 2
     - type: DeviceNetwork
@@ -37221,7 +36936,6 @@ entities:
   - uid: 9574
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-6.5
       parent: 2
     - type: DeviceNetwork
@@ -37230,7 +36944,6 @@ entities:
   - uid: 9577
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,12.5
       parent: 2
   - uid: 10057
@@ -37244,7 +36957,6 @@ entities:
   - uid: 10066
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,51.5
       parent: 2
     - type: DeviceNetwork
@@ -37254,7 +36966,6 @@ entities:
   - uid: 10067
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,50.5
       parent: 2
     - type: DeviceNetwork
@@ -37298,13 +37009,11 @@ entities:
   - uid: 10605
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,1.5
       parent: 2
   - uid: 10606
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,3.5
       parent: 2
     - type: DeviceNetwork
@@ -37313,7 +37022,6 @@ entities:
   - uid: 10607
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,2.5
       parent: 2
     - type: DeviceNetwork
@@ -51400,7 +51108,6 @@ entities:
   - uid: 8087
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,43.5
       parent: 2
 - proto: HolofanProjectorEmpty
@@ -52163,6 +51870,61 @@ entities:
     - type: AccessReader
       accessListsOriginal:
       - - Command
+- proto: LinkedCaptainIDCardSpawner
+  entities:
+  - uid: 10879
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 10881
+    components:
+    - type: Transform
+      pos: -17.5,-6.5
+      parent: 2
+  - uid: 10882
+    components:
+    - type: Transform
+      pos: -4.5,54.5
+      parent: 2
+  - uid: 10883
+    components:
+    - type: Transform
+      pos: -8.5,25.5
+      parent: 2
+  - uid: 10890
+    components:
+    - type: Transform
+      pos: 0.5,72.5
+      parent: 2
+- proto: LinkedCaptainIDCardSpawner2
+  entities:
+  - uid: 10880
+    components:
+    - type: Transform
+      pos: 42.5,15.5
+      parent: 2
+- proto: LinkedCaptainIDCardSpawner3
+  entities:
+  - uid: 10878
+    components:
+    - type: Transform
+      pos: 23.5,39.5
+      parent: 2
+- proto: LinkedCaptainIDCardSpawner4
+  entities:
+  - uid: 5518
+    components:
+    - type: Transform
+      pos: -0.5,65.5
+      parent: 2
+- proto: LinkedCaptainIDCardSpawner5
+  entities:
+  - uid: 10877
+    components:
+    - type: Transform
+      pos: 11.5,45.5
+      parent: 2
 - proto: LockableButtonAtmospherics
   entities:
   - uid: 1449
@@ -56460,7 +56222,6 @@ entities:
   - uid: 4250
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,34.5
       parent: 2
   - uid: 8468
@@ -56587,31 +56348,26 @@ entities:
   - uid: 4792
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,19.5
       parent: 2
   - uid: 6072
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,15.5
       parent: 2
   - uid: 6191
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,18.5
       parent: 2
   - uid: 6193
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,20.5
       parent: 2
   - uid: 7102
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,12.5
       parent: 2
   - uid: 7963
@@ -56792,7 +56548,6 @@ entities:
   - uid: 10369
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,45.5
       parent: 2
 - proto: RandomSnacks
@@ -57068,7 +56823,6 @@ entities:
   - uid: 9
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,0.5
       parent: 2
   - uid: 53
@@ -57089,19 +56843,16 @@ entities:
   - uid: 111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 2
   - uid: 136
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 2
   - uid: 143
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 2
   - uid: 190
@@ -57262,7 +57013,6 @@ entities:
   - uid: 5065
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 2
   - uid: 6011
@@ -57283,13 +57033,11 @@ entities:
   - uid: 6221
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,19.5
       parent: 2
   - uid: 6222
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,20.5
       parent: 2
   - uid: 6257
@@ -57537,49 +57285,41 @@ entities:
   - uid: 1231
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,18.5
       parent: 2
   - uid: 1649
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,34.5
       parent: 2
   - uid: 1650
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,34.5
       parent: 2
   - uid: 1651
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,34.5
       parent: 2
   - uid: 1811
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,71.5
       parent: 2
   - uid: 1880
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,71.5
       parent: 2
   - uid: 1882
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,70.5
       parent: 2
   - uid: 1888
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,71.5
       parent: 2
   - uid: 1892
@@ -57725,7 +57465,6 @@ entities:
   - uid: 3637
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,16.5
       parent: 2
   - uid: 4101
@@ -57736,19 +57475,16 @@ entities:
   - uid: 4155
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,33.5
       parent: 2
   - uid: 4324
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,26.5
       parent: 2
   - uid: 4325
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,25.5
       parent: 2
   - uid: 4635
@@ -57764,85 +57500,71 @@ entities:
   - uid: 4780
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,58.5
       parent: 2
   - uid: 4782
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,60.5
       parent: 2
   - uid: 4783
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,64.5
       parent: 2
   - uid: 4784
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,65.5
       parent: 2
   - uid: 4785
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,66.5
       parent: 2
   - uid: 4786
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,69.5
       parent: 2
   - uid: 4787
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,68.5
       parent: 2
   - uid: 4793
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,69.5
       parent: 2
   - uid: 4794
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,68.5
       parent: 2
   - uid: 4795
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,66.5
       parent: 2
   - uid: 4796
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,65.5
       parent: 2
   - uid: 4797
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,64.5
       parent: 2
   - uid: 4798
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,60.5
       parent: 2
   - uid: 4799
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,58.5
       parent: 2
   - uid: 5303
@@ -57858,19 +57580,16 @@ entities:
   - uid: 5481
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,70.5
       parent: 2
   - uid: 5482
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,70.5
       parent: 2
   - uid: 5483
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,70.5
       parent: 2
   - uid: 5866
@@ -57911,13 +57630,11 @@ entities:
   - uid: 6080
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 43.5,16.5
       parent: 2
   - uid: 6081
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,16.5
       parent: 2
   - uid: 6285
@@ -57943,7 +57660,6 @@ entities:
   - uid: 7070
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-4.5
       parent: 2
   - uid: 7107
@@ -57954,13 +57670,11 @@ entities:
   - uid: 7331
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-15.5
       parent: 2
   - uid: 7592
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,31.5
       parent: 2
   - uid: 7994
@@ -57981,43 +57695,36 @@ entities:
   - uid: 8093
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,47.5
       parent: 2
   - uid: 8256
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,52.5
       parent: 2
   - uid: 8257
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,52.5
       parent: 2
   - uid: 8324
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,33.5
       parent: 2
   - uid: 8326
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,34.5
       parent: 2
   - uid: 8332
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,56.5
       parent: 2
   - uid: 8346
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-15.5
       parent: 2
   - uid: 8950
@@ -58028,97 +57735,81 @@ entities:
   - uid: 9177
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,32.5
       parent: 2
   - uid: 9729
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,45.5
       parent: 2
   - uid: 9730
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,46.5
       parent: 2
   - uid: 9836
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,47.5
       parent: 2
   - uid: 9847
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,40.5
       parent: 2
   - uid: 9848
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,42.5
       parent: 2
   - uid: 9864
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,44.5
       parent: 2
   - uid: 9865
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,48.5
       parent: 2
   - uid: 9903
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,50.5
       parent: 2
   - uid: 9904
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,52.5
       parent: 2
   - uid: 9905
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,52.5
       parent: 2
   - uid: 9906
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,52.5
       parent: 2
   - uid: 9907
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,52.5
       parent: 2
   - uid: 9909
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,57.5
       parent: 2
   - uid: 9910
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,57.5
       parent: 2
   - uid: 9931
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,57.5
       parent: 2
   - uid: 9947
@@ -58134,7 +57825,6 @@ entities:
   - uid: 10049
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,48.5
       parent: 2
   - uid: 10109
@@ -60446,7 +60136,6 @@ entities:
   - uid: 10614
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,6.5
       parent: 2
 - proto: SpawnMobPossumMorty
@@ -60625,13 +60314,11 @@ entities:
   - uid: 8923
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-14.5
       parent: 2
   - uid: 9033
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-14.5
       parent: 2
 - proto: SpawnPointLibrarian
@@ -64723,67 +64410,56 @@ entities:
   - uid: 18
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 2
   - uid: 19
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 2
   - uid: 21
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 2
   - uid: 22
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 2
   - uid: 35
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 2
   - uid: 36
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 2
   - uid: 54
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 2
   - uid: 150
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 2
   - uid: 155
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 2
   - uid: 158
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 2
   - uid: 189
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 2
   - uid: 204
@@ -64804,7 +64480,6 @@ entities:
   - uid: 209
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 2
   - uid: 237
@@ -65127,31 +64802,26 @@ entities:
   - uid: 95
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,3.5
       parent: 2
   - uid: 96
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,3.5
       parent: 2
   - uid: 97
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,3.5
       parent: 2
   - uid: 98
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,3.5
       parent: 2
   - uid: 99
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,3.5
       parent: 2
   - uid: 100
@@ -65197,13 +64867,11 @@ entities:
   - uid: 109
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,-0.5
       parent: 2
   - uid: 112
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,2.5
       parent: 2
   - uid: 113
@@ -65234,61 +64902,51 @@ entities:
   - uid: 118
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,11.5
       parent: 2
   - uid: 119
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 2
   - uid: 120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,11.5
       parent: 2
   - uid: 121
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,14.5
       parent: 2
   - uid: 122
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 2
   - uid: 123
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 2
   - uid: 124
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,14.5
       parent: 2
   - uid: 125
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 2
   - uid: 126
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,14.5
       parent: 2
   - uid: 127
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,14.5
       parent: 2
   - uid: 128
@@ -65299,127 +64957,106 @@ entities:
   - uid: 132
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 2
   - uid: 142
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 2
   - uid: 217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 2
   - uid: 218
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 2
   - uid: 219
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-2.5
       parent: 2
   - uid: 220
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 2
   - uid: 221
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-2.5
       parent: 2
   - uid: 222
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 2
   - uid: 223
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-2.5
       parent: 2
   - uid: 224
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
       parent: 2
   - uid: 226
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,0.5
       parent: 2
   - uid: 230
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,3.5
       parent: 2
   - uid: 231
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,3.5
       parent: 2
   - uid: 232
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 2
   - uid: 233
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 2
   - uid: 256
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,0.5
       parent: 2
   - uid: 275
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-2.5
       parent: 2
   - uid: 281
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 2
   - uid: 282
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-2.5
       parent: 2
   - uid: 283
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,14.5
       parent: 2
   - uid: 284
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 2
   - uid: 286
@@ -65430,103 +65067,86 @@ entities:
   - uid: 289
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,10.5
       parent: 2
   - uid: 290
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,14.5
       parent: 2
   - uid: 293
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-0.5
       parent: 2
   - uid: 294
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-0.5
       parent: 2
   - uid: 295
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-1.5
       parent: 2
   - uid: 321
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,14.5
       parent: 2
   - uid: 323
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,14.5
       parent: 2
   - uid: 324
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,14.5
       parent: 2
   - uid: 382
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,11.5
       parent: 2
   - uid: 383
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
   - uid: 386
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,11.5
       parent: 2
   - uid: 387
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,11.5
       parent: 2
   - uid: 388
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,11.5
       parent: 2
   - uid: 389
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,12.5
       parent: 2
   - uid: 390
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,11.5
       parent: 2
   - uid: 391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,11.5
       parent: 2
   - uid: 396
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,14.5
       parent: 2
   - uid: 401
@@ -65542,31 +65162,26 @@ entities:
   - uid: 463
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,15.5
       parent: 2
   - uid: 464
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,15.5
       parent: 2
   - uid: 465
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,15.5
       parent: 2
   - uid: 473
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,11.5
       parent: 2
   - uid: 476
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,15.5
       parent: 2
   - uid: 571
@@ -65607,139 +65222,116 @@ entities:
   - uid: 618
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,0.5
       parent: 2
   - uid: 619
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,0.5
       parent: 2
   - uid: 620
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,0.5
       parent: 2
   - uid: 621
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,0.5
       parent: 2
   - uid: 622
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,14.5
       parent: 2
   - uid: 623
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,15.5
       parent: 2
   - uid: 624
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,1.5
       parent: 2
   - uid: 625
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,2.5
       parent: 2
   - uid: 626
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,3.5
       parent: 2
   - uid: 627
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,4.5
       parent: 2
   - uid: 628
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,5.5
       parent: 2
   - uid: 629
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,6.5
       parent: 2
   - uid: 630
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,7.5
       parent: 2
   - uid: 631
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,8.5
       parent: 2
   - uid: 632
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,9.5
       parent: 2
   - uid: 633
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,10.5
       parent: 2
   - uid: 634
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,11.5
       parent: 2
   - uid: 635
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,46.5
       parent: 2
   - uid: 636
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,13.5
       parent: 2
   - uid: 637
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,15.5
       parent: 2
   - uid: 638
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,15.5
       parent: 2
   - uid: 639
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,15.5
       parent: 2
   - uid: 640
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,19.5
       parent: 2
   - uid: 646
@@ -65970,13 +65562,11 @@ entities:
   - uid: 1262
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,5.5
       parent: 2
   - uid: 1428
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,14.5
       parent: 2
   - uid: 1432
@@ -66017,37 +65607,31 @@ entities:
   - uid: 1658
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,17.5
       parent: 2
   - uid: 1693
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,39.5
       parent: 2
   - uid: 1701
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,40.5
       parent: 2
   - uid: 1702
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,41.5
       parent: 2
   - uid: 1703
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,42.5
       parent: 2
   - uid: 1709
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-15.5
       parent: 2
   - uid: 1710
@@ -66058,43 +65642,36 @@ entities:
   - uid: 1711
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,47.5
       parent: 2
   - uid: 1718
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,41.5
       parent: 2
   - uid: 1719
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,40.5
       parent: 2
   - uid: 1720
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,39.5
       parent: 2
   - uid: 1727
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-1.5
       parent: 2
   - uid: 1733
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-0.5
       parent: 2
   - uid: 1737
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,0.5
       parent: 2
   - uid: 1739
@@ -66105,7 +65682,6 @@ entities:
   - uid: 1751
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,55.5
       parent: 2
   - uid: 1754
@@ -66116,67 +65692,56 @@ entities:
   - uid: 1756
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,43.5
       parent: 2
   - uid: 1757
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,44.5
       parent: 2
   - uid: 1759
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,44.5
       parent: 2
   - uid: 1765
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,44.5
       parent: 2
   - uid: 1766
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,47.5
       parent: 2
   - uid: 1772
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,43.5
       parent: 2
   - uid: 1774
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,44.5
       parent: 2
   - uid: 1775
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,44.5
       parent: 2
   - uid: 1777
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,44.5
       parent: 2
   - uid: 1778
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-17.5
       parent: 2
   - uid: 1783
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,44.5
       parent: 2
   - uid: 1788
@@ -66187,37 +65752,31 @@ entities:
   - uid: 1789
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,47.5
       parent: 2
   - uid: 1790
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,47.5
       parent: 2
   - uid: 1791
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,47.5
       parent: 2
   - uid: 1792
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,47.5
       parent: 2
   - uid: 1794
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,47.5
       parent: 2
   - uid: 1795
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,47.5
       parent: 2
   - uid: 1796
@@ -66253,19 +65812,16 @@ entities:
   - uid: 1805
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,48.5
       parent: 2
   - uid: 1807
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,49.5
       parent: 2
   - uid: 1810
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,57.5
       parent: 2
   - uid: 1829
@@ -66276,73 +65832,61 @@ entities:
   - uid: 1836
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,47.5
       parent: 2
   - uid: 1837
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,44.5
       parent: 2
   - uid: 1838
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,49.5
       parent: 2
   - uid: 1839
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,48.5
       parent: 2
   - uid: 1840
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,46.5
       parent: 2
   - uid: 1841
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,45.5
       parent: 2
   - uid: 1850
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,48.5
       parent: 2
   - uid: 1923
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-2.5
       parent: 2
   - uid: 1933
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 2
   - uid: 1934
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 2
   - uid: 1935
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-5.5
       parent: 2
   - uid: 1936
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-6.5
       parent: 2
   - uid: 1961
@@ -66398,79 +65942,66 @@ entities:
   - uid: 1981
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,44.5
       parent: 2
   - uid: 1983
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,45.5
       parent: 2
   - uid: 1984
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,-1.5
       parent: 2
   - uid: 1986
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,47.5
       parent: 2
   - uid: 1987
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,46.5
       parent: 2
   - uid: 1989
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,49.5
       parent: 2
   - uid: 1992
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,49.5
       parent: 2
   - uid: 1995
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,49.5
       parent: 2
   - uid: 1996
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,29.5
       parent: 2
   - uid: 1997
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,30.5
       parent: 2
   - uid: 1998
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,34.5
       parent: 2
   - uid: 2001
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-7.5
       parent: 2
   - uid: 2003
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-7.5
       parent: 2
   - uid: 2004
@@ -66486,13 +66017,11 @@ entities:
   - uid: 2006
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-7.5
       parent: 2
   - uid: 2008
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-7.5
       parent: 2
   - uid: 2009
@@ -66508,31 +66037,26 @@ entities:
   - uid: 2011
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-6.5
       parent: 2
   - uid: 2012
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-7.5
       parent: 2
   - uid: 2013
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-8.5
       parent: 2
   - uid: 2014
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-9.5
       parent: 2
   - uid: 2016
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-9.5
       parent: 2
   - uid: 2017
@@ -66548,103 +66072,86 @@ entities:
   - uid: 2019
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-11.5
       parent: 2
   - uid: 2020
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-9.5
       parent: 2
   - uid: 2021
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-11.5
       parent: 2
   - uid: 2022
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-11.5
       parent: 2
   - uid: 2030
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-14.5
       parent: 2
   - uid: 2033
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-17.5
       parent: 2
   - uid: 2034
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-15.5
       parent: 2
   - uid: 2035
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-17.5
       parent: 2
   - uid: 2038
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-15.5
       parent: 2
   - uid: 2039
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-14.5
       parent: 2
   - uid: 2047
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-14.5
       parent: 2
   - uid: 2048
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-14.5
       parent: 2
   - uid: 2050
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-11.5
       parent: 2
   - uid: 2051
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-12.5
       parent: 2
   - uid: 2052
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-13.5
       parent: 2
   - uid: 2055
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-15.5
       parent: 2
   - uid: 2057
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-17.5
       parent: 2
   - uid: 2072
@@ -66665,7 +66172,6 @@ entities:
   - uid: 2075
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,35.5
       parent: 2
   - uid: 2076
@@ -66681,13 +66187,11 @@ entities:
   - uid: 2083
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,31.5
       parent: 2
   - uid: 2085
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,33.5
       parent: 2
   - uid: 2086
@@ -66758,13 +66262,11 @@ entities:
   - uid: 2145
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-11.5
       parent: 2
   - uid: 2146
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-8.5
       parent: 2
   - uid: 2148
@@ -66775,31 +66277,26 @@ entities:
   - uid: 2150
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-13.5
       parent: 2
   - uid: 2151
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-13.5
       parent: 2
   - uid: 2152
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-13.5
       parent: 2
   - uid: 2153
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-11.5
       parent: 2
   - uid: 2154
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-12.5
       parent: 2
   - uid: 2271
@@ -66840,43 +66337,36 @@ entities:
   - uid: 2478
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-9.5
       parent: 2
   - uid: 2479
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-7.5
       parent: 2
   - uid: 2480
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-7.5
       parent: 2
   - uid: 2481
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-9.5
       parent: 2
   - uid: 2482
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-8.5
       parent: 2
   - uid: 2483
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-10.5
       parent: 2
   - uid: 2584
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,57.5
       parent: 2
   - uid: 2761
@@ -66907,13 +66397,11 @@ entities:
   - uid: 3041
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,18.5
       parent: 2
   - uid: 3052
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,2.5
       parent: 2
   - uid: 3171
@@ -66979,7 +66467,6 @@ entities:
   - uid: 3437
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,17.5
       parent: 2
   - uid: 3438
@@ -66995,31 +66482,26 @@ entities:
   - uid: 3444
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,14.5
       parent: 2
   - uid: 3445
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,18.5
       parent: 2
   - uid: 3446
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,14.5
       parent: 2
   - uid: 3447
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,14.5
       parent: 2
   - uid: 3460
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,18.5
       parent: 2
   - uid: 3469
@@ -67030,37 +66512,31 @@ entities:
   - uid: 3474
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,18.5
       parent: 2
   - uid: 3475
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,15.5
       parent: 2
   - uid: 3481
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,18.5
       parent: 2
   - uid: 3482
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,17.5
       parent: 2
   - uid: 3483
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,16.5
       parent: 2
   - uid: 3484
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,15.5
       parent: 2
   - uid: 3490
@@ -67171,19 +66647,16 @@ entities:
   - uid: 3661
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,19.5
       parent: 2
   - uid: 3662
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,19.5
       parent: 2
   - uid: 3663
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,19.5
       parent: 2
   - uid: 3664
@@ -67249,25 +66722,21 @@ entities:
   - uid: 3941
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,23.5
       parent: 2
   - uid: 3942
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,23.5
       parent: 2
   - uid: 3946
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,22.5
       parent: 2
   - uid: 3947
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,23.5
       parent: 2
   - uid: 3965
@@ -67353,7 +66822,6 @@ entities:
   - uid: 4001
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,51.5
       parent: 2
   - uid: 4002
@@ -67409,7 +66877,6 @@ entities:
   - uid: 4019
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,55.5
       parent: 2
   - uid: 4020
@@ -67800,49 +67267,41 @@ entities:
   - uid: 4723
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,-13.5
       parent: 2
   - uid: 4742
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,61.5
       parent: 2
   - uid: 4743
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,61.5
       parent: 2
   - uid: 4745
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,59.5
       parent: 2
   - uid: 4746
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,59.5
       parent: 2
   - uid: 4749
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,56.5
       parent: 2
   - uid: 4750
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,56.5
       parent: 2
   - uid: 4751
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,56.5
       parent: 2
   - uid: 4752
@@ -67853,25 +67312,21 @@ entities:
   - uid: 4754
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,55.5
       parent: 2
   - uid: 4755
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,54.5
       parent: 2
   - uid: 4756
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,54.5
       parent: 2
   - uid: 4757
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,54.5
       parent: 2
   - uid: 4758
@@ -67882,13 +67337,11 @@ entities:
   - uid: 4760
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,64.5
       parent: 2
   - uid: 4762
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,54.5
       parent: 2
   - uid: 4763
@@ -67904,13 +67357,11 @@ entities:
   - uid: 4765
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,54.5
       parent: 2
   - uid: 4766
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,54.5
       parent: 2
   - uid: 4769
@@ -67921,31 +67372,26 @@ entities:
   - uid: 4770
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,65.5
       parent: 2
   - uid: 4771
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,64.5
       parent: 2
   - uid: 4772
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,64.5
       parent: 2
   - uid: 4773
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,64.5
       parent: 2
   - uid: 4774
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,64.5
       parent: 2
   - uid: 4775
@@ -67956,13 +67402,11 @@ entities:
   - uid: 4776
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,65.5
       parent: 2
   - uid: 4777
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,64.5
       parent: 2
   - uid: 4781
@@ -67973,13 +67417,11 @@ entities:
   - uid: 4788
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-1.5
       parent: 2
   - uid: 4789
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,0.5
       parent: 2
   - uid: 4800
@@ -68125,7 +67567,6 @@ entities:
   - uid: 5096
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,34.5
       parent: 2
   - uid: 5099
@@ -68136,7 +67577,6 @@ entities:
   - uid: 5112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,49.5
       parent: 2
   - uid: 5116
@@ -68157,7 +67597,6 @@ entities:
   - uid: 5177
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,34.5
       parent: 2
   - uid: 5317
@@ -68168,103 +67607,86 @@ entities:
   - uid: 5324
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,37.5
       parent: 2
   - uid: 5334
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,46.5
       parent: 2
   - uid: 5337
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,10.5
       parent: 2
   - uid: 5338
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,11.5
       parent: 2
   - uid: 5339
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,12.5
       parent: 2
   - uid: 5340
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,13.5
       parent: 2
   - uid: 5341
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,14.5
       parent: 2
   - uid: 5342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,15.5
       parent: 2
   - uid: 5344
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-2.5
       parent: 2
   - uid: 5345
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,43.5
       parent: 2
   - uid: 5347
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,19.5
       parent: 2
   - uid: 5353
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,26.5
       parent: 2
   - uid: 5363
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,56.5
       parent: 2
   - uid: 5364
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,46.5
       parent: 2
   - uid: 5365
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,46.5
       parent: 2
   - uid: 5366
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,46.5
       parent: 2
   - uid: 5369
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,49.5
       parent: 2
   - uid: 5370
@@ -68275,55 +67697,46 @@ entities:
   - uid: 5371
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,49.5
       parent: 2
   - uid: 5372
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,49.5
       parent: 2
   - uid: 5373
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,49.5
       parent: 2
   - uid: 5377
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,29.5
       parent: 2
   - uid: 5378
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,29.5
       parent: 2
   - uid: 5380
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,29.5
       parent: 2
   - uid: 5381
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,30.5
       parent: 2
   - uid: 5382
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,31.5
       parent: 2
   - uid: 5383
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,33.5
       parent: 2
   - uid: 5385
@@ -68334,13 +67747,11 @@ entities:
   - uid: 5386
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,32.5
       parent: 2
   - uid: 5388
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,43.5
       parent: 2
   - uid: 5389
@@ -68396,19 +67807,16 @@ entities:
   - uid: 5438
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,59.5
       parent: 2
   - uid: 5439
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,59.5
       parent: 2
   - uid: 5473
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,43.5
       parent: 2
   - uid: 5586
@@ -68429,7 +67837,6 @@ entities:
   - uid: 5619
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-3.5
       parent: 2
   - uid: 5620
@@ -68440,55 +67847,46 @@ entities:
   - uid: 5622
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-1.5
       parent: 2
   - uid: 5626
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-2.5
       parent: 2
   - uid: 5627
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,55.5
       parent: 2
   - uid: 5628
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,52.5
       parent: 2
   - uid: 5630
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,54.5
       parent: 2
   - uid: 5636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,26.5
       parent: 2
   - uid: 5643
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,54.5
       parent: 2
   - uid: 5644
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,52.5
       parent: 2
   - uid: 5645
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,55.5
       parent: 2
   - uid: 5646
@@ -68534,7 +67932,6 @@ entities:
   - uid: 5654
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,56.5
       parent: 2
   - uid: 5656
@@ -68565,13 +67962,11 @@ entities:
   - uid: 5675
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,34.5
       parent: 2
   - uid: 5677
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,34.5
       parent: 2
   - uid: 5678
@@ -68592,199 +67987,166 @@ entities:
   - uid: 5739
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,42.5
       parent: 2
   - uid: 5740
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,38.5
       parent: 2
   - uid: 5741
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,38.5
       parent: 2
   - uid: 5742
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,38.5
       parent: 2
   - uid: 5743
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,38.5
       parent: 2
   - uid: 5744
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,38.5
       parent: 2
   - uid: 5745
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,37.5
       parent: 2
   - uid: 5747
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,40.5
       parent: 2
   - uid: 5748
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,37.5
       parent: 2
   - uid: 5749
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,37.5
       parent: 2
   - uid: 5750
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,37.5
       parent: 2
   - uid: 5751
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,56.5
       parent: 2
   - uid: 5753
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,46.5
       parent: 2
   - uid: 5755
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,41.5
       parent: 2
   - uid: 5758
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,39.5
       parent: 2
   - uid: 5759
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,40.5
       parent: 2
   - uid: 5760
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,41.5
       parent: 2
   - uid: 5761
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,42.5
       parent: 2
   - uid: 5764
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,39.5
       parent: 2
   - uid: 5766
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,37.5
       parent: 2
   - uid: 5768
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,29.5
       parent: 2
   - uid: 5769
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,30.5
       parent: 2
   - uid: 5772
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,49.5
       parent: 2
   - uid: 5773
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,49.5
       parent: 2
   - uid: 5774
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,44.5
       parent: 2
   - uid: 5775
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,56.5
       parent: 2
   - uid: 5776
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,49.5
       parent: 2
   - uid: 5777
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,0.5
       parent: 2
   - uid: 5778
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-1.5
       parent: 2
   - uid: 5779
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-1.5
       parent: 2
   - uid: 5780
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,0.5
       parent: 2
   - uid: 5783
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,42.5
       parent: 2
   - uid: 5784
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,42.5
       parent: 2
   - uid: 5794
@@ -68795,133 +68157,111 @@ entities:
   - uid: 5795
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,53.5
       parent: 2
   - uid: 5796
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,26.5
       parent: 2
   - uid: 5797
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,54.5
       parent: 2
   - uid: 5803
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,52.5
       parent: 2
   - uid: 5804
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,52.5
       parent: 2
   - uid: 5805
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,52.5
       parent: 2
   - uid: 5806
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,52.5
       parent: 2
   - uid: 5807
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,52.5
       parent: 2
   - uid: 5810
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,56.5
       parent: 2
   - uid: 5811
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,52.5
       parent: 2
   - uid: 5813
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,55.5
       parent: 2
   - uid: 5814
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,26.5
       parent: 2
   - uid: 5818
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,57.5
       parent: 2
   - uid: 5819
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,57.5
       parent: 2
   - uid: 5822
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,57.5
       parent: 2
   - uid: 5834
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,29.5
       parent: 2
   - uid: 5838
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,56.5
       parent: 2
   - uid: 5841
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,55.5
       parent: 2
   - uid: 5849
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,54.5
       parent: 2
   - uid: 5855
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,53.5
       parent: 2
   - uid: 5861
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,53.5
       parent: 2
   - uid: 5865
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,2.5
       parent: 2
   - uid: 5936
@@ -68932,13 +68272,11 @@ entities:
   - uid: 5944
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,27.5
       parent: 2
   - uid: 5948
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,30.5
       parent: 2
   - uid: 5953
@@ -69034,7 +68372,6 @@ entities:
   - uid: 6006
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,37.5
       parent: 2
   - uid: 6007
@@ -69120,25 +68457,21 @@ entities:
   - uid: 6036
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,19.5
       parent: 2
   - uid: 6037
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 38.5,11.5
       parent: 2
   - uid: 6041
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,19.5
       parent: 2
   - uid: 6058
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,21.5
       parent: 2
   - uid: 6061
@@ -69149,43 +68482,36 @@ entities:
   - uid: 6068
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,21.5
       parent: 2
   - uid: 6086
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 46.5,16.5
       parent: 2
   - uid: 6134
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,11.5
       parent: 2
   - uid: 6135
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,15.5
       parent: 2
   - uid: 6138
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,15.5
       parent: 2
   - uid: 6140
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,9.5
       parent: 2
   - uid: 6141
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,22.5
       parent: 2
   - uid: 6148
@@ -69196,31 +68522,26 @@ entities:
   - uid: 6152
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,1.5
       parent: 2
   - uid: 6158
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,16.5
       parent: 2
   - uid: 6161
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,19.5
       parent: 2
   - uid: 6162
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,26.5
       parent: 2
   - uid: 6170
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,11.5
       parent: 2
   - uid: 6172
@@ -69231,157 +68552,131 @@ entities:
   - uid: 6173
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,11.5
       parent: 2
   - uid: 6174
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,11.5
       parent: 2
   - uid: 6175
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,11.5
       parent: 2
   - uid: 6199
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,16.5
       parent: 2
   - uid: 6203
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,20.5
       parent: 2
   - uid: 6204
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,19.5
       parent: 2
   - uid: 6205
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,18.5
       parent: 2
   - uid: 6206
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,17.5
       parent: 2
   - uid: 6208
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,15.5
       parent: 2
   - uid: 6209
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,14.5
       parent: 2
   - uid: 6210
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,13.5
       parent: 2
   - uid: 6211
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,12.5
       parent: 2
   - uid: 6212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,11.5
       parent: 2
   - uid: 6213
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 46.5,11.5
       parent: 2
   - uid: 6214
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,11.5
       parent: 2
   - uid: 6215
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,11.5
       parent: 2
   - uid: 6216
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,11.5
       parent: 2
   - uid: 6217
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,11.5
       parent: 2
   - uid: 6218
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,11.5
       parent: 2
   - uid: 6219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 40.5,11.5
       parent: 2
   - uid: 6220
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,11.5
       parent: 2
   - uid: 6224
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,11.5
       parent: 2
   - uid: 6225
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,26.5
       parent: 2
   - uid: 6226
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,30.5
       parent: 2
   - uid: 6227
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,9.5
       parent: 2
   - uid: 6229
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,11.5
       parent: 2
   - uid: 6230
@@ -69397,13 +68692,11 @@ entities:
   - uid: 6244
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,6.5
       parent: 2
   - uid: 6249
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,24.5
       parent: 2
   - uid: 6258
@@ -69414,73 +68707,61 @@ entities:
   - uid: 6277
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,24.5
       parent: 2
   - uid: 6298
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,29.5
       parent: 2
   - uid: 6300
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,3.5
       parent: 2
   - uid: 6301
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,9.5
       parent: 2
   - uid: 6359
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,4.5
       parent: 2
   - uid: 6380
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,12.5
       parent: 2
   - uid: 6391
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,32.5
       parent: 2
   - uid: 6392
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,29.5
       parent: 2
   - uid: 6413
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,2.5
       parent: 2
   - uid: 6528
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,5.5
       parent: 2
   - uid: 6529
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,16.5
       parent: 2
   - uid: 6616
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,5.5
       parent: 2
   - uid: 6705
@@ -69491,25 +68772,21 @@ entities:
   - uid: 6823
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,27.5
       parent: 2
   - uid: 6826
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,16.5
       parent: 2
   - uid: 6838
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,1.5
       parent: 2
   - uid: 6855
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,12.5
       parent: 2
   - uid: 6942
@@ -69520,7 +68797,6 @@ entities:
   - uid: 6978
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,9.5
       parent: 2
   - uid: 6986
@@ -69531,31 +68807,26 @@ entities:
   - uid: 6989
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,25.5
       parent: 2
   - uid: 7046
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-3.5
       parent: 2
   - uid: 7047
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-3.5
       parent: 2
   - uid: 7048
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-5.5
       parent: 2
   - uid: 7049
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-5.5
       parent: 2
   - uid: 7055
@@ -69576,13 +68847,11 @@ entities:
   - uid: 7088
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,32.5
       parent: 2
   - uid: 7098
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,19.5
       parent: 2
   - uid: 7101
@@ -69593,7 +68862,6 @@ entities:
   - uid: 7114
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,2.5
       parent: 2
   - uid: 7115
@@ -69604,13 +68872,11 @@ entities:
   - uid: 7116
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,25.5
       parent: 2
   - uid: 7136
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,1.5
       parent: 2
   - uid: 7155
@@ -69631,19 +68897,16 @@ entities:
   - uid: 7158
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,9.5
       parent: 2
   - uid: 7159
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,56.5
       parent: 2
   - uid: 7163
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,3.5
       parent: 2
   - uid: 7179
@@ -69654,19 +68917,16 @@ entities:
   - uid: 7182
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,9.5
       parent: 2
   - uid: 7185
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,13.5
       parent: 2
   - uid: 7196
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,53.5
       parent: 2
   - uid: 7201
@@ -69687,43 +68947,36 @@ entities:
   - uid: 7312
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,56.5
       parent: 2
   - uid: 7313
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,56.5
       parent: 2
   - uid: 7314
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,52.5
       parent: 2
   - uid: 7315
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,52.5
       parent: 2
   - uid: 7316
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,52.5
       parent: 2
   - uid: 7347
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,15.5
       parent: 2
   - uid: 7348
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,15.5
       parent: 2
   - uid: 7349
@@ -69734,13 +68987,11 @@ entities:
   - uid: 7365
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,-12.5
       parent: 2
   - uid: 7447
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,47.5
       parent: 2
   - uid: 7459
@@ -69776,19 +69027,16 @@ entities:
   - uid: 7577
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,27.5
       parent: 2
   - uid: 7578
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,26.5
       parent: 2
   - uid: 7581
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,12.5
       parent: 2
   - uid: 7586
@@ -69799,13 +69047,11 @@ entities:
   - uid: 7590
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,9.5
       parent: 2
   - uid: 7595
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,1.5
       parent: 2
   - uid: 7599
@@ -69816,13 +69062,11 @@ entities:
   - uid: 7738
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,56.5
       parent: 2
   - uid: 7867
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,13.5
       parent: 2
   - uid: 7869
@@ -69833,19 +69077,16 @@ entities:
   - uid: 7958
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,24.5
       parent: 2
   - uid: 7959
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,18.5
       parent: 2
   - uid: 7960
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,19.5
       parent: 2
   - uid: 7999
@@ -69861,19 +69102,16 @@ entities:
   - uid: 8016
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,11.5
       parent: 2
   - uid: 8020
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,1.5
       parent: 2
   - uid: 8031
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,10.5
       parent: 2
   - uid: 8032
@@ -69884,7 +69122,6 @@ entities:
   - uid: 8036
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,25.5
       parent: 2
   - uid: 8042
@@ -69900,7 +69137,6 @@ entities:
   - uid: 8050
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,24.5
       parent: 2
   - uid: 8074
@@ -69931,7 +69167,6 @@ entities:
   - uid: 8085
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,43.5
       parent: 2
   - uid: 8088
@@ -69987,7 +69222,6 @@ entities:
   - uid: 8146
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,47.5
       parent: 2
   - uid: 8151
@@ -70043,7 +69277,6 @@ entities:
   - uid: 8208
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,12.5
       parent: 2
   - uid: 8209
@@ -70059,19 +69292,16 @@ entities:
   - uid: 8233
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,15.5
       parent: 2
   - uid: 8246
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,30.5
       parent: 2
   - uid: 8293
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,14.5
       parent: 2
   - uid: 8331
@@ -70092,7 +69322,6 @@ entities:
   - uid: 8380
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,-13.5
       parent: 2
   - uid: 8396
@@ -70118,7 +69347,6 @@ entities:
   - uid: 8469
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,25.5
       parent: 2
   - uid: 8476
@@ -70184,25 +69412,21 @@ entities:
   - uid: 8746
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,11.5
       parent: 2
   - uid: 8747
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 53.5,11.5
       parent: 2
   - uid: 8749
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 51.5,11.5
       parent: 2
   - uid: 8753
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,25.5
       parent: 2
   - uid: 8754
@@ -70213,25 +69437,21 @@ entities:
   - uid: 8756
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,28.5
       parent: 2
   - uid: 8757
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 51.5,28.5
       parent: 2
   - uid: 8758
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 52.5,28.5
       parent: 2
   - uid: 8759
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 53.5,28.5
       parent: 2
   - uid: 8773
@@ -70282,7 +69502,6 @@ entities:
   - uid: 9110
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,-15.5
       parent: 2
   - uid: 9114
@@ -70293,19 +69512,16 @@ entities:
   - uid: 9142
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-15.5
       parent: 2
   - uid: 9144
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,-14.5
       parent: 2
   - uid: 9146
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-14.5
       parent: 2
   - uid: 9147
@@ -70478,115 +69694,96 @@ entities:
   - uid: 1001
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
   - uid: 1009
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,7.5
       parent: 2
   - uid: 1010
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,6.5
       parent: 2
   - uid: 1011
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,6.5
       parent: 2
   - uid: 1012
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 2
   - uid: 1013
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,4.5
       parent: 2
   - uid: 1014
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,3.5
       parent: 2
   - uid: 1015
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,2.5
       parent: 2
   - uid: 1020
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,5.5
       parent: 2
   - uid: 1025
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 2
   - uid: 1026
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,6.5
       parent: 2
   - uid: 1028
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,2.5
       parent: 2
   - uid: 1030
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,0.5
       parent: 2
   - uid: 1031
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-0.5
       parent: 2
   - uid: 1032
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-2.5
       parent: 2
   - uid: 1033
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-1.5
       parent: 2
   - uid: 1042
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-1.5
       parent: 2
   - uid: 1043
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-3.5
       parent: 2
   - uid: 1177
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-4.5
       parent: 2
   - uid: 1425
@@ -70607,103 +69804,86 @@ entities:
   - uid: 1661
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,29.5
       parent: 2
   - uid: 1665
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,30.5
       parent: 2
   - uid: 1689
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,44.5
       parent: 2
   - uid: 1691
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,41.5
       parent: 2
   - uid: 1692
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,42.5
       parent: 2
   - uid: 1696
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,44.5
       parent: 2
   - uid: 1699
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,41.5
       parent: 2
   - uid: 1700
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,42.5
       parent: 2
   - uid: 1704
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,41.5
       parent: 2
   - uid: 1707
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,41.5
       parent: 2
   - uid: 1713
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,42.5
       parent: 2
   - uid: 1714
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,42.5
       parent: 2
   - uid: 1715
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,42.5
       parent: 2
   - uid: 1724
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,29.5
       parent: 2
   - uid: 1726
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,34.5
       parent: 2
   - uid: 1732
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,30.5
       parent: 2
   - uid: 1740
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,29.5
       parent: 2
   - uid: 1741
@@ -70714,325 +69894,271 @@ entities:
   - uid: 1742
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,27.5
       parent: 2
   - uid: 1743
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,26.5
       parent: 2
   - uid: 1744
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,25.5
       parent: 2
   - uid: 1745
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,24.5
       parent: 2
   - uid: 1746
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,23.5
       parent: 2
   - uid: 1747
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,22.5
       parent: 2
   - uid: 1749
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,20.5
       parent: 2
   - uid: 1750
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,19.5
       parent: 2
   - uid: 1758
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,44.5
       parent: 2
   - uid: 1760
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,43.5
       parent: 2
   - uid: 1761
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,41.5
       parent: 2
   - uid: 1763
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,41.5
       parent: 2
   - uid: 1769
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,43.5
       parent: 2
   - uid: 1771
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,44.5
       parent: 2
   - uid: 1776
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,41.5
       parent: 2
   - uid: 1779
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,41.5
       parent: 2
   - uid: 1785
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,43.5
       parent: 2
   - uid: 1787
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,44.5
       parent: 2
   - uid: 1814
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,42.5
       parent: 2
   - uid: 1815
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,40.5
       parent: 2
   - uid: 1816
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,39.5
       parent: 2
   - uid: 1817
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,38.5
       parent: 2
   - uid: 1818
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,41.5
       parent: 2
   - uid: 1819
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,38.5
       parent: 2
   - uid: 1820
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,39.5
       parent: 2
   - uid: 1821
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,40.5
       parent: 2
   - uid: 1822
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,41.5
       parent: 2
   - uid: 1823
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,42.5
       parent: 2
   - uid: 1824
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,44.5
       parent: 2
   - uid: 1825
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,45.5
       parent: 2
   - uid: 1826
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,43.5
       parent: 2
   - uid: 1828
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,47.5
       parent: 2
   - uid: 1842
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,35.5
       parent: 2
   - uid: 1843
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,35.5
       parent: 2
   - uid: 1844
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,35.5
       parent: 2
   - uid: 1845
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,35.5
       parent: 2
   - uid: 1846
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,35.5
       parent: 2
   - uid: 1847
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,35.5
       parent: 2
   - uid: 1848
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,35.5
       parent: 2
   - uid: 1851
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,30.5
       parent: 2
   - uid: 1852
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,35.5
       parent: 2
   - uid: 1853
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,35.5
       parent: 2
   - uid: 1854
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,35.5
       parent: 2
   - uid: 1855
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,35.5
       parent: 2
   - uid: 1856
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,35.5
       parent: 2
   - uid: 1857
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,35.5
       parent: 2
   - uid: 1859
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,37.5
       parent: 2
   - uid: 1870
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,29.5
       parent: 2
   - uid: 1871
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,29.5
       parent: 2
   - uid: 1872
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,29.5
       parent: 2
   - uid: 1873
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,29.5
       parent: 2
   - uid: 1874
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,29.5
       parent: 2
   - uid: 1875
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,29.5
       parent: 2
   - uid: 1876
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,29.5
       parent: 2
   - uid: 1884
@@ -71068,205 +70194,171 @@ entities:
   - uid: 1899
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,29.5
       parent: 2
   - uid: 1900
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,29.5
       parent: 2
   - uid: 1901
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,29.5
       parent: 2
   - uid: 1902
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,29.5
       parent: 2
   - uid: 1903
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,29.5
       parent: 2
   - uid: 1904
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,29.5
       parent: 2
   - uid: 1905
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,29.5
       parent: 2
   - uid: 1906
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,31.5
       parent: 2
   - uid: 1907
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,32.5
       parent: 2
   - uid: 1908
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,34.5
       parent: 2
   - uid: 1909
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,35.5
       parent: 2
   - uid: 1910
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,33.5
       parent: 2
   - uid: 1911
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,35.5
       parent: 2
   - uid: 1915
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,32.5
       parent: 2
   - uid: 1916
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,32.5
       parent: 2
   - uid: 1917
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,34.5
       parent: 2
   - uid: 1918
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,33.5
       parent: 2
   - uid: 1938
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-4.5
       parent: 2
   - uid: 1939
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-5.5
       parent: 2
   - uid: 1940
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-5.5
       parent: 2
   - uid: 1941
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-5.5
       parent: 2
   - uid: 1942
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-6.5
       parent: 2
   - uid: 1943
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-7.5
       parent: 2
   - uid: 1944
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-8.5
       parent: 2
   - uid: 1945
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-9.5
       parent: 2
   - uid: 1946
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-9.5
       parent: 2
   - uid: 1947
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-9.5
       parent: 2
   - uid: 1948
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 2
   - uid: 1949
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-9.5
       parent: 2
   - uid: 1956
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 2
   - uid: 1957
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 2
   - uid: 1958
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 2
   - uid: 1959
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 2
   - uid: 1962
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 2
   - uid: 1967
@@ -71332,67 +70424,56 @@ entities:
   - uid: 2446
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,11.5
       parent: 2
   - uid: 2851
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 2
   - uid: 2852
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-10.5
       parent: 2
   - uid: 2853
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 2
   - uid: 2854
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 2
   - uid: 2855
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 2
   - uid: 2856
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-10.5
       parent: 2
   - uid: 2857
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 2
   - uid: 2858
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,-10.5
       parent: 2
   - uid: 2862
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-9.5
       parent: 2
   - uid: 2863
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-9.5
       parent: 2
   - uid: 3006
@@ -71408,25 +70489,21 @@ entities:
   - uid: 3010
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,14.5
       parent: 2
   - uid: 3012
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,14.5
       parent: 2
   - uid: 3022
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,11.5
       parent: 2
   - uid: 3023
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,11.5
       parent: 2
   - uid: 3031
@@ -71437,7 +70514,6 @@ entities:
   - uid: 3032
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,14.5
       parent: 2
   - uid: 3033
@@ -71473,25 +70549,21 @@ entities:
   - uid: 3472
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,10.5
       parent: 2
   - uid: 3473
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,10.5
       parent: 2
   - uid: 3477
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,10.5
       parent: 2
   - uid: 3480
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,10.5
       parent: 2
   - uid: 3542
@@ -71507,19 +70579,16 @@ entities:
   - uid: 3634
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,11.5
       parent: 2
   - uid: 3882
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,4.5
       parent: 2
   - uid: 4050
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,22.5
       parent: 2
   - uid: 4096
@@ -71530,7 +70599,6 @@ entities:
   - uid: 4148
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,34.5
       parent: 2
   - uid: 4362
@@ -71556,7 +70624,6 @@ entities:
   - uid: 5105
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,45.5
       parent: 2
   - uid: 5168
@@ -71572,55 +70639,46 @@ entities:
   - uid: 5360
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,9.5
       parent: 2
   - uid: 5361
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,4.5
       parent: 2
   - uid: 5368
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,9.5
       parent: 2
   - uid: 5374
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,4.5
       parent: 2
   - uid: 5872
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,9.5
       parent: 2
   - uid: 5876
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,28.5
       parent: 2
   - uid: 6082
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 21.5,5.5
       parent: 2
   - uid: 6875
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,35.5
       parent: 2
   - uid: 7147
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,4.5
       parent: 2
   - uid: 7398
@@ -71631,61 +70689,51 @@ entities:
   - uid: 7579
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,9.5
       parent: 2
   - uid: 7615
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,5.5
       parent: 2
   - uid: 7701
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,42.5
       parent: 2
   - uid: 7702
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 30.5,42.5
       parent: 2
   - uid: 8010
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,46.5
       parent: 2
   - uid: 8019
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,13.5
       parent: 2
   - uid: 8026
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,5.5
       parent: 2
   - uid: 8046
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,14.5
       parent: 2
   - uid: 8047
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,12.5
       parent: 2
   - uid: 8049
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,6.5
       parent: 2
   - uid: 8067
@@ -71696,55 +70744,46 @@ entities:
   - uid: 8157
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,44.5
       parent: 2
   - uid: 8164
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,43.5
       parent: 2
   - uid: 8166
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 31.5,42.5
       parent: 2
   - uid: 8406
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-11.5
       parent: 2
   - uid: 8452
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,34.5
       parent: 2
   - uid: 8453
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,36.5
       parent: 2
   - uid: 8456
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,33.5
       parent: 2
   - uid: 9143
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-12.5
       parent: 2
   - uid: 9145
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-11.5
       parent: 2
   - uid: 9638
@@ -71845,13 +70884,11 @@ entities:
   - uid: 10064
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,49.5
       parent: 2
   - uid: 10065
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,49.5
       parent: 2
   - uid: 10180
@@ -71886,67 +70923,56 @@ entities:
   - uid: 1663
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,38.5
       parent: 2
   - uid: 1664
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,38.5
       parent: 2
   - uid: 1670
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,38.5
       parent: 2
   - uid: 1671
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,38.5
       parent: 2
   - uid: 1673
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,38.5
       parent: 2
   - uid: 1674
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,38.5
       parent: 2
   - uid: 1680
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,38.5
       parent: 2
   - uid: 1690
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,39.5
       parent: 2
   - uid: 1694
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,38.5
       parent: 2
   - uid: 1721
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,38.5
       parent: 2
   - uid: 1722
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,39.5
       parent: 2
   - uid: 10114


### PR DESCRIPTION
## About the PR
Puts the linked captain's ID spawners on Saltern and Schooner, in some... fun places. Also hits both of them with fixrotations, which shouldn't break anything I hope.

## Technical details
Mapping changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
Not player facing (mostly).

