### PR TITLE
space cleaner restock fix

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Specific/chemical-containers.yml
@@ -126,7 +126,7 @@
     currentLabel: space cleaner
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink: # imp, beaker isnt a functional component here
         reagents:
         - ReagentId: SpaceCleaner
           Quantity: 200


### PR DESCRIPTION
## About the PR
Fixes the space cleaner restock cargo order to contain space cleaner.

## Why / Balance
It was broken. Now it isn't.

## Technical details
The entity was using a beaker subcomponent instead of a drink one to try and fill the jugs, I assume that subcomponent was either applied with a misunderstanding of how it worked or the function has since been deprecated.

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- fix: Space cleaner restock now includes space cleaner
