### PR TITLE
Revert "removes the plasma vial from the chemistry locker"

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -98,7 +98,7 @@
     - id: BoxPillCanister
     - id: BoxBottle
     - id: BoxVial
-    # - id: PlasmaChemistryVial # imp
+    - id: PlasmaChemistryVial
     - id: ChemBag
     - id: ClothingHandsGlovesLatex
     - id: ClothingHeadsetMedical


### PR DESCRIPTION
Reverts impstation/imp-station-14#2524

## Reasoning
There have been some smaller mentions of this in a few channels on Discord, namely the Chemistry one, but nothing concrete has happened. I'm making this PR as an official way to nudge toward a proper discussion about this change and its effect on chemists' interactions. 

## My Current Opinion
The initial reasoning expressed in the original PR was that Plasma-locked chems were not urgent, and that removing the plasma vials would continue to require chemists to interact with the rest of the station. 
I agree with the first point; the station can function reasonably without plasma chems.

The second point is where I primarily disagree - as of now, it is tedium for the sake of tedium, forcing a handshake interaction for the sake of it. 

From my experience in-game before the vials were originally added to Wizden, and now on Imp, not much of the process has changed from LRP -> MRP. 
The extent of 9/10 interactions are "Can I have Plasma?" "Yes." "Thank you. Goodbye."
The 1/10 times they say no, I am going to ask the one other department that starts with plasma, or just deconstruct the nearest plasteel table. The interaction is now done, and I have my plasma, no matter the resulting conversation. I have completed the built-in fetch quest. 

My main point is people know about this mechanic enough to know how to help; medical staff will volunteer themselves, or better yet people will just drop plasma unprompted, wordlessly on your front desk because no one wants to hold up the chemist, and even if you do, it's for such a minute amount of time you aren't likely to gain anything aside from short in-character annoyance. 
Further, most stations are mapped with a source of plasma near the chemist anyway - because this was a chore to chemistry experienced well before Imp's existence. The vials were created in recognition of that. 

To be clear, I am not saying the chemist shouldn't interact with the rest of the station, but as someone else pointed out, this is a "False Interaction." It is a checkpoint, not a choice. 

## Proposal
I think there are just better ways to manage Plasma as a resource. For now, I think reverting the original PR can serve as a bridge until that change can be implemented or chem is expanded upon. 