### PR TITLE
Fix rat king and lepidodent stomachs

### DIFF
--- a/Resources/Prototypes/_Impstation/Body/Animals/lepidodent.yml
+++ b/Resources/Prototypes/_Impstation/Body/Animals/lepidodent.yml
@@ -1,3 +1,4 @@
+# for eating normal food and cloth
 - type: entity
   id: OrganLepidodentStomach
   parent: OrganAnimalStomach
@@ -12,6 +13,8 @@
       - ClothMade
       - Paper
       - Pill
+  - type: Metabolizer
+    metabolizerTypes: [ Moth, Animal ]
 
 - type: entity
   id: BaseMobLepidodentBody

--- a/Resources/Prototypes/_Impstation/Body/Animals/rat.yml
+++ b/Resources/Prototypes/_Impstation/Body/Animals/rat.yml
@@ -7,8 +7,8 @@
   - type: Stomach
     specialDigestible:
       tags:
-      - ClothMade
-      - Paper
-      - Pill
+      - Trash
+    isSpecialDigestibleExclusive: false
   - type: Metabolizer
-    metabolizerTypes: [ Moth, Animal ]
+    maxReagents: 3
+    metabolizerTypes: [ Animal, Rat ]

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/lepidodent.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Animals/lepidodent.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: lepidodent
-  parent: [ MobMouse, BaseMobLepidodentBody ]
+  parent: [ BaseMobLepidodentBody, MobMouse ]
   id: MobLepidodent
   description: An unstoppable eating machine.
   components:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Nubody stuff made RK only able to eat cloth and lepidodents unable to eat cloth, this fixes that.
And also RK is supposed to be able to metabolize 3 things at once which was also messed up by that.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Someone accidentally put lepidodent code into the rat organ and the lepidodent stomach wasn't working from another issue.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->

:cl:
- fix: Rat king and lepidodents can eat again.

