### PR TITLE
Allow non-selectable alert level to be changed on comms console, supermatter resonance cascade delta alert on crystal plant

### DIFF
--- a/Content.Server/AlertLevel/AlertLevelComponent.cs
+++ b/Content.Server/AlertLevel/AlertLevelComponent.cs
@@ -46,7 +46,10 @@ public sealed partial class AlertLevelComponent : Component
                 return false;
             }
 
-            return level.Selectable && !level.DisableSelection && !IsLevelLocked;
+            /* Imp removal
+            return level.Selectable && !level.DisableSelection && !IsLevelLocked
+            */
+            return !level.DisableSelection && !IsLevelLocked; // Imp
         }
     }
 }

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -154,11 +154,13 @@ namespace Content.Server.Communications
                             {
                                 levels.Add(id);
                             }
-                            // Imp start
-                            else if (alertComp.CurrentLevel == id)
-                                levels.Add(id);
-                            // Imp end
                         }
+
+                        // Imp start
+                        if (alertComp.AlertLevels.Levels.TryGetValue(alertComp.CurrentLevel, out var level)
+                            && !level.Selectable)
+                            levels.Add(alertComp.CurrentLevel);
+                        // Imp end
                     }
 
                     currentLevel = alertComp.CurrentLevel;

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -155,6 +155,12 @@ namespace Content.Server.Communications
                                 levels.Add(id);
                             }
                         }
+
+                        // Imp start
+                        if (alertComp.AlertLevels.Levels.TryGetValue(alertComp.CurrentLevel, out var level)
+                            && !level.Selectable)
+                            levels.Add(alertComp.CurrentLevel);
+                        // Imp end
                     }
 
                     currentLevel = alertComp.CurrentLevel;

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -154,13 +154,11 @@ namespace Content.Server.Communications
                             {
                                 levels.Add(id);
                             }
+                            // Imp start
+                            else if (alertComp.CurrentLevel == id)
+                                levels.Add(id);
+                            // Imp end
                         }
-
-                        // Imp start
-                        if (alertComp.AlertLevels.Levels.TryGetValue(alertComp.CurrentLevel, out var level)
-                            && !level.Selectable)
-                            levels.Add(alertComp.CurrentLevel);
-                        // Imp end
                     }
 
                     currentLevel = alertComp.CurrentLevel;

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server._Impstation.StrangeMoods;
 using Content.Server.Administration.Logs;
+using Content.Server.AlertLevel;
 using Content.Server.Announcements.Systems;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
@@ -51,6 +52,7 @@ namespace Content.Server._EE.Supermatter.Systems;
 
 public sealed partial class SupermatterSystem : EntitySystem
 {
+    [Dependency] private readonly AlertLevelSystem _alertLevelSystem = default!;
     [Dependency] private readonly AnnouncerSystem _announcer = default!;
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
@@ -314,6 +316,11 @@ public sealed partial class SupermatterSystem : EntitySystem
             Loc.GetString("resonance-cascade-announcement-sender"),
             colorOverride: Color.Cyan
         );
+
+        var supermatterXform = Transform(uid);
+        var stationUid = _station.GetStationInMap(supermatterXform.MapID);
+        if (stationUid != null)
+            _alertLevelSystem.SetLevel(stationUid.Value, "delta", true, true, true);
 
         _popup.PopupEntity(Loc.GetString("supermatter-destabalize-end"), uid, args.User);
         EntityManager.QueueDeleteEntity(args.Used);

--- a/Content.Server/_Impstation/GameTicking/Rules/CascadeRuleSystem.cs
+++ b/Content.Server/_Impstation/GameTicking/Rules/CascadeRuleSystem.cs
@@ -167,6 +167,6 @@ public sealed class CascadeRuleSystem : GameRuleSystem<CascadeRuleComponent>
             return;
         if (_alertLevelSystem.GetLevel(station.Value) == "delta") // Don't delta if already delta
             return;
-        _alertLevelSystem.SetLevel(station.Value, "delta", true, true, true);
+        _alertLevelSystem.SetLevel(station.Value, "delta", true, true, true, true);
     }
 }

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -53,7 +53,7 @@
         path: /Audio/Misc/delta.ogg
         params:
           volume: -3
-      disableSelection: true
+      # disableSelection: true Imp removal
       color: DarkRed
       emergencyLightColor: Orange
       forceEnableEmergencyLights: true


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More clear on a supermatter delam situation. Allows crew to manually change the alert level back from delta to another selectable one if the threat passes. I would like to have it automatically change alert levels when the supermatter starts healing or heals back to a threshold but that is a different set of challenges to implement.
## Technical details
<!-- Summary of code changes for easier review. -->
There is alot of component values that effect a IsSelectable variable that determines if the alert level can be changed through the communication console and originally was forced into only being able to select the alert levels that were always available to select as if it didn't then the alert level that wasn't selectable but wanted to be changed wouldn't show up on the drop down menu of available alerts. Adds support for that.

Nuke already has lock enabled in .SetLevel for delta so can't be changed.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

https://github.com/user-attachments/assets/847b7ea1-28ec-4a6a-855f-780970352c10


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Destabilizing Crystal causes a delta alert when planted for Resonance Cascade.