### PR TITLE
Make Ghoul Intro Text Respect the Summoner's Pronouns

### DIFF
--- a/Resources/Locale/en-US/_Impstation/Heretic/game-ticking/game-presets/preset-heretic.ftl
+++ b/Resources/Locale/en-US/_Impstation/Heretic/game-ticking/game-presets/preset-heretic.ftl
@@ -27,7 +27,7 @@ heretic-role-greeting-short =
 ## ghoul
 heretic-ghoul-greeting =
     You have been summoned into this world by {CAPITALIZE(THE($ent))}!
-    You must aid him in his journey to ascension and protect him at all costs.
+    You must aid {OBJECT($ent)} in {POSS-ADJ($ent)} journey to ascension and protect {OBJECT($ent)} at all costs.
     You may follow other heretics if your master is beyond resurrection.
 heretic-ghoul-greeting-noname =
     You have been summoned into this world by eldritch forces.


### PR DESCRIPTION
## About the PR
Does what it says on the tin. Makes the ghoul intro text use the summoner's pronouns, rather than he by default.

## Why / Balance
Misgendering :(.

## Technical details
One line FTL edit. Makes the pronouns in the text into their localisation equivalent.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- fix: The intro text for ghouls now respects the summoner's pronouns.
