### PR TITLE
Unhardcode KillSign sprite offset

### DIFF
--- a/Content.Client/Administration/Systems/KillSignSystem.cs
+++ b/Content.Client/Administration/Systems/KillSignSystem.cs
@@ -52,12 +52,13 @@ public sealed class KillSignSystem : EntitySystem
         if (ent.Comp.Sprite == null)
             return;
 
-        var adj = _sprite.GetLocalBounds((ent, sprite)).Height / 2 + ((1.0f / 32) * 6.0f);
+        // Imp: we're using KillSignComponent.Offset instead, no need for this
+        // var adj = _sprite.GetLocalBounds((ent, sprite)).Height / 2 + ((1.0f / 32) * 6.0f);
 
         var layer = _sprite.AddLayer((ent, sprite), ent.Comp.Sprite);
         _sprite.LayerMapSet((ent, sprite), KillSignKey.Key, layer);
         _sprite.LayerSetScale((ent, sprite), layer, ent.Comp.Scale);
-        _sprite.LayerSetOffset((ent, sprite), layer, ent.Comp.DoOffset ? new Vector2(0.0f, adj) : new Vector2(0.0f, 0.0f));
+        _sprite.LayerSetOffset((ent, sprite), layer, new Vector2(0.0f, ent.Comp.Offset)); // Imp: Unhardcoded offset
 
         if (ent.Comp.ForceUnshaded)
             sprite.LayerSetShader(layer, "unshaded");

--- a/Content.Shared/Administration/Components/KillSignComponent.cs
+++ b/Content.Shared/Administration/Components/KillSignComponent.cs
@@ -27,6 +27,7 @@ public sealed partial class KillSignComponent : Component
     /// Whether the granted layer should be offset to be above the entity.
     /// </summary>
     [DataField, AutoNetworkedField]
+    [Obsolete("Set the Offset field instead of toggling DoOffset")]  // Imp: Unhardcode KillSign offset
     public bool DoOffset = true;
 
     /// <summary>
@@ -40,4 +41,12 @@ public sealed partial class KillSignComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public Vector2 Scale = Vector2.One;
+
+    // Imp start
+    /// <summary>
+    /// The vertical offset of the sprite.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Offset = 0.0f;
+    // Imp end
 }


### PR DESCRIPTION
## About the PR

`KillSignComponent.DoOffset` was checked in its system for applying a fixed vertical offset based on the height of the sprite. Now it's deprecated in favor of with `KillSignComponent.Offset`, which can be set to any float to accommodate novel offsets.

## Why / Balance

#4035 wants to use `KillSignComponent.DoOffset` so the sword sprite appears above the mob, but due to the rigidness of the offset calculation, it doesn't properly offset above and is slightly clipping Urist in tests.

Also `DoOffset` is used like nowhere so it's safe to change this to be less annoying

## Technical details

BREAKING CHANGE: `KillSignComponent.DoOffset` has been obsoleted for Offset. For sprites of height 32 using `DoOffset`, the equivalent `Offset` value is 16.1875f.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- THIS IS OPTIONAL. Impstation is licensed under AGPLv3 by default. Check this box if you wish to allow other users to relicense your work to MIT. -->
- [x] I give permission for any changes to the repository made in this PR to be relicensed under MIT.
<!-- THIS IS OPTIONAL. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. 
The name that appears on the changelog will be your GitHub usernabe by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
