### PR TITLE
reduce artifact light effect brightness

### DIFF
--- a/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
+++ b/Resources/Prototypes/_Impstation/Xenoarchaeology/effects.yml
@@ -111,7 +111,7 @@
     components:
     - type: PointLight
       radius: 8
-      energy: 10
+      energy: 1.2
       color: "#daa3fd"
     - type: FlashOnTrigger
       range: 8


### PR DESCRIPTION
## About the PR
reduces the brightness of the point light effect for artifacts! slightly brighter than a flashlight now

## Why / Balance
multiple people with and without vision complications have expressed that the current artifact light is way too bright, to the point of causing considerable eyestrain. and frankly it doesnt need to be 10x brighter than a standard light

## Technical details
adjusts the PointLight component of the XenoArtifactPointLight effect to have an energy of 1.2 instead of 10

## Media
<img width="835" height="973" alt="dgfhjfyukjfgyuk" src="https://github.com/user-attachments/assets/8eb57a7f-ecc8-4a42-9468-cc2e613b6dd2" />


## Requirements
- [X] I have read and am following the Impstation [Design Principles](https://github.com/impstation/imp-station-14/wiki/Design-Principles) and [Coding Standards](https://github.com/impstation/imp-station-14/wiki/Coding-Standards).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I give permission for any changes to the repository made in this PR to be relicensed under MIT.

**Changelog**
:cl:
- tweak: the artifact point light effect is less harsh now.
