### PR TITLE
chaplain bow fix

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/nullrod.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/nullrod.yml
@@ -220,12 +220,8 @@
   - type: ContainerContainer
     containers:
       projectiles: !type:ContainerSlot
-      ballistic-ammo: !type:Container
-  - type: BallisticAmmoProvider
-    whitelist:
-      tags:
-        - HolyArrow
-    capacity: 1
+  - type: ContainerAmmoProvider
+    container: projectiles
   - type: Appearance
   - type: ItemMapper
     spriteLayers:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Misc/nullrod_evil.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Misc/nullrod_evil.yml
@@ -96,12 +96,8 @@
     containers:
       projectiles: !type:ContainerSlot
       ballistic-ammo: !type:Container
-  - type: BallisticAmmoProvider
-    whitelist:
-      tags:
-        - HolyArrow
-        - HolyArrowEvil
-    capacity: 1
+  - type: ContainerAmmoProvider
+    container: projectiles
   - type: Appearance
   - type: ItemMapper
     spriteLayers:


### PR DESCRIPTION
## About the PR
Fixes being able to load two arrows in the holy bow and evil holy bow.

## Why / Balance
It was broken so I unbroke it.

## Technical details
The ballistic ammo provider component wasn't needed so it was removed. The ContainerAmmoProvider component was required so it was added. This also fixes both bows having the wrong sound on being loaded.

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl:
- fix: Aureole arc and umbral arc bows have been fixed
