### PR TITLE
supermatter accent over radio and paracusia sound collecton

### DIFF
--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -611,6 +611,8 @@ public sealed partial class SupermatterSystem
 
         sm.YellLast = _timing.CurTime;
         _chat.TrySendInGameICMessage(uid, message, InGameICChatType.Speak, hideChat: false, checkRadioPrefix: true);
+        if (sm.AllowAccent == true) //imp, check bool for allowing formatted announcements
+            message = _chat.TransformSpeech(uid, message); //imp
         _radio.SendRadioMessage(uid, message, channel, uid);
     }
 
@@ -841,7 +843,7 @@ public sealed partial class SupermatterSystem
             // Everyone else gets hallucinations
             // These values match the paracusia disability, since we can't double up on paracusia
             // TODO: change this from paracusia to actual hallucinations whenever those are real
-            var paracusiaSounds = new SoundCollectionSpecifier("Paracusia");
+            var paracusiaSounds = new SoundCollectionSpecifier(sm.ParacusiaCollection); //imp edit, "Paracusia" > sm.ParacusiaCollection
             var paracusiaMinTime = 0.1f;
             var paracusiaMaxTime = 300f;
             var paracusiaDistance = 7f;

--- a/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
@@ -148,12 +148,19 @@ public sealed partial class SupermatterComponent : Component
     [DataField]
     public ProtoId<SpeechSoundsPrototype>? StatusCurrentSound;
 
+    //imp sounds start
     [DataField]
     public SoundSpecifier GainParacusiaSound = new SoundPathSpecifier("/Audio/Ambience/ambidanger.ogg");
 
     [DataField]
     public SoundSpecifier GiveParacusiaSound = new SoundPathSpecifier("/Audio/Ambience/ambireebe3.ogg");
 
+    /// <summary>
+    /// The sound collection id fed to ParacusiaComponent when looking at the sm unprotected.
+    /// </summary>
+    [DataField]
+    public string ParacusiaCollection = "Paracusia";
+    //imp sounds end
     #endregion
 
     #region Processing
@@ -431,6 +438,13 @@ public sealed partial class SupermatterComponent : Component
     /// </summary>
     [DataField]
     public bool HasBeenPowered;
+
+    // imp add
+    /// <summary>
+    /// Allows delam radio announcements to use accents,
+    /// </summary>
+    [DataField]
+    public bool AllowAccent = true;
 
     #endregion
 


### PR DESCRIPTION
## About the PR
The sound collection for paracusia from the sm can be edited. If the supermatter is given an accent it is audible on the radio delam alerts. These are mainly only admin accessible right now, but this does make one (1) announcement from thusd crystal accurate to what it is saying in person.

## Why / Balance
freedom to goof off with a silly sm. you could theoretically make something like a custom sound collection for the mariah crystal. or you can give the sm vowel rotation (evil).
maybe this is a prereq for a wip map too ;3

## Technical details
Added a datafield for the Paracusia sound collection to SupermatterComponent and changed the paracusia check in supermattersystem.processing to refer to this datafield instead. The default value is the same.
Did this via datafield so that anyone wanting to make a silly crystal only needs yaml or vvwrite

Added a bool to the supermattercomponent for whether to allow accents over the radio for the SM just in case someone wanted that. Added a check for this before sending the supermatter message through the same chat formatting method used for IC speech.

## Media

https://github.com/user-attachments/assets/3b950d2a-e987-4aa8-b435-4f7176818e80


https://github.com/user-attachments/assets/982da349-c38c-4e1a-945e-677186a20554


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [ ] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
don't know if i can check this box since im in ee files

**Changelog**
:cl:
- fix: Thusd crystal yim woota 'beeg' gimbo thusd radio (accents work properly from the supermatter)