### PR TITLE
Update Magic Book Xenoarch Effect

### DIFF
--- a/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
+++ b/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
@@ -405,15 +405,25 @@
       deleteSpawnerAfterSpawn: false
       table: !type:GroupSelector
         children:
-        - id: WizardsGrimoire
-        - id: SpawnSpellbook
         - id: ForceWallSpellbook
         - id: BlinkBook
-        - id: SmiteBook
         - id: KnockSpellbook
-        - id: FireballSpellbook
         - id: SpawnSpaceGreaseSpellbook
         - id: ScrollRunes
+        - id: SpellbookSafeLibrarianFireball
+        - id: SpellbookSafeLibrarianFlashlight
+        - id: SpellbookSafeLibrarianCutting
+        - id: SpellbookSafeLibrarianPrying
+        - id: SpellbookSafeLibrarianAnchoring
+        - id: SpellbookSafeLibrarianScrewing
+        - id: FireballSpellbook
+          weight: 0.6
+        - id: SmiteBook
+          weight: 0.6
+        - id: WizardsGrimoire
+          weight: 0.3
+        - id: SpawnSpellbook
+          weight: 0.6
 
 - type: entity
   id: XenoArtifactCashSpawnMajor


### PR DESCRIPTION
## About the PR
Added the rest of the librarian magic books to the XenoArtifactMagicBook spawner table. Reduced the chances of getting more dangerous books such as Fireball, Spawn, Smite. Reduced the Wizard Grimoire to even lower.

## Why / Balance
Per discussion in the postround channel with Grimbeeper, the Wizard Grimoire should not have the same odds of spawning as something like Force Wall. Per further discussion in the Science workgroup channel, it was decided to add the rest of the magic books to the table as well.

## Technical details
Added the remaining "SpellbookSafeLibrarian" books to the spawner pool. Weighted the Fireball, Smite, and Spawn books at 0.6. Weighted the WizardsGrimoire at 0.3.

## Media
From 100 uses of an artifact with the effect...
<img width="432" height="430" alt="image" src="https://github.com/user-attachments/assets/433df8a8-9acf-4bdc-b6f4-8e24e5b3391a" />
<img width="433" height="419" alt="image" src="https://github.com/user-attachments/assets/f48afd88-e90c-4a11-bde3-91cdb4dd1384" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: dubdubchan
- Tweak: Adjusted and expanded magic book pool for Xenoarcheology effects.
