### PR TITLE
Nymph fix

### DIFF
--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -56,7 +56,7 @@ public sealed partial class NymphSystem : EntitySystem
         // IMP EDIT END - Unborgable trait support
 
         // Move the mind if there is one and it's supposed to be transferred
-        if (comp.TransferMind == true && _mindSystem.TryGetMind(args.Target, out var mindId, out var mind))
+        if (comp.TransferMind && _mindSystem.TryGetMind(uid, out var mindId, out var mind))
             _mindSystem.TransferTo(mindId, nymph, mind: mind);
 
         // Delete the old organ

--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -56,7 +56,7 @@ public sealed partial class NymphSystem : EntitySystem
         // IMP EDIT END - Unborgable trait support
 
         // Move the mind if there is one and it's supposed to be transferred
-        if (comp.TransferMind && _mindSystem.TryGetMind(uid, out var mindId, out var mind))
+        if (comp.TransferMind && _mindSystem.TryGetMind(uid, out var mindId, out var mind)) // imp early merge
             _mindSystem.TransferTo(mindId, nymph, mind: mind);
 
         // Delete the old organ

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -258,7 +258,7 @@
   id: OrganDionaBrainNymphing
   components:
   - type: Nymph
-    transferMind: true
+    transferMind: true # imp early merge
     entityPrototype: OrganDionaNymphBrain
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -258,6 +258,7 @@
   id: OrganDionaBrainNymphing
   components:
   - type: Nymph
+    transferMind: true
     entityPrototype: OrganDionaNymphBrain
 
 - type: entity


### PR DESCRIPTION
## About the PR
early merges wizden https://github.com/space-wizards/space-station-14/commit/769075e92919a7aedd2501204e9dbac9ca5a9e88

## Why / Balance
nymph broke

## Technical details
nymph system pointing and missed field in nymph component

## Media


https://github.com/user-attachments/assets/715062d9-1100-4a81-9511-3d9c5f9105b1


<img width="359" height="245" alt="image" src="https://github.com/user-attachments/assets/98f19a27-a069-48bb-b6e6-91f48f03006a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [ ] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
not applicable, wizden cherry-pick

**Changelog**
:cl: Princess-Cheeseballs
- fix: Diona minds are now correctly transferred to their nymphs when they gib.
