### PR TITLE
Recycler Roundend Killcount

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -28,7 +28,9 @@ using Content.Shared.Gibbing;
 using Content.Shared.Humanoid;
 using Content.Shared.Body.Components; // imp
 using Content.Shared.Damage.Systems; // imp
+using Content.Server.GameTicking; // imp
 using Content.Shared.StatusEffectNew; // imp
+using System.Text; // imp
 
 namespace Content.Server.Materials;
 
@@ -63,6 +65,8 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 
         SubscribeLocalEvent<MaterialReclaimerComponent, BreakageEventArgs>(OnBreakage);
         SubscribeLocalEvent<MaterialReclaimerComponent, RepairedEvent>(OnRepaired);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndText); // imp
     }
 
     private void OnPowerChanged(Entity<MaterialReclaimerComponent> entity, ref PowerChangedEvent args)
@@ -118,6 +122,7 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
             true);
 
         _gibbing.Gib(victim);
+        entity.Comp.KillCount++; // imp
         _appearance.SetData(entity.Owner, RecyclerVisuals.Bloody, true);
         args.Handled = true;
     }
@@ -215,6 +220,7 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
             if (component.ReclaimSolutions)
                 SpawnChemicalsFromComposition(uid, item, completion, false, component, xform);
             _gibbing.Gib(item);
+            component.KillCount++; // imp
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
         }
         else
@@ -313,4 +319,21 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
             _puddle.TrySpillAt(reclaimer, totalChemicals, out _, sound, transformComponent: xform);
         }
     }
+
+
+    // imp start
+    private void OnRoundEndText(RoundEndTextAppendEvent ev)
+    {
+        var query = EntityQueryEnumerator<MaterialReclaimerComponent>();
+        while (query.MoveNext(out var _, out var reclaimerComp))
+        {
+            if (reclaimerComp.KillCount == 0)
+                return;
+
+            var result = new StringBuilder();
+            result.AppendLine(Loc.GetString("recycler-component-souls-consumed", ("count", reclaimerComp.KillCount)));
+            ev.AddLine(result.AppendLine().ToString());
+        }
+    }
+    // imp end
 }

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -157,6 +157,12 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan StatusEffectDuration = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Imp addition, the number of people the reclaimer has killed. Appended to the round end screen.
+    /// </summary>
+    [DataField]
+    public int KillCount = 0;
 }
 
 [NetSerializable, Serializable]

--- a/Resources/Locale/en-US/_Impstation/recycling/components/recycler-component.ftl
+++ b/Resources/Locale/en-US/_Impstation/recycling/components/recycler-component.ftl
@@ -1,0 +1,1 @@
+recycler-component-souls-consumed = A recycler consumed [color=red]{$count} soul(s).[/color]


### PR DESCRIPTION
## About the PR
Recycler now appends a kill count to the round end screen, based on whether or not it killed anyone, and how many it killed.

## Why / Balance
funny

## Technical details
Modifications to MaterialReclaimerSystem.cs for roundend append, added a new field to MaterialReclaimerComponent, new ftl in imp namespace.

## Media
<img width="630" height="353" alt="image" src="https://github.com/user-attachments/assets/d7da8eba-dde8-4312-b968-9676b191d3c8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl:
- add: The recycler now tracks its kills. Watch, lest ye become a statistic.

