### PR TITLE
hotfix: restore kode singing and visuals

### DIFF
--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -72,6 +72,13 @@
       state: "creampie_human"
       visible: false
 
+    # we put kode sing here so we dont have to redefine the whole fucking block elsewhere
+    # it should be fine because kode are the only thing with the componentry to make this visible
+    - map: [ enum.InstrumentVisuals.Layer ]
+      sprite: _DV/Effects/harpysinger.rsi
+      state: singing_music_notes
+      visible: false
+
 - type: entity
   id: BaseSpeciesAppearance
   parent:

--- a/Resources/Prototypes/_Impstation/Body/Species/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Body/Species/kodepiia.yml
@@ -148,6 +148,9 @@
         enum.InstrumentVisuals.Layer:
           False: { visible: false }
           True: { visible: true }
+  - type: Instrument
+    allowPercussion: false
+    program: 52
   # imp edit end
 
 


### PR DESCRIPTION
## About the PR
nubody broke it sorry. this fixes the instrument menu on kode and makes their pretty music visualizer work again

resolves https://github.com/impstation/imp-station-14/issues/4577

## Why / Balance
actively causing errors

## Technical details
i put a new layer on the base species appearance for this. i think its fine to do this and saves us headache elsewhere?

## Media

https://github.com/user-attachments/assets/cbfd2e97-f475-4c9b-9323-9909a1e06795



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [ ] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

i dont know if im allowed to do this because its harpy code sorry
<!-- THIS IS OPTIONAL. -->

**Changelog**

:cl:
- fix: Kode can properly sing again

