### PR TITLE
Hydra Size Correction

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/baseshotguns.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Shotguns/baseshotguns.yml
@@ -77,8 +77,6 @@
       map: [ "enum.GunVisualLayers.Base" ]
   - type: Item
     size: Large
-    shape:
-    - 0,0,4,0
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
     quickEquip: false


### PR DESCRIPTION
## About the PR
The Hydra shotgun is now its appropriate and intended 2x4 size.

## Why / Balance
A missed error from a copy-paste likely. It's not meant to be a 1x5 size or whatever.

## Technical details
One line change baby

## Media
<img width="261" height="141" alt="image" src="https://github.com/user-attachments/assets/a0e6dec4-1575-4fab-b04e-96fc6cde64df" />

## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl: DVD Player
- fix: The Hydra is now the appropriate size
