### PR TITLE
revert #562 (chefvend tweak), aka chefvend stock halved, aka chefvend 9/11

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -22,7 +22,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChefvendFilled
-  cost: 900
+  cost: 680
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -1,26 +1,26 @@
 - type: vendingMachineInventory
   id: ChefvendInventory
   startingInventory:
-    ReagentContainerFlour: 4
-    ReagentContainerCornmeal: 4
-    ReagentContainerSugar: 4
-    ReagentContainerRice: 4
-    FoodCondimentPacketSalt: 8
-    FoodCondimentBottleEnzyme: 4
-    FoodCondimentBottleHotsauce: 2
-    FoodCondimentBottleKetchup: 2
-    FoodCondimentBottleBBQ: 2
-    FoodCondimentBottleVinegar: 4
-    ReagentContainerOliveoil: 4
-    ReagentContainerMayo: 2
+    ReagentContainerFlour: 2
+    ReagentContainerCornmeal: 2
+    ReagentContainerSugar: 2
+    ReagentContainerRice: 2
+    FoodCondimentPacketSalt: 4
+    FoodCondimentBottleEnzyme: 2
+    FoodCondimentBottleHotsauce: 1
+    FoodCondimentBottleKetchup: 1
+    FoodCondimentBottleBBQ: 1
+    FoodCondimentBottleVinegar: 2
+    ReagentContainerOliveoil: 2
+    ReagentContainerMayo: 1
     ExtractBottleVanilla: 2 #imp
     ChefCubeBox: 1 #imp, previously was VariantCubeBox
-    FoodContainerEgg: 2
-    DrinkMilkCarton: 4
-    DrinkSoyMilkCarton: 2
-    FoodButter: 6
-    FoodCheese: 2
-    FoodMeat: 16 #imp, original - 12, upped slightly to account for mild monkey repossession
+    FoodContainerEgg: 1
+    DrinkMilkCarton: 2
+    DrinkSoyMilkCarton: 1
+    FoodButter: 3
+    FoodCheese: 1
+    FoodMeat: 8 #imp, original - 6, upped slightly to account for mild monkey repossession
     FoodSausageCasingRoll: 3 # DEN - Adds sausage casings
     FoodBoxWaffleCone: 1 # Frontier
     FoodCondimentBottleSoysauce: 1 #imp add from _NF


### PR DESCRIPTION
## About the PR
(mostly) reverts #562, which doubled most of the stock of the chefvend and increased its cargo price as a result. it was a different time so there's no explanation for it in the pr, but it might have been a result of bounty pressure on the chef? either way i don't think the chef needs so gosh darn much at roundstart

## Why / Balance
every time i look in the chefvend i am frankly gobsmacked by the amount of Free Shit you get at roundstart. Free Shit is okay with me but 16 whole slabs of meat? 4 cartons of milk? it seems a little egregious to me

## Technical details
every value adjusted in #562 has been reverted to the wizden values, except for `FoodMeat`. #2777 increased the amount of `FoodMeat` by 1.33x, from 12 to 16, so i applied the same multiplier to wizden's 6 to get an impstation special number of 8. or i guess you could just divide 16 by 2. that works as well

i didn't add imp tags to any of this since it's a reversion to upstream numbers

## Media
<img width="340" height="913" alt="image" src="https://github.com/user-attachments/assets/5b35b060-c3c2-4102-839d-74e81cb274a2" />

Yeup. THats food

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- tweak: Most of the ChefVend's stock has been halved to match upstream values. To match, cargo restocks for the machine are cheaper.
