### PR TITLE
fix: grays remember contractions for words with Are

### DIFF
--- a/Resources/Locale/en-US/_Impstation/accent/gray.ftl
+++ b/Resources/Locale/en-US/_Impstation/accent/gray.ftl
@@ -1143,3 +1143,12 @@ accent-gray-words-replace-381 = lobstar
 
 accent-gray-words-382 = redshells
 accent-gray-words-replace-382 = lobstars
+
+accent-gray-words-383 = you're
+accent-gray-words-replace-383 = mozz
+
+accent-gray-words-384 = we're
+accent-gray-words-replace-384 = gleepzz
+
+accent-gray-words-385 = they're
+accent-gray-words-replace-385 = jamgazz

--- a/Resources/Prototypes/_Impstation/Accents/gray_replacements.yml
+++ b/Resources/Prototypes/_Impstation/Accents/gray_replacements.yml
@@ -383,4 +383,7 @@
     accent-gray-words-380: accent-gray-words-replace-380
     accent-gray-words-381: accent-gray-words-replace-381
     accent-gray-words-382: accent-gray-words-replace-382
+    accent-gray-words-383: accent-gray-words-replace-383
+    accent-gray-words-384: accent-gray-words-replace-384
+    accent-gray-words-385: accent-gray-words-replace-385
     


### PR DESCRIPTION
## About the PR
grayspeak contractions for we're, they're and you're now work correctly again

## Why / Balance
they used to do this and it broke. now it fix

## Technical details
added 6 lines of code to an FTL file and 3 lines to a YML file

## Media
<img width="377" height="354" alt="mysentence" src="https://github.com/user-attachments/assets/691cba12-4814-489a-866b-dc3ceda21457" />
<img width="442" height="85" alt="capitalisation" src="https://github.com/user-attachments/assets/f6df5dc7-e07b-4042-8776-b770004aadc4" />

## Requirements
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->

:cl:
- fix: grays use -'re contractions correctly again