### PR TITLE
another single component fix

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/base_rifles.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Rifles/base_rifles.yml
@@ -124,9 +124,6 @@
       DamageVariable:
         types:
           Piercing: 0
-  - type: ChamberMagazineAmmoProvider
-    soundRack:
-      path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: BallisticAmmoProvider
     whitelist:
       tags:


### PR DESCRIPTION
## About the PR
I was investigating a potential sprite error, but that wasn't real (don't know what was going on in that round). Instead I discovered the Astro Ace had the "NO" symbol over the cursor the entire time so I looked into that instead.

## Why / Balance
You could use it still, but the NO symbol is misleading and not good for player experience. So far the component isn't really used for any reason, so I just cut it.

## Technical details
I had "Chamber Magazine Ammo Provider" listed for the BaseWeaponInternalRifle. I don't know why it was there, it wasn't necessary and this base weapon is (so far) only used for the Foam Force rifle. So I just removed it.

## Media
<img width="176" height="211" alt="image" src="https://github.com/user-attachments/assets/839334b8-4322-4e80-aba8-856db922e9aa" />

## Requirements
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl: DVD Player
- fix: The Astro Ace now doesn't say you can't shoot it when you always could
