### PR TITLE
Migrate organs causing stations to fail to load

### DIFF
--- a/Resources/migration_imp.yml
+++ b/Resources/migration_imp.yml
@@ -173,5 +173,10 @@ OrganKodepiiaSkin: OrganKodepiiaTongue
 # 2026-09-03
 # more nubody organ id changes
 LeftFootHuman: OrganHumanFootLeft
+RightFootHuman: OrganHumanFootRight
 LeftHandHuman: OrganHumanHandLeft
 RightHandHuman: OrganHumanHandRight
+LeftFootSkeleton: OrganSkeletonPersonFootLeft
+RightFootSkeleton: OrganSkeletonPersonFootRight
+RightLegSkeleton: OrganSkeletonPersonLegRight
+RightLegArachnid: OrganArachnidLegRight

--- a/Resources/migration_imp.yml
+++ b/Resources/migration_imp.yml
@@ -169,3 +169,9 @@ SpawnMobFeindfish: SpawnMobFiendfish
 # 2026-09-02
 # nubody organ id changes
 OrganKodepiiaSkin: OrganKodepiiaTongue
+
+# 2026-09-03
+# more nubody organ id changes
+LeftFootHuman: OrganHumanFootLeft
+LeftHandHuman: OrganHumanHandLeft
+RightHandHuman: OrganHumanHandRight


### PR DESCRIPTION
## About the PR
Added a few migration entries to migrate various Human, Skeleton, and Arachnid organs to their Nubody variants.

## Why / Balance
Nubody caused many organs to rename, causing stations to fail to load due to missing prototypes. Monarch, Eclipse, Whalefall, and GateImp were affected by these organs.

## Technical details
Added entries to migration_imp.yml

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->