### PR TITLE
dragons can now devour people alive

### DIFF
--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -71,6 +71,7 @@ public sealed class DevourSystem : EntitySystem
             {
                 case MobState.Critical:
                 case MobState.Dead:
+                case MobState.Alive: // imp
 
                     _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, ent.Owner, ent.Comp.DevourTime, new DevourDoAfterEvent(), ent.Owner, target: target, used: ent.Owner)
                     {
@@ -78,7 +79,6 @@ public sealed class DevourSystem : EntitySystem
                     });
                     break;
                 case MobState.Invalid:
-                case MobState.Alive:
                 default:
                     _popupSystem.PopupClient(Loc.GetString("devour-action-popup-message-fail-target-alive"), ent.Owner, ent.Owner);
                     break;

--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -79,6 +79,7 @@ public sealed class DevourSystem : EntitySystem
                     });
                     break;
                 case MobState.Invalid:
+              //case MobState.Alive: // imp
                 default:
                     _popupSystem.PopupClient(Loc.GetString("devour-action-popup-message-fail-target-alive"), ent.Owner, ent.Owner);
                     break;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
the devour ability dragons (and potentially other creatures) have can now target mobs in the alive state (where before it would only allow you to target mobs in the critical or dead state).
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. trust. i think the limitation exists primarily because people on wizden would feign death to get eaten by the dragon and then kill it from inside where the dragon has no way to fight back. this is a valid reason for the limitation to be there, however i personally feel like a private server can uplift restrictions like this since we don't have to deal with the general public and *most* of our population aren't new players.
2. verisimilitude. fancy word to just say that it doesn't make sense that a dragon cannot eat a person alive when they can eat a person who is in critical condition or dead. if a living person doesn't resist, the dragon should be able to just eat them. a living person can easily resist by just walking away or hitting the dragon. it's good to make things sensible not just for immersion reasons but for gameplay as well; it is more intuitive and natural for the dragon to be able to eat whatever it wants to and not be limited by an unnatural rule.
3. player agency. players being able to do more things is good! i once had (during post-round on lowpop) someone arrested for saying that they put ketchup on their salad or some other heinous crime. we also just happened to have a cognizine'd dungeon dragon that was player-controlled and crew-aligned, so i thought an apt punishment would be to feed the prisoner to the dragon alive. however despite the fact they were in cuffs and held by me, the dragon couldn't do it because they were still alive. we were all disappointed (prisoner included). though we ended up critting the prisoner so the dragon could eat them, i think it would've been funnier if the dragon's stomach could've served as a jail cell for the living prisoner.
## If The Above Reasons Are Not Good Enough
there's two ideas (both of which i am very willing and eager to code!) to fix the issue mentioned in the first reason in case that is the reason why this limitation can't be removed.
1. digestion. right now currently if you eat a person alive there is nothing that actually kills them. like they don't even asphyxiate while inside a stomach. when a person dies inside the stomach it's because of the bleeding from the dragon attacking them, having been already in a critical state, and spacing. if a dragon is in an unspaced room and just gobbles up a perfectly healthy creature they just sit in there alive forever. even if the dragon goes crit or dies they're still stuck in there until the dragon gets gibbed/butchered. the change i'd make here is to make it so that being in the stomach of a dragon is Actually Dangerous and kills you with consistent blunt/caustic damage over time. this would also solve the cheeky strat of giving yourself a shit ton of meds before going crit so as to stabilize while inside the dragon. the damage should probably stop once death occurs since rot already covers a body becoming unrecoverable due to time, but on the alternative it could just go on forever, and if so i'd probably want to add a point where the body just gets absorbed fully and disappears or is replaced by the caustic damage equivalent of ashing.
2. regurgitation. give the dragon the ability to selectively regurgitate stuff it ate. that way, if there's a living creature in their stomach causing trouble, they can just spit it out and kill it. of course there'd need to be changes to how the ichor of the dragon is delivered since currently it just injects into the bloodstream when a dragon eats a thing on a whitelist of objects which people are of course included on. my suggestion would be to rework that entirely so that the dragon just gets healed when it metabolizes the blood of creatures, and that the chemicals inside of a person it eats would be transferred into its own bloodstream, which is cool and awesome on its own cause then if a dragon eats someone who's really drunk or high they will also then get drunk or high and that's funny. being able to regurgitate people would also create some potential neat interactions between crew and the dragon where they negotiate to have it spit people out in exchange for something. if digestion was also added any discussion would be on a timer.
## Technical Details
<!-- Summary of code changes for easier review. -->
literally just moving one line so that it does the devour when they're in the alive state instead of not doing it. unless we do one of the two ideas above in which case it'll likely be a lot more than just that.
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl: ActiveMammoth
- tweak: dragon can now eat people alive