### PR TITLE
Make uranium and radium yummy for grays 👍 

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -358,6 +358,12 @@
         damage:
           types:
             Poison: 1
+        # imp edit start
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Gray ] # gray radiation immunity, also it's kinda weird this drink does normal poison when it's made of uranium
+          inverted: true
+        # imp edit start
   fizziness: 0.5
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -255,6 +255,24 @@
   color: "#00ff04"
   meltingPoint: 700.0
   boilingPoint: 1737.0
+# imp edit start
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Radiation: 2
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Gray ] # gray radiation immunity
+          inverted: true
+      - !type:SatiateThirst
+        factor: 2
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Gray ]
+#imp edit end
 
 - type: reagent
   id: Silicon
@@ -346,6 +364,11 @@
         - !type:MetabolizerTypeCondition
           type: [ Gray ] # gray radiation immunity
           inverted: true
+      - !type:SatiateHunger
+        factor: 1
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Gray ]
         # imp edit end
 
 - type: reagent


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Made it so Grays satiate hungry from uranium (0.333x rate) and satiate thirst from radium (at 0.667x rate).
(Also makes it so they don't take damage from nuclear cola)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Since grays have radiation immunity and healing now, I think it just makes sense and is funny for these to be things.
Uranium provides less hunger satiation than normal food, and radium's thirst satiation is the standard rate for most drinks.
Nuclear cola is made of uranium so it makes sense for them to be immune.
## Technical details
<!-- Summary of code changes for easier review. -->
Simple yaml
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="483" height="182" alt="Screenshot 2026-09-08 193216" src="https://github.com/user-attachments/assets/e1d26bbf-282d-4d8a-b900-d644ce276058" />

<img width="479" height="200" alt="Screenshot 2026-09-08 193209" src="https://github.com/user-attachments/assets/97f2db53-640d-4bc7-87c4-89c492d1b165" />

<img width="489" height="200" alt="Screenshot 2026-09-08 193230" src="https://github.com/user-attachments/assets/596be793-b300-4ccd-9a96-60d110e0ce13" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->

:cl:
- tweak: Grays now gain nutritional benefit from uranium and can quench their thirst with radium!

