### PR TITLE
courier module inhand sprite

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/Robotics/Borg/borg_modules.yml
@@ -87,6 +87,23 @@
     layers:
     - state: cargo
     - state: icon-courier
+  - type: Item
+    sprite: Objects/Specific/Robotics/borgmodule.rsi
+    inhandVisuals:
+      left:
+      - state: base-icon-inhand-left
+        color: "#EBD8B7"
+      - state: base-module-inhand-left
+        color: "#613D1D"
+      - state: base-stripes-inhand-left
+        color: "#593718"
+      right:
+      - state: base-icon-inhand-right
+        color: "#EBD8B7"
+      - state: base-module-inhand-right
+        color: "#613D1D"
+      - state: base-stripes-inhand-right
+        color: "#593718"
   - type: ItemBorgModule
     hands:
     - item: MailBag


### PR DESCRIPTION
## About the PR
Points the courier cyborg module to inhand sprites so it doesn't display an error when held.

## Why / Balance
Fix.

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl:
- fix: Courier cyborg module inhands

