### PR TITLE
replace admin door remote on Reach

### DIFF
--- a/Resources/Maps/_Impstation/reach.yml
+++ b/Resources/Maps/_Impstation/reach.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 268.0.0
+  engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/13/2026 23:40:41
+  time: 08/12/2026 22:25:23
   entityCount: 2767
 maps:
 - 1
@@ -8119,7 +8119,7 @@ entities:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
-- proto: DoorRemoteAll
+- proto: DoorRemoteCustom
   entities:
   - uid: 1056
     components:


### PR DESCRIPTION
## About the PR
swaps the super door remote in the bridge on Reach with a custom door remote

## Why / Balance
the super door remote is an admin tool that can overcharge doors, it was originally mapped before this functionality and before the custom door remote was made.

## Technical details
changes DoorRemoteAll to DoorRemoteCustom in the yml

## Media
<img width="126" height="87" alt="ersdthgsertherth" src="https://github.com/user-attachments/assets/592129e4-67dc-4f74-917a-a1926d766afd" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl:
- fix: replaced the super door remote on Reach with a custom door remote
