### PR TITLE
Fix Oasis crashing, add migration for SpawnMobFiendfish and MobFiendfish

### DIFF
--- a/Resources/migration_imp.yml
+++ b/Resources/migration_imp.yml
@@ -160,3 +160,8 @@ PaintingSleepingGypsy: RandomPainting
 # 2026-06-14
 # changed mapped bug plushies with imp plushies
 PlushieBug: PlushieImp
+
+# 2026-07-06
+# changed spelling in entities
+MobFeindfish: MobFiendfish
+SpawnMobFeindfish: SpawnMobFiendfish


### PR DESCRIPTION
## About the PR
https://github.com/impstation/imp-station-14/pull/4417 changed the entity ID for SpawnMobFeindfish changing it to SpawnMobFiendfish, but did not add a migration for it. This caused any maps with it mapped to it (Oasis) to fail to load. This PR rectifies that.

## Why / Balance
Map crash bad, migration good.

## Technical details
Edited one line of yaml in Oasis' map file to change the prototype name. Added migration for the relevant entities in case there are any maps that have these downstream somewhere.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed Oasis not loading.
