### PR TITLE
Cold damage examine text typo fix

### DIFF
--- a/Resources/Locale/en-US/health-examinable/health-examinable-carbon.ftl
+++ b/Resources/Locale/en-US/health-examinable/health-examinable-carbon.ftl
@@ -65,7 +65,7 @@ health-examinable-carbon-Shock-200 = [color=#FFA100]{ CAPITALIZE(POSS-ADJ($targe
 #health-examinable-carbon-Cold-30 = [color=#9CB4DD]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } second-degree frostbite on { POSS-ADJ($target) } extremities.[/color]
 #health-examinable-carbon-Cold-50 = [color=#8E9AD3]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major third-degree frostbite on { POSS-ADJ($target) } extremities.[/color]
 health-examinable-carbon-Cold-8 = [color=#C6FDFA]{ CAPITALIZE(POSS-ADJ($target)) } fingertips are cold to the touch.[/color]
-health-examinable-carbon-Cold-15 = [color=#B1D9ED]]{ CAPITALIZE(POSS-ADJ($target)) } fingertips are flushed and cold.[/color]
+health-examinable-carbon-Cold-15 = [color=#B1D9ED]{ CAPITALIZE(POSS-ADJ($target)) } fingertips are flushed and cold.[/color]
 health-examinable-carbon-Cold-30 = [color=#9CB4DD]{ CAPITALIZE(POSS-ADJ($target)) } extremeties are flushed, cold and hard to the touch.[/color]
 health-examinable-carbon-Cold-50 = [color=#8E9AD3]{ CAPITALIZE(POSS-ADJ($target)) } extremeties are dark and cold.[/color]
 health-examinable-carbon-Cold-75 = [color=#7673C4]{ CAPITALIZE(POSS-ADJ($target)) } limbs are dark, cold and necrotic.[/color]


### PR DESCRIPTION
## About the PR
Fixes a stray square bracket in the 15 cold damage examine text.

## Why / Balance
Fixes a typo.

## Technical details
Deleted one square bracket

## Media
Left screenshot is from round 10513.
<img width="715" height="187" alt="Cold_damage_examine_text" src="https://github.com/user-attachments/assets/b4259a3f-6227-4d87-b635-cd053299436d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
