### PR TITLE
[upmerge bugfix] ant displacements and snail speech sounds

### DIFF
--- a/Resources/Prototypes/_Impstation/Body/Species/ant.yml
+++ b/Resources/Prototypes/_Impstation/Body/Species/ant.yml
@@ -197,9 +197,9 @@
     sprite: _Impstation/Mobs/Species/Visitors/Ants/ants_held.rsi #imp edit, waiting on proper macro merge to migrate files
     inhandVisuals:
       left:
-      - state: inhand-left
+      - state: inhand_left
       right:
-      - state: inhand-right
+      - state: inhand_right
   - type: FlavorProfile
     flavors:
     - ants

--- a/Resources/Prototypes/_Impstation/Body/Species/ant.yml
+++ b/Resources/Prototypes/_Impstation/Body/Species/ant.yml
@@ -12,67 +12,67 @@
       jumpsuit:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: jumpsuit
       head:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: head
       eyes:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: eyes
       ears:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: ears
       mask:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: mask
       neck:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: neck
       outerClothing:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: outerClothing
       gloves:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: hands
       shoes:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: feet
       belt:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: belt
       back:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: back
       suitstorage:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: suitstorage
       id:
         sizeMaps:
           32:
-            sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+            sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
             state: id
   #IMP EDIT START: TO BE REWORKED BY VISUAL NUBODY
   - type: EntityTableContainerFill
@@ -223,12 +223,12 @@
     leftHandDisplacement:
       sizeMaps:
         32:
-          sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+          sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
           state: inhand_left
     rightHandDisplacement:
       sizeMaps:
         32:
-          sprite: _Impstation/Mobs/Species/Visitor/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
+          sprite: _Impstation/Mobs/Species/Visitors/Ants/displacement.rsi #imp edit, waiting on proper macro merge to migrate files
           state: inhand_right
   # imp edit start
   - type: StrongAsFuckAnt
@@ -257,7 +257,7 @@
 #  components:
 #  - type: VisualOrgan
 #    data:
-#      sprite: _Impstation/Mobs/Species/Visitor/Ants/parts.rsi #imp edit, waiting on proper macro merge to migrate files
+#      sprite: _Impstation/Mobs/Species/Visitors/Ants/parts.rsi #imp edit, waiting on proper macro merge to migrate files
 #  - type: VisualOrganMarkings
 #    markingData:
 #      group: Ant
@@ -273,7 +273,7 @@
   # IMP EDIT START: TO BE ENABLED BY VISUAL NUBODY
   #- type: VisualOrgan
   #  data:
-  #    sprite: _Impstation/Mobs/Species/Visitor/Ants/parts.rsi #imp edit, waiting on proper macro merge to migrate files
+  #    sprite: _Impstation/Mobs/Species/Visitors/Ants/parts.rsi #imp edit, waiting on proper macro merge to migrate files
   #- type: VisualOrganMarkings
   #  markingData:
   #    group: Ant

--- a/Resources/Prototypes/_Impstation/Body/Species/gastropoid.yml
+++ b/Resources/Prototypes/_Impstation/Body/Species/gastropoid.yml
@@ -139,6 +139,8 @@
       Male: UnisexSnail
       Female: UnisexSnail
       Unsexed: UnisexSnail
+  - type: Speech
+    speechSounds: Gastropoid
   - type: BodyEmotes
     soundsId: GastropoidBodyEmotes
   - type: GastropoidAccent


### PR DESCRIPTION
## About the PR
fixed ant displacements and snail speech sounds
i wanted to fix hands too so ignore my branch name but i found the upstream pr that fixes it and it's more complicated and touches more files than i feel is good for an early merge, especially with a pr up for another upmerge.

## Why / Balance
bugs

## Technical details
ant rsi path and state typo and speech sounds just missing. yaml

## Media
<img width="621" height="369" alt="image" src="https://github.com/user-attachments/assets/4240a6bd-ec3f-4bbe-b44e-755e413770cf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
:cl:
- fix: Fixed ant displacements
- fix: Gastropoid speech sounds are snaily once again
